### PR TITLE
Check SqlState instead of error message

### DIFF
--- a/src/Weasel.Postgresql.Tests/IntegrationContext.cs
+++ b/src/Weasel.Postgresql.Tests/IntegrationContext.cs
@@ -56,7 +56,7 @@ public abstract class IntegrationContext: IDisposable, IAsyncLifetime
         catch (NpgsqlException e)
         {
             // Quirk of postgres metadata tables, this will throw on the partition querying if the table does not already exist
-            if (!e.Message.Contains("does not exist"))
+            if (e.SqlState != PostgresErrorCodes.UndefinedTable)
             {
                 throw;
             }

--- a/src/Weasel.Postgresql/Tables/Partitioning/ManagedListPartitions.cs
+++ b/src/Weasel.Postgresql/Tables/Partitioning/ManagedListPartitions.cs
@@ -278,7 +278,7 @@ public class ManagedListPartitions : FeatureSchemaBase, IDatabaseInitializer<Npg
         // 42P01: relation "public.mt_tenant_partitions" does not exist
         catch (NpgsqlException e)
         {
-            if (e.Message.Contains("does not exist"))
+            if (e.SqlState == PostgresErrorCodes.UndefinedTable)
             {
                 _hasInitialized = true;
                 return;

--- a/src/Weasel.Postgresql/Tables/Table.FetchExisting.cs
+++ b/src/Weasel.Postgresql/Tables/Table.FetchExisting.cs
@@ -137,7 +137,7 @@ order by column_index;
         }
         catch (NpgsqlException e)
         {
-            if (!e.Message.Contains("does not exist")) throw;
+            if (e.SqlState != PostgresErrorCodes.UndefinedTable) throw;
         }
         return result;
     }

--- a/src/Weasel.Postgresql/Tables/Table.FetchExisting.cs
+++ b/src/Weasel.Postgresql/Tables/Table.FetchExisting.cs
@@ -205,7 +205,7 @@ order by column_index;
         }
         catch (PostgresException e)
         {
-            if (e.Message.Contains("does not exist")) return;
+            if (e.SqlState == PostgresErrorCodes.InvalidSchemaName) return;
             throw;
         }
 


### PR DESCRIPTION
The PostgreSQL error messages are translated, so trying to match them against an english text might not work on different locales.

Please note, that here a 3 more places where the message text is evaluated, two of them only catching an Exception from reader.CloseAsync(). These lines of code are not not covered by any unit test and I couldn't figure out a sane way to trigger an exception there, so I left them untouched.
