### PR TITLE
Handle PrimaryKeyName longer than Postgres's default NAMEDATALEN limit

### DIFF
--- a/src/Weasel.Postgresql.Tests/Tables/detecting_table_deltas.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/detecting_table_deltas.cs
@@ -519,6 +519,16 @@ namespace Weasel.Postgresql.Tests.Tables
         }
 
         [Fact]
+        public async Task detect_primary_key_constraint_name_change_with_key_beyond_namedatalen_limit()
+        {
+            theTable.PrimaryKeyName = "pk_this_primary_key_exceeds_the_postgres_default_namedatalen_limit_of_sixtythree_chars";
+            await CreateSchemaObjectInDatabase(theTable);
+
+            var delta = await theTable.FindDelta(theConnection);
+            delta.HasChanges().ShouldBeFalse();
+        }
+
+        [Fact]
         public async Task detect_new_primary_key_constraint_name_change_when_also_used_as_foreign_key()
         {
             var dudeTable = new Table("deltas.dudes");

--- a/src/Weasel.Postgresql/Tables/Table.cs
+++ b/src/Weasel.Postgresql/Tables/Table.cs
@@ -36,6 +36,11 @@ namespace Weasel.Postgresql.Tables
         public IList<ForeignKey> ForeignKeys { get; } = new List<ForeignKey>();
         public IList<IndexDefinition> Indexes { get; } = new List<IndexDefinition>();
 
+        /// <summary>
+        /// Max identifier length for identifiers like table name, column name, constraints, primary key etc
+        /// </summary>
+        public int MaxIdentifierLength { get; set; } = 63;
+
         public IReadOnlyList<string> PrimaryKeyColumns => _columns.Where(x => x.IsPrimaryKey).Select(x => x.Name).ToList();
 
         public IList<string> PartitionExpressions { get; } = new List<string>();
@@ -251,6 +256,9 @@ namespace Weasel.Postgresql.Tables
             var any = await reader.ReadAsync().ConfigureAwait(false);
             return any;
         }
+
+        public string TruncatedNameIdentifier(string nameIdentifier) =>
+            nameIdentifier.Substring(0, Math.Min(MaxIdentifierLength, nameIdentifier.Length));
 
         public class ColumnExpression
         {

--- a/src/Weasel.Postgresql/Tables/TableDelta.cs
+++ b/src/Weasel.Postgresql/Tables/TableDelta.cs
@@ -37,11 +37,15 @@ namespace Weasel.Postgresql.Tables
             {
                 PrimaryKeyDifference = SchemaPatchDifference.Create;
             }
-            else if (actual.PrimaryKeyName != expected.PrimaryKeyName)
+            else if (actual.PrimaryKeyName != expected.PrimaryKeyName &&
+                     actual.TruncatedNameIdentifier(actual.PrimaryKeyName) !=
+                     expected.TruncatedNameIdentifier(expected.PrimaryKeyName))
             {
                 PrimaryKeyDifference = SchemaPatchDifference.Update;
             }
-            else if (!expected.PrimaryKeyColumns.SequenceEqual(actual.PrimaryKeyColumns))
+            else if (!expected.PrimaryKeyColumns.SequenceEqual(actual.PrimaryKeyColumns) &&
+                     !expected.PrimaryKeyColumns.Select(expected.TruncatedNameIdentifier).SequenceEqual(
+                         actual.PrimaryKeyColumns.Select(actual.TruncatedNameIdentifier)))
             {
                 PrimaryKeyDifference = SchemaPatchDifference.Update;
             }


### PR DESCRIPTION
Postgres automatically truncates index names longer than its internal NAMEDATALEN constant.

    NOTICE: identifier "..." will be truncated to "..."

This breaks schema migration, because the new name will be truncated again and the following error is thrown:

    Npgsql.PostgresException (0x80004005): 42P07: relation "...« already exists

This PR adds a check whether the truncated names are equal before generating a table delta.
