### PR TITLE
Case sensitive improvements

### DIFF
--- a/.github/workflows/ci-build-mssql.yml
+++ b/.github/workflows/ci-build-mssql.yml
@@ -25,6 +25,9 @@ jobs:
             mssql-image:
                 - mcr.microsoft.com/mssql/server:2019-latest
                 - mcr.microsoft.com/mssql/server:2022-latest
+
+    name: MSSQL ${{ matrix.mssql-image }}
+
     services:
       sqlserver:
         image: ${{ matrix.mssql-image }}

--- a/.github/workflows/ci-build-postgres.yml
+++ b/.github/workflows/ci-build-postgres.yml
@@ -31,6 +31,8 @@ jobs:
                 - true
                 - false
 
+    name: Postgres ${{ matrix.postgres-image }} Case Sensitive ${{ matrix.useCaseSensitiveQualifiedNames }}
+
     services:
       postgres:
         image: ${{ matrix.postgres-image }}

--- a/.github/workflows/ci-build-postgres.yml
+++ b/.github/workflows/ci-build-postgres.yml
@@ -27,6 +27,9 @@ jobs:
             postgres-image:
                 - ionx/postgres-plv8:12.2
                 - postgres:15.3-alpine
+            useCaseSensitiveQualifiedNames:
+                - true
+                - false
 
     services:
       postgres:
@@ -37,6 +40,7 @@ jobs:
           POSTGRES_HOST_AUTH_METHOD: trust
           POSTGRES_DB: ${{ env.db_name }}
           POSTGRES_USER: ${{ env.db_user }}
+          USE_CASE_SENSITIVE_QUALIFIED_NAMES:  ${{ matrix.useCaseSensitiveQualifiedNames }}
         options: >-
           --health-cmd pg_isready
           --health-interval 10s

--- a/README.md
+++ b/README.md
@@ -36,3 +36,9 @@ Some of our tests are run against a particular PostgreSQL version. Tests explore
 ```shell
 postgresql_version=15.3
 ```
+
+By default Postgres tests are run with case insensitive names. To run tests against case sensitive, set environment variable:
+
+```
+USE_CASE_SENSITIVE_QUALIFIED_NAMES=true
+```

--- a/src/Weasel.Core.Tests/DbObjectNameTests.cs
+++ b/src/Weasel.Core.Tests/DbObjectNameTests.cs
@@ -7,7 +7,9 @@ public class DbObjectNameTests
 {
     public class StubProvider: IDatabaseProvider
     {
-        public string DefaultDatabaseSchemaName { get; } = "stub";
+        public string DefaultDatabaseSchemaName => "stub";
+
+        public string ToQualifiedName(string objectName) => objectName;
     }
 
     private readonly IDatabaseProvider theProvider = new StubProvider();

--- a/src/Weasel.Core.Tests/DbObjectNameTests.cs
+++ b/src/Weasel.Core.Tests/DbObjectNameTests.cs
@@ -9,7 +9,8 @@ public class DbObjectNameTests
     {
         public string DefaultDatabaseSchemaName => "stub";
 
-        public string ToQualifiedName(string objectName) => objectName;
+        public DbObjectName Parse(string schemaName, string objectName) =>
+            new DbObjectName(schemaName, objectName);
     }
 
     private readonly IDatabaseProvider theProvider = new StubProvider();

--- a/src/Weasel.Core/DatabaseProvider.cs
+++ b/src/Weasel.Core/DatabaseProvider.cs
@@ -1,5 +1,6 @@
 using System.Data.Common;
 using JasperFx.Core;
+using Weasel.Core.Names;
 
 namespace Weasel.Core;
 
@@ -18,6 +19,15 @@ public interface IDatabaseProvider
 
     string ToQualifiedName(string schemaName, string objectName) =>
         $"{ToQualifiedName(schemaName)}.{ToQualifiedName(objectName)}";
+
+    public DbObjectName Parse(string qualifiedName)
+    {
+        var parts = QualifiedNameParser.Parse(this, qualifiedName);
+
+        return Parse(parts[0], parts[1]);
+    }
+
+    DbObjectName Parse(string schemaName, string objectName);
 }
 
 /// <summary>
@@ -93,8 +103,6 @@ public abstract class DatabaseProvider<TCommand, TParameter, TConnection, TTrans
     }
 
     public string DefaultDatabaseSchemaName { get; }
-
-    public virtual string ToQualifiedName(string objectName) => objectName;
 
     public TParameterType? TryGetDbType(Type? type)
     {
@@ -246,4 +254,11 @@ public abstract class DatabaseProvider<TCommand, TParameter, TConnection, TTrans
     {
         return AddNamedParameter(command, name, value, BoolParameterType);
     }
+
+    public virtual string ToQualifiedName(string objectName) => objectName;
+
+    public string ToQualifiedName(string schemaName, string objectName) =>
+        $"{ToQualifiedName(schemaName)}.{ToQualifiedName(objectName)}";
+
+    public abstract DbObjectName Parse(string schemaName, string objectName);
 }

--- a/src/Weasel.Core/DatabaseProvider.cs
+++ b/src/Weasel.Core/DatabaseProvider.cs
@@ -9,6 +9,15 @@ namespace Weasel.Core;
 public interface IDatabaseProvider
 {
     string DefaultDatabaseSchemaName { get; }
+    /// <summary>
+    /// Maps databaseObjectName to include local conventions around case sensitivity etc.
+    /// </summary>
+    /// <param name="objectName">database object name (e.g. table, sequence)</param>
+    /// <returns></returns>
+    string ToQualifiedName(string objectName) => objectName;
+
+    string ToQualifiedName(string schemaName, string objectName) =>
+        $"{ToQualifiedName(schemaName)}.{ToQualifiedName(objectName)}";
 }
 
 /// <summary>
@@ -84,6 +93,8 @@ public abstract class DatabaseProvider<TCommand, TParameter, TConnection, TTrans
     }
 
     public string DefaultDatabaseSchemaName { get; }
+
+    public virtual string ToQualifiedName(string objectName) => objectName;
 
     public TParameterType? TryGetDbType(Type? type)
     {

--- a/src/Weasel.Core/DbCommandBuilder.cs
+++ b/src/Weasel.Core/DbCommandBuilder.cs
@@ -159,4 +159,7 @@ internal class DbDatabaseProvider: DatabaseProvider<DbCommand, DbParameter, DbCo
     {
         parameter.DbType = dbType;
     }
+
+    public override DbObjectName Parse(string schemaName, string objectName) =>
+        new DbObjectName(schemaName, objectName);
 }

--- a/src/Weasel.Core/DbObjectName.cs
+++ b/src/Weasel.Core/DbObjectName.cs
@@ -5,14 +5,14 @@ namespace Weasel.Core;
 /// </summary>
 public class DbObjectName
 {
-    [Obsolete("Use Parse method with IDatabaseProvider instead.")]
+    [Obsolete("Use PostgresqlObjectName, SqlServerObjectName, or Parse method with IDatabaseProvider instead.")]
     public DbObjectName(string schema, string name): this(schema, name, $"{schema}.{name}")
     {
         Schema = schema;
         Name = name;
     }
 
-    private DbObjectName(string schema, string name, string qualifiedName)
+    protected DbObjectName(string schema, string name, string qualifiedName)
     {
         Schema = schema;
         Name = name;
@@ -28,15 +28,13 @@ public class DbObjectName
         return new DbObjectName(Schema, Name + "_temp");
     }
 
-    public static DbObjectName Parse(IDatabaseProvider provider, string qualifiedName)
-    {
-        var parts = ParseQualifiedName(provider, qualifiedName);
+    [Obsolete("Use method from database provider")]
+    public static DbObjectName Parse(IDatabaseProvider provider, string qualifiedName) =>
+        provider.Parse(qualifiedName);
 
-        return Parse(provider, parts[0], parts[1]);
-    }
-
+    [Obsolete("Use method from database provider")]
     public static DbObjectName Parse(IDatabaseProvider provider, string schemaName, string objectName) =>
-        new (schemaName, objectName, provider.ToQualifiedName(schemaName, objectName));
+        provider.Parse(schemaName, objectName);
 
     public override string ToString()
     {
@@ -75,22 +73,5 @@ public class DbObjectName
         {
             return (GetType().GetHashCode() * 397) ^ (QualifiedName?.GetHashCode() ?? 0);
         }
-    }
-
-    protected static string[] ParseQualifiedName(IDatabaseProvider provider, string qualifiedName)
-    {
-        var parts = qualifiedName.Split('.');
-        if (parts.Length == 1)
-        {
-            return new[] { provider.DefaultDatabaseSchemaName, qualifiedName };
-        }
-
-        if (parts.Length != 2)
-        {
-            throw new InvalidOperationException(
-                $"Could not parse QualifiedName: '{qualifiedName}'. Number or parts should be 2s but is {parts.Length}");
-        }
-
-        return parts;
     }
 }

--- a/src/Weasel.Core/DbObjectName.cs
+++ b/src/Weasel.Core/DbObjectName.cs
@@ -5,11 +5,18 @@ namespace Weasel.Core;
 /// </summary>
 public class DbObjectName
 {
-    public DbObjectName(string schema, string name)
+    [Obsolete("Use Parse method with IDatabaseProvider instead.")]
+    public DbObjectName(string schema, string name): this(schema, name, $"{schema}.{name}")
     {
         Schema = schema;
         Name = name;
-        QualifiedName = $"{Schema}.{Name}";
+    }
+
+    private DbObjectName(string schema, string name, string qualifiedName)
+    {
+        Schema = schema;
+        Name = name;
+        QualifiedName = qualifiedName;
     }
 
     public string Schema { get; }
@@ -24,8 +31,12 @@ public class DbObjectName
     public static DbObjectName Parse(IDatabaseProvider provider, string qualifiedName)
     {
         var parts = ParseQualifiedName(provider, qualifiedName);
-        return new DbObjectName(parts[0], parts[1]);
+
+        return Parse(provider, parts[0], parts[1]);
     }
+
+    public static DbObjectName Parse(IDatabaseProvider provider, string schemaName, string objectName) =>
+        new (schemaName, objectName, provider.ToQualifiedName(schemaName, objectName));
 
     public override string ToString()
     {

--- a/src/Weasel.Core/Names/QualifiedNameParser.cs
+++ b/src/Weasel.Core/Names/QualifiedNameParser.cs
@@ -1,0 +1,21 @@
+namespace Weasel.Core.Names;
+
+public static class QualifiedNameParser
+{
+    public static string[] Parse(IDatabaseProvider databaseProvider, string qualifiedName)
+    {
+        var parts = qualifiedName.Split('.');
+        if (parts.Length == 1)
+        {
+            return new[] { databaseProvider.DefaultDatabaseSchemaName, qualifiedName };
+        }
+
+        if (parts.Length != 2)
+        {
+            throw new InvalidOperationException(
+                $"Could not parse QualifiedName: '{qualifiedName}'. Number or parts should be 2s but is {parts.Length}");
+        }
+
+        return parts;
+    }
+}

--- a/src/Weasel.Postgresql.Tests/CommandExtensionsTests.cs
+++ b/src/Weasel.Postgresql.Tests/CommandExtensionsTests.cs
@@ -50,9 +50,9 @@ public class CommandExtensionsTests
     public void CallsSproc_extension_method()
     {
         var command = new NpgsqlCommand();
-        command.CallsSproc(PostgresqlProvider.ToDbObjectName("foo", "proc")).ShouldBeSameAs(command);
+        command.CallsSproc(new PostgresqlObjectName("foo", "proc")).ShouldBeSameAs(command);
         command.CommandType.ShouldBe(CommandType.StoredProcedure);
-        command.CommandText.ShouldBe(ToDbObjectName("foo.proc").QualifiedName);
+        command.CommandText.ShouldBe(Instance.UseCaseSensitiveQualifiedNames ? "\"foo\".\"proc\"" : "foo.proc");
     }
 
     [Fact]

--- a/src/Weasel.Postgresql.Tests/CommandExtensionsTests.cs
+++ b/src/Weasel.Postgresql.Tests/CommandExtensionsTests.cs
@@ -7,6 +7,8 @@ using Xunit;
 
 namespace Weasel.Postgresql.Tests;
 
+using static PostgresqlProvider;
+
 public class CommandExtensionsTests
 {
     [Fact]
@@ -48,9 +50,9 @@ public class CommandExtensionsTests
     public void CallsSproc_extension_method()
     {
         var command = new NpgsqlCommand();
-        command.CallsSproc(new DbObjectName("foo", "proc")).ShouldBeSameAs(command);
+        command.CallsSproc(PostgresqlProvider.ToDbObjectName("foo", "proc")).ShouldBeSameAs(command);
         command.CommandType.ShouldBe(CommandType.StoredProcedure);
-        command.CommandText.ShouldBe("foo.proc");
+        command.CommandText.ShouldBe(ToDbObjectName("foo.proc").QualifiedName);
     }
 
     [Fact]

--- a/src/Weasel.Postgresql.Tests/Functions/FunctionBodyTests.cs
+++ b/src/Weasel.Postgresql.Tests/Functions/FunctionBodyTests.cs
@@ -32,7 +32,7 @@ $BODY$
     [Fact]
     public void derive_the_function_signature_from_the_body()
     {
-        var func = new FunctionBody(PostgresqlProvider.ToDbObjectName("public", "mt_upsert_target"), new string[0], theFunctionBody);
+        var func = new FunctionBody(new PostgresqlObjectName("public", "mt_upsert_target"), new string[0], theFunctionBody);
 
         Function.ParseSignature(func.Body).ShouldBe("public.mt_upsert_target(jsonb, character varying, uuid, uuid)");
     }
@@ -40,7 +40,7 @@ $BODY$
     [Fact]
     public void do_substitutions()
     {
-        var func = new FunctionBody(PostgresqlProvider.ToDbObjectName("public", "mt_upsert_target"), new string[0], theFunctionBody);
+        var func = new FunctionBody(new PostgresqlObjectName("public", "mt_upsert_target"), new string[0], theFunctionBody);
 
         func.BuildTemplate($"*{PostgresqlMigrator.SCHEMA}*").ShouldBe("*public*");
         func.BuildTemplate($"*{PostgresqlMigrator.FUNCTION}*").ShouldBe("*mt_upsert_target*");

--- a/src/Weasel.Postgresql.Tests/Functions/FunctionBodyTests.cs
+++ b/src/Weasel.Postgresql.Tests/Functions/FunctionBodyTests.cs
@@ -32,7 +32,7 @@ $BODY$
     [Fact]
     public void derive_the_function_signature_from_the_body()
     {
-        var func = new FunctionBody(new DbObjectName("public", "mt_upsert_target"), new string[0], theFunctionBody);
+        var func = new FunctionBody(PostgresqlProvider.ToDbObjectName("public", "mt_upsert_target"), new string[0], theFunctionBody);
 
         Function.ParseSignature(func.Body).ShouldBe("public.mt_upsert_target(jsonb, character varying, uuid, uuid)");
     }
@@ -40,7 +40,7 @@ $BODY$
     [Fact]
     public void do_substitutions()
     {
-        var func = new FunctionBody(new DbObjectName("public", "mt_upsert_target"), new string[0], theFunctionBody);
+        var func = new FunctionBody(PostgresqlProvider.ToDbObjectName("public", "mt_upsert_target"), new string[0], theFunctionBody);
 
         func.BuildTemplate($"*{PostgresqlMigrator.SCHEMA}*").ShouldBe("*public*");
         func.BuildTemplate($"*{PostgresqlMigrator.FUNCTION}*").ShouldBe("*mt_upsert_target*");

--- a/src/Weasel.Postgresql.Tests/Functions/FunctionTests.cs
+++ b/src/Weasel.Postgresql.Tests/Functions/FunctionTests.cs
@@ -90,20 +90,20 @@ $$ LANGUAGE plpgsql;
     {
         var function = Function.ForRemoval("functions.mt_hilo");
         function.IsRemoved.ShouldBeTrue();
-        function.Identifier.QualifiedName.ShouldBe("functions.mt_hilo");
+        function.Identifier.QualifiedName.ShouldBe(PostgresqlProvider.ToDbObjectName("functions.mt_hilo").QualifiedName);
     }
 
     [Fact]
     public void can_read_the_function_identifier_from_a_function_body()
     {
         Function.ParseIdentifier(theFunctionBody)
-            .ShouldBe(new DbObjectName("functions", "mt_get_next_hi"));
+            .ShouldBe(PostgresqlProvider.ToDbObjectName( "functions", "mt_get_next_hi"));
     }
 
     [Fact]
     public void can_derive_the_drop_statement_from_the_body()
     {
-        var function = new Function(new DbObjectName("functions", "mt_get_next_hi"), theFunctionBody);
+        var function = new Function(PostgresqlProvider.ToDbObjectName("functions", "mt_get_next_hi"), theFunctionBody);
         function.DropStatements().Single().ShouldBe("drop function if exists functions.mt_get_next_hi(varchar);");
     }
 
@@ -111,7 +111,7 @@ $$ LANGUAGE plpgsql;
     public void can_build_function_object_from_body()
     {
         var function = Function.ForSql(theFunctionBody);
-        function.Identifier.ShouldBe(new DbObjectName("functions", "mt_get_next_hi"));
+        function.Identifier.ShouldBe(PostgresqlProvider.ToDbObjectName("functions", "mt_get_next_hi"));
 
         function.DropStatements().Single()
             .ShouldBe("drop function if exists functions.mt_get_next_hi(varchar);");
@@ -169,7 +169,7 @@ $$ LANGUAGE plpgsql;
 
         var existing = await function.FetchExistingAsync(theConnection);
 
-        existing.Identifier.ShouldBe(new DbObjectName("functions", "mt_get_next_hi"));
+        existing.Identifier.ShouldBe(PostgresqlProvider.ToDbObjectName("functions", "mt_get_next_hi"));
         existing.DropStatements().Single()
             .ShouldBe("DROP FUNCTION IF EXISTS functions.mt_get_next_hi(entity character varying);");
         existing.Body().ShouldNotBeNull();

--- a/src/Weasel.Postgresql.Tests/Functions/FunctionTests.cs
+++ b/src/Weasel.Postgresql.Tests/Functions/FunctionTests.cs
@@ -7,6 +7,8 @@ using Xunit;
 
 namespace Weasel.Postgresql.Tests.Functions;
 
+using static PostgresqlProvider;
+
 [Collection("functions")]
 public class FunctionTests: IntegrationContext
 {
@@ -90,20 +92,20 @@ $$ LANGUAGE plpgsql;
     {
         var function = Function.ForRemoval("functions.mt_hilo");
         function.IsRemoved.ShouldBeTrue();
-        function.Identifier.QualifiedName.ShouldBe(PostgresqlProvider.ToDbObjectName("functions.mt_hilo").QualifiedName);
+        function.Identifier.QualifiedName.ShouldBe(Instance.ToQualifiedName("functions.mt_hilo"));
     }
 
     [Fact]
     public void can_read_the_function_identifier_from_a_function_body()
     {
         Function.ParseIdentifier(theFunctionBody)
-            .ShouldBe(PostgresqlProvider.ToDbObjectName( "functions", "mt_get_next_hi"));
+            .ShouldBe(new PostgresqlObjectName( "functions", "mt_get_next_hi"));
     }
 
     [Fact]
     public void can_derive_the_drop_statement_from_the_body()
     {
-        var function = new Function(PostgresqlProvider.ToDbObjectName("functions", "mt_get_next_hi"), theFunctionBody);
+        var function = new Function(new PostgresqlObjectName("functions", "mt_get_next_hi"), theFunctionBody);
         function.DropStatements().Single().ShouldBe("drop function if exists functions.mt_get_next_hi(varchar);");
     }
 
@@ -111,7 +113,7 @@ $$ LANGUAGE plpgsql;
     public void can_build_function_object_from_body()
     {
         var function = Function.ForSql(theFunctionBody);
-        function.Identifier.ShouldBe(PostgresqlProvider.ToDbObjectName("functions", "mt_get_next_hi"));
+        function.Identifier.ShouldBe(new PostgresqlObjectName("functions", "mt_get_next_hi"));
 
         function.DropStatements().Single()
             .ShouldBe("drop function if exists functions.mt_get_next_hi(varchar);");
@@ -169,7 +171,7 @@ $$ LANGUAGE plpgsql;
 
         var existing = await function.FetchExistingAsync(theConnection);
 
-        existing.Identifier.ShouldBe(PostgresqlProvider.ToDbObjectName("functions", "mt_get_next_hi"));
+        existing.Identifier.ShouldBe(new PostgresqlObjectName("functions", "mt_get_next_hi"));
         existing.DropStatements().Single()
             .ShouldBe("DROP FUNCTION IF EXISTS functions.mt_get_next_hi(entity character varying);");
         existing.Body().ShouldNotBeNull();

--- a/src/Weasel.Postgresql.Tests/Functions/UpsertFunctionTests.cs
+++ b/src/Weasel.Postgresql.Tests/Functions/UpsertFunctionTests.cs
@@ -19,7 +19,7 @@ public class UpsertFunctionTests: IntegrationContext
         theHiloTable.AddColumn<int>("next_value");
         theHiloTable.AddColumn<int>("hi_value");
 
-        theFunction = new UpsertFunction(PostgresqlProvider.ToDbObjectName("functions", "upsert_mt_hilo"), theHiloTable,
+        theFunction = new UpsertFunction(new PostgresqlObjectName("functions", "upsert_mt_hilo"), theHiloTable,
             "next_value", "hi_value");
     }
 

--- a/src/Weasel.Postgresql.Tests/Functions/UpsertFunctionTests.cs
+++ b/src/Weasel.Postgresql.Tests/Functions/UpsertFunctionTests.cs
@@ -19,7 +19,7 @@ public class UpsertFunctionTests: IntegrationContext
         theHiloTable.AddColumn<int>("next_value");
         theHiloTable.AddColumn<int>("hi_value");
 
-        theFunction = new UpsertFunction(new DbObjectName("functions", "upsert_mt_hilo"), theHiloTable,
+        theFunction = new UpsertFunction(PostgresqlProvider.ToDbObjectName("functions", "upsert_mt_hilo"), theHiloTable,
             "next_value", "hi_value");
     }
 

--- a/src/Weasel.Postgresql.Tests/Migrations/migration_scenario_tests.cs
+++ b/src/Weasel.Postgresql.Tests/Migrations/migration_scenario_tests.cs
@@ -137,7 +137,7 @@ public class NamedTableFeature: FeatureSchemaBase
 
     public Table AddTable(string schemaName, string tableName)
     {
-        var table = new NamedTable(PostgresqlProvider.ToDbObjectName(schemaName, tableName));
+        var table = new NamedTable(new PostgresqlObjectName(schemaName, tableName));
         Tables[table.Identifier.QualifiedName] = table;
 
         return table;

--- a/src/Weasel.Postgresql.Tests/Migrations/migration_scenario_tests.cs
+++ b/src/Weasel.Postgresql.Tests/Migrations/migration_scenario_tests.cs
@@ -137,7 +137,7 @@ public class NamedTableFeature: FeatureSchemaBase
 
     public Table AddTable(string schemaName, string tableName)
     {
-        var table = new NamedTable(new DbObjectName(schemaName, tableName));
+        var table = new NamedTable(PostgresqlProvider.ToDbObjectName(schemaName, tableName));
         Tables[table.Identifier.QualifiedName] = table;
 
         return table;

--- a/src/Weasel.Postgresql.Tests/SequenceTester.cs
+++ b/src/Weasel.Postgresql.Tests/SequenceTester.cs
@@ -7,7 +7,7 @@ namespace Weasel.Postgresql.Tests;
 [Collection("sequences")]
 public class SequenceTester: IntegrationContext
 {
-    private readonly Sequence theSequence = new(PostgresqlProvider.ToDbObjectName("sequences", "mysequence"));//mySeQuEnCe
+    private readonly Sequence theSequence = new(PostgresqlProvider.ToDbObjectName("sequences", "mysequence"));
 
     public SequenceTester(): base("sequences")
     {

--- a/src/Weasel.Postgresql.Tests/SequenceTester.cs
+++ b/src/Weasel.Postgresql.Tests/SequenceTester.cs
@@ -7,7 +7,7 @@ namespace Weasel.Postgresql.Tests;
 [Collection("sequences")]
 public class SequenceTester: IntegrationContext
 {
-    private readonly Sequence theSequence = new(PostgresqlProvider.ToDbObjectName("sequences", "mysequence"));
+    private readonly Sequence theSequence = new(new PostgresqlObjectName("sequences", "mysequence"));
 
     public SequenceTester(): base("sequences")
     {
@@ -18,7 +18,7 @@ public class SequenceTester: IntegrationContext
     [Theory]
     public async Task can_create_sequence_without_blowing_up(string sequenceName)
     {
-        var sequence = new Sequence(PostgresqlProvider.ToDbObjectName("sequences", sequenceName));
+        var sequence = new Sequence(new PostgresqlObjectName("sequences", sequenceName));
 
         await ResetSchema();
 
@@ -30,7 +30,7 @@ public class SequenceTester: IntegrationContext
     [Theory]
     public async Task can_create_with_startup_sequence_without_blowing_up(string sequenceName)
     {
-        var sequence = new Sequence(PostgresqlProvider.ToDbObjectName("sequences", sequenceName), 5);
+        var sequence = new Sequence(new PostgresqlObjectName("sequences", sequenceName), 5);
 
         await ResetSchema();
 
@@ -57,7 +57,7 @@ public class SequenceTester: IntegrationContext
 
         await can_create_sequence_without_blowing_up(sequenceName);
 
-        var sequence = new Sequence(PostgresqlProvider.ToDbObjectName("sequences", sequenceName));
+        var sequence = new Sequence(new PostgresqlObjectName("sequences", sequenceName));
 
         var delta = await sequence.FindDeltaAsync(theConnection);
 
@@ -75,7 +75,7 @@ public class SequenceTester: IntegrationContext
 
         await can_create_sequence_without_blowing_up(sequenceName);
 
-        var sequence = new Sequence(PostgresqlProvider.ToDbObjectName("sequences", sequenceName));
+        var sequence = new Sequence(new PostgresqlObjectName("sequences", sequenceName));
 
         var delta = await sequence.FindDeltaAsync(theConnection);
 

--- a/src/Weasel.Postgresql.Tests/Tables/ForeignKeyTests.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/ForeignKeyTests.cs
@@ -1,5 +1,4 @@
 using Shouldly;
-using Weasel.Core;
 using Weasel.Postgresql.Tables;
 using Xunit;
 
@@ -15,7 +14,7 @@ public class ForeignKeyTests
         var table = new Table("people");
         var fk = new ForeignKey("fk_state")
         {
-            LinkedTable = ToDbObjectName("public", "states"),
+            LinkedTable = new PostgresqlObjectName("public", "states"),
             ColumnNames = new[] { "state_id" },
             LinkedNames = new[] { "id" }
         };
@@ -24,9 +23,9 @@ public class ForeignKeyTests
         ddl.ShouldNotContain("ON DELETE");
         ddl.ShouldNotContain("ON UPDATE");
 
-        ddl.ShouldContain($"ALTER TABLE {ToDbObjectName("public.people")}");
+        ddl.ShouldContain($"ALTER TABLE {Instance.ToQualifiedName("public.people")}");
         ddl.ShouldContain("ADD CONSTRAINT fk_state FOREIGN KEY(state_id)");
-        ddl.ShouldContain($"REFERENCES {ToDbObjectName("public.states")}(id)");
+        ddl.ShouldContain($"REFERENCES {Instance.ToQualifiedName("public.states")}(id)");
     }
 
     [Fact]
@@ -35,7 +34,7 @@ public class ForeignKeyTests
         var table = new Table("people");
         var fk = new ForeignKey("fk_state")
         {
-            LinkedTable = PostgresqlProvider.ToDbObjectName("public", "states"),
+            LinkedTable = new PostgresqlObjectName("public", "states"),
             ColumnNames = new[] { "state_id" },
             LinkedNames = new[] { "id" },
             OnDelete = CascadeAction.Restrict
@@ -53,7 +52,7 @@ public class ForeignKeyTests
         var table = new Table("people");
         var fk = new ForeignKey("fk_state")
         {
-            LinkedTable = PostgresqlProvider.ToDbObjectName("public", "states"),
+            LinkedTable = new PostgresqlObjectName("public", "states"),
             ColumnNames = new[] { "state_id" },
             LinkedNames = new[] { "id" },
             OnUpdate = CascadeAction.Cascade
@@ -71,7 +70,7 @@ public class ForeignKeyTests
         var table = new Table("people");
         var fk = new ForeignKey("fk_state")
         {
-            LinkedTable = PostgresqlProvider.ToDbObjectName("public", "states"),
+            LinkedTable = new PostgresqlObjectName("public", "states"),
             ColumnNames = new[] { "state_id", "tenant_id" },
             LinkedNames = new[] { "id", "tenant_id" }
         };
@@ -79,9 +78,9 @@ public class ForeignKeyTests
         var ddl = fk.ToDDL(table);
 
 
-        ddl.ShouldContain($"ALTER TABLE {ToDbObjectName("public.people")}");
+        ddl.ShouldContain($"ALTER TABLE {Instance.ToQualifiedName("public.people")}");
         ddl.ShouldContain("ADD CONSTRAINT fk_state FOREIGN KEY(state_id, tenant_id)");
-        ddl.ShouldContain($"REFERENCES {ToDbObjectName("public.states")}(id, tenant_id)");
+        ddl.ShouldContain($"REFERENCES {Instance.ToQualifiedName("public.states")}(id, tenant_id)");
     }
 
     [Theory]
@@ -106,7 +105,7 @@ public class ForeignKeyTests
         CascadeAction.NoAction)]
     public void read_on_delete_and_on_update(string definition, CascadeAction onDelete, CascadeAction onUpdate)
     {
-        var fk = new ForeignKey("fk_people_state_id") { };
+        var fk = new ForeignKey("fk_people_state_id");
 
         fk.Parse(definition);
         fk.OnDelete.ShouldBe(onDelete);
@@ -116,25 +115,25 @@ public class ForeignKeyTests
     [Fact]
     public void parse_single_column_fk_definition()
     {
-        var fk = new ForeignKey("fk_people_state_id") { };
+        var fk = new ForeignKey("fk_people_state_id");
 
         fk.Parse("FOREIGN KEY (state_id) REFERENCES states(id)");
 
         fk.ColumnNames.Single().ShouldBe("state_id");
         fk.LinkedNames.Single().ShouldBe("id");
-        fk.LinkedTable.ShouldBe(PostgresqlProvider.ToDbObjectName("public", "states"));
+        fk.LinkedTable.ShouldBe(new PostgresqlObjectName("public", "states"));
     }
 
     [Fact]
     public void parse_multiple_column_fk_definition()
     {
-        var fk = new ForeignKey("fk_people_state_id") { };
+        var fk = new ForeignKey("fk_people_state_id");
 
         fk.Parse("FOREIGN KEY (state_id, tenant_id) REFERENCES states(id, tenant_id)");
 
-        fk.ColumnNames.ShouldBe(new string[] { "state_id", "tenant_id" });
-        fk.LinkedNames.ShouldBe(new string[] { "id", "tenant_id" });
-        fk.LinkedTable.ShouldBe(PostgresqlProvider.ToDbObjectName("public", "states"));
+        fk.ColumnNames.ShouldBe(new[] { "state_id", "tenant_id" });
+        fk.LinkedNames.ShouldBe(new[] { "id", "tenant_id" });
+        fk.LinkedTable.ShouldBe(new PostgresqlObjectName("public", "states"));
     }
 
     [Fact]
@@ -148,7 +147,7 @@ public class ForeignKeyTests
 
         foreignKey.ColumnNames.Single().ShouldBe("state_id");
         foreignKey.LinkedNames.Single().ShouldBe("id");
-        var expectedLinkedTable = PostgresqlProvider.ToDbObjectName(schema, "states");
+        var expectedLinkedTable = new PostgresqlObjectName(schema, "states");
         foreignKey.LinkedTable.ShouldBe(expectedLinkedTable);
     }
 }

--- a/src/Weasel.Postgresql.Tests/Tables/ForeignKeyTests.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/ForeignKeyTests.cs
@@ -5,6 +5,8 @@ using Xunit;
 
 namespace Weasel.Postgresql.Tests.Tables;
 
+using static PostgresqlProvider;
+
 public class ForeignKeyTests
 {
     [Fact]
@@ -13,7 +15,7 @@ public class ForeignKeyTests
         var table = new Table("people");
         var fk = new ForeignKey("fk_state")
         {
-            LinkedTable = new DbObjectName("public", "states"),
+            LinkedTable = ToDbObjectName("public", "states"),
             ColumnNames = new[] { "state_id" },
             LinkedNames = new[] { "id" }
         };
@@ -22,9 +24,9 @@ public class ForeignKeyTests
         ddl.ShouldNotContain("ON DELETE");
         ddl.ShouldNotContain("ON UPDATE");
 
-        ddl.ShouldContain("ALTER TABLE public.people");
+        ddl.ShouldContain($"ALTER TABLE {ToDbObjectName("public.people")}");
         ddl.ShouldContain("ADD CONSTRAINT fk_state FOREIGN KEY(state_id)");
-        ddl.ShouldContain("REFERENCES public.states(id)");
+        ddl.ShouldContain($"REFERENCES {ToDbObjectName("public.states")}(id)");
     }
 
     [Fact]
@@ -33,7 +35,7 @@ public class ForeignKeyTests
         var table = new Table("people");
         var fk = new ForeignKey("fk_state")
         {
-            LinkedTable = new DbObjectName("public", "states"),
+            LinkedTable = PostgresqlProvider.ToDbObjectName("public", "states"),
             ColumnNames = new[] { "state_id" },
             LinkedNames = new[] { "id" },
             OnDelete = CascadeAction.Restrict
@@ -51,7 +53,7 @@ public class ForeignKeyTests
         var table = new Table("people");
         var fk = new ForeignKey("fk_state")
         {
-            LinkedTable = new DbObjectName("public", "states"),
+            LinkedTable = PostgresqlProvider.ToDbObjectName("public", "states"),
             ColumnNames = new[] { "state_id" },
             LinkedNames = new[] { "id" },
             OnUpdate = CascadeAction.Cascade
@@ -69,7 +71,7 @@ public class ForeignKeyTests
         var table = new Table("people");
         var fk = new ForeignKey("fk_state")
         {
-            LinkedTable = new DbObjectName("public", "states"),
+            LinkedTable = PostgresqlProvider.ToDbObjectName("public", "states"),
             ColumnNames = new[] { "state_id", "tenant_id" },
             LinkedNames = new[] { "id", "tenant_id" }
         };
@@ -77,9 +79,9 @@ public class ForeignKeyTests
         var ddl = fk.ToDDL(table);
 
 
-        ddl.ShouldContain("ALTER TABLE public.people");
+        ddl.ShouldContain($"ALTER TABLE {ToDbObjectName("public.people")}");
         ddl.ShouldContain("ADD CONSTRAINT fk_state FOREIGN KEY(state_id, tenant_id)");
-        ddl.ShouldContain("REFERENCES public.states(id, tenant_id)");
+        ddl.ShouldContain($"REFERENCES {ToDbObjectName("public.states")}(id, tenant_id)");
     }
 
     [Theory]
@@ -120,7 +122,7 @@ public class ForeignKeyTests
 
         fk.ColumnNames.Single().ShouldBe("state_id");
         fk.LinkedNames.Single().ShouldBe("id");
-        fk.LinkedTable.ShouldBe(new DbObjectName("public", "states"));
+        fk.LinkedTable.ShouldBe(PostgresqlProvider.ToDbObjectName("public", "states"));
     }
 
     [Fact]
@@ -132,7 +134,7 @@ public class ForeignKeyTests
 
         fk.ColumnNames.ShouldBe(new string[] { "state_id", "tenant_id" });
         fk.LinkedNames.ShouldBe(new string[] { "id", "tenant_id" });
-        fk.LinkedTable.ShouldBe(new DbObjectName("public", "states"));
+        fk.LinkedTable.ShouldBe(PostgresqlProvider.ToDbObjectName("public", "states"));
     }
 
     [Fact]
@@ -146,7 +148,7 @@ public class ForeignKeyTests
 
         foreignKey.ColumnNames.Single().ShouldBe("state_id");
         foreignKey.LinkedNames.Single().ShouldBe("id");
-        var expectedLinkedTable = new DbObjectName(schema, "states");
+        var expectedLinkedTable = PostgresqlProvider.ToDbObjectName(schema, "states");
         foreignKey.LinkedTable.ShouldBe(expectedLinkedTable);
     }
 }

--- a/src/Weasel.Postgresql.Tests/Tables/IndexDefinitionTests.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/IndexDefinitionTests.cs
@@ -4,6 +4,8 @@ using Xunit;
 
 namespace Weasel.Postgresql.Tests.Tables;
 
+using static PostgresqlProvider;
+
 public class IndexDefinitionTests
 {
     private IndexDefinition theIndex = new IndexDefinition("idx_1")
@@ -64,7 +66,7 @@ public class IndexDefinitionTests
     public void write_basic_index()
     {
         theIndex.ToDDL(parent)
-            .ShouldBe("CREATE INDEX idx_1 ON public.people USING btree (column1);");
+            .ShouldBe($"CREATE INDEX idx_1 ON {ToDbObjectName("public.people")} USING btree (column1);");
     }
 
     [Fact]
@@ -73,7 +75,7 @@ public class IndexDefinitionTests
         theIndex.IsUnique = true;
 
         theIndex.ToDDL(parent)
-            .ShouldBe("CREATE UNIQUE INDEX idx_1 ON public.people USING btree (column1);");
+            .ShouldBe($"CREATE UNIQUE INDEX idx_1 ON {ToDbObjectName("public.people")} USING btree (column1);");
     }
 
     [Fact]
@@ -83,7 +85,7 @@ public class IndexDefinitionTests
 
         theIndex.ToDDL(parent)
             .ShouldBe($"--WEASEL_INDEX_CREATION_BEGIN{Environment.NewLine}" +
-                      $"CREATE INDEX CONCURRENTLY idx_1 ON public.people USING btree (column1);{Environment.NewLine}" +
+                      $"CREATE INDEX CONCURRENTLY idx_1 ON {ToDbObjectName("public.people")} USING btree (column1);{Environment.NewLine}" +
                       "--WEASEL_INDEX_CREATION_END");
     }
 
@@ -95,7 +97,7 @@ public class IndexDefinitionTests
 
         theIndex.ToDDL(parent)
             .ShouldBe($"--WEASEL_INDEX_CREATION_BEGIN{Environment.NewLine}" +
-                      $"CREATE UNIQUE INDEX CONCURRENTLY idx_1 ON public.people USING btree (column1);{Environment.NewLine}" +
+                      $"CREATE UNIQUE INDEX CONCURRENTLY idx_1 ON {ToDbObjectName("public.people")} USING btree (column1);{Environment.NewLine}" +
                       "--WEASEL_INDEX_CREATION_END");
     }
 
@@ -108,7 +110,7 @@ public class IndexDefinitionTests
 
         theIndex.ToDDL(parent)
             .ShouldBe($"--WEASEL_INDEX_CREATION_BEGIN{Environment.NewLine}" +
-                      $"CREATE UNIQUE INDEX CONCURRENTLY idx_1 ON public.people USING btree (column1) NULLS NOT DISTINCT ;{Environment.NewLine}" +
+                      $"CREATE UNIQUE INDEX CONCURRENTLY idx_1 ON {ToDbObjectName("public.people")} USING btree (column1) NULLS NOT DISTINCT ;{Environment.NewLine}" +
                       "--WEASEL_INDEX_CREATION_END");
     }
 
@@ -118,7 +120,7 @@ public class IndexDefinitionTests
         theIndex.SortOrder = SortOrder.Desc;
 
         theIndex.ToDDL(parent)
-            .ShouldBe("CREATE INDEX idx_1 ON public.people USING btree (column1 DESC);");
+            .ShouldBe($"CREATE INDEX idx_1 ON {ToDbObjectName("public.people")} USING btree (column1 DESC);");
     }
 
     [Fact]
@@ -127,7 +129,7 @@ public class IndexDefinitionTests
         theIndex.Method = IndexMethod.gin;
 
         theIndex.ToDDL(parent)
-            .ShouldBe("CREATE INDEX idx_1 ON public.people USING gin (column1);");
+            .ShouldBe($"CREATE INDEX idx_1 ON {ToDbObjectName("public.people")} USING gin (column1);");
     }
 
     [Fact]
@@ -137,7 +139,7 @@ public class IndexDefinitionTests
         theIndex.Method = IndexMethod.gin;
 
         theIndex.ToDDL(parent)
-            .ShouldBe("CREATE INDEX idx_1 ON public.people USING gin (column1) TABLESPACE green;");
+            .ShouldBe($"CREATE INDEX idx_1 ON {ToDbObjectName("public.people")} USING gin (column1) TABLESPACE green;");
     }
 
     [Fact]
@@ -148,7 +150,7 @@ public class IndexDefinitionTests
         theIndex.Predicate = "foo > 1";
 
         theIndex.ToDDL(parent)
-            .ShouldBe("CREATE INDEX idx_1 ON public.people USING gin (column1) TABLESPACE green WHERE (foo > 1);");
+            .ShouldBe($"CREATE INDEX idx_1 ON {ToDbObjectName("public.people")} USING gin (column1) TABLESPACE green WHERE (foo > 1);");
     }
 
     [Fact]
@@ -161,7 +163,7 @@ public class IndexDefinitionTests
 
         theIndex.ToDDL(parent)
             .ShouldBe(
-                "CREATE INDEX idx_1 ON public.people USING gin (column1) TABLESPACE green WHERE (foo > 1) WITH (fillfactor='70');");
+                $"CREATE INDEX idx_1 ON {ToDbObjectName("public.people")} USING gin (column1) TABLESPACE green WHERE (foo > 1) WITH (fillfactor='70');");
     }
 
     [Fact]
@@ -170,7 +172,7 @@ public class IndexDefinitionTests
         theIndex.SortOrder = SortOrder.Desc;
 
         theIndex.ToDDL(parent)
-            .ShouldBe("CREATE INDEX idx_1 ON public.people USING btree (column1 DESC);");
+            .ShouldBe($"CREATE INDEX idx_1 ON {ToDbObjectName("public.people")} USING btree (column1 DESC);");
     }
 
 
@@ -561,13 +563,13 @@ public class IndexDefinitionTests
         };
 
         var ddl = index.ToDDL(new Table("table"));
-        ddl.ShouldBe("CREATE UNIQUE INDEX index ON public.table USING btree (column1, column2) NULLS NOT DISTINCT ;");
+        ddl.ShouldBe($"CREATE UNIQUE INDEX index ON {ToDbObjectName("public.table")} USING btree (column1, column2) NULLS NOT DISTINCT ;");
     }
 
     [Fact]
     public void should_be_able_to_parse_index_with_nulls_not_distinct()
     {
-        var index = IndexDefinition.Parse("CREATE UNIQUE INDEX index ON public.table USING btree (column1, column2) NULLS NOT DISTINCT;");
+        var index = IndexDefinition.Parse($"CREATE UNIQUE INDEX index ON {ToDbObjectName("public.table")} USING btree (column1, column2) NULLS NOT DISTINCT;");
         index.IsUnique.ShouldBeTrue();
         index.NullsNotDistinct.ShouldBeTrue();
 

--- a/src/Weasel.Postgresql.Tests/Tables/IndexDefinitionTests.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/IndexDefinitionTests.cs
@@ -66,7 +66,7 @@ public class IndexDefinitionTests
     public void write_basic_index()
     {
         theIndex.ToDDL(parent)
-            .ShouldBe($"CREATE INDEX idx_1 ON {ToDbObjectName("public.people")} USING btree (column1);");
+            .ShouldBe($"CREATE INDEX idx_1 ON {Instance.ToQualifiedName("public.people")} USING btree (column1);");
     }
 
     [Fact]
@@ -75,7 +75,7 @@ public class IndexDefinitionTests
         theIndex.IsUnique = true;
 
         theIndex.ToDDL(parent)
-            .ShouldBe($"CREATE UNIQUE INDEX idx_1 ON {ToDbObjectName("public.people")} USING btree (column1);");
+            .ShouldBe($"CREATE UNIQUE INDEX idx_1 ON {Instance.ToQualifiedName("public.people")} USING btree (column1);");
     }
 
     [Fact]
@@ -85,7 +85,7 @@ public class IndexDefinitionTests
 
         theIndex.ToDDL(parent)
             .ShouldBe($"--WEASEL_INDEX_CREATION_BEGIN{Environment.NewLine}" +
-                      $"CREATE INDEX CONCURRENTLY idx_1 ON {ToDbObjectName("public.people")} USING btree (column1);{Environment.NewLine}" +
+                      $"CREATE INDEX CONCURRENTLY idx_1 ON {Instance.ToQualifiedName("public.people")} USING btree (column1);{Environment.NewLine}" +
                       "--WEASEL_INDEX_CREATION_END");
     }
 
@@ -97,7 +97,7 @@ public class IndexDefinitionTests
 
         theIndex.ToDDL(parent)
             .ShouldBe($"--WEASEL_INDEX_CREATION_BEGIN{Environment.NewLine}" +
-                      $"CREATE UNIQUE INDEX CONCURRENTLY idx_1 ON {ToDbObjectName("public.people")} USING btree (column1);{Environment.NewLine}" +
+                      $"CREATE UNIQUE INDEX CONCURRENTLY idx_1 ON {Instance.ToQualifiedName("public.people")} USING btree (column1);{Environment.NewLine}" +
                       "--WEASEL_INDEX_CREATION_END");
     }
 
@@ -110,7 +110,7 @@ public class IndexDefinitionTests
 
         theIndex.ToDDL(parent)
             .ShouldBe($"--WEASEL_INDEX_CREATION_BEGIN{Environment.NewLine}" +
-                      $"CREATE UNIQUE INDEX CONCURRENTLY idx_1 ON {ToDbObjectName("public.people")} USING btree (column1) NULLS NOT DISTINCT ;{Environment.NewLine}" +
+                      $"CREATE UNIQUE INDEX CONCURRENTLY idx_1 ON {Instance.ToQualifiedName("public.people")} USING btree (column1) NULLS NOT DISTINCT ;{Environment.NewLine}" +
                       "--WEASEL_INDEX_CREATION_END");
     }
 
@@ -120,7 +120,7 @@ public class IndexDefinitionTests
         theIndex.SortOrder = SortOrder.Desc;
 
         theIndex.ToDDL(parent)
-            .ShouldBe($"CREATE INDEX idx_1 ON {ToDbObjectName("public.people")} USING btree (column1 DESC);");
+            .ShouldBe($"CREATE INDEX idx_1 ON {Instance.ToQualifiedName("public.people")} USING btree (column1 DESC);");
     }
 
     [Fact]
@@ -129,7 +129,7 @@ public class IndexDefinitionTests
         theIndex.Method = IndexMethod.gin;
 
         theIndex.ToDDL(parent)
-            .ShouldBe($"CREATE INDEX idx_1 ON {ToDbObjectName("public.people")} USING gin (column1);");
+            .ShouldBe($"CREATE INDEX idx_1 ON {Instance.ToQualifiedName("public.people")} USING gin (column1);");
     }
 
     [Fact]
@@ -139,7 +139,7 @@ public class IndexDefinitionTests
         theIndex.Method = IndexMethod.gin;
 
         theIndex.ToDDL(parent)
-            .ShouldBe($"CREATE INDEX idx_1 ON {ToDbObjectName("public.people")} USING gin (column1) TABLESPACE green;");
+            .ShouldBe($"CREATE INDEX idx_1 ON {Instance.ToQualifiedName("public.people")} USING gin (column1) TABLESPACE green;");
     }
 
     [Fact]
@@ -150,7 +150,7 @@ public class IndexDefinitionTests
         theIndex.Predicate = "foo > 1";
 
         theIndex.ToDDL(parent)
-            .ShouldBe($"CREATE INDEX idx_1 ON {ToDbObjectName("public.people")} USING gin (column1) TABLESPACE green WHERE (foo > 1);");
+            .ShouldBe($"CREATE INDEX idx_1 ON {Instance.ToQualifiedName("public.people")} USING gin (column1) TABLESPACE green WHERE (foo > 1);");
     }
 
     [Fact]
@@ -163,7 +163,7 @@ public class IndexDefinitionTests
 
         theIndex.ToDDL(parent)
             .ShouldBe(
-                $"CREATE INDEX idx_1 ON {ToDbObjectName("public.people")} USING gin (column1) TABLESPACE green WHERE (foo > 1) WITH (fillfactor='70');");
+                $"CREATE INDEX idx_1 ON {Instance.ToQualifiedName("public.people")} USING gin (column1) TABLESPACE green WHERE (foo > 1) WITH (fillfactor='70');");
     }
 
     [Fact]
@@ -172,7 +172,7 @@ public class IndexDefinitionTests
         theIndex.SortOrder = SortOrder.Desc;
 
         theIndex.ToDDL(parent)
-            .ShouldBe($"CREATE INDEX idx_1 ON {ToDbObjectName("public.people")} USING btree (column1 DESC);");
+            .ShouldBe($"CREATE INDEX idx_1 ON {Instance.ToQualifiedName("public.people")} USING btree (column1 DESC);");
     }
 
 
@@ -563,13 +563,13 @@ public class IndexDefinitionTests
         };
 
         var ddl = index.ToDDL(new Table("table"));
-        ddl.ShouldBe($"CREATE UNIQUE INDEX index ON {ToDbObjectName("public.table")} USING btree (column1, column2) NULLS NOT DISTINCT ;");
+        ddl.ShouldBe($"CREATE UNIQUE INDEX index ON {Instance.ToQualifiedName("public.table")} USING btree (column1, column2) NULLS NOT DISTINCT ;");
     }
 
     [Fact]
     public void should_be_able_to_parse_index_with_nulls_not_distinct()
     {
-        var index = IndexDefinition.Parse($"CREATE UNIQUE INDEX index ON {ToDbObjectName("public.table")} USING btree (column1, column2) NULLS NOT DISTINCT;");
+        var index = IndexDefinition.Parse($"CREATE UNIQUE INDEX index ON {Instance.ToQualifiedName("public.table")} USING btree (column1, column2) NULLS NOT DISTINCT;");
         index.IsUnique.ShouldBeTrue();
         index.NullsNotDistinct.ShouldBeTrue();
 

--- a/src/Weasel.Postgresql.Tests/Tables/TableColumnTests.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/TableColumnTests.cs
@@ -117,6 +117,6 @@ public class TableColumnTests
         var column = table.AddColumn<string>("name1").NotNull().Column;
 
         column.AddColumnSql(table)
-            .ShouldBe($"alter table {ToDbObjectName("public.people")} add column name1 varchar NOT NULL;");
+            .ShouldBe($"alter table {Instance.ToQualifiedName("public.people")} add column name1 varchar NOT NULL;");
     }
 }

--- a/src/Weasel.Postgresql.Tests/Tables/TableColumnTests.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/TableColumnTests.cs
@@ -3,6 +3,7 @@ using Weasel.Postgresql.Tables;
 using Xunit;
 
 namespace Weasel.Postgresql.Tests.Tables;
+using static PostgresqlProvider;
 
 public class TableColumnTests
 {
@@ -116,6 +117,6 @@ public class TableColumnTests
         var column = table.AddColumn<string>("name1").NotNull().Column;
 
         column.AddColumnSql(table)
-            .ShouldBe("alter table public.people add column name1 varchar NOT NULL;");
+            .ShouldBe($"alter table {ToDbObjectName("public.people")} add column name1 varchar NOT NULL;");
     }
 }

--- a/src/Weasel.Postgresql.Tests/Tables/TableTests.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/TableTests.cs
@@ -120,8 +120,8 @@ public class TableTests
 
         var lines = ddl.ReadLines().ToArray();
 
-        lines.ShouldContain($"DROP TABLE IF EXISTS {ToDbObjectName("public.people")} CASCADE;");
-        lines.ShouldContain($"CREATE TABLE {ToDbObjectName("public.people")} (");
+        lines.ShouldContain($"DROP TABLE IF EXISTS {Instance.ToQualifiedName("public.people")} CASCADE;");
+        lines.ShouldContain($"CREATE TABLE {Instance.ToQualifiedName("public.people")} (");
     }
 
     [Fact]
@@ -143,7 +143,7 @@ public class TableTests
 
         var lines = ddl.ReadLines().ToArray();
 
-        lines.ShouldContain($"CREATE TABLE IF NOT EXISTS {ToDbObjectName("public.people")} (");
+        lines.ShouldContain($"CREATE TABLE IF NOT EXISTS {Instance.ToQualifiedName("public.people")} (");
     }
 
     [Fact]

--- a/src/Weasel.Postgresql.Tests/Tables/TableTests.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/TableTests.cs
@@ -7,6 +7,8 @@ using Xunit.Abstractions;
 
 namespace Weasel.Postgresql.Tests.Tables;
 
+using static PostgresqlProvider;
+
 public class TableTests
 {
     private readonly ITestOutputHelper _output;
@@ -118,8 +120,8 @@ public class TableTests
 
         var lines = ddl.ReadLines().ToArray();
 
-        lines.ShouldContain("DROP TABLE IF EXISTS public.people CASCADE;");
-        lines.ShouldContain("CREATE TABLE public.people (");
+        lines.ShouldContain($"DROP TABLE IF EXISTS {ToDbObjectName("public.people")} CASCADE;");
+        lines.ShouldContain($"CREATE TABLE {ToDbObjectName("public.people")} (");
     }
 
     [Fact]
@@ -141,7 +143,7 @@ public class TableTests
 
         var lines = ddl.ReadLines().ToArray();
 
-        lines.ShouldContain("CREATE TABLE IF NOT EXISTS public.people (");
+        lines.ShouldContain($"CREATE TABLE IF NOT EXISTS {ToDbObjectName("public.people")} (");
     }
 
     [Fact]

--- a/src/Weasel.Postgresql.Tests/TestSetup.cs
+++ b/src/Weasel.Postgresql.Tests/TestSetup.cs
@@ -1,0 +1,22 @@
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+[assembly: TestFramework("Weasel.Postgresql.Tests.TestSetup", "Weasel.Postgresql.Tests")]
+
+namespace Weasel.Postgresql.Tests;
+
+public class TestSetup: XunitTestFramework
+{
+    public TestSetup(IMessageSink messageSink)
+        : base(messageSink)
+    {
+        if (bool.TryParse(
+                Environment.GetEnvironmentVariable("USE_CASE_SENSITIVE_QUALIFIED_NAMES"),
+                out var useCaseSensitiveQualifiedNames)
+           )
+        {
+            PostgresqlProvider.Instance.UseCaseSensitiveQualifiedNames = useCaseSensitiveQualifiedNames;
+        }
+    }
+}

--- a/src/Weasel.Postgresql.Tests/Views/ViewTests.cs
+++ b/src/Weasel.Postgresql.Tests/Views/ViewTests.cs
@@ -7,6 +7,8 @@ using Xunit.Abstractions;
 
 namespace Weasel.Postgresql.Tests.Views;
 
+using static PostgresqlProvider;
+
 public class ViewTests
 {
     private readonly ITestOutputHelper _output;
@@ -48,7 +50,7 @@ public class ViewTests
 
         var lines = ddl.ReadLines().ToArray();
 
-        lines.ShouldContain("DROP VIEW IF EXISTS public.people_view;");
-        lines.ShouldContain("CREATE VIEW public.people_view AS SELECT 1 AS id;");
+        lines.ShouldContain($"DROP VIEW IF EXISTS {ToDbObjectName("public.people_view")};");
+        lines.ShouldContain($"CREATE VIEW {ToDbObjectName("public.people_view")} AS SELECT 1 AS id;");
     }
 }

--- a/src/Weasel.Postgresql.Tests/Views/ViewTests.cs
+++ b/src/Weasel.Postgresql.Tests/Views/ViewTests.cs
@@ -50,7 +50,7 @@ public class ViewTests
 
         var lines = ddl.ReadLines().ToArray();
 
-        lines.ShouldContain($"DROP VIEW IF EXISTS {ToDbObjectName("public.people_view")};");
-        lines.ShouldContain($"CREATE VIEW {ToDbObjectName("public.people_view")} AS SELECT 1 AS id;");
+        lines.ShouldContain($"DROP VIEW IF EXISTS {Instance.ToQualifiedName("public.people_view")};");
+        lines.ShouldContain($"CREATE VIEW {Instance.ToQualifiedName("public.people_view")} AS SELECT 1 AS id;");
     }
 }

--- a/src/Weasel.Postgresql/Extension.cs
+++ b/src/Weasel.Postgresql/Extension.cs
@@ -26,7 +26,7 @@ public class Extension: ISchemaObject
         writer.WriteLine($"DROP EXTENSION IF EXISTS {ExtensionName} CASCADE;");
     }
 
-    public DbObjectName Identifier => DbObjectName.Parse(PostgresqlProvider.Instance, "public", ExtensionName);
+    public DbObjectName Identifier => new PostgresqlObjectName("public", ExtensionName);
 
     public void ConfigureQueryCommand(DbCommandBuilder builder)
     {

--- a/src/Weasel.Postgresql/Extension.cs
+++ b/src/Weasel.Postgresql/Extension.cs
@@ -26,7 +26,7 @@ public class Extension: ISchemaObject
         writer.WriteLine($"DROP EXTENSION IF EXISTS {ExtensionName} CASCADE;");
     }
 
-    public DbObjectName Identifier => new("public", ExtensionName);
+    public DbObjectName Identifier => DbObjectName.Parse(PostgresqlProvider.Instance, "public", ExtensionName);
 
     public void ConfigureQueryCommand(DbCommandBuilder builder)
     {

--- a/src/Weasel.Postgresql/PostgresqlMigrator.cs
+++ b/src/Weasel.Postgresql/PostgresqlMigrator.cs
@@ -75,16 +75,18 @@ $$;
 
     private static void WriteSql(string databaseSchemaName, TextWriter writer)
     {
-        writer.WriteLine($@"
-    IF NOT EXISTS(
-        SELECT schema_name
-          FROM information_schema.schemata
-          WHERE schema_name = '{databaseSchemaName}'
-      )
-    THEN
-      EXECUTE 'CREATE SCHEMA {databaseSchemaName}';
-    END IF;
-");
+        writer.WriteLine(
+            $"""
+                 IF NOT EXISTS(
+                     SELECT schema_name
+                       FROM information_schema.schemata
+                       WHERE schema_name = '{databaseSchemaName}'
+                   )
+                 THEN
+                   EXECUTE 'CREATE SCHEMA {PostgresqlProvider.Instance.ToQualifiedName(databaseSchemaName)}';
+                 END IF;
+
+             """);
     }
 
     protected override async Task executeDelta(
@@ -93,7 +95,7 @@ $$;
         AutoCreate autoCreate,
         IMigrationLogger logger,
         CancellationToken ct = default
-        )
+    )
     {
         var writer = new StringWriter();
 

--- a/src/Weasel.Postgresql/PostgresqlObjectName.cs
+++ b/src/Weasel.Postgresql/PostgresqlObjectName.cs
@@ -1,0 +1,15 @@
+using Weasel.Core;
+
+namespace Weasel.Postgresql;
+
+public class PostgresqlObjectName: DbObjectName
+{
+    public PostgresqlObjectName(string schema, string name)
+        : base(schema, name, PostgresqlProvider.Instance.ToQualifiedName(schema, name))
+    {
+    }
+    public PostgresqlObjectName(string schema, string name, string qualifiedName)
+        : base(schema, name, qualifiedName)
+    {
+    }
+}

--- a/src/Weasel.Postgresql/PostgresqlProvider.cs
+++ b/src/Weasel.Postgresql/PostgresqlProvider.cs
@@ -271,9 +271,6 @@ public class PostgresqlProvider: DatabaseProvider<NpgsqlCommand, NpgsqlParameter
             ? objectName
             : $"\"{objectName}\"";
 
-    public static DbObjectName ToDbObjectName(string qualifiedName) =>
-        DbObjectName.Parse(Instance, qualifiedName);
-
-    public static DbObjectName ToDbObjectName(string schema, string table) =>
-        DbObjectName.Parse(Instance, schema, table);
+    public override DbObjectName Parse(string schemaName, string objectName) =>
+        new PostgresqlObjectName(schemaName, objectName, ToQualifiedName(schemaName, objectName));
 }

--- a/src/Weasel.Postgresql/SchemaObjectsExtensions.cs
+++ b/src/Weasel.Postgresql/SchemaObjectsExtensions.cs
@@ -199,7 +199,8 @@ public static class SchemaObjectsExtensions
 
     private static async Task<DbObjectName> ReadDbObjectNameAsync(DbDataReader reader, CancellationToken ct = default)
     {
-        return new DbObjectName(
+        return DbObjectName.Parse(
+            PostgresqlProvider.Instance,
             await reader.GetFieldValueAsync<string>(0, ct).ConfigureAwait(false),
             await reader.GetFieldValueAsync<string>(1, ct).ConfigureAwait(false)
         );

--- a/src/Weasel.Postgresql/SchemaObjectsExtensions.cs
+++ b/src/Weasel.Postgresql/SchemaObjectsExtensions.cs
@@ -199,8 +199,7 @@ public static class SchemaObjectsExtensions
 
     private static async Task<DbObjectName> ReadDbObjectNameAsync(DbDataReader reader, CancellationToken ct = default)
     {
-        return DbObjectName.Parse(
-            PostgresqlProvider.Instance,
+        return new PostgresqlObjectName(
             await reader.GetFieldValueAsync<string>(0, ct).ConfigureAwait(false),
             await reader.GetFieldValueAsync<string>(1, ct).ConfigureAwait(false)
         );

--- a/src/Weasel.Postgresql/Tables/Table.FetchExisting.cs
+++ b/src/Weasel.Postgresql/Tables/Table.FetchExisting.cs
@@ -1,5 +1,6 @@
 using System.Data.Common;
 using Npgsql;
+using Weasel.Core;
 using DbCommandBuilder = Weasel.Core.DbCommandBuilder;
 
 namespace Weasel.Postgresql.Tables;
@@ -10,7 +11,7 @@ public partial class Table
     {
         var schemaParam = builder.AddParameter(Identifier.Schema).ParameterName;
         var nameParam = builder.AddParameter(Identifier.Name).ParameterName;
-        var nameWithSchemaParam = builder.AddParameter(Identifier.QualifiedName).ParameterName;
+        var nameWithSchemaParam = builder.AddParameter($"{Identifier.Schema}.{Identifier.Name}").ParameterName;
 
         builder.Append($@"
 select column_name, data_type, character_maximum_length, udt_name
@@ -254,7 +255,7 @@ order by column_index;
 
 
             if ((Identifier.Schema == schemaName && Identifier.Name == tableName) ||
-                Identifier.QualifiedName == tableName)
+                Equals(Identifier, DbObjectName.Parse(PostgresqlProvider.Instance, tableName)))
             {
                 var index = IndexDefinition.Parse(ddl);
 

--- a/src/Weasel.Postgresql/Tables/Table.cs
+++ b/src/Weasel.Postgresql/Tables/Table.cs
@@ -155,9 +155,9 @@ public partial class Table: ISchemaObject
     {
         yield return Identifier;
 
-        foreach (var index in Indexes) yield return new DbObjectName(Identifier.Schema, index.Name);
+        foreach (var index in Indexes) yield return DbObjectName.Parse(PostgresqlProvider.Instance, Identifier.Schema, index.Name);
 
-        foreach (var fk in ForeignKeys) yield return new DbObjectName(Identifier.Schema, fk.Name);
+        foreach (var fk in ForeignKeys) yield return DbObjectName.Parse(PostgresqlProvider.Instance, Identifier.Schema, fk.Name);
     }
 
     /// <summary>
@@ -166,7 +166,7 @@ public partial class Table: ISchemaObject
     /// <param name="schemaName"></param>
     public void MoveToSchema(string schemaName)
     {
-        var identifier = new DbObjectName(schemaName, Identifier.Name);
+        var identifier = DbObjectName.Parse(PostgresqlProvider.Instance, schemaName, Identifier.Name);
         Identifier = identifier;
     }
 

--- a/src/Weasel.Postgresql/Tables/Table.cs
+++ b/src/Weasel.Postgresql/Tables/Table.cs
@@ -155,9 +155,9 @@ public partial class Table: ISchemaObject
     {
         yield return Identifier;
 
-        foreach (var index in Indexes) yield return DbObjectName.Parse(PostgresqlProvider.Instance, Identifier.Schema, index.Name);
+        foreach (var index in Indexes) yield return new PostgresqlObjectName(Identifier.Schema, index.Name);
 
-        foreach (var fk in ForeignKeys) yield return DbObjectName.Parse(PostgresqlProvider.Instance, Identifier.Schema, fk.Name);
+        foreach (var fk in ForeignKeys) yield return new PostgresqlObjectName(Identifier.Schema, fk.Name);
     }
 
     /// <summary>
@@ -166,7 +166,7 @@ public partial class Table: ISchemaObject
     /// <param name="schemaName"></param>
     public void MoveToSchema(string schemaName)
     {
-        var identifier = DbObjectName.Parse(PostgresqlProvider.Instance, schemaName, Identifier.Name);
+        var identifier = new PostgresqlObjectName(schemaName, Identifier.Name);
         Identifier = identifier;
     }
 
@@ -328,7 +328,15 @@ public partial class Table: ISchemaObject
             return ForeignKeyTo(referencedTable.Identifier, referencedColumnName, fkName, onDelete, onUpdate);
         }
 
+
+
+        [Obsolete("Use Overload with PostgresqlObjectName identifier name")]
         public ColumnExpression ForeignKeyTo(DbObjectName referencedIdentifier, string referencedColumnName,
+            string? fkName = null, CascadeAction onDelete = CascadeAction.NoAction,
+            CascadeAction onUpdate = CascadeAction.NoAction) =>
+            ForeignKeyTo((PostgresqlObjectName)referencedIdentifier, referencedColumnName, fkName, onDelete, onUpdate);
+
+        public ColumnExpression ForeignKeyTo(PostgresqlObjectName referencedIdentifier, string referencedColumnName,
             string? fkName = null, CascadeAction onDelete = CascadeAction.NoAction,
             CascadeAction onUpdate = CascadeAction.NoAction)
         {

--- a/src/Weasel.Postgresql/Views/View.cs
+++ b/src/Weasel.Postgresql/Views/View.cs
@@ -32,7 +32,7 @@ public class View: ISchemaObject
     /// <param name="schemaName"></param>
     public void MoveToSchema(string schemaName)
     {
-        var identifier = new DbObjectName(schemaName, Identifier.Name);
+        var identifier = DbObjectName.Parse(PostgresqlProvider.Instance, schemaName, Identifier.Name);
         Identifier = identifier;
     }
 

--- a/src/Weasel.Postgresql/Views/View.cs
+++ b/src/Weasel.Postgresql/Views/View.cs
@@ -32,7 +32,7 @@ public class View: ISchemaObject
     /// <param name="schemaName"></param>
     public void MoveToSchema(string schemaName)
     {
-        var identifier = DbObjectName.Parse(PostgresqlProvider.Instance, schemaName, Identifier.Name);
+        var identifier = new PostgresqlObjectName(schemaName, Identifier.Name);
         Identifier = identifier;
     }
 

--- a/src/Weasel.SqlServer.Tests/Functions/FunctionBodyTests.cs
+++ b/src/Weasel.SqlServer.Tests/Functions/FunctionBodyTests.cs
@@ -18,7 +18,7 @@ END;";
     [Fact]
     public void derive_the_function_identifier_from_the_body()
     {
-        var func = new FunctionBody(new DbObjectName("public", "sample"), new string[0], theFunctionBody);
-        Function.ParseIdentifier(func.Body).ShouldBe(new DbObjectName("public", "sample"));
+        var func = new FunctionBody(new SqlServerObjectName("public", "sample"), new string[0], theFunctionBody);
+        Function.ParseIdentifier(func.Body).ShouldBe(new SqlServerObjectName("public", "sample"));
     }
 }

--- a/src/Weasel.SqlServer.Tests/Functions/FunctionTests.cs
+++ b/src/Weasel.SqlServer.Tests/Functions/FunctionTests.cs
@@ -52,13 +52,13 @@ END;";
     public void can_read_the_function_identifier_from_a_function_body()
     {
         Function.ParseIdentifier(theFunctionBody)
-            .ShouldBe(new DbObjectName("functions", "add_10"));
+            .ShouldBe(new SqlServerObjectName("functions", "add_10"));
     }
 
     [Fact]
     public void can_derive_the_drop_statement_from_the_body()
     {
-        var function = new Function(new DbObjectName("functions", "add_10"), theFunctionBody);
+        var function = new Function(new SqlServerObjectName("functions", "add_10"), theFunctionBody);
         function.DropStatements().Single().ShouldBe("drop function if exists functions.add_10;");
     }
 
@@ -66,7 +66,7 @@ END;";
     public void can_build_function_object_from_body()
     {
         var function = Function.ForSql(theFunctionBody);
-        function.Identifier.ShouldBe(new DbObjectName("functions", "add_10"));
+        function.Identifier.ShouldBe(new SqlServerObjectName("functions", "add_10"));
 
         function.DropStatements().Single()
             .ShouldBe("drop function if exists functions.add_10;");
@@ -118,7 +118,7 @@ END;";
 
         var existing = await function.FetchExistingAsync(theConnection);
 
-        existing!.Identifier.ShouldBe(new DbObjectName("functions", "add_10"));
+        existing!.Identifier.ShouldBe(new SqlServerObjectName("functions", "add_10"));
         existing.DropStatements().Single()
             .ShouldBe("drop function if exists functions.add_10;");
         existing.Body().ShouldNotBeNull();

--- a/src/Weasel.SqlServer.Tests/Procedures/StoredProcedureTests.cs
+++ b/src/Weasel.SqlServer.Tests/Procedures/StoredProcedureTests.cs
@@ -10,7 +10,7 @@ internal class OutgoingEnvelopeTable: Table
 {
     public static readonly string TableName = "jasper_outgoing_envelopes";
 
-    public OutgoingEnvelopeTable(string schemaName): base(new DbObjectName(schemaName, TableName))
+    public OutgoingEnvelopeTable(string schemaName): base(new SqlServerObjectName(schemaName, TableName))
     {
         AddColumn<Guid>("id").AsPrimaryKey();
         AddColumn<int>("owner_id").NotNull();
@@ -24,7 +24,7 @@ internal class IncomingEnvelopeTable: Table
 {
     public static readonly string TableName = "jasper_incoming_envelopes";
 
-    public IncomingEnvelopeTable(string schemaName): base(new DbObjectName(schemaName, TableName))
+    public IncomingEnvelopeTable(string schemaName): base(new SqlServerObjectName(schemaName, TableName))
     {
         AddColumn<Guid>("id").AsPrimaryKey();
         AddColumn<string>("status").NotNull();
@@ -39,7 +39,7 @@ internal class DeadLettersTable: Table
 {
     public static readonly string TableName = "jasper_dead_letters";
 
-    public DeadLettersTable(string schemaName): base(new DbObjectName(schemaName, TableName))
+    public DeadLettersTable(string schemaName): base(new SqlServerObjectName(schemaName, TableName))
     {
         AddColumn<Guid>("id").AsPrimaryKey();
         AddColumn<string>("source");
@@ -58,7 +58,7 @@ public class StoredProcedureTests: IntegrationContext
 
     public StoredProcedureTests(): base("procs")
     {
-        theProcedure = new StoredProcedure(new DbObjectName("procs", "uspDeleteIncomingEnvelopes"), @"
+        theProcedure = new StoredProcedure(new SqlServerObjectName("procs", "uspDeleteIncomingEnvelopes"), @"
 CREATE PROCEDURE procs.uspDeleteIncomingEnvelopes
     @IDLIST procs.EnvelopeIdList READONLY
 AS
@@ -74,7 +74,7 @@ AS
         var table = new IncomingEnvelopeTable("procs");
         await table.CreateAsync(theConnection);
 
-        var type = new TableType(new DbObjectName("procs", "EnvelopeIdList"));
+        var type = new TableType(new SqlServerObjectName("procs", "EnvelopeIdList"));
         type.AddColumn<Guid>("ID");
 
         await type.ApplyChangesAsync(theConnection);
@@ -82,7 +82,7 @@ AS
 
     private void afterChangingTheProcedure()
     {
-        theProcedure = new StoredProcedure(new DbObjectName("procs", "uspDeleteIncomingEnvelopes"), @"
+        theProcedure = new StoredProcedure(new SqlServerObjectName("procs", "uspDeleteIncomingEnvelopes"), @"
 CREATE PROCEDURE procs.uspDeleteIncomingEnvelopes
     @IDLIST procs.EnvelopeIdList READONLY
 AS

--- a/src/Weasel.SqlServer.Tests/SequenceTester.cs
+++ b/src/Weasel.SqlServer.Tests/SequenceTester.cs
@@ -6,7 +6,7 @@ namespace Weasel.SqlServer.Tests;
 
 public class SequenceTester: IntegrationContext
 {
-    private readonly Sequence theSequence = new(new DbObjectName("sequences", "mysequence"));
+    private readonly Sequence theSequence = new(new SqlServerObjectName("sequences", "mysequence"));
 
     public SequenceTester(): base("sequences")
     {
@@ -25,7 +25,7 @@ public class SequenceTester: IntegrationContext
     [Fact]
     public async Task can_create_with_startup_sequence_without_blowing_up()
     {
-        var sequence = new Sequence(new DbObjectName("sequences", "seq1"), 5);
+        var sequence = new Sequence(new SqlServerObjectName("sequences", "seq1"), 5);
 
         await ResetSchema();
 

--- a/src/Weasel.SqlServer.Tests/Tables/ForeignKeyTests.cs
+++ b/src/Weasel.SqlServer.Tests/Tables/ForeignKeyTests.cs
@@ -13,7 +13,7 @@ public class ForeignKeyTests
         var table = new Table("people");
         var fk = new ForeignKey("fk_state")
         {
-            LinkedTable = new DbObjectName("dbo", "states"),
+            LinkedTable = new SqlServerObjectName("dbo", "states"),
             ColumnNames = new[] { "state_id" },
             LinkedNames = new[] { "id" }
         };
@@ -33,7 +33,7 @@ public class ForeignKeyTests
         var table = new Table("people");
         var fk = new ForeignKey("fk_state")
         {
-            LinkedTable = new DbObjectName("dbo", "states"),
+            LinkedTable = new SqlServerObjectName("dbo", "states"),
             ColumnNames = new[] { "state_id" },
             LinkedNames = new[] { "id" },
             OnDelete = CascadeAction.Cascade
@@ -51,7 +51,7 @@ public class ForeignKeyTests
         var table = new Table("people");
         var fk = new ForeignKey("fk_state")
         {
-            LinkedTable = new DbObjectName("dbo", "states"),
+            LinkedTable = new SqlServerObjectName("dbo", "states"),
             ColumnNames = new[] { "state_id" },
             LinkedNames = new[] { "id" },
             OnUpdate = CascadeAction.Cascade
@@ -69,7 +69,7 @@ public class ForeignKeyTests
         var table = new Table("people");
         var fk = new ForeignKey("fk_state")
         {
-            LinkedTable = new DbObjectName("dbo", "states"),
+            LinkedTable = new SqlServerObjectName("dbo", "states"),
             ColumnNames = new[] { "state_id", "tenant_id" },
             LinkedNames = new[] { "id", "tenant_id" }
         };
@@ -116,7 +116,7 @@ public class ForeignKeyTests
 
         fk.ColumnNames.Single().ShouldBe("state_id");
         fk.LinkedNames.Single().ShouldBe("id");
-        fk.LinkedTable.ShouldBe(new DbObjectName("dbo", "states"));
+        fk.LinkedTable.ShouldBe(new SqlServerObjectName("dbo", "states"));
     }
 
     [Fact]
@@ -128,6 +128,6 @@ public class ForeignKeyTests
 
         fk.ColumnNames.ShouldBe(new string[] { "state_id", "tenant_id" });
         fk.LinkedNames.ShouldBe(new string[] { "id", "tenant_id" });
-        fk.LinkedTable.ShouldBe(new DbObjectName("dbo", "states"));
+        fk.LinkedTable.ShouldBe(new SqlServerObjectName("dbo", "states"));
     }
 }

--- a/src/Weasel.SqlServer.Tests/Tables/TableTypeTests.cs
+++ b/src/Weasel.SqlServer.Tests/Tables/TableTypeTests.cs
@@ -16,7 +16,7 @@ public class TableTypeTests: IntegrationContext
     {
         await ResetSchema();
 
-        var type = new TableType(new DbObjectName("table_types", "EnvelopeIdList"));
+        var type = new TableType(new SqlServerObjectName("table_types", "EnvelopeIdList"));
         type.AddColumn<Guid>("ID");
 
         await type.CreateAsync(theConnection);
@@ -27,7 +27,7 @@ public class TableTypeTests: IntegrationContext
     {
         await ResetSchema();
 
-        var dbObjectName = new DbObjectName("table_types", "EnvelopeIdList");
+        var dbObjectName = new SqlServerObjectName("table_types", "EnvelopeIdList");
         var type = new TableType(dbObjectName);
         type.AddColumn<Guid>("ID");
 
@@ -40,7 +40,7 @@ public class TableTypeTests: IntegrationContext
     {
         await ResetSchema();
 
-        var dbObjectName = new DbObjectName("table_types", "EnvelopeIdList");
+        var dbObjectName = new SqlServerObjectName("table_types", "EnvelopeIdList");
         var type = new TableType(dbObjectName);
         type.AddColumn<Guid>("ID");
 
@@ -57,7 +57,7 @@ public class TableTypeTests: IntegrationContext
     {
         await ResetSchema();
 
-        var dbObjectName = new DbObjectName("table_types", "EnvelopeIdList");
+        var dbObjectName = new SqlServerObjectName("table_types", "EnvelopeIdList");
         var type = new TableType(dbObjectName);
         type.AddColumn<Guid>("ID");
 
@@ -71,7 +71,7 @@ public class TableTypeTests: IntegrationContext
     {
         await ResetSchema();
 
-        var dbObjectName = new DbObjectName("table_types", "EnvelopeIdList");
+        var dbObjectName = new SqlServerObjectName("table_types", "EnvelopeIdList");
         var type = new TableType(dbObjectName);
         type.AddColumn<Guid>("ID");
 
@@ -87,7 +87,7 @@ public class TableTypeTests: IntegrationContext
     {
         await ResetSchema();
 
-        var dbObjectName = new DbObjectName("table_types", "EnvelopeIdList");
+        var dbObjectName = new SqlServerObjectName("table_types", "EnvelopeIdList");
         var type = new TableType(dbObjectName);
         type.AddColumn<Guid>("ID");
 
@@ -102,7 +102,7 @@ public class TableTypeTests: IntegrationContext
     {
         await ResetSchema();
 
-        var dbObjectName = new DbObjectName("table_types", "EnvelopeIdList");
+        var dbObjectName = new SqlServerObjectName("table_types", "EnvelopeIdList");
         var type = new TableType(dbObjectName);
         type.AddColumn<Guid>("ID");
         type.AddColumn("name", "varchar");
@@ -119,7 +119,7 @@ public class TableTypeTests: IntegrationContext
     {
         await ResetSchema();
 
-        var dbObjectName = new DbObjectName("table_types", "EnvelopeIdList");
+        var dbObjectName = new SqlServerObjectName("table_types", "EnvelopeIdList");
         var type = new TableType(dbObjectName);
         type.AddColumn<Guid>("ID");
 
@@ -137,7 +137,7 @@ public class TableTypeTests: IntegrationContext
     {
         await ResetSchema();
 
-        var dbObjectName = new DbObjectName("table_types", "EnvelopeIdList");
+        var dbObjectName = new SqlServerObjectName("table_types", "EnvelopeIdList");
         var type = new TableType(dbObjectName);
         type.AddColumn<Guid>("ID");
 
@@ -155,7 +155,7 @@ public class TableTypeTests: IntegrationContext
     {
         await ResetSchema();
 
-        var dbObjectName = new DbObjectName("table_types", "EnvelopeIdList");
+        var dbObjectName = new SqlServerObjectName("table_types", "EnvelopeIdList");
         var type = new TableType(dbObjectName);
         type.AddColumn<Guid>("ID");
 
@@ -173,7 +173,7 @@ public class TableTypeTests: IntegrationContext
     {
         await ResetSchema();
 
-        var dbObjectName = new DbObjectName("table_types", "EnvelopeIdList");
+        var dbObjectName = new SqlServerObjectName("table_types", "EnvelopeIdList");
         var type = new TableType(dbObjectName);
         type.AddColumn<Guid>("ID");
 
@@ -192,7 +192,7 @@ public class TableTypeTests: IntegrationContext
     {
         await ResetSchema();
 
-        var dbObjectName = new DbObjectName("table_types", "EnvelopeIdList");
+        var dbObjectName = new SqlServerObjectName("table_types", "EnvelopeIdList");
         var type = new TableType(dbObjectName);
         type.AddColumn<Guid>("ID");
 

--- a/src/Weasel.SqlServer/SchemaObjectsExtensions.cs
+++ b/src/Weasel.SqlServer/SchemaObjectsExtensions.cs
@@ -235,7 +235,7 @@ IF NOT EXISTS ( SELECT  *
 
     private static async Task<DbObjectName> ReadDbObjectNameAsync(DbDataReader reader, CancellationToken ct = default)
     {
-        return new DbObjectName(
+        return new SqlServerObjectName(
             await reader.GetFieldValueAsync<string>(0, ct).ConfigureAwait(false),
             await reader.GetFieldValueAsync<string>(1, ct).ConfigureAwait(false)
         );

--- a/src/Weasel.SqlServer/SqlServerObjectName.cs
+++ b/src/Weasel.SqlServer/SqlServerObjectName.cs
@@ -1,0 +1,12 @@
+using JasperFx.Core.Reflection;
+using Weasel.Core;
+
+namespace Weasel.SqlServer;
+
+public class SqlServerObjectName: DbObjectName
+{
+    public SqlServerObjectName(string schema, string name)
+        : base(schema, name, SqlServerProvider.Instance.As<IDatabaseProvider>().ToQualifiedName(schema, name))
+    {
+    }
+}

--- a/src/Weasel.SqlServer/SqlServerProvider.cs
+++ b/src/Weasel.SqlServer/SqlServerProvider.cs
@@ -75,6 +75,8 @@ public class SqlServerProvider: DatabaseProvider<SqlCommand, SqlParameter, SqlCo
         return Type.EmptyTypes;
     }
 
+    public override DbObjectName Parse(string schemaName, string objectName) =>
+        new SqlServerObjectName(schemaName, objectName);
 
     public string ConvertSynonyms(string type)
     {

--- a/src/Weasel.SqlServer/Tables/Table.FetchExisting.cs
+++ b/src/Weasel.SqlServer/Tables/Table.FetchExisting.cs
@@ -136,7 +136,7 @@ order by
             var onUpdate = await reader.GetFieldValueAsync<string>(6, ct).ConfigureAwait(false);
 
             var fk = existing.FindOrCreateForeignKey(fkName);
-            fk.LinkedTable = new DbObjectName(schemaName, tableName);
+            fk.LinkedTable = new SqlServerObjectName(schemaName, tableName);
             fk.ReadReferentialActions(onDelete, onUpdate);
 
             fk.LinkColumns(columnName, referencedName);

--- a/src/Weasel.SqlServer/Tables/Table.cs
+++ b/src/Weasel.SqlServer/Tables/Table.cs
@@ -154,9 +154,9 @@ public partial class Table: ISchemaObject
     {
         yield return Identifier;
 
-        foreach (var index in Indexes) yield return new DbObjectName(Identifier.Schema, index.Name);
+        foreach (var index in Indexes) yield return new SqlServerObjectName(Identifier.Schema, index.Name);
 
-        foreach (var fk in ForeignKeys) yield return new DbObjectName(Identifier.Schema, fk.Name);
+        foreach (var fk in ForeignKeys) yield return new SqlServerObjectName(Identifier.Schema, fk.Name);
     }
 
     /// <summary>


### PR DESCRIPTION
- Added method that parses object names using quotes
- Added option to enable case sensitivity checks
- Added test setup to run test matrix for case-sensitive handling

Fixes #100 

_**Note:** Consider making case-sensitive comparison a default in the next major version. Also, remove the singleton `PostgresInstanceProvider`._