### PR TITLE
Use correct path when generating patches

### DIFF
--- a/src/Weasel.CommandLine/PatchCommand.cs
+++ b/src/Weasel.CommandLine/PatchCommand.cs
@@ -36,8 +36,9 @@ public class PatchCommand : OaktonAsyncCommand<PatchInput>
             database.Migrator.IsTransactional = true;
         }
 
-        await database.Migrator.WriteMigrationFile(input.FileName, migration);
-        AnsiConsole.MarkupLine($"[green]Wrote migration file to {input.FileName.ToFullPath()}[/]");
+        var fullPathToFile = input.FileName.ToFullPath();
+        await database.Migrator.WriteMigrationFile(fullPathToFile, migration);
+        AnsiConsole.MarkupLine($"[green]Wrote migration file to {fullPathToFile}[/]");
 
         return true;
     }


### PR DESCRIPTION
`ToFullPath` seems the correct choice for the CLI command as the filename will either be relative to the current working directory or rooted.

This looks like the appropriate place to do it as I think the `WriteMigrationFile` method is used by `WriteMigrationFileAsync` when writing in-proc as described here: https://martendb.io/schema/migrations.html#exporting-database-migrations so the `AppContext.BaseDirectory.AppendPath` seems appropriate there.