### PR TITLE
Fix issue with parsing foreign key definitions

### DIFF
--- a/src/Weasel.Postgresql.Tests/Tables/ForeignKeyTests.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/ForeignKeyTests.cs
@@ -143,5 +143,20 @@ namespace Weasel.Postgresql.Tests.Tables
             fk.LinkedNames.ShouldBe(new string[]{"id", "tenant_id"});
             fk.LinkedTable.ShouldBe(new DbObjectName("public","states"));
         }
+		
+		[Fact]
+        public void parse_single_column_fk_definition_with_schema_set_explicitly()
+        {
+            var foreignKey = new ForeignKey("fk_people_state_id");
+            const string definition = "FOREIGN KEY (state_id) REFERENCES states(id)";
+            const string schema = "test";
+
+            foreignKey.Parse(definition, schema);
+
+            foreignKey.ColumnNames.Single().ShouldBe("state_id");
+            foreignKey.LinkedNames.Single().ShouldBe("id");
+            var expectedLinkedTable = new DbObjectName(schema, "states");
+            foreignKey.LinkedTable.ShouldBe(expectedLinkedTable);
+        }
     }
 }

--- a/src/Weasel.Postgresql/Tables/ForeignKey.cs
+++ b/src/Weasel.Postgresql/Tables/ForeignKey.cs
@@ -69,7 +69,7 @@ namespace Weasel.Postgresql.Tables
         /// </summary>
         /// <param name="definition"></param>
         /// <exception cref="NotImplementedException"></exception>
-        public void Parse(string definition)
+        public void Parse(string definition, string schema = "public")
         {
             var open1 = definition.IndexOf('(');
             var closed1 = definition.IndexOf(')');
@@ -86,6 +86,10 @@ namespace Weasel.Postgresql.Tables
             var tableStart = definition.IndexOf(references) + references.Length;
 
             var tableName = definition.Substring(tableStart, open2 - tableStart).Trim();
+			if (!tableName.Contains('.'))
+            {
+                tableName = $"{schema}.{tableName}";
+            }
             LinkedTable = DbObjectName.Parse(PostgresqlProvider.Instance, tableName);
 
             if (definition.ContainsIgnoreCase("ON DELETE CASCADE"))

--- a/src/Weasel.Postgresql/Tables/Table.FetchExisting.cs
+++ b/src/Weasel.Postgresql/Tables/Table.FetchExisting.cs
@@ -221,10 +221,11 @@ order by column_index;
             while (await reader.ReadAsync().ConfigureAwait(false))
             {
                 var name = await reader.GetFieldValueAsync<string>(0).ConfigureAwait(false);
+                var schema = await reader.GetFieldValueAsync<string>(2).ConfigureAwait(false);
                 var definition = await reader.GetFieldValueAsync<string>(5).ConfigureAwait(false);
 
                 var fk = new ForeignKey(name);
-                fk.Parse(definition);
+                fk.Parse(definition, schema);
 
                 existing.ForeignKeys.Add(fk);
             }


### PR DESCRIPTION
When creating a database patch, there's an issue with the patch containing creation instructions for foreign keys that already exists in the database. This issue affects only some Postgres versions. From what I've observed, it's not a problem on a Postgres instance with version `PostgreSQL 10.7 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-28), 64-bit`, but is an issue on another instance with version `PostgreSQL 12.4 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 7.5.0-3ubuntu1~18.04) 7.5.0, 64-bit`.

The problem originates from how the `pg_get_constraintdef` function behaves on different versions of Postgres. On some versions, `pg_get_constraintdef` will return the foreign key definition with the fully qualified name of the linked table like so:
```
FOREIGN KEY (stream_id) REFERENCES test.mt_streams(id) ON DELETE CASCADE
```
Howerver, on other versions, `pg_get_constraintdef` will only return the name of the linked table without the schema qualifier like so:
```
FOREIGN KEY (stream_id) REFERENCES mt_streams(id) ON DELETE CASCADE
```

This enhancement fixes this issue.