### PR TITLE
Replaced cast to PostgresqlObjectName from DBObjectName with conversion

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>6.4.0</Version>
+        <Version>6.4.1</Version>
         <LangVersion>11.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/src/Weasel.Core/DatabaseProvider.cs
+++ b/src/Weasel.Core/DatabaseProvider.cs
@@ -1,5 +1,6 @@
 using System.Data.Common;
 using JasperFx.Core;
+using JasperFx.Core.Reflection;
 using Weasel.Core.Names;
 
 namespace Weasel.Core;
@@ -253,6 +254,13 @@ public abstract class DatabaseProvider<TCommand, TParameter, TConnection, TTrans
     public TParameter AddNamedParameter(TCommand command, string name, bool value)
     {
         return AddNamedParameter(command, name, value, BoolParameterType);
+    }
+
+    public DbObjectName Parse(string qualifiedName)
+    {
+        var parts = QualifiedNameParser.Parse(this, qualifiedName);
+
+        return Parse(parts[0], parts[1]);
     }
 
     public virtual string ToQualifiedName(string objectName) => objectName;

--- a/src/Weasel.Core/DbObjectName.cs
+++ b/src/Weasel.Core/DbObjectName.cs
@@ -43,8 +43,7 @@ public class DbObjectName
 
     protected bool Equals(DbObjectName other)
     {
-        return GetType() == other.GetType() &&
-               string.Equals(QualifiedName, other.QualifiedName, StringComparison.OrdinalIgnoreCase);
+        return string.Equals(QualifiedName, other.QualifiedName, StringComparison.OrdinalIgnoreCase);
     }
 
     public override bool Equals(object? obj)
@@ -59,12 +58,12 @@ public class DbObjectName
             return true;
         }
 
-        if (obj.GetType() != GetType())
+        if (obj is not DbObjectName name)
         {
             return false;
         }
 
-        return Equals((DbObjectName)obj);
+        return Equals(name);
     }
 
     public override int GetHashCode()

--- a/src/Weasel.Postgresql.Tests/Functions/FunctionTests.cs
+++ b/src/Weasel.Postgresql.Tests/Functions/FunctionTests.cs
@@ -92,7 +92,7 @@ $$ LANGUAGE plpgsql;
     {
         var function = Function.ForRemoval("functions.mt_hilo");
         function.IsRemoved.ShouldBeTrue();
-        function.Identifier.QualifiedName.ShouldBe(Instance.ToQualifiedName("functions.mt_hilo"));
+        function.Identifier.QualifiedName.ShouldBe(Instance.Parse("functions.mt_hilo").QualifiedName);
     }
 
     [Fact]

--- a/src/Weasel.Postgresql.Tests/PostgresqlObjectNameTests.cs
+++ b/src/Weasel.Postgresql.Tests/PostgresqlObjectNameTests.cs
@@ -1,0 +1,45 @@
+using Shouldly;
+using Weasel.Core;
+using Xunit;
+
+namespace Weasel.Postgresql.Tests;
+
+public class PostgresqlObjectNameTests
+{
+    [Fact]
+    public void ShouldBeCreatedFromDBObjectName_RespectingCaseSensitivityOptions()
+    {
+        // Given
+        const string schema = "sChEmA";
+        const string name = "NaMe";
+        var dbObjectName = new DbObjectName("sChEmA", "NaMe");
+
+        //When
+        var pgObjectName = PostgresqlObjectName.From(dbObjectName);
+
+        var expectedQualifiedName = PostgresqlProvider.Instance.UseCaseSensitiveQualifiedNames
+            ? $"\"{schema}\".\"{name}\""
+            : $"{schema}.{name}";
+
+        pgObjectName.Schema.ShouldBe(schema);
+        pgObjectName.Name.ShouldBe(name);
+        pgObjectName.QualifiedName.ShouldBe(expectedQualifiedName);
+    }
+
+
+    [Fact]
+    public void ShouldEqualsDbObjectName_IfQualifiedNameMatches()
+    {
+        // Given
+        const string schema = "sChEmA";
+        const string name = "NaMe";
+        var dbObjectName = new DbObjectName(schema, name);
+        var pgObjectName = new PostgresqlObjectName(schema, name, $"{schema}.{name}");
+
+        // When
+        // Then
+        (pgObjectName.Equals(dbObjectName)).ShouldBeTrue();
+        (dbObjectName.GetHashCode().Equals(pgObjectName.GetHashCode())).ShouldBeTrue();
+        (dbObjectName.Equals(pgObjectName)).ShouldBeTrue();
+    }
+}

--- a/src/Weasel.Postgresql.Tests/Tables/IndexDefinitionTests.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/IndexDefinitionTests.cs
@@ -66,7 +66,7 @@ public class IndexDefinitionTests
     public void write_basic_index()
     {
         theIndex.ToDDL(parent)
-            .ShouldBe($"CREATE INDEX idx_1 ON {Instance.ToQualifiedName("public.people")} USING btree (column1);");
+            .ShouldBe($"CREATE INDEX idx_1 ON {Instance.Parse("public.people")} USING btree (column1);");
     }
 
     [Fact]
@@ -75,7 +75,7 @@ public class IndexDefinitionTests
         theIndex.IsUnique = true;
 
         theIndex.ToDDL(parent)
-            .ShouldBe($"CREATE UNIQUE INDEX idx_1 ON {Instance.ToQualifiedName("public.people")} USING btree (column1);");
+            .ShouldBe($"CREATE UNIQUE INDEX idx_1 ON {Instance.Parse("public.people")} USING btree (column1);");
     }
 
     [Fact]
@@ -85,7 +85,7 @@ public class IndexDefinitionTests
 
         theIndex.ToDDL(parent)
             .ShouldBe($"--WEASEL_INDEX_CREATION_BEGIN{Environment.NewLine}" +
-                      $"CREATE INDEX CONCURRENTLY idx_1 ON {Instance.ToQualifiedName("public.people")} USING btree (column1);{Environment.NewLine}" +
+                      $"CREATE INDEX CONCURRENTLY idx_1 ON {Instance.Parse("public.people")} USING btree (column1);{Environment.NewLine}" +
                       "--WEASEL_INDEX_CREATION_END");
     }
 
@@ -97,7 +97,7 @@ public class IndexDefinitionTests
 
         theIndex.ToDDL(parent)
             .ShouldBe($"--WEASEL_INDEX_CREATION_BEGIN{Environment.NewLine}" +
-                      $"CREATE UNIQUE INDEX CONCURRENTLY idx_1 ON {Instance.ToQualifiedName("public.people")} USING btree (column1);{Environment.NewLine}" +
+                      $"CREATE UNIQUE INDEX CONCURRENTLY idx_1 ON {Instance.Parse("public.people")} USING btree (column1);{Environment.NewLine}" +
                       "--WEASEL_INDEX_CREATION_END");
     }
 
@@ -110,7 +110,7 @@ public class IndexDefinitionTests
 
         theIndex.ToDDL(parent)
             .ShouldBe($"--WEASEL_INDEX_CREATION_BEGIN{Environment.NewLine}" +
-                      $"CREATE UNIQUE INDEX CONCURRENTLY idx_1 ON {Instance.ToQualifiedName("public.people")} USING btree (column1) NULLS NOT DISTINCT ;{Environment.NewLine}" +
+                      $"CREATE UNIQUE INDEX CONCURRENTLY idx_1 ON {Instance.Parse("public.people")} USING btree (column1) NULLS NOT DISTINCT ;{Environment.NewLine}" +
                       "--WEASEL_INDEX_CREATION_END");
     }
 
@@ -120,7 +120,7 @@ public class IndexDefinitionTests
         theIndex.SortOrder = SortOrder.Desc;
 
         theIndex.ToDDL(parent)
-            .ShouldBe($"CREATE INDEX idx_1 ON {Instance.ToQualifiedName("public.people")} USING btree (column1 DESC);");
+            .ShouldBe($"CREATE INDEX idx_1 ON {Instance.Parse("public.people")} USING btree (column1 DESC);");
     }
 
     [Fact]
@@ -129,7 +129,7 @@ public class IndexDefinitionTests
         theIndex.Method = IndexMethod.gin;
 
         theIndex.ToDDL(parent)
-            .ShouldBe($"CREATE INDEX idx_1 ON {Instance.ToQualifiedName("public.people")} USING gin (column1);");
+            .ShouldBe($"CREATE INDEX idx_1 ON {Instance.Parse("public.people")} USING gin (column1);");
     }
 
     [Fact]
@@ -139,7 +139,7 @@ public class IndexDefinitionTests
         theIndex.Method = IndexMethod.gin;
 
         theIndex.ToDDL(parent)
-            .ShouldBe($"CREATE INDEX idx_1 ON {Instance.ToQualifiedName("public.people")} USING gin (column1) TABLESPACE green;");
+            .ShouldBe($"CREATE INDEX idx_1 ON {Instance.Parse("public.people")} USING gin (column1) TABLESPACE green;");
     }
 
     [Fact]
@@ -150,7 +150,7 @@ public class IndexDefinitionTests
         theIndex.Predicate = "foo > 1";
 
         theIndex.ToDDL(parent)
-            .ShouldBe($"CREATE INDEX idx_1 ON {Instance.ToQualifiedName("public.people")} USING gin (column1) TABLESPACE green WHERE (foo > 1);");
+            .ShouldBe($"CREATE INDEX idx_1 ON {Instance.Parse("public.people")} USING gin (column1) TABLESPACE green WHERE (foo > 1);");
     }
 
     [Fact]
@@ -163,7 +163,7 @@ public class IndexDefinitionTests
 
         theIndex.ToDDL(parent)
             .ShouldBe(
-                $"CREATE INDEX idx_1 ON {Instance.ToQualifiedName("public.people")} USING gin (column1) TABLESPACE green WHERE (foo > 1) WITH (fillfactor='70');");
+                $"CREATE INDEX idx_1 ON {Instance.Parse("public.people")} USING gin (column1) TABLESPACE green WHERE (foo > 1) WITH (fillfactor='70');");
     }
 
     [Fact]
@@ -172,7 +172,7 @@ public class IndexDefinitionTests
         theIndex.SortOrder = SortOrder.Desc;
 
         theIndex.ToDDL(parent)
-            .ShouldBe($"CREATE INDEX idx_1 ON {Instance.ToQualifiedName("public.people")} USING btree (column1 DESC);");
+            .ShouldBe($"CREATE INDEX idx_1 ON {Instance.Parse("public.people")} USING btree (column1 DESC);");
     }
 
 
@@ -563,13 +563,13 @@ public class IndexDefinitionTests
         };
 
         var ddl = index.ToDDL(new Table("table"));
-        ddl.ShouldBe($"CREATE UNIQUE INDEX index ON {Instance.ToQualifiedName("public.table")} USING btree (column1, column2) NULLS NOT DISTINCT ;");
+        ddl.ShouldBe($"CREATE UNIQUE INDEX index ON {Instance.Parse("public.table")} USING btree (column1, column2) NULLS NOT DISTINCT ;");
     }
 
     [Fact]
     public void should_be_able_to_parse_index_with_nulls_not_distinct()
     {
-        var index = IndexDefinition.Parse($"CREATE UNIQUE INDEX index ON {Instance.ToQualifiedName("public.table")} USING btree (column1, column2) NULLS NOT DISTINCT;");
+        var index = IndexDefinition.Parse($"CREATE UNIQUE INDEX index ON {Instance.Parse("public.table")} USING btree (column1, column2) NULLS NOT DISTINCT;");
         index.IsUnique.ShouldBeTrue();
         index.NullsNotDistinct.ShouldBeTrue();
 

--- a/src/Weasel.Postgresql.Tests/Tables/TableColumnTests.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/TableColumnTests.cs
@@ -117,6 +117,6 @@ public class TableColumnTests
         var column = table.AddColumn<string>("name1").NotNull().Column;
 
         column.AddColumnSql(table)
-            .ShouldBe($"alter table {Instance.ToQualifiedName("public.people")} add column name1 varchar NOT NULL;");
+            .ShouldBe($"alter table {Instance.Parse("public.people")} add column name1 varchar NOT NULL;");
     }
 }

--- a/src/Weasel.Postgresql.Tests/Tables/TableTests.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/TableTests.cs
@@ -120,8 +120,8 @@ public class TableTests
 
         var lines = ddl.ReadLines().ToArray();
 
-        lines.ShouldContain($"DROP TABLE IF EXISTS {Instance.ToQualifiedName("public.people")} CASCADE;");
-        lines.ShouldContain($"CREATE TABLE {Instance.ToQualifiedName("public.people")} (");
+        lines.ShouldContain($"DROP TABLE IF EXISTS {Instance.Parse("public.people")} CASCADE;");
+        lines.ShouldContain($"CREATE TABLE {Instance.Parse("public.people")} (");
     }
 
     [Fact]
@@ -143,7 +143,7 @@ public class TableTests
 
         var lines = ddl.ReadLines().ToArray();
 
-        lines.ShouldContain($"CREATE TABLE IF NOT EXISTS {Instance.ToQualifiedName("public.people")} (");
+        lines.ShouldContain($"CREATE TABLE IF NOT EXISTS {Instance.Parse("public.people")} (");
     }
 
     [Fact]

--- a/src/Weasel.Postgresql.Tests/Views/ViewTests.cs
+++ b/src/Weasel.Postgresql.Tests/Views/ViewTests.cs
@@ -50,7 +50,7 @@ public class ViewTests
 
         var lines = ddl.ReadLines().ToArray();
 
-        lines.ShouldContain($"DROP VIEW IF EXISTS {Instance.ToQualifiedName("public.people_view")};");
-        lines.ShouldContain($"CREATE VIEW {Instance.ToQualifiedName("public.people_view")} AS SELECT 1 AS id;");
+        lines.ShouldContain($"DROP VIEW IF EXISTS {Instance.Parse("public.people_view")};");
+        lines.ShouldContain($"CREATE VIEW {Instance.Parse("public.people_view")} AS SELECT 1 AS id;");
     }
 }

--- a/src/Weasel.Postgresql/PostgresqlObjectName.cs
+++ b/src/Weasel.Postgresql/PostgresqlObjectName.cs
@@ -8,8 +8,39 @@ public class PostgresqlObjectName: DbObjectName
         : base(schema, name, PostgresqlProvider.Instance.ToQualifiedName(schema, name))
     {
     }
+
     public PostgresqlObjectName(string schema, string name, string qualifiedName)
         : base(schema, name, qualifiedName)
     {
+    }
+
+    private PostgresqlObjectName(DbObjectName dbObjectName): this(dbObjectName.Schema, dbObjectName.Name)
+    {
+    }
+
+    public static PostgresqlObjectName From(DbObjectName dbObjectName) =>
+        new PostgresqlObjectName(dbObjectName);
+
+    private new bool Equals(DbObjectName other)
+    {
+        return string.Equals(QualifiedName, other.QualifiedName, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is DbObjectName dbObjectName)
+        {
+            return Equals(dbObjectName);
+        }
+
+        return base.Equals(obj);
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            return (typeof(DbObjectName).GetHashCode() * 397) ^ QualifiedName.GetHashCode();
+        }
     }
 }

--- a/src/Weasel.Postgresql/Tables/Table.cs
+++ b/src/Weasel.Postgresql/Tables/Table.cs
@@ -334,7 +334,7 @@ public partial class Table: ISchemaObject
         public ColumnExpression ForeignKeyTo(DbObjectName referencedIdentifier, string referencedColumnName,
             string? fkName = null, CascadeAction onDelete = CascadeAction.NoAction,
             CascadeAction onUpdate = CascadeAction.NoAction) =>
-            ForeignKeyTo((PostgresqlObjectName)referencedIdentifier, referencedColumnName, fkName, onDelete, onUpdate);
+            ForeignKeyTo(PostgresqlObjectName.From(referencedIdentifier), referencedColumnName, fkName, onDelete, onUpdate);
 
         public ColumnExpression ForeignKeyTo(PostgresqlObjectName referencedIdentifier, string referencedColumnName,
             string? fkName = null, CascadeAction onDelete = CascadeAction.NoAction,

--- a/src/Weasel.SqlServer.Tests/SqlServerObjectNameTests.cs
+++ b/src/Weasel.SqlServer.Tests/SqlServerObjectNameTests.cs
@@ -1,0 +1,41 @@
+using Shouldly;
+using Weasel.Core;
+using Xunit;
+
+namespace Weasel.SqlServer.Tests;
+
+public class SqlServerObjectNameTests
+{
+    [Fact]
+    public void ShouldBeCreatedFromDBObjectName_RespectingCaseSensitivityOptions()
+    {
+        // Given
+        const string schema = "sChEmA";
+        const string name = "NaMe";
+        var dbObjectName = new DbObjectName("sChEmA", "NaMe");
+
+        //When
+        var pgObjectName = SqlServerObjectName.From(dbObjectName);
+
+        pgObjectName.Schema.ShouldBe(schema);
+        pgObjectName.Name.ShouldBe(name);
+        pgObjectName.QualifiedName.ShouldBe($"{schema}.{name}");
+    }
+
+
+    [Fact]
+    public void ShouldEqualsDbObjectName_IfQualifiedNameMatches()
+    {
+        // Given
+        const string schema = "sChEmA";
+        const string name = "NaMe";
+        var dbObjectName = new DbObjectName(schema, name);
+        var pgObjectName = new SqlServerObjectName(schema, name);
+
+        // When
+        // Then
+        (pgObjectName.Equals(dbObjectName)).ShouldBeTrue();
+        (dbObjectName.GetHashCode().Equals(pgObjectName.GetHashCode())).ShouldBeTrue();
+        (dbObjectName.Equals(pgObjectName)).ShouldBeTrue();
+    }
+}

--- a/src/Weasel.SqlServer/SqlServerObjectName.cs
+++ b/src/Weasel.SqlServer/SqlServerObjectName.cs
@@ -9,4 +9,34 @@ public class SqlServerObjectName: DbObjectName
         : base(schema, name, SqlServerProvider.Instance.As<IDatabaseProvider>().ToQualifiedName(schema, name))
     {
     }
+
+    private SqlServerObjectName(DbObjectName dbObjectName): this(dbObjectName.Schema, dbObjectName.Name)
+    {
+    }
+
+    public static SqlServerObjectName From(DbObjectName dbObjectName) =>
+        new SqlServerObjectName(dbObjectName);
+
+    private new bool Equals(DbObjectName other)
+    {
+        return string.Equals(QualifiedName, other.QualifiedName, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is DbObjectName dbObjectName)
+        {
+            return Equals(dbObjectName);
+        }
+
+        return base.Equals(obj);
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            return (typeof(DbObjectName).GetHashCode() * 397) ^ QualifiedName.GetHashCode();
+        }
+    }
 }


### PR DESCRIPTION
- Replaced cast to PostgresqlObjectName from DBObjectName with conversion,
- Overloaded also equality comparison to ensure that schema diffs will be backwards compatible,
- Bumped to 6.4.1.

This should fix the regression introduced in https://github.com/JasperFx/weasel/pull/103.