### PR TITLE
Schema comparison fixes (Marten GH-1821)

### DIFF
--- a/src/Weasel.Postgresql.Tests/Tables/detecting_table_deltas.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/detecting_table_deltas.cs
@@ -254,8 +254,26 @@ namespace Weasel.Postgresql.Tests.Tables
             yield return ("Simple gin", t => t.ModifyColumn("data").AddIndex(i => i.Method = IndexMethod.gin));
             yield return ("Simple gist", t => t.AddColumn("data2", "tsvector").AddIndex(i => i.Method = IndexMethod.gist));
             yield return ("Simple hash", t => t.ModifyColumn("user_name").AddIndex(i => i.Method = IndexMethod.hash));
+
+            yield return ("Simple jsonb property", t => t.ModifyColumn("data").AddIndex(i => i.Columns = new[] {"(data ->> 'Name')"}));
+            yield return ("Simple jsonb property + unique", t => t.ModifyColumn("data").AddIndex(i =>
+            {
+                i.Columns = new[] {"(data ->> 'Name')"};
+                i.IsUnique = true;
+            }));
             
-            
+            yield return ("Jsonb property with function", t => t.ModifyColumn("data").AddIndex(i => i.Columns = new[] {"lower(data ->> 'Name')"}));
+            yield return ("Jsonb property with function + unique", t => t.ModifyColumn("data").AddIndex(i =>
+            {
+                i.Columns = new[] {"lower(data ->> 'Name')"};
+                i.IsUnique = true;
+            }));
+            yield return ("Jsonb property with function as expression", t => t.ModifyColumn("data").AddIndex(i =>
+            {
+                i.Expression = "(lower(?))";
+                i.Columns = new[] {"(data ->> 'Name')"};
+                i.IsUnique = true;
+            }));
         }
 
 

--- a/src/Weasel.Postgresql/Tables/ActualIndex.cs
+++ b/src/Weasel.Postgresql/Tables/ActualIndex.cs
@@ -16,6 +16,8 @@ namespace Weasel.Postgresql.Tables
             return index.ToDDL(parent)
                     .Replace("INDEX CONCURRENTLY", "INDEX")
                     .Replace("::text", "")
+                    .Replace("(", "")
+                    .Replace(")", "")
                 ;
         }
         

--- a/src/Weasel.Postgresql/Tables/ForeignKey.cs
+++ b/src/Weasel.Postgresql/Tables/ForeignKey.cs
@@ -35,7 +35,7 @@ namespace Weasel.Postgresql.Tables
                 return true;
             }
 
-            if (obj.GetType() != this.GetType())
+            if (!obj.GetType().CanBeCastTo<ForeignKey>())
             {
                 return false;
             }

--- a/src/Weasel.Postgresql/Tables/Table.cs
+++ b/src/Weasel.Postgresql/Tables/Table.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data.Common;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -349,7 +350,7 @@ namespace Weasel.Postgresql.Tables
             
             public ColumnExpression DefaultValue(double value)
             {
-                return DefaultValueByExpression(value.ToString());
+                return DefaultValueByExpression(value.ToString(CultureInfo.InvariantCulture));
             }
 
             public ColumnExpression DefaultValueFromSequence(Sequence sequence)


### PR DESCRIPTION
Fixes for schema validation failures original reported in JasperFx/marten#1821

I'm not 100% sure about the fix for index equality comparison as there might be cases where parenthesis are significant for equality. I couldn't come up with any examples off the top of my head, so went with the current solution. All tests in Weasel and Marten passed (at least on my machine ;))

This alone does not fully fix the bugs reported in JasperFx/marten#1821, but I will create PR for changes required in Marten.

While running tests, I found that `ColumnExpression.DefaultValue(double value)` generated invalid SQL if current culture used decimal separator other than ".", so fixed that one also.