### PR TITLE
Detects primary key constraint name change when migrating #39

### DIFF
--- a/src/Weasel.Postgresql.Tests/Tables/detecting_table_deltas.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/detecting_table_deltas.cs
@@ -509,7 +509,25 @@ namespace Weasel.Postgresql.Tests.Tables
             
             await AssertNoDeltasAfterPatching(theTable);
         }
-        
+
+
+        [Fact]
+        public async Task detect_new_primary_key_constraint_name_change()
+        {
+            await CreateSchemaObjectInDatabase(theTable);
+
+            theTable.PrimaryKeyName = "pk_newchange";
+
+            var delta = await theTable.FindDelta(theConnection);
+
+            delta.PrimaryKeyDifference.ShouldBe(SchemaPatchDifference.Update);
+
+            delta.HasChanges().ShouldBeTrue();
+
+            await AssertNoDeltasAfterPatching(theTable);
+        }
+
+
         [Fact]
         public async Task equivalency_with_the_postgres_synonym_issue()
         {

--- a/src/Weasel.Postgresql/Tables/Table.FetchExisting.cs
+++ b/src/Weasel.Postgresql/Tables/Table.FetchExisting.cs
@@ -1,10 +1,8 @@
-using System;
+using Npgsql;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Linq;
 using System.Threading.Tasks;
-using Baseline;
-using Npgsql;
 
 namespace Weasel.Postgresql.Tables
 {
@@ -174,7 +172,6 @@ order by column_index;
                 existing._columns.Add(column);
             }
         }
-
         private static async Task<TableColumn> readColumn(DbDataReader reader)
         {
             var column = new TableColumn(await reader.GetFieldValueAsync<string>(0),
@@ -193,7 +190,6 @@ order by column_index;
 
             return column;
         }
-
         private async Task readConstraints(DbDataReader reader, Table existing)
         {
             await reader.NextResultAsync();
@@ -218,7 +214,11 @@ order by column_index;
                     continue;
                 
                 var isPrimary = await reader.GetFieldValueAsync<bool>(6);
-                if (isPrimary) continue;
+                if (isPrimary)
+                {
+                    existing.PrimaryKeyName = await reader.GetFieldValueAsync<string>(3);
+                    continue;
+                }
 
                 var schemaName = await reader.GetFieldValueAsync<string>(1);
                 var tableName = await reader.GetFieldValueAsync<string>(2);
@@ -244,9 +244,5 @@ order by column_index;
             }
             return pks;
         }
-
-        
-    }
-    
-    
+    }    
 }

--- a/src/Weasel.Postgresql/Tables/TableDelta.cs
+++ b/src/Weasel.Postgresql/Tables/TableDelta.cs
@@ -37,6 +37,10 @@ namespace Weasel.Postgresql.Tables
             {
                 PrimaryKeyDifference = SchemaPatchDifference.Create;
             }
+            else if (actual.PrimaryKeyName != expected.PrimaryKeyName)
+            {
+                PrimaryKeyDifference = SchemaPatchDifference.Update;
+            }
             else if (!expected.PrimaryKeyColumns.SequenceEqual(actual.PrimaryKeyColumns))
             {
                 PrimaryKeyDifference = SchemaPatchDifference.Update;


### PR DESCRIPTION
- Adds missing condition for determining primary key schema change
- Assigns primary key constraint name when creating existing delta