### PR TITLE
Fix issue with retrieving table indexes

### DIFF
--- a/src/Weasel.Postgresql/Tables/Table.FetchExisting.cs
+++ b/src/Weasel.Postgresql/Tables/Table.FetchExisting.cs
@@ -60,7 +60,9 @@ FROM (
       nspname = :{schemaParam} AND
       NOT nspname LIKE 'pg%'
 ) ind
-WHERE ind.table_name = :{(Identifier.Schema == "public" ? nameParam : nameWithSchemaParam)};
+WHERE
+      ind.table_name = :{nameParam} OR
+      ind.table_name = :{nameWithSchemaParam};
 
 SELECT c.conname                                     AS constraint_name,
        c.contype                                     AS constraint_type,


### PR DESCRIPTION
When creating a database patch, there's an issue with the patch containing creation instructions for indexes that already exists in the database. This issue affects only some Postgres versions. From what I've observed, it's not a problem on a Postgres instance with version `PostgreSQL 10.7 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-28), 64-bit`, but is an issue on another instance with version `PostgreSQL 12.4 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 7.5.0-3ubuntu1~18.04) 7.5.0, 64-bit`.

The problem originates from how casting `pg_index.indexrelid` to `regclass` behaves on different versions of Postgres. On some versions, `pg_index.indexrelid::regclass` returns the qualified name of the table that the index belongs to. However, on some other versions `pg_index.indexrelid::regclass` returns just the name of the table without the schema qualifier.

This enhancement fixes this issue.