### PR TITLE
Add support for PostgreSQL 15's NULLS NOT DISTINCT for unique indexes

### DIFF
--- a/.github/workflows/ci-build-postgres.yml
+++ b/.github/workflows/ci-build-postgres.yml
@@ -25,7 +25,7 @@ jobs:
     # define the test matrix
         matrix:
             postgres-image:
-                - oskardudycz/postgres-plv8:12-2
+                - ionx/postgres-plv8:12.2
                 - postgres:15.3-alpine
 
     services:

--- a/src/Weasel.Postgresql.Tests/ExtensionTests.cs
+++ b/src/Weasel.Postgresql.Tests/ExtensionTests.cs
@@ -15,7 +15,7 @@ public class ExtensionTests: IntegrationContext
     public async Task can_create_extension()
     {
         await ResetSchema();
-        var extension = new Extension("hstore");
+        var extension = new Extension("pgcrypto");
         await DropSchemaObjectInDatabase(extension);
 
         var migration = await SchemaMigration.DetermineAsync(theConnection, extension);

--- a/src/Weasel.Postgresql.Tests/PgVersionTargetedFact.cs
+++ b/src/Weasel.Postgresql.Tests/PgVersionTargetedFact.cs
@@ -10,7 +10,7 @@ namespace Weasel.Postgresql.Tests;
 /// Allows targeting test at specified minimum and/or maximum version of PG
 /// </summary>
 [AttributeUsage(AttributeTargets.Method)]
-[XunitTestCaseDiscoverer("Marten.Testing.Harness.PgVersionTargetedFactDiscoverer", "Marten.Testing")]
+[XunitTestCaseDiscoverer("Weasel.Postgresql.Tests.PgVersionTargetedFactDiscoverer", "Weasel.Postgresql.Tests")]
 public sealed class PgVersionTargetedFact: FactAttribute
 {
     public string MinimumVersion { get; set; }
@@ -23,6 +23,13 @@ public sealed class PgVersionTargetedFactDiscoverer: FactDiscoverer
 
     static PgVersionTargetedFactDiscoverer()
     {
+        var versionFromEnv = Environment.GetEnvironmentVariable("postgresql_version");
+        if (!string.IsNullOrEmpty(versionFromEnv))
+        {
+            Version = Version.Parse(versionFromEnv);
+            return;
+        }
+
         // PG version does not change during test run so we can do static ctor
         using var c = new NpgsqlConnection(ConnectionSource.ConnectionString);
         c.Open();

--- a/src/Weasel.Postgresql.Tests/PgVersionTargetedTheory.cs
+++ b/src/Weasel.Postgresql.Tests/PgVersionTargetedTheory.cs
@@ -10,7 +10,7 @@ namespace Weasel.Postgresql.Tests;
 /// Allows targeting test at specified minimum and/or maximum version of PG
 /// </summary>
 [AttributeUsage(AttributeTargets.Method)]
-[XunitTestCaseDiscoverer("Marten.Testing.Harness.PgVersionTargetedTheoryDiscoverer", "Marten.Testing")]
+[XunitTestCaseDiscoverer("Weasel.Postgresql.Tests.PgVersionTargetedTheoryDiscoverer", "Weasel.Postgresql.Tests")]
 public sealed class PgVersionTargetedTheory: TheoryAttribute
 {
     public string MinimumVersion { get; set; }

--- a/src/Weasel.Postgresql.Tests/Tables/IndexDefinitionTests.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/IndexDefinitionTests.cs
@@ -527,4 +527,34 @@ public class IndexDefinitionTests
 
         IndexDefinition.CanonicizeDdl(index1, table).ShouldBe(IndexDefinition.CanonicizeDdl(index2, table));
     }
+
+    [Fact]
+    public void nulls_not_distinct_should_generate_correct_index()
+    {
+        var index = new IndexDefinition("index")
+        {
+            Columns = new[]
+            {
+                "column1",
+                "column2"
+            },
+            IsUnique = true,
+            NullsNotDistinct = true
+        };
+
+        var ddl = index.ToDDL(new Table("table"));
+        ddl.ShouldBe("CREATE UNIQUE INDEX index ON public.table USING btree (column1, column2) NULLS NOT DISTINCT ;");
+    }
+
+    [Fact]
+    public void should_be_able_to_parse_index_with_nulls_not_distinct()
+    {
+        var index = IndexDefinition.Parse("CREATE UNIQUE INDEX index ON public.table USING btree (column1, column2) NULLS NOT DISTINCT;");
+        index.IsUnique.ShouldBeTrue();
+        index.NullsNotDistinct.ShouldBeTrue();
+
+        index = IndexDefinition.Parse("CREATE UNIQUE INDEX index ON public.table USING btree (column1, column2) NULLS DISTINCT;");
+        index.IsUnique.ShouldBeTrue();
+        index.NullsNotDistinct.ShouldBeFalse();
+    }
 }

--- a/src/Weasel.Postgresql.Tests/Tables/IndexDefinitionTests.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/IndexDefinitionTests.cs
@@ -96,6 +96,17 @@ public class IndexDefinitionTests
     }
 
     [Fact]
+    public void write_unique_and_concurrent_index_with_distinct_nulls()
+    {
+        theIndex.IsUnique = true;
+        theIndex.NullsNotDistinct = true;
+        theIndex.IsConcurrent = true;
+
+        theIndex.ToDDL(parent)
+            .ShouldBe("CREATE UNIQUE INDEX CONCURRENTLY idx_1 ON public.people USING btree (column1) NULLS NOT DISTINCT ;");
+    }
+
+    [Fact]
     public void write_desc()
     {
         theIndex.SortOrder = SortOrder.Desc;
@@ -162,6 +173,7 @@ public class IndexDefinitionTests
         yield return new[] { new IndexDefinition("idx_1").AgainstColumns("name") };
         yield return new[] { new IndexDefinition("idx_1").AgainstColumns("name", "age") };
         yield return new[] { new IndexDefinition("idx_1") { IsUnique = true }.AgainstColumns("name", "age") };
+        yield return new[] { new IndexDefinition("idx_1") { IsUnique = true, NullsNotDistinct = true}.AgainstColumns("name", "age") };
 
         yield return new[] { new IndexDefinition("idx_1") { SortOrder = SortOrder.Desc }.AgainstColumns("name") };
     }

--- a/src/Weasel.Postgresql.Tests/Tables/creating_tables_in_database.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/creating_tables_in_database.cs
@@ -133,14 +133,19 @@ public class creating_tables_in_database: IntegrationContext
 
     [PgVersionTargetedFact(MaximumVersion = "13.0")]
     public Task create_tables_with_indexes_concurrently_too_in_the_database_with_different_methods() =>
-        create_tables_with_indexes_too_in_the_database_with_different_methods(true);
+        create_tables_with_indexes_too_in_the_database_with_different_methods(true, false);
 
     [Fact]
     public Task create_tables_with_indexes_not_concurrently_too_in_the_database_with_different_methods() =>
-        create_tables_with_indexes_too_in_the_database_with_different_methods(false);
+        create_tables_with_indexes_too_in_the_database_with_different_methods(false, false);
+
+    [PgVersionTargetedFact(MinimumVersion = "15.0")]
+    public Task create_tables_with_indexes_not_concurrently_and_distinct_nulls_too_in_the_database_with_different_methods() =>
+        create_tables_with_indexes_too_in_the_database_with_different_methods(false, true);
 
     public async Task create_tables_with_indexes_too_in_the_database_with_different_methods(
-        bool withConcurrentIndexIndex
+        bool withConcurrentIndexIndex,
+        bool withDistinctNulls
     )
     {
         await theConnection.OpenAsync();
@@ -156,6 +161,7 @@ public class creating_tables_in_database: IntegrationContext
         table.AddColumn<int>("id").AsPrimaryKey();
         table.AddColumn<string>("first_name").AddIndex(x =>
         {
+            x.NullsNotDistinct = withDistinctNulls;
             x.IsConcurrent = withConcurrentIndexIndex;
             x.IsUnique = true;
             x.SortOrder = SortOrder.Desc;

--- a/src/Weasel.Postgresql/Tables/IndexDefinition.cs
+++ b/src/Weasel.Postgresql/Tables/IndexDefinition.cs
@@ -21,6 +21,7 @@ public class IndexDefinition: INamed
     private string? _customIndexMethod;
 
     private string? _indexName;
+    private bool _isUnique;
 
     public IndexDefinition(string indexName)
     {
@@ -62,7 +63,17 @@ public class IndexDefinition: INamed
     /// <summary>
     ///     Option to create unique index
     /// </summary>
-    public bool IsUnique { get; set; }
+    public bool IsUnique
+    {
+        get => _isUnique;
+        set
+        {
+            _isUnique = value;
+
+            if (_isUnique == false)
+                NullsNotDistinct = false;
+        }
+    }
 
     /// <summary>
     ///     Should unique index consider nulls non distinct.

--- a/src/Weasel.Postgresql/Tables/IndexDefinition.cs
+++ b/src/Weasel.Postgresql/Tables/IndexDefinition.cs
@@ -65,8 +65,11 @@ public class IndexDefinition: INamed
     public bool IsUnique { get; set; }
 
     /// <summary>
-    ///     Should unique index consider nulls non distinct. Requires PostgreSQL version 15
+    ///     Should unique index consider nulls non distinct.
     /// </summary>
+    /// <remarks>
+    ///     Requires PostgreSQL version 15
+    /// </remarks>
     public bool NullsNotDistinct { get; set; }
 
     /// <summary>


### PR DESCRIPTION
In PostgreSQL 15 a new feature was added to unique indexes. Now unique indexes can be created with 'NULLS NOT DISTINCT' after which the index considers all null values the same. This PR adds support for creating indexes with this feature. Tested locally with Marten 6.0-RC1 and all seemed to work.