### PR TITLE
Add support for adding named parameters using dictionaries.

### DIFF
--- a/src/Weasel.Postgresql.Tests/BatchBuilderTests.cs
+++ b/src/Weasel.Postgresql.Tests/BatchBuilderTests.cs
@@ -36,6 +36,16 @@ public class BatchBuilderTests : IntegrationContext
         batcher.Append("insert into batching.thing (id, tag, age) values (");
         batcher.AppendParameters(5, "green", 11);
         batcher.Append(")");
+        batcher.StartNewCommand();
+        batcher.Append("insert into batching.thing (id, tag, age) values (:id, :tag, :age)");
+        batcher.AddParameters(new { id = 6, tag = "yellow", age = 12 });
+        batcher.StartNewCommand();
+        batcher.Append("insert into batching.thing (id, tag, age) values (:id, :tag, :age)");
+        batcher.AddParameters((object)new Dictionary<string, object?> { { "id", 7 }, { "tag", "red" }, { "age", 13 } });
+        batcher.StartNewCommand();
+        batcher.Append("insert into batching.thing (id, tag, age) values (:id, :tag, :age)");
+        batcher.AddParameters((object)new Dictionary<string, int> { { "id", 8 }, { "age", 14 } });
+        batcher.AddParameters((object)new Dictionary<string, string> { { "tag", "purple" } });
         batcher.Compile();
 
         await batch.ExecuteNonQueryAsync();
@@ -54,5 +64,23 @@ public class BatchBuilderTests : IntegrationContext
         (await reader.GetFieldValueAsync<int>(0)).ShouldBe(5);
         (await reader.GetFieldValueAsync<string>(1)).ShouldBe("green");
         (await reader.GetFieldValueAsync<int>(2)).ShouldBe(11);
+
+        await reader.ReadAsync();
+
+        (await reader.GetFieldValueAsync<int>(0)).ShouldBe(6);
+        (await reader.GetFieldValueAsync<string>(1)).ShouldBe("yellow");
+        (await reader.GetFieldValueAsync<int>(2)).ShouldBe(12);
+
+        await reader.ReadAsync();
+
+        (await reader.GetFieldValueAsync<int>(0)).ShouldBe(7);
+        (await reader.GetFieldValueAsync<string>(1)).ShouldBe("red");
+        (await reader.GetFieldValueAsync<int>(2)).ShouldBe(13);
+
+        await reader.ReadAsync();
+
+        (await reader.GetFieldValueAsync<int>(0)).ShouldBe(8);
+        (await reader.GetFieldValueAsync<string>(1)).ShouldBe("purple");
+        (await reader.GetFieldValueAsync<int>(2)).ShouldBe(14);
     }
 }

--- a/src/Weasel.Postgresql.Tests/CommandBuilderIntegrationTests.cs
+++ b/src/Weasel.Postgresql.Tests/CommandBuilderIntegrationTests.cs
@@ -41,6 +41,151 @@ public class CommandBuilderIntegrationTests: IntegrationContext
     }
 
     [Fact]
+    public async Task use_parameters_to_query_by_dictionary_string_nullable_object()
+    {
+        var table = new Table("integration.thing");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn<string>("tag");
+        table.AddColumn<int>("age");
+
+        await ResetSchema();
+
+        await CreateSchemaObjectInDatabase(table);
+
+        var builder = new CommandBuilder();
+        builder.Append("insert into integration.thing (id, tag, age) values (:id, :tag, :age)");
+        var parameters = new Dictionary<string, object?> { { "id", 3 }, { "tag", "Toodles" }, { "age", 5 } };
+        builder.AddParameters(parameters);
+
+        await theConnection.ExecuteNonQueryAsync(builder);
+
+        await using var reader = await theConnection.CreateCommand("select id, tag, age from integration.thing")
+            .ExecuteReaderAsync();
+
+        await reader.ReadAsync();
+
+        (await reader.GetFieldValueAsync<int>(0)).ShouldBe(3);
+        (await reader.GetFieldValueAsync<string>(1)).ShouldBe("Toodles");
+        (await reader.GetFieldValueAsync<int>(2)).ShouldBe(5);
+    }
+
+    [Fact]
+    public async Task use_parameters_to_query_by_dictionary_string_object()
+    {
+        var table = new Table("integration.thing");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn<string>("tag");
+        table.AddColumn<int>("age");
+
+        await ResetSchema();
+
+        await CreateSchemaObjectInDatabase(table);
+
+        var builder = new CommandBuilder();
+        builder.Append("insert into integration.thing (id, tag, age) values (:id, :tag, :age)");
+        var parameters = new Dictionary<string, object> { { "id", 3 }, { "tag", "Toodles" }, { "age", 5 } };
+        builder.AddParameters(parameters);
+
+        await theConnection.ExecuteNonQueryAsync(builder);
+
+        await using var reader = await theConnection.CreateCommand("select id, tag, age from integration.thing")
+            .ExecuteReaderAsync();
+
+        await reader.ReadAsync();
+
+        (await reader.GetFieldValueAsync<int>(0)).ShouldBe(3);
+        (await reader.GetFieldValueAsync<string>(1)).ShouldBe("Toodles");
+        (await reader.GetFieldValueAsync<int>(2)).ShouldBe(5);
+    }
+
+    [Fact]
+    public async Task use_parameters_to_query_by_dictionary_string_string()
+    {
+        var table = new Table("integration.thing");
+        table.AddColumn<string>("id").AsPrimaryKey();
+        table.AddColumn<string>("tag");
+        table.AddColumn<string>("age");
+
+        await ResetSchema();
+
+        await CreateSchemaObjectInDatabase(table);
+
+        var builder = new CommandBuilder();
+        builder.Append("insert into integration.thing (id, tag, age) values (:id, :tag, :age)");
+        var parameters = new Dictionary<string, string> { { "id", "3" }, { "tag", "Toodles" }, { "age", "5" } };
+        builder.AddParameters(parameters);
+
+        await theConnection.ExecuteNonQueryAsync(builder);
+
+        await using var reader = await theConnection.CreateCommand("select id, tag, age from integration.thing")
+            .ExecuteReaderAsync();
+
+        await reader.ReadAsync();
+
+        (await reader.GetFieldValueAsync<string>(0)).ShouldBe("3");
+        (await reader.GetFieldValueAsync<string>(1)).ShouldBe("Toodles");
+        (await reader.GetFieldValueAsync<string>(2)).ShouldBe("5");
+    }
+
+    [Fact]
+    public async Task use_parameters_to_query_by_dictionary_string_nullable_object_as_object()
+    {
+        var table = new Table("integration.thing");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn<string>("tag");
+        table.AddColumn<int>("age");
+
+        await ResetSchema();
+
+        await CreateSchemaObjectInDatabase(table);
+
+        var builder = new CommandBuilder();
+        builder.Append("insert into integration.thing (id, tag, age) values (:id, :tag, :age)");
+        var parameters = new Dictionary<string, object?> { { "id", 3 }, { "tag", "Toodles" }, { "age", 5 } };
+        builder.AddParameters((object)parameters);
+
+        await theConnection.ExecuteNonQueryAsync(builder);
+
+        await using var reader = await theConnection.CreateCommand("select id, tag, age from integration.thing")
+            .ExecuteReaderAsync();
+
+        await reader.ReadAsync();
+
+        (await reader.GetFieldValueAsync<int>(0)).ShouldBe(3);
+        (await reader.GetFieldValueAsync<string>(1)).ShouldBe("Toodles");
+        (await reader.GetFieldValueAsync<int>(2)).ShouldBe(5);
+    }
+
+    [Fact]
+    public async Task use_parameters_to_query_by_dictionary_string_string_as_object()
+    {
+        var table = new Table("integration.thing");
+        table.AddColumn<string>("id").AsPrimaryKey();
+        table.AddColumn<string>("tag");
+        table.AddColumn<string>("age");
+
+        await ResetSchema();
+
+        await CreateSchemaObjectInDatabase(table);
+
+        var builder = new CommandBuilder();
+        builder.Append("insert into integration.thing (id, tag, age) values (:id, :tag, :age)");
+        var parameters = new Dictionary<string, string> { { "id", "3" }, { "tag", "Toodles" }, { "age", "5" } };
+        builder.AddParameters((object)parameters);
+
+        await theConnection.ExecuteNonQueryAsync(builder);
+
+        await using var reader = await theConnection.CreateCommand("select id, tag, age from integration.thing")
+            .ExecuteReaderAsync();
+
+        await reader.ReadAsync();
+
+        (await reader.GetFieldValueAsync<string>(0)).ShouldBe("3");
+        (await reader.GetFieldValueAsync<string>(1)).ShouldBe("Toodles");
+        (await reader.GetFieldValueAsync<string>(2)).ShouldBe("5");
+    }
+
+    [Fact]
     public async Task use_parameters_to_query_by_anonymous_type_by_generic_command_builder()
     {
         var table = new Table("integration.thing");

--- a/src/Weasel.Postgresql/ICommandBuilder.cs
+++ b/src/Weasel.Postgresql/ICommandBuilder.cs
@@ -48,8 +48,21 @@ public interface ICommandBuilder
     void StartNewCommand();
 
     /// <summary>
-    /// Use an anonymous type to add named parameters
+    ///     Use an anonymous type to add named parameters.
+    ///     If a dictionary is passed in then its key-value pairs will be used as named parameters
     /// </summary>
     /// <param name="parameters"></param>
     void AddParameters(object parameters);
+
+    /// <summary>
+    ///     Use a dictionary to add named parameters
+    /// </summary>
+    /// <param name="parameters"></param>
+    void AddParameters(IDictionary<string, object?> parameters);
+
+    /// <summary>
+    ///     Use a dictionary to add named parameters
+    /// </summary>
+    /// <param name="parameters"></param>
+    void AddParameters<T>(IDictionary<string, T> parameters);
 }


### PR DESCRIPTION
New methods:
```csharp
void ICommandBuilder.AddParameters(IDictionary<string, object?> parameters);
void ICommandBuilder.AddParameters<T>(IDictionary<string, T> parameters);
```

These will take the passed in dictionary and parse it as a set of named parameters. Additionally, `ICommandBuilder.AddParameters(object)` will now detect if the passed in object is an `IDictionary` with a key type of `string`, and if so will pass to the new methods to handle.

This does result in a change of behaviour for the existing `AddParameters` method, but the old behaviour when passing a dictionary in would have been for npgsql to throw an error, so not seeing this as a downside.


Testing - added/updated tests to cover both the new methods and new behaviour in existing methods (in both the command builder and batch builder)


Next steps: update marten to support this, document named params in marten (both via anon objects and via dictionaries)