### PR TITLE
Add ability to ignore certain indexes

### DIFF
--- a/src/Weasel.Postgresql.Tests/Tables/detecting_table_deltas.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/detecting_table_deltas.cs
@@ -205,6 +205,23 @@ namespace Weasel.Postgresql.Tests.Tables
             await AssertNoDeltasAfterPatching();
         }
 
+        [Fact]
+        public async Task ignore_new_index_that_is_ignored()
+        {
+            var existing = new detecting_table_deltas().theTable;
+            existing.ModifyColumn("user_name").AddIndex(idx => idx.Name = "ignore_me");
+
+            await CreateSchemaObjectInDatabase(existing);
+
+            theTable.IgnoreIndex("ignore_me");
+
+            var delta = await theTable.FindDelta(theConnection);
+            delta.HasChanges().ShouldBeFalse();
+
+            delta.Difference.ShouldBe(SchemaPatchDifference.None);
+
+            await AssertNoDeltasAfterPatching();
+        }
 
         [Theory]
         [MemberData(nameof(IndexTestData))]

--- a/src/Weasel.Postgresql.Tests/Tables/rolling_back_table_deltas.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/rolling_back_table_deltas.cs
@@ -86,6 +86,16 @@ namespace Weasel.Postgresql.Tests.Tables
         }
 
         [Fact]
+        public async Task changed_ignored_index()
+        {
+            initial.ModifyColumn("last_name").AddIndex(); // required to have non-empty rollback
+            initial.ModifyColumn("user_name").AddIndex(idx => idx.Name = "ignore_me");
+            configured.IgnoreIndex("ignore_me");
+
+            await AssertRollbackIsSuccessful();
+        }
+
+        [Fact]
         public async Task new_fkey_should_be_dropped_on_rollback()
         {
             var states = new Table("rollbacks.states");

--- a/src/Weasel.Postgresql/Tables/TableDelta.cs
+++ b/src/Weasel.Postgresql/Tables/TableDelta.cs
@@ -21,7 +21,8 @@ namespace Weasel.Postgresql.Tables
             }
 
             Columns = new ItemDelta<TableColumn>(expected.Columns, actual.Columns);
-            Indexes = new ItemDelta<IndexDefinition>(expected.Indexes, actual.Indexes,
+            Indexes = new ItemDelta<IndexDefinition>(expected.Indexes.Where(x => !expected.HasIgnoredIndex(x.Name)),
+                actual.Indexes.Where(x => !expected.HasIgnoredIndex(x.Name)),
                 (e, a) => e.Matches(a, Expected));
 
             ForeignKeys = new ItemDelta<ForeignKey>(expected.ForeignKeys, actual.ForeignKeys);


### PR DESCRIPTION
This is related to this Marten issue: https://github.com/JasperFx/marten/issues/2207

Basically, we don't want Marten to intervene with some of the manually defined indexes, because it's extremely hard to define those through the DDL.

Comments welcome.