### PR TITLE
Fix: Prevent DROP TABLE CASCADE for new schema objects during migrations

### DIFF
--- a/src/Weasel.Core/Migrator.cs
+++ b/src/Weasel.Core/Migrator.cs
@@ -160,7 +160,10 @@ public abstract class Migrator
                 return false;
 
             case SchemaPatchDifference.Create:
+                var originalCreationStyle = TableCreation;
+                TableCreation = CreationStyle.CreateIfNotExists;
                 delta.SchemaObject.WriteCreateStatement(this, writer);
+                TableCreation = originalCreationStyle;
                 return true;
 
             case SchemaPatchDifference.Update:

--- a/src/Weasel.Core/SchemaMigration.cs
+++ b/src/Weasel.Core/SchemaMigration.cs
@@ -125,7 +125,10 @@ public class SchemaMigration
                     break;
 
                 case SchemaPatchDifference.Create:
+                    var originalCreationStyle = rules.TableCreation;
+                    rules.TableCreation = CreationStyle.CreateIfNotExists;
                     delta.SchemaObject.WriteCreateStatement(rules, writer);
+                    rules.TableCreation = originalCreationStyle;
                     break;
 
                 case SchemaPatchDifference.Update:


### PR DESCRIPTION
When adding a new schema with tables to an existing PostgreSQL database that already contains tables in other schemas, Weasel generates SQL that drops and recreates **all existing tables** with `DROP TABLE IF EXISTS ... CASCADE`, even though they have not changed. This is dangerous because:

1. The CASCADE option drops dependent objects in other schemas
2. Existing schemas are unnecessarily dropped and recreated
3. This can cause data loss and service disruption

### Reproduction

To recreate within Wolverine, change the samples/TodoWebService to:

```csharp
#region sample_bootstrapping_wolverine_http

using Marten;
using JasperFx;
using JasperFx.Events;
using JasperFx.Resources;
using Marten.Events.Projections;
using Marten.Schema;
using Wolverine;
using Wolverine.Http;
using Wolverine.Marten;

var builder = WebApplication.CreateBuilder(args);

// Adding Marten for persistence
builder.Services.AddMarten(opts =>
{
opts.Connection(builder.Configuration.GetConnectionString("Marten"));

        // doesn't matter if this is inline or async
        opts.Projections.Snapshot<TestSnapshot>(SnapshotLifecycle.Inline);

        // Uncomment this for the second run
        // opts.Schema.For<Surprise>()
        //     .DatabaseSchemaName("newschema");
    })
    .InitializeWith<TestInit>()
    .IntegrateWithWolverine()
    .ApplyAllDatabaseChangesOnStartup();

builder.Services.AddResourceSetupOnStartup();

// Wolverine usage is required for WolverineFx.Http
builder.Host.UseWolverine(opts =>
{
// This middleware will apply to the HTTP
// endpoints as well
opts.Policies.AutoApplyTransactions();

    // Setting up the outbox on all locally handled
    // background tasks
    opts.Policies.UseDurableLocalQueues();
});

// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
builder.Services.AddEndpointsApiExplorer();
builder.Services.AddSwaggerGen();

builder.Services.AddWolverineHttp();

var app = builder.Build();

// Configure the HTTP request pipeline.
if (app.Environment.IsDevelopment())
{
app.UseSwagger();
app.UseSwaggerUI();
}

// Let's add in Wolverine HTTP endpoints to the routing tree
app.MapWolverineEndpoints();

return await app.RunJasperFxCommands(args);

public record TestSnapshot(Guid Id, string Name)
{
public static TestSnapshot Create(IEvent<SnapCreated> @event)
{
return new TestSnapshot(@event.StreamId, "");
}
}

public record SnapCreated
{
}

public class TestInit : IInitialData
{
public async Task Populate(IDocumentStore store, CancellationToken cancellation)
{
await using var session = store.LightweightSession();

        session.Events.StartStream<TestSnapshot>(new SnapCreated());

        await session.SaveChangesAsync(cancellation);
    }
}

public record Surprise(string Id, string Name)
{
}

#endregion
```

### Steps

1. Run db-apply or start app
2. Uncomment code
3. Run db-apply or start app again
4. Observe existing tables in `public` schema are dropped and recreated

### Second Run Sql

```sql
Executed schema update SQL:
      DO $$
      BEGIN    IF NOT EXISTS(
              SELECT schema_name
                FROM information_schema.schemata
                WHERE schema_name = 'newschema'
            )
          THEN
            EXECUTE 'CREATE SCHEMA newschema';
          END IF;
      
      END
      $$;
      
      
      DROP TABLE IF EXISTS newschema.mt_doc_surprise CASCADE;
      CREATE TABLE newschema.mt_doc_surprise (
          id                  varchar                     NOT NULL,
          data                jsonb                       NOT NULL,
          mt_last_modified    timestamp with time zone    NULL DEFAULT (transaction_timestamp()),
          mt_version          uuid                        NOT NULL DEFAULT (md5(random()::text || clock_timestamp()::text)::uuid),
          mt_dotnet_type      varchar                     NULL,
      CONSTRAINT pkey_mt_doc_surprise_id PRIMARY KEY (id)
      );

... trimmed ...

DROP TABLE IF EXISTS public.mt_doc_testsnapshot CASCADE;
      CREATE TABLE public.mt_doc_testsnapshot (
          id                  uuid                        NOT NULL,
          data                jsonb                       NOT NULL,
          mt_last_modified    timestamp with time zone    NULL DEFAULT (transaction_timestamp()),
          mt_dotnet_type      varchar                     NULL,
          mt_version          integer                     NOT NULL DEFAULT 0,
      CONSTRAINT pkey_mt_doc_testsnapshot_id PRIMARY KEY (id)
      );

... trimmed ...

DROP TABLE IF EXISTS public.mt_streams CASCADE;
      CREATE TABLE public.mt_streams (
          id                  uuid           NOT NULL,
          type                varchar        NULL,
          version             bigint         NULL,
          timestamp           timestamptz    NOT NULL DEFAULT (now()),
          snapshot            jsonb          NULL,
          snapshot_version    integer        NULL,
          created             timestamptz    NOT NULL DEFAULT (now()),
          tenant_id           varchar        NULL DEFAULT '*DEFAULT*',
          is_archived         bool           NULL DEFAULT FALSE,
      CONSTRAINT pkey_mt_streams_id PRIMARY KEY (id)
      );
      DROP TABLE IF EXISTS public.mt_events CASCADE;
      CREATE TABLE public.mt_events (
          seq_id            bigint                      NOT NULL,
          id                uuid                        NOT NULL,
          stream_id         uuid                        NULL,
          version           bigint                      NOT NULL,
          data              jsonb                       NOT NULL,
          type              varchar(500)                NOT NULL,
          timestamp         timestamp with time zone    NOT NULL DEFAULT '(now())',
          tenant_id         varchar                     NULL DEFAULT '*DEFAULT*',
          mt_dotnet_type    varchar                     NULL,
          is_archived       bool                        NULL DEFAULT FALSE,
      CONSTRAINT pkey_mt_events_seq_id PRIMARY KEY (seq_id)
      );
...trimmed...

```

## Root Cause

`Table.WriteCreateStatement()` in `src/Weasel.Postgresql/Tables/Table.cs` unconditionally generates `DROP TABLE IF EXISTS ... CASCADE` when `Migrator.TableCreation == CreationStyle.DropThenCreate` (the default), regardless of whether the table is:

- **Create**: Brand new table being created
- **Update**: Existing table with schema changes
- **Invalid**: Existing table with structural issues requiring rebuild

For new objects (`SchemaPatchDifference.Create`), the DROP statement is unnecessary and dangerous because the object doesn't exist yet in the database.

## Solution

Modified two methods to use `CREATE IF NOT EXISTS` instead of `DROP TABLE ... CASCADE` when processing `Create` deltas:

### Changes Made

#### 1. `src/Weasel.Core/SchemaMigration.cs` (lines 127-132)

```csharp
case SchemaPatchDifference.Create:
    var originalCreationStyle = rules.TableCreation;
    rules.TableCreation = CreationStyle.CreateIfNotExists;
    delta.SchemaObject.WriteCreateStatement(rules, writer);
    rules.TableCreation = originalCreationStyle;
    break;
```

#### 2. `src/Weasel.Core/Migrator.cs` (lines 162-167)

```csharp
case SchemaPatchDifference.Create:
    var originalCreationStyle = TableCreation;
    TableCreation = CreationStyle.CreateIfNotExists;
    delta.SchemaObject.WriteCreateStatement(this, writer);
    TableCreation = originalCreationStyle;
    return true;
```

#### 3. `src/Weasel.Postgresql.Tests/Tables/TableTests.cs` (new unit tests)

Added two unit tests:
- `schema_migration_uses_create_if_not_exists_for_create_deltas` - Verifies new tables use `CREATE TABLE IF NOT EXISTS`
- `adding_new_schema_does_not_drop_existing_tables_in_other_schemas` - Verifies existing tables are not affected

## Results

### Generated SQL (BEFORE FIX)
```sql
... trimmed ...
DROP TABLE IF EXISTS public.existing_table CASCADE;
CREATE TABLE public.existing_table (...)  -- existing_table table unchanged but dropped!
... trimmed ...
DROP TABLE IF EXISTS newschema.new_table CASCADE;
CREATE TABLE newschema.new_table (...)
```

### Generated SQL (AFTER FIX)

```sql
DO $$
BEGIN
  IF NOT EXISTS(SELECT schema_name FROM information_schema.schemata WHERE schema_name = 'newschema')
  THEN
    EXECUTE 'CREATE SCHEMA newschema';
  END IF;
END
$$;

CREATE TABLE IF NOT EXISTS newschema.new_table (...)  -- Safe!
```

Existing tables in other schemas are not touched at all.

## Impact

- **Safety**: New schemas can be added without risking existing data
- **Correctness**: Semantically correct - only create new objects, don't destroy unchanged ones
- **Backward Compatible**: No breaking changes to public APIs
- **Minimal Changes**: Only 2 files modified, focused changes
- **Existing Behavior Preserved**: Invalid deltas still use DROP + CREATE for true schema rebuilds

## Testing

### Unit Tests (no database required)

1. **schema_migration_uses_create_if_not_exists_for_create_deltas**: Basic scenario where a new table is being created
2. **adding_new_schema_does_not_drop_existing_tables_in_other_schemas**: Simulates existing database with multiple schemas

All existing tests pass on .NET 9 and .NET 10, I do not have .NET 8 installed

### Wolverine
I have **not** confirmed the change works as expected when used from Wolverine

## Breaking Changes

None. This is a pure bug fix that makes migration behavior safer and more correct.

## Migration Guide for Users

No action required. The fix improves migration safety automatically. Existing code will continue to work, but migrations will now be safer when adding new schemas to existing databases.
