### PR TITLE
Added support for IEnumerable parameters as Command Parameters

### DIFF
--- a/Analysis.Build.props
+++ b/Analysis.Build.props
@@ -11,7 +11,7 @@
             <ExcludeAssets>none</ExcludeAssets>
             <IncludeAssets>all</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Meziantou.Analyzer" Version="2.0.29">
+        <PackageReference Include="Meziantou.Analyzer" Version="2.0.45">
             <PrivateAssets>all</PrivateAssets>
             <ExcludeAssets>none</ExcludeAssets>
             <IncludeAssets>all</IncludeAssets>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>6.0.0-rc.2</Version>
+        <Version>6.0.0-rc.3</Version>
         <LangVersion>11.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/src/Weasel.CommandLine.Tests/Weasel.CommandLine.Tests.csproj
+++ b/src/Weasel.CommandLine.Tests/Weasel.CommandLine.Tests.csproj
@@ -16,7 +16,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
         <PackageReference Include="NSubstitute" Version="5.0.0" />
-        <PackageReference Include="Shouldly" Version="4.1.0" />
+        <PackageReference Include="Shouldly" Version="4.2.1" />
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Weasel.CommandLine/Weasel.CommandLine.csproj
+++ b/src/Weasel.CommandLine/Weasel.CommandLine.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Oakton" Version="6.0.0" />
+      <PackageReference Include="Oakton" Version="6.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Weasel.Core.Tests/Weasel.Core.Tests.csproj
+++ b/src/Weasel.Core.Tests/Weasel.Core.Tests.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
         <PackageReference Include="NSubstitute" Version="5.0.0" />
-        <PackageReference Include="Shouldly" Version="4.1.0" />
+        <PackageReference Include="Shouldly" Version="4.2.1" />
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Weasel.Core/Weasel.Core.csproj
+++ b/src/Weasel.Core/Weasel.Core.csproj
@@ -16,7 +16,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="JasperFx.Core" Version="1.2.0" />
+        <PackageReference Include="JasperFx.Core" Version="1.4.0" />
     </ItemGroup>
     <Import Project="../../Analysis.Build.props" />
 </Project>

--- a/src/Weasel.Postgresql.Tests/Weasel.Postgresql.Tests.csproj
+++ b/src/Weasel.Postgresql.Tests/Weasel.Postgresql.Tests.csproj
@@ -8,7 +8,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
         <PackageReference Include="NSubstitute" Version="5.0.0" />
-        <PackageReference Include="Shouldly" Version="4.1.0" />
+        <PackageReference Include="Shouldly" Version="4.2.1" />
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Weasel.Postgresql/PostgresqlProvider.cs
+++ b/src/Weasel.Postgresql/PostgresqlProvider.cs
@@ -170,7 +170,9 @@ public class PostgresqlProvider: DatabaseProvider<NpgsqlCommand, NpgsqlParameter
         var typeInfo = type.GetTypeInfo();
 
         var ilist = typeInfo.ImplementedInterfaces.FirstOrDefault(x =>
-            x.GetTypeInfo().IsGenericType && x.GetGenericTypeDefinition() == typeof(IList<>));
+            x.GetTypeInfo().IsGenericType && x.IsGenericEnumerable()
+        );
+
         if (ilist != null)
         {
             dbType = NpgsqlDbType.Array | ToParameterType(ilist.GetGenericArguments()[0]);

--- a/src/Weasel.Postgresql/SqlGeneration/CommandParameter.cs
+++ b/src/Weasel.Postgresql/SqlGeneration/CommandParameter.cs
@@ -21,10 +21,16 @@ public class CommandParameter: ISqlFragment
     public CommandParameter(object? value)
     {
         Value = value;
-        if (value != null)
-        {
-            DbType = PostgresqlProvider.Instance.TryGetDbType(value.GetType())!.Value;
-        }
+        if (value == null) return;
+
+        var valueType = value.GetType();
+
+        var dbType = PostgresqlProvider.Instance.TryGetDbType(valueType);
+
+        if (!dbType.HasValue)
+            return;
+
+        DbType = dbType.Value;
     }
 
     public CommandParameter(object value, NpgsqlDbType npgsqlDbType)
@@ -34,7 +40,7 @@ public class CommandParameter: ISqlFragment
     }
 
     public object? Value { get; }
-    public NpgsqlDbType DbType { get; }
+    public NpgsqlDbType? DbType { get; }
 
     public void Apply(CommandBuilder builder)
     {

--- a/src/Weasel.Postgresql/Weasel.Postgresql.csproj
+++ b/src/Weasel.Postgresql/Weasel.Postgresql.csproj
@@ -17,7 +17,7 @@
 
     <ItemGroup>
 
-        <PackageReference Include="Npgsql" Version="7.0.2" />
+        <PackageReference Include="Npgsql" Version="7.0.4" />
     </ItemGroup>
 
     <!--SourceLink specific settings-->

--- a/src/Weasel.SqlServer.Tests/Weasel.SqlServer.Tests.csproj
+++ b/src/Weasel.SqlServer.Tests/Weasel.SqlServer.Tests.csproj
@@ -9,7 +9,7 @@
         <PackageReference Include="Baseline" Version="4.1.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
         <PackageReference Include="NSubstitute" Version="5.0.0" />
-        <PackageReference Include="Shouldly" Version="4.1.0" />
+        <PackageReference Include="Shouldly" Version="4.2.1" />
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
- Added support for IEnumerable parameters as Command Parameters to support linq for types like Hashset (see https://github.com/JasperFx/marten/pull/2535)
- Added fallback to default Npgsql type mapping for unknown type instead of throwing null reference exception
- Bumped packages