### PR TITLE
Fix parsing of multicolumn fulltext indexes

### DIFF
--- a/src/Weasel.Postgresql/Tables/IndexDefinition.cs
+++ b/src/Weasel.Postgresql/Tables/IndexDefinition.cs
@@ -734,10 +734,12 @@ public class IndexDefinition: INamed
             .Replace("IS NOT NULL", "is not null")
             .Replace("INDEX CONCURRENTLY", "INDEX")
             .Replace("::text", "")
+            .Replace("::regconfig", "")
             .Replace(" ->> ", "->>")
             .Replace(" -> ", "->")
             .Replace(IndexCreationBeginComment, "")
             .Replace(IndexCreationEndComment, "")
+            .Replace(", ", ",")
             .Trim()
             .TrimEnd(new[] { ';' })
             .ToLowerInvariant();


### PR DESCRIPTION
Some edge cases where parsing did not match the generated DDL,

Specifically, the `::regconfig` and spaces between index columns was causing trouble.

Side note, there is no good way to define an index like the following from marten, none of the overloads give you enough control over the columns to add the tsvector mask to only 1 column, and the order of the tenant column cannot be chosen (it defaults to the end of the index, though with future partitioning it would likely need to be the start of the index).

```csharp
var index1 = new IndexDefinition("mt_doc_mydata_idx_fulltext_search")
{
    Columns =
    [
        "tenant_id",
        "type",
        "is_active_and_not_archived",
        "to_tsvector('english', (data ->> 'SearchableValue'::text))"
    ],
    Method = IndexMethod.gin
};
```