### PR TITLE
Consistent generic support

### DIFF
--- a/src/Weasel.Core/DbCommandBuilder.cs
+++ b/src/Weasel.Core/DbCommandBuilder.cs
@@ -141,10 +141,8 @@ internal class DbDatabaseProvider: DatabaseProvider<DbCommand, DbParameter, DbTy
         var resolveSqlDbType = ResolveSqlDbType(type);
         if (resolveSqlDbType != null)
         {
-            {
-                dbType = resolveSqlDbType.Value;
-                return true;
-            }
+            dbType = resolveSqlDbType.Value;
+            return true;
         }
 
         if (type.IsNullable())
@@ -167,6 +165,12 @@ internal class DbDatabaseProvider: DatabaseProvider<DbCommand, DbParameter, DbTy
         if (type == typeof(DBNull))
         {
             dbType = DbType.Object;
+            return true;
+        }
+
+        if (type.IsConstructedGenericType)
+        {
+            dbType = ToParameterType(type.GetGenericTypeDefinition());
             return true;
         }
 

--- a/src/Weasel.Core/DbCommandBuilder.cs
+++ b/src/Weasel.Core/DbCommandBuilder.cs
@@ -213,13 +213,17 @@ internal class DbDatabaseProvider: DatabaseProvider<DbCommand, DbParameter, DbTy
             return GetDatabaseType(memberType.GetInnerTypeFromNullable(), enumStyle);
         }
 
-        if (memberType.IsConstructedGenericType)
+        if (ResolveDatabaseType(memberType) is { } result)
         {
-            var templateType = memberType.GetGenericTypeDefinition();
-            return ResolveDatabaseType(templateType) ?? "json";
+            return result;
         }
 
-        return ResolveDatabaseType(memberType) ?? "json";
+        if (memberType.IsConstructedGenericType)
+        {
+            return GetDatabaseType(memberType.GetGenericTypeDefinition(), enumStyle);
+        }
+
+        return "json";
     }
 
     // Lazily retrieve the CLR type to SqlDbType and PgTypeName mapping from exposed ISqlTypeMapper.Mappings.

--- a/src/Weasel.Postgresql.Tests/PostgresqlProviderTests.cs
+++ b/src/Weasel.Postgresql.Tests/PostgresqlProviderTests.cs
@@ -133,6 +133,112 @@ public class PostgresqlProviderTests
     {
         PostgresqlProvider.Instance.ConvertSynonyms(type).ShouldBe(synonym);
     }
+
+    [Fact]
+    public void execute_to_parameter_type_with_open_generics()
+    {
+        PostgresqlProvider.Instance.RegisterMapping(typeof(WithOpenGeneric<>), "varchar", NpgsqlDbType.Varchar);
+        PostgresqlProvider.Instance.ToParameterType(typeof(WithOpenGeneric<>)).ShouldBe(NpgsqlDbType.Varchar);
+    }
+
+    [Fact]
+    public void execute_to_parameter_type_with_closed_generics_falls_back_to_open()
+    {
+        PostgresqlProvider.Instance.RegisterMapping(typeof(WithOpenGeneric<>), "varchar", NpgsqlDbType.Varchar);
+        PostgresqlProvider.Instance.ToParameterType(typeof(WithOpenGeneric<int>)).ShouldBe(NpgsqlDbType.Varchar);
+    }
+
+    [Fact]
+    public void execute_to_parameter_type_with_closed_generics()
+    {
+        PostgresqlProvider.Instance.RegisterMapping(typeof(WithClosedGeneric<int>), "varchar", NpgsqlDbType.Varchar);
+        PostgresqlProvider.Instance.ToParameterType(typeof(WithClosedGeneric<int>)).ShouldBe(NpgsqlDbType.Varchar);
+    }
+
+    [Fact]
+    public void execute_to_parameter_type_with_closed_generics_open_generic()
+    {
+        PostgresqlProvider.Instance.RegisterMapping(typeof(WithClosedGeneric<int>), "varchar", NpgsqlDbType.Varchar);
+        Action act = () => PostgresqlProvider.Instance.ToParameterType(typeof(WithClosedGeneric<>));
+        act.ShouldThrow<NotSupportedException>();
+    }
+
+    [Fact]
+    public void execute_to_parameter_type_with_closed_generics_generic_override()
+    {
+        PostgresqlProvider.Instance.RegisterMapping(typeof(WithClosedGeneric<int>), "varchar", NpgsqlDbType.Varchar);
+        Action act = () => PostgresqlProvider.Instance.ToParameterType(typeof(WithClosedGeneric<string>));
+        act.ShouldThrow<NotSupportedException>();
+    }
+
+    [Fact]
+    public void execute_to_parameter_type_with_closed_generics_overrides_definitions_with_open_generic()
+    {
+        PostgresqlProvider.Instance.RegisterMapping(typeof(WithMixedGeneric<>), "varchar", NpgsqlDbType.Varchar);
+        PostgresqlProvider.Instance.RegisterMapping(typeof(WithMixedGeneric<int>), "integer", NpgsqlDbType.Integer);
+        PostgresqlProvider.Instance.RegisterMapping(typeof(WithMixedGeneric<bool>), "boolean", NpgsqlDbType.Boolean);
+        PostgresqlProvider.Instance.ToParameterType(typeof(WithMixedGeneric<int>)).ShouldBe(NpgsqlDbType.Integer);
+        PostgresqlProvider.Instance.ToParameterType(typeof(WithMixedGeneric<bool>)).ShouldBe(NpgsqlDbType.Boolean);
+        PostgresqlProvider.Instance.ToParameterType(typeof(WithMixedGeneric<string>)).ShouldBe(NpgsqlDbType.Varchar);
+    }
+
+    [Fact]
+    public void execute_to_db_type_with_open_generics()
+    {
+        PostgresqlProvider.Instance.RegisterMapping(typeof(WithOpenGeneric<>), "varchar", NpgsqlDbType.Varchar);
+        PostgresqlProvider.Instance.GetDatabaseType(typeof(WithOpenGeneric<>), EnumStorage.AsInteger).ShouldBe("varchar");
+    }
+
+    [Fact]
+    public void execute_to_db_type_with_closed_generics_falls_back_to_open()
+    {
+        PostgresqlProvider.Instance.RegisterMapping(typeof(WithOpenGeneric<>), "varchar", NpgsqlDbType.Varchar);
+        PostgresqlProvider.Instance.GetDatabaseType(typeof(WithOpenGeneric<int>), EnumStorage.AsInteger).ShouldBe("varchar");
+    }
+
+    [Fact]
+    public void execute_to_db_type_with_closed_generics()
+    {
+        PostgresqlProvider.Instance.RegisterMapping(typeof(WithClosedGeneric<int>), "varchar", NpgsqlDbType.Varchar);
+        PostgresqlProvider.Instance.GetDatabaseType(typeof(WithClosedGeneric<int>), EnumStorage.AsInteger).ShouldBe("varchar");
+    }
+
+    [Fact]
+    public void execute_to_db_type_with_closed_generics_open_generic()
+    {
+        PostgresqlProvider.Instance.RegisterMapping(typeof(WithClosedGeneric<int>), "varchar", NpgsqlDbType.Varchar);
+        PostgresqlProvider.Instance.GetDatabaseType(typeof(WithClosedGeneric<>), EnumStorage.AsInteger).ShouldBe("jsonb");
+    }
+
+    [Fact]
+    public void execute_to_db_type_with_closed_generics_generic_override()
+    {
+        PostgresqlProvider.Instance.RegisterMapping(typeof(WithClosedGeneric<int>), "varchar", NpgsqlDbType.Varchar);
+        PostgresqlProvider.Instance.GetDatabaseType(typeof(WithClosedGeneric<string>), EnumStorage.AsInteger).ShouldBe("jsonb");
+    }
+
+    [Fact]
+    public void execute_to_db_type_with_closed_generics_overrides_definitions_with_open_generic()
+    {
+        PostgresqlProvider.Instance.RegisterMapping(typeof(WithMixedGeneric<>), "varchar", NpgsqlDbType.Varchar);
+        PostgresqlProvider.Instance.RegisterMapping(typeof(WithMixedGeneric<int>), "integer", NpgsqlDbType.Integer);
+        PostgresqlProvider.Instance.RegisterMapping(typeof(WithMixedGeneric<bool>), "boolean", NpgsqlDbType.Boolean);
+        PostgresqlProvider.Instance.GetDatabaseType(typeof(WithMixedGeneric<int>), EnumStorage.AsInteger).ShouldBe("integer");
+        PostgresqlProvider.Instance.GetDatabaseType(typeof(WithMixedGeneric<bool>), EnumStorage.AsInteger).ShouldBe("boolean");
+        PostgresqlProvider.Instance.GetDatabaseType(typeof(WithMixedGeneric<string>), EnumStorage.AsInteger).ShouldBe("varchar");
+    }
+
+    public class WithOpenGeneric<T>
+    {
+    }
+
+    public class WithClosedGeneric<T>
+    {
+    }
+
+    public class WithMixedGeneric<T>
+    {
+    }
 }
 
 [CollectionDefinition("PostgresqlProviderTests", DisableParallelization = true)]

--- a/src/Weasel.Postgresql/PostgresqlProvider.cs
+++ b/src/Weasel.Postgresql/PostgresqlProvider.cs
@@ -219,13 +219,17 @@ public class PostgresqlProvider: DatabaseProvider<NpgsqlCommand, NpgsqlParameter
             return GetDatabaseType(memberType.GetInnerTypeFromNullable(), enumStyle);
         }
 
-        if (memberType.IsConstructedGenericType)
+        if (ResolveDatabaseType(memberType) is { } result)
         {
-            var templateType = memberType.GetGenericTypeDefinition();
-            return ResolveDatabaseType(templateType) ?? "jsonb";
+            return result;
         }
 
-        return ResolveDatabaseType(memberType) ?? "jsonb";
+        if (memberType.IsConstructedGenericType)
+        {
+            return GetDatabaseType(memberType.GetGenericTypeDefinition(), enumStyle);
+        }
+
+        return "jsonb";
     }
 
     public override void AddParameter(NpgsqlCommand command, NpgsqlParameter parameter)

--- a/src/Weasel.Postgresql/PostgresqlProvider.cs
+++ b/src/Weasel.Postgresql/PostgresqlProvider.cs
@@ -142,10 +142,8 @@ public class PostgresqlProvider: DatabaseProvider<NpgsqlCommand, NpgsqlParameter
         var npgsqlDbType = ResolveNpgsqlDbType(type);
         if (npgsqlDbType != null)
         {
-            {
-                dbType = npgsqlDbType.Value;
-                return true;
-            }
+            dbType = npgsqlDbType.Value;
+            return true;
         }
 
         if (type.IsNullable())
@@ -168,10 +166,8 @@ public class PostgresqlProvider: DatabaseProvider<NpgsqlCommand, NpgsqlParameter
                 return true;
             }
 
-            {
-                dbType = NpgsqlDbType.Array | ToParameterType(type.GetElementType()!);
-                return true;
-            }
+            dbType = NpgsqlDbType.Array | ToParameterType(type.GetElementType()!);
+            return true;
         }
 
         var typeInfo = type.GetTypeInfo();
@@ -195,6 +191,12 @@ public class PostgresqlProvider: DatabaseProvider<NpgsqlCommand, NpgsqlParameter
         if (type == typeof(DBNull))
         {
             dbType = NpgsqlDbType.Unknown;
+            return true;
+        }
+
+        if (typeInfo.IsConstructedGenericType)
+        {
+            dbType = ToParameterType(type.GetGenericTypeDefinition());
             return true;
         }
 

--- a/src/Weasel.SqlServer.Tests/SqlServerProviderTests.cs
+++ b/src/Weasel.SqlServer.Tests/SqlServerProviderTests.cs
@@ -1,5 +1,6 @@
-﻿using System.Data;
+using System.Data;
 using Shouldly;
+using Weasel.Core;
 using Xunit;
 
 namespace Weasel.SqlServer.Tests;
@@ -40,5 +41,111 @@ public class SqlServerProviderTests
         var inputString = "Darth        Maroon the   First";
         var expectedString = "Darth Maroon the First";
         inputString.ReplaceMultiSpace(" ").ShouldBe(expectedString);
+    }
+
+    [Fact]
+    public void execute_to_parameter_type_with_open_generics()
+    {
+        SqlServerProvider.Instance.RegisterMapping(typeof(WithOpenGeneric<>), "VarChar", SqlDbType.VarChar);
+        SqlServerProvider.Instance.ToParameterType(typeof(WithOpenGeneric<>)).ShouldBe(SqlDbType.VarChar);
+    }
+
+    [Fact(Skip = "Different backing behaviour than for Postgres")]
+    public void execute_to_parameter_type_with_closed_generics_falls_back_to_open()
+    {
+        SqlServerProvider.Instance.RegisterMapping(typeof(WithOpenGeneric<>), "VarChar", SqlDbType.VarChar);
+        SqlServerProvider.Instance.ToParameterType(typeof(WithOpenGeneric<int>)).ShouldBe(SqlDbType.VarChar);
+    }
+
+    [Fact]
+    public void execute_to_parameter_type_with_closed_generics()
+    {
+        SqlServerProvider.Instance.RegisterMapping(typeof(WithClosedGeneric<int>), "VarChar", SqlDbType.VarChar);
+        SqlServerProvider.Instance.ToParameterType(typeof(WithClosedGeneric<int>)).ShouldBe(SqlDbType.VarChar);
+    }
+
+    [Fact(Skip = "Different backing behaviour than for Postgres")]
+    public void execute_to_parameter_type_with_closed_generics_open_generic()
+    {
+        SqlServerProvider.Instance.RegisterMapping(typeof(WithClosedGeneric<int>), "VarChar", SqlDbType.VarChar);
+        Action act = () => SqlServerProvider.Instance.ToParameterType(typeof(WithClosedGeneric<>));
+        act.ShouldThrow<NotSupportedException>();
+    }
+
+    [Fact(Skip = "Different backing behaviour than for Postgres")]
+    public void execute_to_parameter_type_with_closed_generics_generic_override()
+    {
+        SqlServerProvider.Instance.RegisterMapping(typeof(WithClosedGeneric<int>), "VarChar", SqlDbType.VarChar);
+        Action act = () => SqlServerProvider.Instance.ToParameterType(typeof(WithClosedGeneric<string>));
+        act.ShouldThrow<NotSupportedException>();
+    }
+
+    [Fact(Skip = "Different backing behaviour than for Postgres")]
+    public void execute_to_parameter_type_with_closed_generics_overrides_definitions_with_open_generic()
+    {
+        SqlServerProvider.Instance.RegisterMapping(typeof(WithMixedGeneric<>), "VarChar", SqlDbType.VarChar);
+        SqlServerProvider.Instance.RegisterMapping(typeof(WithMixedGeneric<int>), "integer", SqlDbType.Int);
+        SqlServerProvider.Instance.RegisterMapping(typeof(WithMixedGeneric<bool>), "boolean", SqlDbType.Bit);
+        SqlServerProvider.Instance.ToParameterType(typeof(WithMixedGeneric<int>)).ShouldBe(SqlDbType.Int);
+        SqlServerProvider.Instance.ToParameterType(typeof(WithMixedGeneric<bool>)).ShouldBe(SqlDbType.Bit);
+        SqlServerProvider.Instance.ToParameterType(typeof(WithMixedGeneric<string>)).ShouldBe(SqlDbType.VarChar);
+    }
+
+    [Fact]
+    public void execute_to_db_type_with_open_generics()
+    {
+        SqlServerProvider.Instance.RegisterMapping(typeof(WithOpenGeneric<>), "VarChar", SqlDbType.VarChar);
+        SqlServerProvider.Instance.GetDatabaseType(typeof(WithOpenGeneric<>), EnumStorage.AsInteger).ShouldBe("VarChar");
+    }
+
+    [Fact(Skip = "Different backing behaviour than for Postgres")]
+    public void execute_to_db_type_with_closed_generics_falls_back_to_open()
+    {
+        SqlServerProvider.Instance.RegisterMapping(typeof(WithOpenGeneric<>), "VarChar", SqlDbType.VarChar);
+        SqlServerProvider.Instance.GetDatabaseType(typeof(WithOpenGeneric<int>), EnumStorage.AsInteger).ShouldBe("VarChar");
+    }
+
+    [Fact]
+    public void execute_to_db_type_with_closed_generics()
+    {
+        SqlServerProvider.Instance.RegisterMapping(typeof(WithClosedGeneric<int>), "VarChar", SqlDbType.VarChar);
+        SqlServerProvider.Instance.GetDatabaseType(typeof(WithClosedGeneric<int>), EnumStorage.AsInteger).ShouldBe("VarChar");
+    }
+
+    [Fact(Skip = "Different backing behaviour than for Postgres")]
+    public void execute_to_db_type_with_closed_generics_open_generic()
+    {
+        SqlServerProvider.Instance.RegisterMapping(typeof(WithClosedGeneric<int>), "VarChar", SqlDbType.VarChar);
+        SqlServerProvider.Instance.GetDatabaseType(typeof(WithClosedGeneric<>), EnumStorage.AsInteger).ShouldBe("nvarchar(max)");
+    }
+
+    [Fact(Skip = "Different backing behaviour than for Postgres")]
+    public void execute_to_db_type_with_closed_generics_generic_override()
+    {
+        SqlServerProvider.Instance.RegisterMapping(typeof(WithClosedGeneric<int>), "VarChar", SqlDbType.VarChar);
+        SqlServerProvider.Instance.GetDatabaseType(typeof(WithClosedGeneric<string>), EnumStorage.AsInteger).ShouldBe("nvarchar(max)");
+    }
+
+    [Fact(Skip = "Different backing behaviour than for Postgres")]
+    public void execute_to_db_type_with_closed_generics_overrides_definitions_with_open_generic()
+    {
+        SqlServerProvider.Instance.RegisterMapping(typeof(WithMixedGeneric<>), "VarChar", SqlDbType.VarChar);
+        SqlServerProvider.Instance.RegisterMapping(typeof(WithMixedGeneric<int>), "integer", SqlDbType.Int);
+        SqlServerProvider.Instance.RegisterMapping(typeof(WithMixedGeneric<bool>), "boolean", SqlDbType.Bit);
+        SqlServerProvider.Instance.GetDatabaseType(typeof(WithMixedGeneric<int>), EnumStorage.AsInteger).ShouldBe("integer");
+        SqlServerProvider.Instance.GetDatabaseType(typeof(WithMixedGeneric<bool>), EnumStorage.AsInteger).ShouldBe("boolean");
+        SqlServerProvider.Instance.GetDatabaseType(typeof(WithMixedGeneric<string>), EnumStorage.AsInteger).ShouldBe("VarChar");
+    }
+
+    public class WithOpenGeneric<T>
+    {
+    }
+
+    public class WithClosedGeneric<T>
+    {
+    }
+
+    public class WithMixedGeneric<T>
+    {
     }
 }

--- a/src/Weasel.SqlServer/SqlServerProvider.cs
+++ b/src/Weasel.SqlServer/SqlServerProvider.cs
@@ -101,10 +101,8 @@ public class SqlServerProvider: DatabaseProvider<SqlCommand, SqlParameter, SqlDb
         var SqlDbType = ResolveSqlDbType(type);
         if (SqlDbType != null)
         {
-            {
-                dbType = SqlDbType.Value;
-                return true;
-            }
+            dbType = SqlDbType.Value;
+            return true;
         }
 
         if (type.IsNullable())
@@ -127,6 +125,12 @@ public class SqlServerProvider: DatabaseProvider<SqlCommand, SqlParameter, SqlDb
         if (type == typeof(DBNull))
         {
             dbType = System.Data.SqlDbType.Variant;
+            return true;
+        }
+
+        if (type.IsConstructedGenericType)
+        {
+            dbType = ToParameterType(type.GetGenericTypeDefinition());
             return true;
         }
 

--- a/src/Weasel.SqlServer/SqlServerProvider.cs
+++ b/src/Weasel.SqlServer/SqlServerProvider.cs
@@ -151,13 +151,17 @@ public class SqlServerProvider: DatabaseProvider<SqlCommand, SqlParameter, SqlDb
             return GetDatabaseType(memberType.GetInnerTypeFromNullable(), enumStyle);
         }
 
-        if (memberType.IsConstructedGenericType)
+        if (ResolveDatabaseType(memberType) is { } result)
         {
-            var templateType = memberType.GetGenericTypeDefinition();
-            return ResolveDatabaseType(templateType) ?? "nvarchar(max)";
+            return result;
         }
 
-        return ResolveDatabaseType(memberType) ?? "nvarchar(max)";
+        if (memberType.IsConstructedGenericType)
+        {
+            return GetDatabaseType(memberType.GetGenericTypeDefinition(), enumStyle);
+        }
+
+        return "nvarchar(max)";
     }
 
     public override void AddParameter(SqlCommand command, SqlParameter parameter)


### PR DESCRIPTION
Resolves #128 

Copy from issue:

Currenlty the implementation of GetDatabaseType and ToParameterType treat types with generics in different ways:

- GetDatabaseType always strips the concrete generic arguments to retrieve the generic type definition and uses that to try and retrieve the registered type name.
- ToParameterType does not have special handling.

I would expect these two functions to treat generic types in the same way (otherwise it is always required to add 1 concrete and 1 open version to e.g. the NpgsqlTypeMapping implementation).

My proposal would be to first attempt to find a mapping for the type directly, if there is no such definition, retry on the open generic version of it.