### PR TITLE
Migrated NpgsqlTypeMapping to ImHashMap to fix concurrency issue on Marten startup

### DIFF
--- a/src/Weasel.Postgresql.Tests/PostgresqlProviderTests.cs
+++ b/src/Weasel.Postgresql.Tests/PostgresqlProviderTests.cs
@@ -20,12 +20,13 @@ public class PostgresqlProviderTests
     [Fact]
     public void execute_to_db_custom_mappings_resolve()
     {
-        NpgsqlTypeMapper.Mappings.Add(new NpgsqlTypeMapping(
-            NpgsqlDbType.Varchar,
-            DbType.String,
-            "varchar",
-            typeof(MappedTarget)
-        ));
+        NpgsqlTypeMapper.Mappings[NpgsqlDbType.Varchar] =
+            new NpgsqlTypeMapping(
+                NpgsqlDbType.Varchar,
+                DbType.String,
+                "varchar",
+                typeof(MappedTarget)
+            );
 
         PostgresqlProvider.Instance.ToParameterType(typeof(MappedTarget)).ShouldBe(NpgsqlDbType.Varchar);
         ShouldThrowExtensions.ShouldThrow<Exception>(() =>

--- a/src/Weasel.Postgresql/NpgsqlTypeMapping.cs
+++ b/src/Weasel.Postgresql/NpgsqlTypeMapping.cs
@@ -6,6 +6,7 @@ using System.Net;
 using System.Net.NetworkInformation;
 using System.Numerics;
 using System.Text.Json;
+using JasperFx.Core;
 using NpgsqlTypes;
 
 namespace Weasel.Postgresql;
@@ -37,112 +38,103 @@ public class NpgsqlTypeMapping
 /// </remarks>
 public class NpgsqlTypeMapper
 {
-    public static readonly List<NpgsqlTypeMapping> Mappings = new()
+    public static readonly Cache<NpgsqlDbType, NpgsqlTypeMapping> Mappings = new(new Dictionary<NpgsqlDbType, NpgsqlTypeMapping>
     {
         // Numeric types
-        new NpgsqlTypeMapping(NpgsqlDbType.Smallint, DbType.Int16, "smallint", typeof(short), typeof(byte),
-            typeof(sbyte)),
-        new NpgsqlTypeMapping(NpgsqlDbType.Integer, DbType.Int32, "integer", typeof(int)),
-        new NpgsqlTypeMapping(NpgsqlDbType.Integer, DbType.Int32, "integer", typeof(int)),
-        new NpgsqlTypeMapping(NpgsqlDbType.Bigint, DbType.Int64, "bigint", typeof(long)),
-        new NpgsqlTypeMapping(NpgsqlDbType.Real, DbType.Single, "real", typeof(float)),
-        new NpgsqlTypeMapping(NpgsqlDbType.Double, DbType.Double, "double precision", typeof(double)),
-        new NpgsqlTypeMapping(NpgsqlDbType.Numeric, DbType.Decimal, "decimal", typeof(decimal), typeof(BigInteger)),
-        new NpgsqlTypeMapping(NpgsqlDbType.Numeric, DbType.Decimal, "decimal", typeof(decimal), typeof(BigInteger)),
-        new NpgsqlTypeMapping(NpgsqlDbType.Money, DbType.Int16, "money"),
+        {NpgsqlDbType.Smallint,new NpgsqlTypeMapping(NpgsqlDbType.Smallint, DbType.Int16, "smallint", typeof(short), typeof(byte),
+            typeof(sbyte))},
+        {NpgsqlDbType.Integer, new NpgsqlTypeMapping(NpgsqlDbType.Integer, DbType.Int32, "integer", typeof(int))},
+        {NpgsqlDbType.Bigint, new NpgsqlTypeMapping(NpgsqlDbType.Bigint, DbType.Int64, "bigint", typeof(long))},
+        {NpgsqlDbType.Real, new NpgsqlTypeMapping(NpgsqlDbType.Real, DbType.Single, "real", typeof(float))},
+        {NpgsqlDbType.Double, new NpgsqlTypeMapping(NpgsqlDbType.Double, DbType.Double, "double precision", typeof(double))},
+        {NpgsqlDbType.Numeric, new NpgsqlTypeMapping(NpgsqlDbType.Numeric, DbType.Decimal, "decimal", typeof(decimal), typeof(BigInteger))},
+        {NpgsqlDbType.Money, new NpgsqlTypeMapping(NpgsqlDbType.Money, DbType.Int16, "money")},
 
         // Text types
-        new NpgsqlTypeMapping(NpgsqlDbType.Text, DbType.String, "text", typeof(string), typeof(char[]), typeof(char),
-            typeof(ArraySegment<char>)),
-        new NpgsqlTypeMapping(NpgsqlDbType.Xml, DbType.Xml, "xml"),
-        new NpgsqlTypeMapping(NpgsqlDbType.Varchar, DbType.String, "character varying"),
-        new NpgsqlTypeMapping(NpgsqlDbType.Varchar, DbType.String, "character varying"),
-        new NpgsqlTypeMapping(NpgsqlDbType.Char, DbType.String, "character"),
-        new NpgsqlTypeMapping(NpgsqlDbType.Name, DbType.String, "name"),
-        new NpgsqlTypeMapping(NpgsqlDbType.Refcursor, DbType.String, "refcursor"),
-        new NpgsqlTypeMapping(NpgsqlDbType.Citext, DbType.String, "citext"),
-        new NpgsqlTypeMapping(NpgsqlDbType.Jsonb, DbType.Object, "jsonb", typeof(JsonDocument)),
-        new NpgsqlTypeMapping(NpgsqlDbType.Json, DbType.Object, "json"),
-        new NpgsqlTypeMapping(NpgsqlDbType.JsonPath, DbType.Object, "jsonpath"),
+        {NpgsqlDbType.Text, new NpgsqlTypeMapping(NpgsqlDbType.Text, DbType.String, "text", typeof(string), typeof(char[]), typeof(char),
+            typeof(ArraySegment<char>))},
+        {NpgsqlDbType.Xml, new NpgsqlTypeMapping(NpgsqlDbType.Xml, DbType.Xml, "xml")},
+        {NpgsqlDbType.Varchar, new NpgsqlTypeMapping(NpgsqlDbType.Varchar, DbType.String, "character varying")},
+        {NpgsqlDbType.Char, new NpgsqlTypeMapping(NpgsqlDbType.Char, DbType.String, "character")},
+        {NpgsqlDbType.Name, new NpgsqlTypeMapping(NpgsqlDbType.Name, DbType.String, "name")},
+        {NpgsqlDbType.Refcursor, new NpgsqlTypeMapping(NpgsqlDbType.Refcursor, DbType.String, "refcursor")},
+        {NpgsqlDbType.Citext, new NpgsqlTypeMapping(NpgsqlDbType.Citext, DbType.String, "citext")},
+        {NpgsqlDbType.Jsonb, new NpgsqlTypeMapping(NpgsqlDbType.Jsonb, DbType.Object, "jsonb", typeof(JsonDocument))},
+        {NpgsqlDbType.Json, new NpgsqlTypeMapping(NpgsqlDbType.Json, DbType.Object, "json")},
+        {NpgsqlDbType.JsonPath, new NpgsqlTypeMapping(NpgsqlDbType.JsonPath, DbType.Object, "jsonpath")},
 
         // Date/time types
-#pragma warning disable 618 // NpgsqlDateTime is obsolete, remove in 7.0
-        new NpgsqlTypeMapping(NpgsqlDbType.Timestamp, DbType.DateTime, "timestamp without time zone", typeof(DateTime)),
-#pragma warning disable 618
-        new NpgsqlTypeMapping(NpgsqlDbType.TimestampTz, DbType.DateTimeOffset, "timestamp with time zone",
-            typeof(DateTimeOffset)),
-        new NpgsqlTypeMapping(NpgsqlDbType.Date, DbType.Date, "date", typeof(DateOnly)),
-        new NpgsqlTypeMapping(NpgsqlDbType.Time, DbType.Time, "time without time zone", typeof(TimeOnly)),
-        new NpgsqlTypeMapping(NpgsqlDbType.TimeTz, DbType.Object, "time with time zone"),
-        new NpgsqlTypeMapping(NpgsqlDbType.Interval, DbType.Object, "interval", typeof(TimeSpan)),
-        new NpgsqlTypeMapping(NpgsqlDbType.Array | NpgsqlDbType.Timestamp, DbType.Object,
-            "timestamp without time zone[]"),
-        new NpgsqlTypeMapping(NpgsqlDbType.Array | NpgsqlDbType.TimestampTz, DbType.Object,
-            "timestamp with time zone[]"),
-        new NpgsqlTypeMapping(NpgsqlDbType.Range | NpgsqlDbType.Timestamp, DbType.Object, "tsrange"),
-        new NpgsqlTypeMapping(NpgsqlDbType.Range | NpgsqlDbType.TimestampTz, DbType.Object, "tstzrange"),
-        new NpgsqlTypeMapping(NpgsqlDbType.Multirange | NpgsqlDbType.Timestamp, DbType.Object, "tsmultirange"),
-        new NpgsqlTypeMapping(NpgsqlDbType.Multirange | NpgsqlDbType.TimestampTz, DbType.Object, "tstzmultirange"),
+        {NpgsqlDbType.Timestamp, new NpgsqlTypeMapping(NpgsqlDbType.Timestamp, DbType.DateTime, "timestamp without time zone", typeof(DateTime))},
+        {NpgsqlDbType.TimestampTz, new NpgsqlTypeMapping(NpgsqlDbType.TimestampTz, DbType.DateTimeOffset, "timestamp with time zone",
+            typeof(DateTimeOffset))},
+        {NpgsqlDbType.Date, new NpgsqlTypeMapping(NpgsqlDbType.Date, DbType.Date, "date", typeof(DateOnly))},
+        {NpgsqlDbType.Time, new NpgsqlTypeMapping(NpgsqlDbType.Time, DbType.Time, "time without time zone", typeof(TimeOnly))},
+        {NpgsqlDbType.TimeTz, new NpgsqlTypeMapping(NpgsqlDbType.TimeTz, DbType.Object, "time with time zone")},
+        {NpgsqlDbType.Interval, new NpgsqlTypeMapping(NpgsqlDbType.Interval, DbType.Object, "interval", typeof(TimeSpan))},
+        {NpgsqlDbType.Array | NpgsqlDbType.Timestamp, new NpgsqlTypeMapping(NpgsqlDbType.Array | NpgsqlDbType.Timestamp, DbType.Object,
+            "timestamp without time zone[]")},
+        {NpgsqlDbType.Array | NpgsqlDbType.TimestampTz, new NpgsqlTypeMapping(NpgsqlDbType.Array | NpgsqlDbType.TimestampTz, DbType.Object,
+            "timestamp with time zone[]")},
+        {NpgsqlDbType.Range | NpgsqlDbType.Timestamp, new NpgsqlTypeMapping(NpgsqlDbType.Range | NpgsqlDbType.Timestamp, DbType.Object, "tsrange")},
+        {NpgsqlDbType.Range | NpgsqlDbType.TimestampTz, new NpgsqlTypeMapping(NpgsqlDbType.Range | NpgsqlDbType.TimestampTz, DbType.Object, "tstzrange")},
+        {NpgsqlDbType.Multirange | NpgsqlDbType.Timestamp, new NpgsqlTypeMapping(NpgsqlDbType.Multirange | NpgsqlDbType.Timestamp, DbType.Object, "tsmultirange")},
+        {NpgsqlDbType.Multirange | NpgsqlDbType.TimestampTz, new NpgsqlTypeMapping(NpgsqlDbType.Multirange | NpgsqlDbType.TimestampTz, DbType.Object, "tstzmultirange")},
 
         // Network types
-        new NpgsqlTypeMapping(NpgsqlDbType.Cidr, DbType.Object, "cidr"),
-#pragma warning disable 618
-        new NpgsqlTypeMapping(NpgsqlDbType.Inet, DbType.Object, "inet", typeof(IPAddress),
-            typeof((IPAddress Address, int Subnet)), typeof(NpgsqlInet), IPAddress.Loopback.GetType()),
-#pragma warning restore 618
-        new NpgsqlTypeMapping(NpgsqlDbType.MacAddr, DbType.Object, "macaddr", typeof(PhysicalAddress)),
-        new NpgsqlTypeMapping(NpgsqlDbType.MacAddr8, DbType.Object, "macaddr8"),
+        {NpgsqlDbType.Cidr, new NpgsqlTypeMapping(NpgsqlDbType.Cidr, DbType.Object, "cidr")},
+        {NpgsqlDbType.Inet, new NpgsqlTypeMapping(NpgsqlDbType.Inet, DbType.Object, "inet", typeof(IPAddress),
+            typeof((IPAddress Address, int Subnet)), typeof(NpgsqlInet), IPAddress.Loopback.GetType())},
+        {NpgsqlDbType.MacAddr, new NpgsqlTypeMapping(NpgsqlDbType.MacAddr, DbType.Object, "macaddr", typeof(PhysicalAddress))},
+        {NpgsqlDbType.MacAddr8, new NpgsqlTypeMapping(NpgsqlDbType.MacAddr8, DbType.Object, "macaddr8")},
 
         // Full-text search types
-        new NpgsqlTypeMapping(NpgsqlDbType.TsQuery, DbType.Object, "tsquery",
+        {NpgsqlDbType.TsQuery, new NpgsqlTypeMapping(NpgsqlDbType.TsQuery, DbType.Object, "tsquery",
             typeof(NpgsqlTsQuery), typeof(NpgsqlTsQueryAnd), typeof(NpgsqlTsQueryEmpty),
             typeof(NpgsqlTsQueryFollowedBy),
             typeof(NpgsqlTsQueryLexeme), typeof(NpgsqlTsQueryNot), typeof(NpgsqlTsQueryOr), typeof(NpgsqlTsQueryBinOp)
-        ),
-        new NpgsqlTypeMapping(NpgsqlDbType.TsVector, DbType.Object, "tsvector", typeof(NpgsqlTsVector)),
+        )},
+        {NpgsqlDbType.TsVector, new NpgsqlTypeMapping(NpgsqlDbType.TsVector, DbType.Object, "tsvector", typeof(NpgsqlTsVector))},
 
         // Geometry types
-        new NpgsqlTypeMapping(NpgsqlDbType.Box, DbType.Object, "box", typeof(NpgsqlBox)),
-        new NpgsqlTypeMapping(NpgsqlDbType.Circle, DbType.Object, "circle", typeof(NpgsqlCircle)),
-        new NpgsqlTypeMapping(NpgsqlDbType.Line, DbType.Object, "line", typeof(NpgsqlLine)),
-        new NpgsqlTypeMapping(NpgsqlDbType.LSeg, DbType.Object, "lseg", typeof(NpgsqlLSeg)),
-        new NpgsqlTypeMapping(NpgsqlDbType.Path, DbType.Object, "path", typeof(NpgsqlPath)),
-        new NpgsqlTypeMapping(NpgsqlDbType.Point, DbType.Object, "point", typeof(NpgsqlPoint)),
-        new NpgsqlTypeMapping(NpgsqlDbType.Polygon, DbType.Object, "polygon", typeof(NpgsqlPolygon)),
+        {NpgsqlDbType.Box, new NpgsqlTypeMapping(NpgsqlDbType.Box, DbType.Object, "box", typeof(NpgsqlBox))},
+        {NpgsqlDbType.Circle, new NpgsqlTypeMapping(NpgsqlDbType.Circle, DbType.Object, "circle", typeof(NpgsqlCircle))},
+        {NpgsqlDbType.Line, new NpgsqlTypeMapping(NpgsqlDbType.Line, DbType.Object, "line", typeof(NpgsqlLine))},
+        {NpgsqlDbType.LSeg, new NpgsqlTypeMapping(NpgsqlDbType.LSeg, DbType.Object, "lseg", typeof(NpgsqlLSeg))},
+        {NpgsqlDbType.Path, new NpgsqlTypeMapping(NpgsqlDbType.Path, DbType.Object, "path", typeof(NpgsqlPath))},
+        {NpgsqlDbType.Point, new NpgsqlTypeMapping(NpgsqlDbType.Point, DbType.Object, "point", typeof(NpgsqlPoint))},
+        {NpgsqlDbType.Polygon, new NpgsqlTypeMapping(NpgsqlDbType.Polygon, DbType.Object, "polygon", typeof(NpgsqlPolygon))},
 
         // LTree types
-        new NpgsqlTypeMapping(NpgsqlDbType.LQuery, DbType.Object, "lquery"),
-        new NpgsqlTypeMapping(NpgsqlDbType.LTree, DbType.Object, "ltree"),
-        new NpgsqlTypeMapping(NpgsqlDbType.LTxtQuery, DbType.Object, "ltxtquery"),
+        {NpgsqlDbType.LQuery, new NpgsqlTypeMapping(NpgsqlDbType.LQuery, DbType.Object, "lquery")},
+        {NpgsqlDbType.LTree, new NpgsqlTypeMapping(NpgsqlDbType.LTree, DbType.Object, "ltree")},
+        {NpgsqlDbType.LTxtQuery, new NpgsqlTypeMapping(NpgsqlDbType.LTxtQuery, DbType.Object, "ltxtquery")},
 
         // UInt types
-        new NpgsqlTypeMapping(NpgsqlDbType.Oid, DbType.Object, "oid"),
-        new NpgsqlTypeMapping(NpgsqlDbType.Xid, DbType.Object, "xid"),
-        new NpgsqlTypeMapping(NpgsqlDbType.Xid8, DbType.Object, "xid8"),
-        new NpgsqlTypeMapping(NpgsqlDbType.Cid, DbType.Object, "cid"),
-        new NpgsqlTypeMapping(NpgsqlDbType.Regtype, DbType.Object, "regtype"),
-        new NpgsqlTypeMapping(NpgsqlDbType.Regconfig, DbType.Object, "regconfig"),
+        {NpgsqlDbType.Oid, new NpgsqlTypeMapping(NpgsqlDbType.Oid, DbType.Object, "oid")},
+        {NpgsqlDbType.Xid, new NpgsqlTypeMapping(NpgsqlDbType.Xid, DbType.Object, "xid")},
+        {NpgsqlDbType.Xid8, new NpgsqlTypeMapping(NpgsqlDbType.Xid8, DbType.Object, "xid8")},
+        {NpgsqlDbType.Cid, new NpgsqlTypeMapping(NpgsqlDbType.Cid, DbType.Object, "cid")},
+        {NpgsqlDbType.Regtype, new NpgsqlTypeMapping(NpgsqlDbType.Regtype, DbType.Object, "regtype")},
+        {NpgsqlDbType.Regconfig, new NpgsqlTypeMapping(NpgsqlDbType.Regconfig, DbType.Object, "regconfig")},
 
         // Misc types
-        new NpgsqlTypeMapping(NpgsqlDbType.Boolean, DbType.Boolean, "boolean", typeof(bool)),
-        new NpgsqlTypeMapping(NpgsqlDbType.Boolean, DbType.Boolean, "boolean", typeof(bool)),
-        new NpgsqlTypeMapping(NpgsqlDbType.Bytea, DbType.Binary, "bytea", typeof(byte[]), typeof(ArraySegment<byte>),
-            typeof(ReadOnlyMemory<byte>), typeof(Memory<byte>)),
-        new NpgsqlTypeMapping(NpgsqlDbType.Uuid, DbType.Guid, "uuid", typeof(Guid)),
-        new NpgsqlTypeMapping(NpgsqlDbType.Varbit, DbType.Object, "bit varying", typeof(BitArray), typeof(BitVector32)),
-        new NpgsqlTypeMapping(NpgsqlDbType.Varbit, DbType.Object, "bit varying", typeof(BitArray), typeof(BitVector32)),
-        new NpgsqlTypeMapping(NpgsqlDbType.Bit, DbType.Object, "bit"),
-        new NpgsqlTypeMapping(NpgsqlDbType.Hstore, DbType.Object, "hstore", typeof(Dictionary<string, string?>),
-            typeof(IDictionary<string, string?>), typeof(ImmutableDictionary<string, string?>)),
+        {NpgsqlDbType.Boolean, new NpgsqlTypeMapping(NpgsqlDbType.Boolean, DbType.Boolean, "boolean", typeof(bool))},
+        {NpgsqlDbType.Bytea, new NpgsqlTypeMapping(NpgsqlDbType.Bytea, DbType.Binary, "bytea", typeof(byte[]), typeof(ArraySegment<byte>),
+            typeof(ReadOnlyMemory<byte>), typeof(Memory<byte>))},
+        {NpgsqlDbType.Uuid, new NpgsqlTypeMapping(NpgsqlDbType.Uuid, DbType.Guid, "uuid", typeof(Guid))},
+        {NpgsqlDbType.Varbit, new NpgsqlTypeMapping(NpgsqlDbType.Varbit, DbType.Object, "bit varying", typeof(BitArray), typeof(BitVector32))},
+        {NpgsqlDbType.Bit, new NpgsqlTypeMapping(NpgsqlDbType.Bit, DbType.Object, "bit")},
+        {NpgsqlDbType.Hstore, new NpgsqlTypeMapping(NpgsqlDbType.Hstore, DbType.Object, "hstore", typeof(Dictionary<string, string?>),
+            typeof(IDictionary<string, string?>), typeof(ImmutableDictionary<string, string?>))},
 
         // Internal types
-        new NpgsqlTypeMapping(NpgsqlDbType.Int2Vector, DbType.Object, "int2vector"),
-        new NpgsqlTypeMapping(NpgsqlDbType.Oidvector, DbType.Object, "oidvector"),
-        new NpgsqlTypeMapping(NpgsqlDbType.PgLsn, DbType.Object, "pg_lsn", typeof(NpgsqlLogSequenceNumber)),
-        new NpgsqlTypeMapping(NpgsqlDbType.Tid, DbType.Object, "tid", typeof(NpgsqlTid)),
-        new NpgsqlTypeMapping(NpgsqlDbType.InternalChar, DbType.Object, "char"),
+        {NpgsqlDbType.Int2Vector, new NpgsqlTypeMapping(NpgsqlDbType.Int2Vector, DbType.Object, "int2vector")},
+        {NpgsqlDbType.Oidvector, new NpgsqlTypeMapping(NpgsqlDbType.Oidvector, DbType.Object, "oidvector")},
+        {NpgsqlDbType.PgLsn, new NpgsqlTypeMapping(NpgsqlDbType.PgLsn, DbType.Object, "pg_lsn", typeof(NpgsqlLogSequenceNumber))},
+        {NpgsqlDbType.Tid, new NpgsqlTypeMapping(NpgsqlDbType.Tid, DbType.Object, "tid", typeof(NpgsqlTid))},
+        {NpgsqlDbType.InternalChar, new NpgsqlTypeMapping(NpgsqlDbType.InternalChar, DbType.Object, "char")},
 
         // Special types
-        new NpgsqlTypeMapping(NpgsqlDbType.Unknown, DbType.Object, "unknown")
-    };
+        {NpgsqlDbType.Unknown, new NpgsqlTypeMapping(NpgsqlDbType.Unknown, DbType.Object, "unknown")}
+    });
 }


### PR DESCRIPTION
Per @Hawxy at [Discord conversation](https://discord.com/channels/1074998995086225460/1088112401418825799/1088119007258882218), `NpgsqlTypeMapping` is causing the issue when starting multiple Marten instances in parallel:

````
Object reference not set to an instance of an object.
   at Weasel.Postgresql.PostgresqlProvider.<>c__DisplayClass15_0.<GetTypeMapping>b__0(NpgsqlTypeMapping mapping)
   at System.Linq.Enumerable.TryGetLast[TSource](IEnumerable`1 source, Func`2 predicate, Boolean& found)
   at System.Linq.Enumerable.LastOrDefault[TSource](IEnumerable`1 source, Func`2 predicate)
   at Weasel.Postgresql.PostgresqlProvider.GetTypeMapping(Type type)
   at Weasel.Postgresql.PostgresqlProvider.ResolveDatabaseType(Type type)
   at Weasel.Postgresql.PostgresqlProvider.GetDatabaseType(Type memberType, EnumStorage enumStyle)
   at Marten.Storage.Metadata.MetadataColumn`1..ctor(String name, Expression`1 property) in C:\Source\marten\src\Marten\Storage\Metadata\MetadataColumn.cs:line 100
   at Marten.Storage.Metadata.LastModifiedColumn..ctor() in C:\Source\marten\src\Marten\Storage\Metadata\LastModifiedColumn.cs:line 10
   at Marten.Schema.DocumentMetadataCollection..ctor(DocumentMapping parent) in C:\Source\marten\src\Marten\Schema\DocumentMetadataCollection.cs:line 14
   at Marten.Schema.DocumentMapping..ctor(Type documentType, StoreOptions storeOptions) in C:\Source\marten\src\Marten\Schema\DocumentMapping.cs:line 81
   at Marten.Schema.DocumentMapping`1..ctor(StoreOptions storeOptions) in C:\Source\marten\src\Marten\Schema\DocumentMapping.cs:line 665
   at Marten.DocumentMappingBuilder`1.Build(StoreOptions options) in C:\Source\marten\src\Marten\MartenRegistry.cs:line 47
   at Marten.Storage.StorageFeatures.Build(Type type, StoreOptions options) in C:\Source\marten\src\Marten\Storage\StorageFeatures.cs:line 93
   at Marten.Storage.StorageFeatures.MappingFor(Type documentType) in C:\Source\marten\src\Marten\Storage\StorageFeatures.cs:line 175
   at Marten.Storage.StorageFeatures.FindMapping(Type documentType) in C:\Source\marten\src\Marten\Storage\StorageFeatures.cs:line 194
   at Marten.Storage.StorageFeatures.BuildAllMappings() in C:\Source\marten\src\Marten\Storage\StorageFeatures.cs:line 128
````
Changed `NpgsqlTypeMapping` to use `ImHashMap` for thread-safe usage.

@jeremydmiller, @mysticmind  FYI.