### PR TITLE
Bug fix to handle index name containing upper case chars

### DIFF
--- a/src/Weasel.Postgresql.Tests/Tables/detecting_table_deltas.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/detecting_table_deltas.cs
@@ -741,4 +741,18 @@ public class detecting_table_deltas(): IndexDeltasDetectionContext("deltas")
 
         await AssertNoDeltasAfterPatching(table);
     }
+
+    [Fact]
+    public async Task patching_and_detecting_deltas_with_upper_case_chars_in_index_name()
+    {
+        var table = new Table("deltas.blobs");
+        table.AddColumn<string>("key").AsPrimaryKey();
+        table.AddColumn("data", "jsonb");
+
+        await CreateSchemaObjectInDatabase(table);
+
+        table.Indexes.Add(new IndexDefinition("IdxBlobsDataName") { Columns = new[] { "(data ->> 'Name')" } });
+
+        await AssertNoDeltasAfterPatching(table);
+    }
 }

--- a/src/Weasel.Postgresql/SchemaUtils.cs
+++ b/src/Weasel.Postgresql/SchemaUtils.cs
@@ -46,7 +46,7 @@ public static class SchemaUtils
 
     public static string QuoteName(string name)
     {
-        return ReservedKeywords.Contains(name, StringComparer.InvariantCultureIgnoreCase) ? $"\"{name}\"" : name;
+        return ReservedKeywords.Contains(name, StringComparer.InvariantCultureIgnoreCase) || name.Any(char.IsUpper) ? $"\"{name}\"" : name;
     }
 
     private static readonly string[] ReservedKeywords =

--- a/src/Weasel.Postgresql/Tables/IndexDefinition.cs
+++ b/src/Weasel.Postgresql/Tables/IndexDefinition.cs
@@ -205,7 +205,8 @@ public class IndexDefinition: INamed
             builder.Append("CONCURRENTLY ");
         }
 
-        builder.Append(Name);
+        // Add double quotes if the index name contains upper case characters
+        builder.Append(Name.Any(char.IsUpper) ? $"\"{Name}\"" : Name);
 
         builder.Append(" ON ");
         builder.Append(parent.Identifier);
@@ -370,7 +371,7 @@ public class IndexDefinition: INamed
                     continue;
 
                 case "INDEX":
-                    var name = tokens.Dequeue();
+                    var name = tokens.Dequeue().Trim('"');
                     index = new IndexDefinition(name) { Mask = string.Empty, IsUnique = isUnique };
                     break;
 

--- a/src/Weasel.Postgresql/Tables/IndexDefinition.cs
+++ b/src/Weasel.Postgresql/Tables/IndexDefinition.cs
@@ -160,6 +160,8 @@ public class IndexDefinition: INamed
         set => _indexName = value;
     }
 
+    public string QuotedName => SchemaUtils.QuoteName(Name);
+
     protected virtual string deriveIndexName()
     {
         throw new NotSupportedException();
@@ -205,8 +207,7 @@ public class IndexDefinition: INamed
             builder.Append("CONCURRENTLY ");
         }
 
-        // Add double quotes if the index name contains upper case characters
-        builder.Append(Name.Any(char.IsUpper) ? $"\"{Name}\"" : Name);
+        builder.Append(QuotedName);
 
         builder.Append(" ON ");
         builder.Append(parent.Identifier);

--- a/src/Weasel.Postgresql/Tables/StringWriterExtensions.cs
+++ b/src/Weasel.Postgresql/Tables/StringWriterExtensions.cs
@@ -29,7 +29,7 @@ internal static class StringWriterExtensions
     public static void WriteDropIndex(this TextWriter writer, Table table, IndexDefinition index)
     {
         var concurrently = index.IsConcurrent ? "concurrently " : string.Empty;
-        writer.WriteLine($"drop index {concurrently}if exists {table.Identifier.Schema}.{index.Name};");
+        writer.WriteLine($"drop index {concurrently}if exists {table.Identifier.Schema}.{index.QuotedName};");
     }
 
     public static void WriteDropFunction(this TextWriter writer, Function function)


### PR DESCRIPTION
- Bug fix to handle index name containing upper case chars
- Fixes https://github.com/JasperFx/marten/issues/3596

Note that if you don't add quotes around index name containing upper case chars, Postgres will convert it to lower case index name.