### PR TITLE
add postgis geometry as valid column type

### DIFF
--- a/src/Weasel.Postgresql.Tests/Tables/TableColumnTests.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/TableColumnTests.cs
@@ -1,3 +1,4 @@
+using NetTopologySuite.Geometries;
 using Shouldly;
 using Weasel.Postgresql.Tables;
 using Xunit;
@@ -118,5 +119,15 @@ public class TableColumnTests
 
         column.AddColumnSql(table)
             .ShouldBe($"alter table {Instance.Parse("public.people")} add column name1 varchar NOT NULL;");
+    }
+
+    [Fact]
+    public void add_column_sql_geometry()
+    {
+        var table = new Table("map");
+        var column = table.AddColumn<Geometry>("geom").NotNull().Column;
+
+        column.AddColumnSql(table)
+            .ShouldBe($"alter table {Instance.Parse("public.map")} add column geom geometry NOT NULL;");
     }
 }

--- a/src/Weasel.Postgresql/NpgsqlTypeMapping.cs
+++ b/src/Weasel.Postgresql/NpgsqlTypeMapping.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Immutable;
 using System.Collections.Specialized;
 using System.Data;
@@ -7,6 +7,7 @@ using System.Net.NetworkInformation;
 using System.Numerics;
 using System.Text.Json;
 using JasperFx.Core;
+using NetTopologySuite.Geometries;
 using NpgsqlTypes;
 
 namespace Weasel.Postgresql;
@@ -103,6 +104,7 @@ public class NpgsqlTypeMapper
         {NpgsqlDbType.Path, new NpgsqlTypeMapping(NpgsqlDbType.Path, DbType.Object, "path", typeof(NpgsqlPath))},
         {NpgsqlDbType.Point, new NpgsqlTypeMapping(NpgsqlDbType.Point, DbType.Object, "point", typeof(NpgsqlPoint))},
         {NpgsqlDbType.Polygon, new NpgsqlTypeMapping(NpgsqlDbType.Polygon, DbType.Object, "polygon", typeof(NpgsqlPolygon))},
+        {NpgsqlDbType.Geometry, new NpgsqlTypeMapping(NpgsqlDbType.Geometry, DbType.Object, "geometry", typeof(Geometry))},
 
         // LTree types
         {NpgsqlDbType.LQuery, new NpgsqlTypeMapping(NpgsqlDbType.LQuery, DbType.Object, "lquery")},

--- a/src/Weasel.Postgresql/Weasel.Postgresql.csproj
+++ b/src/Weasel.Postgresql/Weasel.Postgresql.csproj
@@ -33,6 +33,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+        <PackageReference Include="Npgsql.NetTopologySuite" Version="8.0.3" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Weasel.Core\Weasel.Core.csproj" />


### PR DESCRIPTION
This small pr simply also adds the PostGIS geometry type as a valid Type when creating a column.

`table.AddColumn<Geometry>("geom");`

Will now correctly create the type. Note that if the PostGIS extension is not enabled you will run into errors.