### PR TITLE
Add a typed value overload for AppendParameter

### DIFF
--- a/src/Weasel.Postgresql/BatchBuilder.cs
+++ b/src/Weasel.Postgresql/BatchBuilder.cs
@@ -49,6 +49,21 @@ public class BatchBuilder: ICommandBuilder
         _builder.Append(character);
     }
 
+    public NpgsqlParameter AppendParameter<T>(T value)
+    {
+        _current ??= appendCommand();
+        var param = new NpgsqlParameter<T>() {
+            TypedValue = value,
+        };
+
+        _current.Parameters.Add(param);
+
+        _builder.Append('$');
+        _builder.Append(_current.Parameters.Count);
+
+        return param;
+    }
+
     public NpgsqlParameter AppendParameter(object value)
     {
         _current ??= appendCommand();

--- a/src/Weasel.Postgresql/CommandBuilder.cs
+++ b/src/Weasel.Postgresql/CommandBuilder.cs
@@ -32,6 +32,12 @@ public class CommandBuilder: CommandBuilderBase<NpgsqlCommand, NpgsqlParameter, 
         AppendParameter(values, NpgsqlDbType.Varchar | NpgsqlDbType.Array);
     }
 
+    NpgsqlParameter ICommandBuilder.AppendParameter<T>(T value)
+    {
+        AppendParameter(value);
+        return _command.Parameters[^1];
+    }
+
     NpgsqlParameter ICommandBuilder.AppendParameter(object value)
     {
         AppendParameter(value);

--- a/src/Weasel.Postgresql/ICommandBuilder.cs
+++ b/src/Weasel.Postgresql/ICommandBuilder.cs
@@ -18,6 +18,7 @@ public interface ICommandBuilder
 
     void Append(string sql);
     void Append(char character);
+    NpgsqlParameter AppendParameter<T>(T value);
     NpgsqlParameter AppendParameter(object value);
     NpgsqlParameter AppendParameter(object? value, NpgsqlDbType? dbType);
     void AppendParameters(params object[] parameters);

--- a/src/Weasel.Postgresql/Weasel.Postgresql.csproj
+++ b/src/Weasel.Postgresql/Weasel.Postgresql.csproj
@@ -17,7 +17,7 @@
 
     <ItemGroup>
 
-        <PackageReference Include="Npgsql" Version="8.0.0" />
+        <PackageReference Include="Npgsql" Version="8.0.1" />
     </ItemGroup>
 
     <!--SourceLink specific settings-->


### PR DESCRIPTION
There's a handful of places in the marten codebase where this'll avoid a box, so may as well.