### PR TITLE
Implement fix for marten issue #3068

### DIFF
--- a/src/Weasel.Postgresql.Tests/Tables/IndexDefinitionTests.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/IndexDefinitionTests.cs
@@ -1,4 +1,5 @@
 using Shouldly;
+using Weasel.Core;
 using Weasel.Postgresql.Tables;
 using Xunit;
 
@@ -575,5 +576,18 @@ public class IndexDefinitionTests
         index = IndexDefinition.Parse("CREATE UNIQUE INDEX index ON public.table USING btree (column1, column2) NULLS DISTINCT;");
         index.IsUnique.ShouldBeTrue();
         index.NullsNotDistinct.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Marten_bug_3068()
+    {
+        var table = new Table("app.mt_doc_user");
+        var index1 =
+            IndexDefinition.Parse(
+                "CREATE INDEX mt_doc_user_idx_fts ON app.mt_doc_user USING gin (app.mt_grams_vector(data ->> 'FirstName'))");
+        var index2 =
+            IndexDefinition.Parse(
+                "CREATE INDEX mt_doc_user_idx_fts ON app.mt_doc_user USING gin (mt_grams_vector(data ->> 'FirstName'))");
+        IndexDefinition.CanonicizeDdl(index1, table).ShouldBe(IndexDefinition.CanonicizeDdl(index2, table));
     }
 }

--- a/src/Weasel.Postgresql/Tables/IndexDefinition.cs
+++ b/src/Weasel.Postgresql/Tables/IndexDefinition.cs
@@ -706,10 +706,10 @@ public class IndexDefinition: INamed
     public static string CanonicizeDdl(IndexDefinition index, Table parent)
     {
         var canonicizedStr = index.ToDDL(parent);
-        return CanonicizeDdl(canonicizedStr);
+        return CanonicizeDdl(canonicizedStr, parent.Identifier.Schema);
     }
 
-    public static string CanonicizeDdl(string sql)
+    public static string CanonicizeDdl(string sql, string schema)
     {
         // This was caused by https://github.com/JasperFx/marten/issues/2983
         sql = sql.Replace("if not exists", "", StringComparison.OrdinalIgnoreCase);
@@ -717,6 +717,7 @@ public class IndexDefinition: INamed
         sql = sql.Replace("asc nulls first", "asc", StringComparison.OrdinalIgnoreCase);
         sql = sql.Replace("TABLESPACE pg_default", "", StringComparison.OrdinalIgnoreCase);
         sql = sql.Replace("public.", "");
+        sql = sql.Replace($"{schema}.", "");
 
         // replace multiple spaces with single space
         sql = Regex.Replace(sql, @"\s+", " ");


### PR DESCRIPTION
Implements a fix for issues encountered creating ngram indexes on AWS RDS postgres instance.  See https://github.com/JasperFx/marten/issues/3068 for more details.

Similar to issue #120 but relates to schemas other than `public`