### PR TITLE
Added support for CI for different Postgres versions

### DIFF
--- a/.github/workflows/ci-build-postgres.yml
+++ b/.github/workflows/ci-build-postgres.yml
@@ -21,9 +21,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
+    strategy:
+    # define the test matrix
+        matrix:
+            postgres-image:
+                - oskardudycz/postgres-plv8:12-2
+
     services:
       postgres:
-        image: oskardudycz/postgres-plv8:12-2
+        image: ${{ matrix.postgres-image }}
         ports:
           - 5432:5432
         env:

--- a/.github/workflows/ci-build-postgres.yml
+++ b/.github/workflows/ci-build-postgres.yml
@@ -26,6 +26,7 @@ jobs:
         matrix:
             postgres-image:
                 - oskardudycz/postgres-plv8:12-2
+                - postgres:15.3-alpine
 
     services:
       postgres:

--- a/src/Weasel.Postgresql.Tests/ExtensionTests.cs
+++ b/src/Weasel.Postgresql.Tests/ExtensionTests.cs
@@ -15,16 +15,14 @@ public class ExtensionTests: IntegrationContext
     public async Task can_create_extension()
     {
         await ResetSchema();
-        var extension = new Extension("plv8");
+        var extension = new Extension("plpgsql");
         await DropSchemaObjectInDatabase(extension);
-
 
         var migration = await SchemaMigration.DetermineAsync(theConnection, extension);
 
         migration.Difference.ShouldBe(SchemaPatchDifference.Create);
 
-        await this.CreateSchemaObjectInDatabase(extension);
-
+        await CreateSchemaObjectInDatabase(extension);
 
         migration = await SchemaMigration.DetermineAsync(theConnection, extension);
         migration.Difference.ShouldBe(SchemaPatchDifference.None);

--- a/src/Weasel.Postgresql.Tests/ExtensionTests.cs
+++ b/src/Weasel.Postgresql.Tests/ExtensionTests.cs
@@ -15,7 +15,7 @@ public class ExtensionTests: IntegrationContext
     public async Task can_create_extension()
     {
         await ResetSchema();
-        var extension = new Extension("plpgsql");
+        var extension = new Extension("hstore");
         await DropSchemaObjectInDatabase(extension);
 
         var migration = await SchemaMigration.DetermineAsync(theConnection, extension);

--- a/src/Weasel.Postgresql.Tests/PgVersionTargetedFact.cs
+++ b/src/Weasel.Postgresql.Tests/PgVersionTargetedFact.cs
@@ -1,0 +1,87 @@
+using Npgsql;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Weasel.Postgresql.Tests;
+
+/// <summary>
+/// Allows targeting test at specified minimum and/or maximum version of PG
+/// </summary>
+[AttributeUsage(AttributeTargets.Method)]
+[XunitTestCaseDiscoverer("Marten.Testing.Harness.PgVersionTargetedFactDiscoverer", "Marten.Testing")]
+public sealed class PgVersionTargetedFact: FactAttribute
+{
+    public string MinimumVersion { get; set; }
+    public string MaximumVersion { get; set; }
+}
+
+public sealed class PgVersionTargetedFactDiscoverer: FactDiscoverer
+{
+    internal static readonly Version Version;
+
+    static PgVersionTargetedFactDiscoverer()
+    {
+        // PG version does not change during test run so we can do static ctor
+        using var c = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        c.Open();
+        Version = c.PostgreSqlVersion;
+        c.Close();
+    }
+
+    public PgVersionTargetedFactDiscoverer(IMessageSink diagnosticMessageSink): base(diagnosticMessageSink)
+    {
+    }
+
+    public override IEnumerable<IXunitTestCase> Discover(ITestFrameworkDiscoveryOptions discoveryOptions,
+        ITestMethod testMethod,
+        IAttributeInfo factAttribute)
+    {
+        var minimumVersion = factAttribute.GetNamedArgument<string>(nameof(PgVersionTargetedFact.MinimumVersion));
+        var maximumVersion = factAttribute.GetNamedArgument<string>(nameof(PgVersionTargetedFact.MaximumVersion));
+
+        if (minimumVersion != null && Version.TryParse(minimumVersion, out var minVersion) && Version < minVersion)
+        {
+            yield return new TestCaseSkippedDueToVersion(
+                $"Minimum required PG version {minimumVersion} is higher than {Version}", DiagnosticMessageSink,
+                discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(),
+                testMethod);
+        }
+
+        if (maximumVersion != null && Version.TryParse(maximumVersion, out var maxVersion) && Version > maxVersion)
+        {
+            yield return new TestCaseSkippedDueToVersion(
+                $"Maximum allowed PG version {maximumVersion} is higher than {Version}", DiagnosticMessageSink,
+                discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(),
+                testMethod);
+        }
+
+        yield return base.CreateTestCase(discoveryOptions, testMethod, factAttribute);
+    }
+
+    internal sealed class TestCaseSkippedDueToVersion: XunitTestCase
+    {
+        [Obsolete("Called by the de-serializer", true)]
+        public TestCaseSkippedDueToVersion()
+        {
+        }
+
+        public TestCaseSkippedDueToVersion(string skipReason, IMessageSink diagnosticMessageSink,
+            TestMethodDisplay defaultMethodDisplay, TestMethodDisplayOptions defaultMethodDisplayOptions,
+            ITestMethod testMethod, object[] testMethodArguments = null): base(diagnosticMessageSink,
+            defaultMethodDisplay, defaultMethodDisplayOptions, testMethod, testMethodArguments)
+        {
+            SkipReason = skipReason;
+        }
+    }
+}
+
+public class PgVersionTargetedFactDiscovererTests
+{
+    [Fact]
+    public void PgVersionTargetedFactDiscoverer_CanConnectToDatabase()
+    {
+        PgVersionTargetedFactDiscoverer.Version.ShouldNotBe(default);
+    }
+}

--- a/src/Weasel.Postgresql.Tests/PgVersionTargetedTheory.cs
+++ b/src/Weasel.Postgresql.Tests/PgVersionTargetedTheory.cs
@@ -1,0 +1,95 @@
+using Npgsql;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Weasel.Postgresql.Tests;
+
+/// <summary>
+/// Allows targeting test at specified minimum and/or maximum version of PG
+/// </summary>
+[AttributeUsage(AttributeTargets.Method)]
+[XunitTestCaseDiscoverer("Marten.Testing.Harness.PgVersionTargetedTheoryDiscoverer", "Marten.Testing")]
+public sealed class PgVersionTargetedTheory: TheoryAttribute
+{
+    public string MinimumVersion { get; set; }
+    public string MaximumVersion { get; set; }
+}
+
+public sealed class PgVersionTargetedTheoryDiscoverer: TheoryDiscoverer
+{
+    internal static readonly Version Version;
+
+    static PgVersionTargetedTheoryDiscoverer()
+    {
+        // PG version does not change during test run so we can do static ctor
+        using var c = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        c.Open();
+        Version = c.PostgreSqlVersion;
+        c.Close();
+    }
+
+    public PgVersionTargetedTheoryDiscoverer(IMessageSink diagnosticMessageSink): base(diagnosticMessageSink)
+    {
+    }
+
+    public override IEnumerable<IXunitTestCase> Discover(ITestFrameworkDiscoveryOptions discoveryOptions,
+        ITestMethod testMethod,
+        IAttributeInfo theoryAttribute)
+    {
+        var minimumVersion = theoryAttribute.GetNamedArgument<string>(nameof(PgVersionTargetedTheory.MinimumVersion));
+        var maximumVersion = theoryAttribute.GetNamedArgument<string>(nameof(PgVersionTargetedTheory.MaximumVersion));
+
+        if (minimumVersion != null && Version.TryParse(minimumVersion, out var minVersion) && Version < minVersion)
+        {
+            return new[]
+            {
+                new TestCaseSkippedDueToVersion(
+                    $"Minimum required PG version {minimumVersion} is higher than {Version}", DiagnosticMessageSink,
+                    discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(),
+                    testMethod)
+            };
+        }
+
+        if (maximumVersion != null && Version.TryParse(maximumVersion, out var maxVersion) && Version > maxVersion)
+        {
+            return new[]
+            {
+                new TestCaseSkippedDueToVersion(
+                    $"Maximum allowed PG version {maximumVersion} is higher than {Version}", DiagnosticMessageSink,
+                    discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(),
+                    testMethod)
+            };
+        }
+
+        return CreateTestCasesForTheory(discoveryOptions, testMethod, theoryAttribute);
+    }
+
+    internal sealed class TestCaseSkippedDueToVersion: XunitTestCase
+    {
+        [Obsolete("Called by the de-serializer", true)]
+        public TestCaseSkippedDueToVersion()
+        {
+        }
+
+        public TestCaseSkippedDueToVersion(string skipReason, IMessageSink diagnosticMessageSink,
+            TestMethodDisplay defaultMethodDisplay, TestMethodDisplayOptions defaultMethodDisplayOptions,
+            ITestMethod testMethod, object[] testMethodArguments = null): base(diagnosticMessageSink,
+            defaultMethodDisplay, defaultMethodDisplayOptions, testMethod, testMethodArguments)
+        {
+            SkipReason = skipReason;
+        }
+    }
+}
+
+public class PgVersionTargetedTheoryDiscovererTests
+{
+    [Theory]
+    [InlineData("test1")]
+    [InlineData("test2")]
+    public void PgVersionTargetedTheoryDiscoverer_CanConnectToDatabase(string ignore)
+    {
+        PgVersionTargetedTheoryDiscoverer.Version.ShouldNotBe(default);
+    }
+}

--- a/src/Weasel.Postgresql.Tests/Tables/creating_tables_in_database.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/creating_tables_in_database.cs
@@ -99,8 +99,15 @@ public class creating_tables_in_database: IntegrationContext
             .ShouldBeTrue();
     }
 
+    [PgVersionTargetedFact(MaximumVersion = "13.0")]
+    public Task create_tables_with_indexes_concurrently_too_in_the_database() =>
+        create_tables_with_indexes_too_in_the_database(true);
+
     [Fact]
-    public async Task create_tables_with_indexes_too_in_the_database()
+    public Task create_tables_with_indexes_not_concurrently_too_in_the_database() =>
+        create_tables_with_indexes_too_in_the_database(false);
+
+    private async Task create_tables_with_indexes_too_in_the_database(bool withConcurrentIndexIndex)
     {
         await theConnection.OpenAsync();
 
@@ -111,10 +118,9 @@ public class creating_tables_in_database: IntegrationContext
 
         await CreateSchemaObjectInDatabase(states);
 
-
         var table = new Table("people");
         table.AddColumn<int>("id").AsPrimaryKey();
-        table.AddColumn<string>("first_name").NotNull().AddIndex(x => x.IsConcurrent = true);
+        table.AddColumn<string>("first_name").NotNull().AddIndex(x => x.IsConcurrent = withConcurrentIndexIndex);
         table.AddColumn<string>("last_name").NotNull().AddIndex();
         table.AddColumn<int>("state_id").ForeignKeyTo(states, "id");
 
@@ -124,8 +130,18 @@ public class creating_tables_in_database: IntegrationContext
             .ShouldBeTrue();
     }
 
+
+    [PgVersionTargetedFact(MaximumVersion = "13.0")]
+    public Task create_tables_with_indexes_concurrently_too_in_the_database_with_different_methods() =>
+        create_tables_with_indexes_too_in_the_database_with_different_methods(true);
+
     [Fact]
-    public async Task create_tables_with_indexes_too_in_the_database_with_different_methods()
+    public Task create_tables_with_indexes_not_concurrently_too_in_the_database_with_different_methods() =>
+        create_tables_with_indexes_too_in_the_database_with_different_methods(false);
+
+    public async Task create_tables_with_indexes_too_in_the_database_with_different_methods(
+        bool withConcurrentIndexIndex
+    )
     {
         await theConnection.OpenAsync();
 
@@ -136,12 +152,11 @@ public class creating_tables_in_database: IntegrationContext
 
         await CreateSchemaObjectInDatabase(states);
 
-
         var table = new Table("people");
         table.AddColumn<int>("id").AsPrimaryKey();
         table.AddColumn<string>("first_name").AddIndex(x =>
         {
-            x.IsConcurrent = true;
+            x.IsConcurrent = withConcurrentIndexIndex;
             x.IsUnique = true;
             x.SortOrder = SortOrder.Desc;
             x.Predicate = "id > 3";

--- a/src/Weasel.Postgresql.Tests/Tables/reading_existing_table_from_database.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/reading_existing_table_from_database.cs
@@ -83,26 +83,32 @@ public class reading_existing_table_from_database: IntegrationContext
             .ShouldBe(new[] { "id", "tenant_id" });
     }
 
+    [PgVersionTargetedFact(MaximumVersion = "13.0")]
+    public Task read_indexes_with_concurrent_index()=>
+        read_indexes(true);
+
     [Fact]
-    public async Task read_indexes()
+    public Task read_indexes_without_concurrent_index() =>
+        read_indexes(false);
+
+
+    public async Task read_indexes(bool withConcurrentIndex)
     {
         await theConnection.OpenAsync();
 
         await theConnection.ResetSchemaAsync("tables");
-
 
         var states = new Table("states");
         states.AddColumn<int>("id").AsPrimaryKey();
 
         await CreateSchemaObjectInDatabase(states);
 
-
         var table = new Table("people");
         table.AddColumn<int>("id").AsPrimaryKey();
         table.AddColumn<string>("first_name").AddIndex();
         table.AddColumn<string>("last_name").AddIndex(i =>
         {
-            i.IsConcurrent = true;
+            i.IsConcurrent = withConcurrentIndex;
             i.Method = IndexMethod.hash;
         });
 
@@ -112,30 +118,34 @@ public class reading_existing_table_from_database: IntegrationContext
 
         var existing = await table.FetchExistingAsync(theConnection);
 
-
         existing.Indexes.Count.ShouldBe(2);
     }
 
+    [PgVersionTargetedFact(MaximumVersion = "13.0")]
+    public Task read_fk_with_concurrent_index()=>
+        read_fk(true);
+
     [Fact]
-    public async Task read_fk()
+    public Task read_fk_without_concurrent_index() =>
+        read_fk(false);
+
+    public async Task read_fk(bool withConcurrentIndex)
     {
         await theConnection.OpenAsync();
 
         await theConnection.ResetSchemaAsync("tables");
-
 
         var states = new Table("states");
         states.AddColumn<int>("id").AsPrimaryKey();
 
         await CreateSchemaObjectInDatabase(states);
 
-
         var table = new Table("people");
         table.AddColumn<int>("id").AsPrimaryKey();
         table.AddColumn<string>("first_name").AddIndex();
         table.AddColumn<string>("last_name").AddIndex(i =>
         {
-            i.IsConcurrent = true;
+            i.IsConcurrent = withConcurrentIndex;
             i.Method = IndexMethod.hash;
         });
 
@@ -145,7 +155,6 @@ public class reading_existing_table_from_database: IntegrationContext
         await CreateSchemaObjectInDatabase(table);
 
         var existing = await table.FetchExistingAsync(theConnection);
-
 
         var fk = existing.ForeignKeys.Single();
 
@@ -159,13 +168,19 @@ public class reading_existing_table_from_database: IntegrationContext
         fk.OnUpdate.ShouldBe(CascadeAction.Restrict);
     }
 
+    [PgVersionTargetedFact(MaximumVersion = "13.0")]
+    public Task read_fk_with_multiple_columns_with_concurrent_index()=>
+        read_fk_with_multiple_columns(true);
+
     [Fact]
-    public async Task read_fk_with_multiple_columns()
+    public Task read_fk_with_multiple_columns_without_concurrent_index() =>
+        read_fk_with_multiple_columns(false);
+
+    public async Task read_fk_with_multiple_columns(bool withConcurrentIndex)
     {
         await theConnection.OpenAsync();
 
         await theConnection.ResetSchemaAsync("tables");
-
 
         var states = new Table("states");
         states.AddColumn<int>("id").AsPrimaryKey();
@@ -173,13 +188,12 @@ public class reading_existing_table_from_database: IntegrationContext
 
         await CreateSchemaObjectInDatabase(states);
 
-
         var table = new Table("people");
         table.AddColumn<int>("id").AsPrimaryKey();
         table.AddColumn<string>("first_name").AddIndex();
         table.AddColumn<string>("last_name").AddIndex(i =>
         {
-            i.IsConcurrent = true;
+            i.IsConcurrent = withConcurrentIndex;
             i.Method = IndexMethod.hash;
         });
 
@@ -198,7 +212,6 @@ public class reading_existing_table_from_database: IntegrationContext
         await CreateSchemaObjectInDatabase(table);
 
         var existing = await table.FetchExistingAsync(theConnection);
-
 
         var fk = existing.ForeignKeys.Single();
 

--- a/src/Weasel.Postgresql/Tables/IndexDefinition.cs
+++ b/src/Weasel.Postgresql/Tables/IndexDefinition.cs
@@ -67,6 +67,15 @@ public class IndexDefinition: INamed
     /// <summary>
     ///     Option to build index without taking any locks that prevent concurrent inserts, updates or deletes in table
     /// </summary>
+    /// <remarks>
+    ///     From Postgresql 14, you cannot create indexes concurrently within a transaction.
+    ///     Npgsql applies batches of statements automatically as implicit transactions.
+    ///     Thus, concurrent indexes creation or update will only work if you apply them separately.
+    ///     <br/><br/>
+    ///     Read more in:<br/>
+    ///     - https://github.com/npgsql/npgsql/issues/462#issuecomment-925054226<br/>
+    ///     - https://www.migops.com/blog/important-postgresql-14-update-to-avoid-silent-corruption-of-indexes/
+    /// </remarks>
     public bool IsConcurrent { get; set; }
 
     // Define the columns part of the index definition


### PR DESCRIPTION
Added:
- test attribute to support running tests on specific Postgres versions
- GitHub action matrix to support running multiple Postgres versions

I also detected the change in Postgres behaviour with respect to handling creating indexes concurrently.

From Postgresql 14, you cannot create indexes concurrently within a transaction. Npgsql applies batches of statements automatically as implicit transactions. Thus, concurrent index creation or update will only work if you apply them separately.

Read more in:
- https://github.com/npgsql/npgsql/issues/462#issuecomment-925054226
- https://www.migops.com/blog/important-postgresql-14-update-to-avoid-silent-corruption-of-indexes/

Effectively, that concurrent index apply will only work if the delta contains only index creation. If it contains other statements, then it will fail.

Updated tests accordingly and added remarks in the documentation.