### PR TITLE
Support named parameters in where fragments

### DIFF
--- a/src/Weasel.Postgresql/SqlGeneration/CustomizableWhereFragment.cs
+++ b/src/Weasel.Postgresql/SqlGeneration/CustomizableWhereFragment.cs
@@ -1,14 +1,15 @@
-using JasperFx.Core;
+using System.Collections;
+using JasperFx.Core.Reflection;
 
 namespace Weasel.Postgresql.SqlGeneration;
 
 public class CustomizableWhereFragment: ISqlFragment
 {
-    private readonly CommandParameter[] _parameters;
+    private readonly object[] _parameters;
     private readonly string _sql;
     private readonly char _token;
 
-    public CustomizableWhereFragment(string sql, string paramReplacementToken, params CommandParameter[] parameters)
+    public CustomizableWhereFragment(string sql, string paramReplacementToken, params object[] parameters)
     {
         _sql = sql;
         _parameters = parameters;
@@ -17,13 +18,31 @@ public class CustomizableWhereFragment: ISqlFragment
 
     public void Apply(ICommandBuilder builder)
     {
+        // backwards compatibility, old version of this class accepted CommandParameter[]
+        if (_parameters is [CommandParameter { Value: { } firstVal }] && (firstVal.IsAnonymousType() || firstVal is IDictionary { Keys: ICollection<string> }))
+        {
+            builder.Append(_sql);
+            builder.AddParameters(firstVal);
+            return;
+        }
+
+        if (_parameters is [{ } first] && (first.IsAnonymousType() || first is IDictionary { Keys: ICollection<string> }))
+        {
+            builder.Append(_sql);
+            builder.AddParameters(first);
+            return;
+        }
+        
+
         var parameters = builder.AppendWithParameters(_sql, _token);
         for (var i = 0; i < parameters.Length; i++)
         {
-            parameters[i].Value = _parameters[i].Value;
-            if (_parameters[i].DbType.HasValue)
+            // backwards compatibility, old version of this class accepted CommandParameter[]
+            var commandParameter = _parameters[i] as CommandParameter ?? new CommandParameter(_parameters[i]);
+            parameters[i].Value = commandParameter.Value;
+            if (commandParameter.DbType.HasValue)
             {
-                parameters[i].NpgsqlDbType = _parameters[i].DbType.Value;
+                parameters[i].NpgsqlDbType = commandParameter.DbType.Value;
             }
         }
     }

--- a/src/Weasel.Postgresql/SqlGeneration/WhereFragment.cs
+++ b/src/Weasel.Postgresql/SqlGeneration/WhereFragment.cs
@@ -2,8 +2,7 @@ namespace Weasel.Postgresql.SqlGeneration;
 
 public class WhereFragment: CustomizableWhereFragment
 {
-    public WhereFragment(string sql, params object[] parameters): base(sql, "?",
-        parameters.Select(x => new CommandParameter(x)).ToArray())
+    public WhereFragment(string sql, params object[] parameters): base(sql, "?", parameters)
     {
     }
 }


### PR DESCRIPTION
Updated `CustomizableWhereFragment` to automatically handle named parameters being passed in (as either an anonymous object or a Dictionary<string, something>).  This was missing from my last PR and meant that some places I expected named parameters to work didnt work.


Regarding testing, there seems to be no tests for these codegen fragments in Weasel, they all seem to be in Marten. I have updated the tests in https://github.com/JasperFx/marten/pull/3604 but the marten PR will only pass if this PR is merged and referenced.

