### PR TITLE
Added "bigserial" and "smallserial" to the type mappings

### DIFF
--- a/src/Weasel.Postgresql.Tests/PostgresqlProviderTests.cs
+++ b/src/Weasel.Postgresql.Tests/PostgresqlProviderTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Data;
+using System.Data;
 using Npgsql;
 using NpgsqlTypes;
 using Shouldly;
@@ -94,6 +94,12 @@ public class PostgresqlProviderTests
         var serialAsInt = new TableColumn("id", "serial");
         serialAsInt.ShouldBe(new TableColumn("id", "int"));
 
+        var bigserialAsBigint = new TableColumn("id", "bigserial");
+        bigserialAsBigint.ShouldBe(new TableColumn("id", "bigint"));
+
+        var smallserialAsSmallint = new TableColumn("id", "smallserial");
+        smallserialAsSmallint.ShouldBe(new TableColumn("id", "smallint"));
+
         var varchararrAsArray = new TableColumn("comments", "varchar[]");
         varchararrAsArray.ShouldBe(new TableColumn("comments", "array"));
 
@@ -111,6 +117,8 @@ public class PostgresqlProviderTests
     [InlineData("bool", "boolean")]
     [InlineData("integer", "int")]
     [InlineData("serial", "int")]
+    [InlineData("bigserial", "bigint")]
+    [InlineData("smallserial", "smallint")]
     [InlineData("integer[]", "int[]")]
     [InlineData("decimal", "decimal")]
     [InlineData("numeric", "decimal")]

--- a/src/Weasel.Postgresql/PostgresqlProvider.cs
+++ b/src/Weasel.Postgresql/PostgresqlProvider.cs
@@ -109,6 +109,12 @@ public class PostgresqlProvider: DatabaseProvider<NpgsqlCommand, NpgsqlParameter
             case "serial":
                 return "int";
 
+            case "bigserial":
+                return "bigint";
+
+            case "smallserial":
+                return "smallint";
+
             case "integer[]":
                 return "int[]";
 

--- a/src/Weasel.Postgresql/Tables/TableColumn.cs
+++ b/src/Weasel.Postgresql/Tables/TableColumn.cs
@@ -181,12 +181,19 @@ public abstract class ColumnCheck
     }
 }
 
-public class SerialValue: ColumnCheck
+public class SerialValue : ColumnCheck
 {
-    public override string Declaration()
-    {
-        return "SERIAL";
-    }
+    public override string Declaration() => "SERIAL";
+}
+
+public class BigSerialValue : ColumnCheck
+{
+    public override string Declaration() => "BIGSERIAL";
+}
+
+public class SmallSerialValue: ColumnCheck
+{
+    public override string Declaration() => "SMALLSERIAL";
 }
 
 /*


### PR DESCRIPTION
https://github.com/JasperFx/weasel/pull/87 tried to fix https://github.com/JasperFx/weasel/issues/76, but unfortunately some pieces were missing, as that error still occurs.
With this change that 🐛 should be finally be gone.

(IIRC the change was tested locally and it worked, but now I realized it's not working...)