### PR TITLE
Set default table creation style to `CreationStyle.CreateIfNotExists`

### DIFF
--- a/src/Weasel.Core/Migrator.cs
+++ b/src/Weasel.Core/Migrator.cs
@@ -35,7 +35,7 @@ public abstract class Migrator
     /// <summary>
     ///     Alters the syntax used to create tables in DDL
     /// </summary>
-    public CreationStyle TableCreation { get; set; } = CreationStyle.DropThenCreate;
+    public CreationStyle TableCreation { get; set; } = CreationStyle.CreateIfNotExists;
 
     /// <summary>
     ///     Alters the user rights for the upsert functions in DDL

--- a/src/Weasel.Postgresql.Tests/DdlRulesTester.cs
+++ b/src/Weasel.Postgresql.Tests/DdlRulesTester.cs
@@ -19,9 +19,9 @@ public class MigratorTester
     }
 
     [Fact]
-    public void table_creation_is_drop_then_create_by_default()
+    public void table_creation_is_create_if_not_exists_by_default()
     {
-        new PostgresqlMigrator().TableCreation.ShouldBe(CreationStyle.DropThenCreate);
+        new PostgresqlMigrator().TableCreation.ShouldBe(CreationStyle.CreateIfNotExists);
     }
 
     [Fact]

--- a/src/Weasel.Postgresql.Tests/Tables/TableTests.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/TableTests.cs
@@ -107,7 +107,7 @@ public class TableTests
         table.AddColumn<string>("first_name");
         table.AddColumn<string>("last_name");
 
-        var rules = new PostgresqlMigrator { TableCreation = CreationStyle.DropThenCreate };
+        var rules = new PostgresqlMigrator { TableCreation = CreationStyle.CreateIfNotExists };
 
         var writer = new StringWriter();
         table.WriteCreateStatement(rules, writer);
@@ -118,8 +118,7 @@ public class TableTests
 
         var lines = ddl.ReadLines().ToArray();
 
-        lines.ShouldContain("DROP TABLE IF EXISTS public.people CASCADE;");
-        lines.ShouldContain("CREATE TABLE public.people (");
+        lines.ShouldContain("CREATE TABLE IF NOT EXISTS public.people (");
     }
 
     [Fact]

--- a/src/Weasel.SqlServer.Tests/DdlRulesTester.cs
+++ b/src/Weasel.SqlServer.Tests/DdlRulesTester.cs
@@ -19,9 +19,9 @@ public class DdlRulesTester
     }
 
     [Fact]
-    public void table_creation_is_drop_then_create_by_default()
+    public void table_creation_is_create_if_not_exists_by_default()
     {
-        new SqlServerMigrator().TableCreation.ShouldBe(CreationStyle.DropThenCreate);
+        new SqlServerMigrator().TableCreation.ShouldBe(CreationStyle.CreateIfNotExists);
     }
 
     [Fact]

--- a/src/Weasel.SqlServer.Tests/Tables/TableTests.cs
+++ b/src/Weasel.SqlServer.Tests/Tables/TableTests.cs
@@ -99,7 +99,7 @@ public class TableTests
         table.AddColumn<string>("first_name");
         table.AddColumn<string>("last_name");
 
-        var rules = new SqlServerMigrator { TableCreation = CreationStyle.DropThenCreate };
+        var rules = new SqlServerMigrator { TableCreation = CreationStyle.CreateIfNotExists };
 
         var writer = new StringWriter();
         table.WriteCreateStatement(rules, writer);
@@ -110,8 +110,7 @@ public class TableTests
 
         var lines = ddl.ReadLines().ToArray();
 
-        lines.ShouldContain("DROP TABLE IF EXISTS dbo.people;");
-        lines.ShouldContain("CREATE TABLE dbo.people (");
+        lines.ShouldContain("CREATE TABLE IF NOT EXISTS dbo.people (");
     }
 
     [Fact]


### PR DESCRIPTION
I'm pushing this PR to ensure that the default table creation style is `CreationStyle.CreateIfNotExists`.

The motivation for this change is safety. Given that applying a migration script is a process that is prone to human errors, I think it's wise to safeguard against such errors as much as possible. 

With the default as `CreationStyle.DropThenCreate`, if any migration script is run a second time by mistake, then tables can be dropped, resulting in a loss of data, which can be catastrophic in a production environment. 