### PR TITLE
Remove System.Data.Common package dependency

### DIFF
--- a/src/Weasel.Core/Weasel.Core.csproj
+++ b/src/Weasel.Core/Weasel.Core.csproj
@@ -17,7 +17,6 @@
 
     <ItemGroup>
         <PackageReference Include="JasperFx.Core" Version="1.5.1" />
-        <PackageReference Include="System.Data.Common" Version="4.3.0" />
     </ItemGroup>
     <Import Project="../../Analysis.Build.props" />
 </Project>


### PR DESCRIPTION
`System.Data.Common` is part of .NET and the package dependency is not needed. The package dependency also generates false positive security warnings in some scanning tools, as it references packages with known security issues. It is a false positive because when the application is deployed, the current version from .NET is used, not version 4.3.0.

Closes #125 