### PR TITLE
Remove intermediary allocations from Function & HashPartition parsing

### DIFF
--- a/src/Weasel.Postgresql/Tables/Partitioning/HashPartition.cs
+++ b/src/Weasel.Postgresql/Tables/Partitioning/HashPartition.cs
@@ -23,10 +23,11 @@ public record HashPartition
     public static HashPartition Parse(string suffix, string expression)
     {
         // FOR VALUES WITH (modulus 3, remainder 0)
-        var parts = expression.GetStringWithinParantheses().ToDelimitedArray();
-        var modulus = int.Parse(parts[0].Substring(7).Trim());
-        var remainder = int.Parse(parts[1].Substring(9).Trim());
-
+        var span = expression.GetSpanWithinParentheses();
+        Span<Range> ranges = stackalloc Range[2];
+        span.Split(ranges, ',', StringSplitOptions.TrimEntries);
+        var modulus = int.Parse(span[ranges[0]][7..]);
+        var remainder = int.Parse(span[ranges[1]][9..]);
         return new HashPartition(suffix, modulus, remainder);
     }
 

--- a/src/Weasel.Postgresql/Tables/Partitioning/PartitionExtensions.cs
+++ b/src/Weasel.Postgresql/Tables/Partitioning/PartitionExtensions.cs
@@ -46,7 +46,7 @@ public static class PartitionExtensions
             suffix = suffix.Substring(identifier.Name.Length);
         }
 
-    return suffix.TrimStart('_');
+        return suffix.TrimStart('_');
     }
 
     internal static string GetStringWithinParantheses(this string raw)
@@ -54,6 +54,13 @@ public static class PartitionExtensions
         var start = raw.IndexOf('(');
         var end = raw.IndexOf(')');
         return raw.Substring(start + 1, end - start - 1);
+    }
+
+    internal static ReadOnlySpan<char> GetSpanWithinParentheses(this string raw)
+    {
+        var start = raw.IndexOf('(');
+        var end = raw.IndexOf(')');
+        return raw.AsSpan(start + 1, end - start - 1);
     }
 
 }


### PR DESCRIPTION
Edit: Damn, forgot this work was blocked by the .NET 6 target. 