### PR TITLE
Add functionality to auto reload Npgsql types for added PG extensions

### DIFF
--- a/src/Weasel.Core/Migrations/Database.cs
+++ b/src/Weasel.Core/Migrations/Database.cs
@@ -214,7 +214,7 @@ public abstract class DatabaseBase<TConnection>: IDatabase<TConnection> where TC
         return await SchemaMigration.DetermineAsync(conn, ct, objects).ConfigureAwait(false);
     }
 
-    public Task<SchemaPatchDifference> ApplyAllConfiguredChangesToDatabaseAsync(
+    public virtual Task<SchemaPatchDifference> ApplyAllConfiguredChangesToDatabaseAsync(
         AutoCreate? @override = null,
         ReconnectionOptions? reconnectionOptions = null,
         CancellationToken ct = default

--- a/src/Weasel.Postgresql.Tests/Migrations/creating_and_dropping_databases.cs
+++ b/src/Weasel.Postgresql.Tests/Migrations/creating_and_dropping_databases.cs
@@ -33,15 +33,15 @@ public class SingleInstanceDatabaseCollectionTests
         (await theDatabases.FindOrCreateDatabase("three")).ShouldBeSameAs(three);
     }
 
-    public class Databases: SingleServerDatabaseCollection<DatabaseWithTables>
+    public class Databases: SingleServerDatabaseCollection<TestDatabase>
     {
         public Databases() : base(ConnectionSource.ConnectionString)
         {
         }
 
-        protected override DatabaseWithTables buildDatabase(string databaseName, string connectionString)
+        protected override TestDatabase buildDatabase(string databaseName, string connectionString)
         {
-            return new DatabaseWithTables(databaseName, connectionString);
+            return new TestDatabase(databaseName, connectionString);
         }
     }
 }


### PR DESCRIPTION
- Add functionality to auto reload Npgsql types for PG extensions added via schema objects
- Add unit test

This fixes Marten issue https://github.com/JasperFx/marten/issues/2515