### PR TITLE
Updated DefaultNpgsqlDataSourceFactory to maintain the lifetime of data sources

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>7.0.0-alpha.4</Version>
+        <Version>7.0.0-alpha.5</Version>
         <LangVersion>12.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/src/Weasel.Postgresql/Connections/INpgsqlDataSourceFactory.cs
+++ b/src/Weasel.Postgresql/Connections/INpgsqlDataSourceFactory.cs
@@ -5,7 +5,18 @@ namespace Weasel.Postgresql.Connections;
 public interface INpgsqlDataSourceFactory
 {
     NpgsqlDataSource Create(string connectionString);
+}
 
+public static class NpgsqlDataSourceFactoryExtensions
+{
+    public static NpgsqlDataSource Create(
+        this INpgsqlDataSourceFactory dataSourceFactory,
+        string masterConnectionString,
+        string databaseName
+    )
+    {
+        var builder = new NpgsqlConnectionStringBuilder(masterConnectionString) { Database = databaseName };
 
-    NpgsqlDataSource Create(string masterConnectionString, string databaseName);
+        return dataSourceFactory.Create(builder.ConnectionString);
+    }
 }

--- a/src/Weasel.Postgresql/Connections/SingleNpgsqlDataSourceFactory.cs
+++ b/src/Weasel.Postgresql/Connections/SingleNpgsqlDataSourceFactory.cs
@@ -1,0 +1,19 @@
+using Npgsql;
+
+namespace Weasel.Postgresql.Connections;
+
+/// <summary>
+/// A factory that, by default, just caches the data source it got from outside (e.g. from DI).
+/// That means that it's NOT managing its lifetime.
+/// It still allows the creation and maintenance of a lifetime of child data sources.
+/// </summary>
+public class SingleNpgsqlDataSourceFactory(
+    Func<string, NpgsqlDataSourceBuilder> dataSourceBuilderFactory,
+    NpgsqlDataSource dataSource
+): DefaultNpgsqlDataSourceFactory(dataSourceBuilderFactory)
+{
+    public override NpgsqlDataSource Create(string connectionString) =>
+        dataSource.ConnectionString.Equals(connectionString)
+            ? dataSource
+            : base.Create(connectionString);
+}


### PR DESCRIPTION
- Added SingleNpgsqlDataSourceFactory to support easier DI scenarios where NpgsqlDataSource is injected and we should not maintain its lifetime. 
- Moved child data source setup to extension method not to pollute the main interface.