### PR TITLE
Add index def parsing to handle column name using a PG keyword

### DIFF
--- a/src/Weasel.Postgresql.Tests/Tables/IndexDefinitionTests.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/IndexDefinitionTests.cs
@@ -472,5 +472,22 @@ namespace Weasel.Postgresql.Tests.Tables
 
             IndexDefinition.CanonicizeDdl(index1, table).ShouldBe(IndexDefinition.CanonicizeDdl(index2, table));
         }
+
+        [Fact]
+        public void ensure_handling_of_index_def_with_column_name_using_pg_keyword()
+        {
+            var table = new Table("mt_doc_user");
+            // index does not contain using clause
+            var index1 =
+                IndexDefinition.Parse(
+                    "CREATE INDEX idx_1 ON public.mt_doc_user using btree (\"time\" desc);");
+
+            var index2 = new IndexDefinition("idx_1")
+            {
+                Columns = new[] {"time"}, Method = IndexMethod.btree, SortOrder = SortOrder.Desc
+            };
+
+            IndexDefinition.CanonicizeDdl(index1, table).ShouldBe(IndexDefinition.CanonicizeDdl(index2, table));
+        }
     }
 }

--- a/src/Weasel.Postgresql/Tables/IndexDefinition.cs
+++ b/src/Weasel.Postgresql/Tables/IndexDefinition.cs
@@ -518,6 +518,11 @@ public class IndexDefinition: INamed
             expression = expression.Substring(1, expression.Length - 2);
         }
 
+        if (expression.StartsWith('"') && expression.EndsWith('"'))
+        {
+            expression = expression.Trim('"');
+        }
+
         return CanonicizeCast(expression);
     }
 
@@ -528,30 +533,34 @@ public class IndexDefinition: INamed
 
         return expression switch
         {
-            var expr when expr.EndsWith($"{Descending})") =>
+            var expr when expr.EndsWith($"{Descending})", StringComparison.InvariantCultureIgnoreCase) =>
                 (expr.Substring(0, expr.Length - Descending.Length - spaceAndEndParenthesis) + ")",
                     SortOrder.Desc, NullsSortOrder.None),
-            var expr when expr.EndsWith($"{DescendingNullsFirst})") =>
+            var expr when expr.EndsWith($"{DescendingNullsFirst})", StringComparison.InvariantCultureIgnoreCase) =>
                 (expr.Substring(0,
                         expr.Length - DescendingNullsFirst.Length - spaceAndEndParenthesis) + ")",
                     SortOrder.Desc, NullsSortOrder.First),
-            var expr when expr.EndsWith($"{DescendingNullsLast})") =>
+            var expr when expr.EndsWith($"{DescendingNullsLast})", StringComparison.InvariantCultureIgnoreCase) =>
                 (expr.Substring(0,
                         expr.Length - DescendingNullsLast.Length - spaceAndEndParenthesis) + ")",
                     SortOrder.Desc, NullsSortOrder.Last),
-            var expr when expr.EndsWith($"{Ascending})") =>
+            var expr when expr.EndsWith($"{Ascending})", StringComparison.InvariantCultureIgnoreCase) =>
                 (expr.Substring(0, expr.Length - Ascending.Length - spaceAndEndParenthesis) + ")",
                     SortOrder.Asc, NullsSortOrder.None),
-            var expr when expr.EndsWith($"{AscendingNullsLast})") =>
+            var expr when expr.EndsWith($"{AscendingNullsLast})", StringComparison.InvariantCultureIgnoreCase) =>
                 (expr.Substring(0, expr.Length - AscendingNullsLast.Length - spaceAndEndParenthesis) + ")",
                     SortOrder.Asc, NullsSortOrder.Last),
-            var expr when expr.EndsWith($"{AscendingNullsFirst})") =>
+            var expr when expr.EndsWith($"{AscendingNullsFirst})", StringComparison.InvariantCultureIgnoreCase) =>
                 (expr.Substring(0, expr.Length - AscendingNullsFirst.Length - spaceAndEndParenthesis) + ")",
                     SortOrder.Asc, NullsSortOrder.First),
-            var expr when !expr.Contains(Ascending) && !expr.Contains(Descending) && expr.EndsWith($"{NullsFirst})") =>
+            var expr when !expr.Contains(Ascending, StringComparison.InvariantCultureIgnoreCase) &&
+                          !expr.Contains(Descending, StringComparison.InvariantCultureIgnoreCase) &&
+                          expr.EndsWith($"{NullsFirst})", StringComparison.InvariantCultureIgnoreCase) =>
                 (expr.Substring(0, expr.Length - NullsFirst.Length - spaceAndEndParenthesis) + ")",
                     SortOrder.Asc, NullsSortOrder.First),
-            var expr when !expr.Contains(Ascending) && !expr.Contains(Descending) && expr.EndsWith($"{NullsLast})") =>
+            var expr when !expr.Contains(Ascending, StringComparison.InvariantCultureIgnoreCase) &&
+                          !expr.Contains(Descending, StringComparison.InvariantCultureIgnoreCase) &&
+                          expr.EndsWith($"{NullsLast})", StringComparison.InvariantCultureIgnoreCase) =>
                 (expr.Substring(0, expr.Length - NullsLast.Length - spaceAndEndParenthesis) + ")",
                     SortOrder.Asc, NullsSortOrder.Last),
             _ => (expression.Trim(), SortOrder.Asc, NullsSortOrder.None)

--- a/src/Weasel.Postgresql/Tables/IndexDefinition.cs
+++ b/src/Weasel.Postgresql/Tables/IndexDefinition.cs
@@ -513,15 +513,13 @@ public class IndexDefinition: INamed
     private static string canonicizeColumn(string expression)
     {
         expression = expression.Trim().Replace("::text", "");
-        while (expression.StartsWith("(") && expression.EndsWith(")"))
+        while (expression.StartsWith('(') && expression.EndsWith(')'))
         {
             expression = expression.Substring(1, expression.Length - 2);
         }
 
-        if (expression.StartsWith('"') && expression.EndsWith('"'))
-        {
-            expression = expression.Trim('"');
-        }
+        // If Postgres keyword are used as a column name then those are enclosed in double quotes
+        expression = expression.Trim('"');
 
         return CanonicizeCast(expression);
     }


### PR DESCRIPTION
When an index is created on table column name using a Postgres keyword such as `time`, index definition from db returns the column name with double quotes. Added logic to canonize the ddl pertaining to double quotes.

Additionally, if an index definition has sort order in lower case, it fails to parse the same hence added a fix for this as well.

This issue resolves https://github.com/JasperFx/marten/issues/2414 