### PR TITLE
Link to repository URL in NuGet package

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
         <Nullable>enable</Nullable>
         <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
         <Authors>Jeremy D. Miller;Babu Annamalai;Oskar Dudycz;Joona-Pekka Kokko</Authors>
-        <PackageProjectUrl>http://github.io/jasperfx/weasel</PackageProjectUrl>
+        <PackageProjectUrl>https://github.com/JasperFx/weasel</PackageProjectUrl>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618</NoWarn>
         <PackageIconUrl>https://raw.githubusercontent.com/JasperFx/JasperFx.Core/main/jasperfx-logo.jpg?raw=true</PackageIconUrl>


### PR DESCRIPTION
`http://github.io/jasperfx/weasel` is not a valid URL. As I couldn't find a documentation page for Weasel I changed it to the repository URL.