### PR TITLE
Make all params named params

### DIFF
--- a/src/Weasel.Postgresql.Tests/SqlGeneration/CommandParameterTests.cs
+++ b/src/Weasel.Postgresql.Tests/SqlGeneration/CommandParameterTests.cs
@@ -56,7 +56,7 @@ public class CommandParameterTests
         dbParameter.Value.ShouldBe(parameter.Value);
         dbParameter.NpgsqlDbType.ShouldBe(parameter.DbType!.Value);
 
-        command.CommandText.ShouldEndWith("$1");
+        command.CommandText.ShouldEndWith(":p0");
     }
 
     [Theory]

--- a/src/Weasel.Postgresql/BatchBuilder.cs
+++ b/src/Weasel.Postgresql/BatchBuilder.cs
@@ -30,6 +30,20 @@ public class BatchBuilder: ICommandBuilder
         return command;
     }
 
+    private NpgsqlParameter addPositionalParameterAsNamedParameter(NpgsqlParameter parameter)
+    {
+        _current ??= appendCommand();
+        var name = "p" + _current.Parameters.Count;
+        parameter.ParameterName = name;
+
+        _current.Parameters.Add(parameter);
+
+        _builder.Append(':');
+        _builder.Append(name);
+
+        return parameter;
+    }
+
     public string TenantId { get; set; }
 
     /// <summary>
@@ -58,12 +72,7 @@ public class BatchBuilder: ICommandBuilder
             TypedValue = value,
         };
 
-        _current.Parameters.Add(param);
-
-        _builder.Append('$');
-        _builder.Append(_current.Parameters.Count);
-
-        return param;
+        return addPositionalParameterAsNamedParameter(param);
     }
 
     public NpgsqlParameter AppendParameter<T>(T value, NpgsqlDbType dbType)
@@ -74,12 +83,7 @@ public class BatchBuilder: ICommandBuilder
             NpgsqlDbType = dbType
         };
 
-        _current.Parameters.Add(param);
-
-        _builder.Append('$');
-        _builder.Append(_current.Parameters.Count);
-
-        return param;
+        return addPositionalParameterAsNamedParameter(param);
     }
 
 
@@ -92,12 +96,7 @@ public class BatchBuilder: ICommandBuilder
             //ParameterName = "p" + _current.Parameters.Count
         };
 
-        _current.Parameters.Add(param);
-
-        _builder.Append('$');
-        _builder.Append(_current.Parameters.Count);
-
-        return param;
+        return addPositionalParameterAsNamedParameter(param);
     }
 
     public void AppendParameters(params object[] parameters)
@@ -262,11 +261,7 @@ public class BatchBuilder: ICommandBuilder
         _current ??= appendCommand();
         var param = new NpgsqlParameter { Value = value};
         if (dbType.HasValue) param.NpgsqlDbType = dbType.Value;
-        _current.Parameters.Add(param);
 
-        _builder.Append('$');
-        _builder.Append(_current.Parameters.Count);
-
-        return param;
+        return addPositionalParameterAsNamedParameter(param);
     }
 }


### PR DESCRIPTION
Needed by https://github.com/JasperFx/marten/pull/3604

Update the `BatchBuilder` to add all positional parameters as named parameters. This is the same behavior as `CommandBuilder`.

Under the hood what is going on is that if there is a mix of positional and named parameters, then npgsql does not edit the query to normalise all parameters. This results in postgres throwing an error (cant mix positional and named parameters).  If there were only positional parameters (old behaviour), the npgsql will rewrite the query to convert all positional params to named params. This is done for maximum compatibility.  The easiest way to make things consistently work is to make all positional params as named params from the start, which is what `CommandBuilder`/`CommandBuilderBase` does.

This _may_ be a breaking change - but only if people were already using named parameters with the batch builder and only if they were naming their params `p0`, `p1`, etc.