### PR TITLE
fix: When comparing indexes, drop the "public." prefix from index

### DIFF
--- a/src/Weasel.Postgresql/Tables/IndexDefinition.cs
+++ b/src/Weasel.Postgresql/Tables/IndexDefinition.cs
@@ -716,6 +716,7 @@ public class IndexDefinition: INamed
         sql = sql.Replace("desc nulls first", "desc", StringComparison.OrdinalIgnoreCase);
         sql = sql.Replace("asc nulls first", "asc", StringComparison.OrdinalIgnoreCase);
         sql = sql.Replace("TABLESPACE pg_default", "", StringComparison.OrdinalIgnoreCase);
+        sql = sql.Replace("public.", "", StringComparison.OrdinalIgnoreCase);
 
         // replace multiple spaces with single space
         sql = Regex.Replace(sql, @"\s+", " ");


### PR DESCRIPTION
When comparing indexes, drop the "public." prefix from index expression; Azure Database for PostgreSQL flexible server; Pg 16.0 somehow does not have the public. prefix for some functions

Fixes https://github.com/JasperFx/marten/issues/2983