### PR TITLE
executes index creation in a separate command in case of IsConcurrent=true

### DIFF
--- a/src/Weasel.Postgresql.Tests/IntegrationContext.cs
+++ b/src/Weasel.Postgresql.Tests/IntegrationContext.cs
@@ -37,17 +37,19 @@ public abstract class IntegrationContext: IDisposable, IAsyncLifetime
     protected async Task CreateSchemaObjectInDatabase(ISchemaObject schemaObject)
     {
         var rules = new PostgresqlMigrator();
-        var writer = new StringWriter();
-        schemaObject.WriteCreateStatement(rules, writer);
+        var builder = new DbCommandBuilder(theConnection);
+        schemaObject.ConfigureQueryCommand(builder);
+        await using var reader = await builder.ExecuteReaderAsync(theConnection);
+        var schemaMigration = new SchemaMigration(await schemaObject.CreateDeltaAsync(reader));
+        await reader.CloseAsync();
 
         try
         {
-            await theConnection.CreateCommand(writer.ToString())
-                .ExecuteNonQueryAsync();
+            await rules.ApplyAllAsync(theConnection, schemaMigration, AutoCreate.All);
         }
         catch (Exception e)
         {
-            throw new Exception("DDL Execution Failure.\n" + writer, e);
+            throw new Exception("DDL Execution Failure.\n", e);
         }
     }
 

--- a/src/Weasel.Postgresql.Tests/IntegrationContext.cs
+++ b/src/Weasel.Postgresql.Tests/IntegrationContext.cs
@@ -45,7 +45,7 @@ public abstract class IntegrationContext: IDisposable, IAsyncLifetime
 
         try
         {
-            await rules.ApplyAllAsync(theConnection, schemaMigration, AutoCreate.CreateOrUpdate);
+            await rules.ApplyAllAsync(theConnection, schemaMigration, AutoCreate.All);
         }
         catch (Exception e)
         {

--- a/src/Weasel.Postgresql.Tests/IntegrationContext.cs
+++ b/src/Weasel.Postgresql.Tests/IntegrationContext.cs
@@ -45,7 +45,7 @@ public abstract class IntegrationContext: IDisposable, IAsyncLifetime
 
         try
         {
-            await rules.ApplyAllAsync(theConnection, schemaMigration, AutoCreate.All);
+            await rules.ApplyAllAsync(theConnection, schemaMigration, AutoCreate.CreateOrUpdate);
         }
         catch (Exception e)
         {

--- a/src/Weasel.Postgresql.Tests/Tables/IndexDefinitionTests.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/IndexDefinitionTests.cs
@@ -107,7 +107,9 @@ public class IndexDefinitionTests
         theIndex.IsConcurrent = true;
 
         theIndex.ToDDL(parent)
-            .ShouldBe("CREATE UNIQUE INDEX CONCURRENTLY idx_1 ON public.people USING btree (column1) NULLS NOT DISTINCT ;");
+            .ShouldBe("--WEASEL_INDEX_CREATION_BEGIN\n" +
+                      "CREATE UNIQUE INDEX CONCURRENTLY idx_1 ON public.people USING btree (column1) NULLS NOT DISTINCT ;\n" +
+                      "--WEASEL_INDEX_CREATION_END");
     }
 
     [Fact]

--- a/src/Weasel.Postgresql.Tests/Tables/IndexDefinitionTests.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/IndexDefinitionTests.cs
@@ -82,7 +82,9 @@ public class IndexDefinitionTests
         theIndex.IsConcurrent = true;
 
         theIndex.ToDDL(parent)
-            .ShouldBe("CREATE INDEX CONCURRENTLY idx_1 ON public.people USING btree (column1);");
+            .ShouldBe("--WEASEL_INDEX_CREATION_BEGIN\n" +
+                      "CREATE INDEX CONCURRENTLY idx_1 ON public.people USING btree (column1);\n" +
+                      "--WEASEL_INDEX_CREATION_END");
     }
 
     [Fact]
@@ -92,7 +94,9 @@ public class IndexDefinitionTests
         theIndex.IsConcurrent = true;
 
         theIndex.ToDDL(parent)
-            .ShouldBe("CREATE UNIQUE INDEX CONCURRENTLY idx_1 ON public.people USING btree (column1);");
+            .ShouldBe("--WEASEL_INDEX_CREATION_BEGIN\n" +
+                      "CREATE UNIQUE INDEX CONCURRENTLY idx_1 ON public.people USING btree (column1);\n" +
+                      "--WEASEL_INDEX_CREATION_END");
     }
 
     [Fact]

--- a/src/Weasel.Postgresql.Tests/Tables/IndexDefinitionTests.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/IndexDefinitionTests.cs
@@ -82,8 +82,8 @@ public class IndexDefinitionTests
         theIndex.IsConcurrent = true;
 
         theIndex.ToDDL(parent)
-            .ShouldBe("--WEASEL_INDEX_CREATION_BEGIN\n" +
-                      "CREATE INDEX CONCURRENTLY idx_1 ON public.people USING btree (column1);\n" +
+            .ShouldBe($"--WEASEL_INDEX_CREATION_BEGIN{Environment.NewLine}" +
+                      $"CREATE INDEX CONCURRENTLY idx_1 ON public.people USING btree (column1);{Environment.NewLine}" +
                       "--WEASEL_INDEX_CREATION_END");
     }
 
@@ -94,8 +94,8 @@ public class IndexDefinitionTests
         theIndex.IsConcurrent = true;
 
         theIndex.ToDDL(parent)
-            .ShouldBe("--WEASEL_INDEX_CREATION_BEGIN\n" +
-                      "CREATE UNIQUE INDEX CONCURRENTLY idx_1 ON public.people USING btree (column1);\n" +
+            .ShouldBe($"--WEASEL_INDEX_CREATION_BEGIN{Environment.NewLine}" +
+                      $"CREATE UNIQUE INDEX CONCURRENTLY idx_1 ON public.people USING btree (column1);{Environment.NewLine}" +
                       "--WEASEL_INDEX_CREATION_END");
     }
 
@@ -107,8 +107,8 @@ public class IndexDefinitionTests
         theIndex.IsConcurrent = true;
 
         theIndex.ToDDL(parent)
-            .ShouldBe("--WEASEL_INDEX_CREATION_BEGIN\n" +
-                      "CREATE UNIQUE INDEX CONCURRENTLY idx_1 ON public.people USING btree (column1) NULLS NOT DISTINCT ;\n" +
+            .ShouldBe($"--WEASEL_INDEX_CREATION_BEGIN{Environment.NewLine}" +
+                      $"CREATE UNIQUE INDEX CONCURRENTLY idx_1 ON public.people USING btree (column1) NULLS NOT DISTINCT ;{Environment.NewLine}" +
                       "--WEASEL_INDEX_CREATION_END");
     }
 

--- a/src/Weasel.Postgresql.Tests/Tables/detecting_table_deltas.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/detecting_table_deltas.cs
@@ -145,7 +145,11 @@ public class detecting_table_deltas: IntegrationContext
     public Task detect_new_index_without_distinct_nulls() =>
         detect_new_index(false);
 
-    private async Task detect_new_index(bool withDistinctNulls)
+    [Fact]
+    public Task detect_new_index_with_concurrent_creation() =>
+        detect_new_index(false, true);
+
+    private async Task detect_new_index(bool withDistinctNulls, bool isConcurrent = false)
     {
         await CreateSchemaObjectInDatabase(theTable);
 
@@ -153,6 +157,7 @@ public class detecting_table_deltas: IntegrationContext
         {
             i.IsUnique = true;
             i.NullsNotDistinct = withDistinctNulls;
+            i.IsConcurrent = isConcurrent;
         });
 
         var delta = await theTable.FindDeltaAsync(theConnection);
@@ -174,12 +179,17 @@ public class detecting_table_deltas: IntegrationContext
     public Task detect_matched_index_without_distinct_nulls() =>
         detect_matched_index(false);
 
-    private async Task detect_matched_index(bool withDistinctNulls)
+    [Fact]
+    public Task detect_matched_index_with_concurrent_creation() =>
+        detect_matched_index(false, true);
+
+    private async Task detect_matched_index(bool withDistinctNulls, bool isConcurrent = false)
     {
         theTable.ModifyColumn("user_name").AddIndex(i =>
         {
             i.IsUnique = true;
             i.NullsNotDistinct = withDistinctNulls;
+            i.IsConcurrent = isConcurrent;
         });
 
         await CreateSchemaObjectInDatabase(theTable);
@@ -201,12 +211,17 @@ public class detecting_table_deltas: IntegrationContext
     public Task detect_different_index_without_distinct_nulls() =>
         detect_different_index(false);
 
-    private async Task detect_different_index(bool withDistinctNulls)
+    [Fact]
+    public Task detect_different_index_with_concurrent_creation() =>
+        detect_different_index(false, true);
+
+    private async Task detect_different_index(bool withDistinctNulls, bool isConcurrent = false)
     {
         theTable.ModifyColumn("user_name").AddIndex(i =>
         {
             i.IsUnique = true;
             i.NullsNotDistinct = withDistinctNulls;
+            i.IsConcurrent = isConcurrent;
         });
 
         await CreateSchemaObjectInDatabase(theTable);
@@ -237,12 +252,17 @@ public class detecting_table_deltas: IntegrationContext
     public Task detect_extra_index_without_distinct_nulls() =>
         detect_extra_index(false);
 
-    public async Task detect_extra_index(bool withDistinctNulls)
+    [Fact]
+    public Task detect_extra_index_with_concurrent_creation() =>
+        detect_extra_index(false, true);
+
+    private async Task detect_extra_index(bool withDistinctNulls, bool isConcurrent = false)
     {
         theTable.ModifyColumn("user_name").AddIndex(i =>
         {
             i.IsUnique = true;
             i.NullsNotDistinct = withDistinctNulls;
+            i.IsConcurrent = isConcurrent;
         });
         await CreateSchemaObjectInDatabase(theTable);
 

--- a/src/Weasel.Postgresql.Tests/Tables/reading_existing_table_from_database.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/reading_existing_table_from_database.cs
@@ -75,6 +75,7 @@ public class reading_existing_table_from_database: IntegrationContext
         table.AddColumn<string>("first_name");
         table.AddColumn<string>("last_name");
 
+        await DropSchemaObjectInDatabase(table);
         await CreateSchemaObjectInDatabase(table);
 
         var existing = await table.FetchExistingAsync(theConnection);
@@ -138,6 +139,7 @@ public class reading_existing_table_from_database: IntegrationContext
         var states = new Table("states");
         states.AddColumn<int>("id").AsPrimaryKey();
 
+        await DropSchemaObjectInDatabase(states);
         await CreateSchemaObjectInDatabase(states);
 
         var table = new Table("people");

--- a/src/Weasel.Postgresql.Tests/Tables/reading_existing_table_from_database.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/reading_existing_table_from_database.cs
@@ -75,7 +75,6 @@ public class reading_existing_table_from_database: IntegrationContext
         table.AddColumn<string>("first_name");
         table.AddColumn<string>("last_name");
 
-        await DropSchemaObjectInDatabase(table);
         await CreateSchemaObjectInDatabase(table);
 
         var existing = await table.FetchExistingAsync(theConnection);
@@ -139,7 +138,6 @@ public class reading_existing_table_from_database: IntegrationContext
         var states = new Table("states");
         states.AddColumn<int>("id").AsPrimaryKey();
 
-        await DropSchemaObjectInDatabase(states);
         await CreateSchemaObjectInDatabase(states);
 
         var table = new Table("people");

--- a/src/Weasel.Postgresql.Tests/Tables/reading_existing_table_from_database.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/reading_existing_table_from_database.cs
@@ -83,7 +83,7 @@ public class reading_existing_table_from_database: IntegrationContext
             .ShouldBe(new[] { "id", "tenant_id" });
     }
 
-    [PgVersionTargetedFact(MaximumVersion = "13.0")]
+    [Fact]
     public Task read_indexes_with_concurrent_index()=>
         read_indexes(true);
 
@@ -121,7 +121,7 @@ public class reading_existing_table_from_database: IntegrationContext
         existing.Indexes.Count.ShouldBe(2);
     }
 
-    [PgVersionTargetedFact(MaximumVersion = "13.0")]
+    [Fact]
     public Task read_fk_with_concurrent_index()=>
         read_fk(true);
 
@@ -168,7 +168,7 @@ public class reading_existing_table_from_database: IntegrationContext
         fk.OnUpdate.ShouldBe(CascadeAction.Restrict);
     }
 
-    [PgVersionTargetedFact(MaximumVersion = "13.0")]
+    [Fact]
     public Task read_fk_with_multiple_columns_with_concurrent_index()=>
         read_fk_with_multiple_columns(true);
 


### PR DESCRIPTION
According to [Postgres documentation](https://www.postgresql.org/docs/current/sql-createindex.html#SQL-CREATEINDEX-CONCURRENTLY) it's not allowed to create indexes concurrently inside a transaction block which may be any other expression. Basically now we faced with an issue when we don't have any chance to create an index concurrently. This PR attempts to solve this. Beside unit tests I tested out this solution with our current delta.

> Regular index builds permit other regular index builds on the same table to occur simultaneously, but only one concurrent index build can occur on a table at a time. In either case, schema modification of the table is not allowed while the index is being built. Another difference is that a regular CREATE INDEX command can be performed within a transaction block, but CREATE INDEX CONCURRENTLY cannot.
