### PR TITLE
Add Weasel.MySql library with table support and schema migrations

### DIFF
--- a/.github/workflows/ci-build-mysql.yml
+++ b/.github/workflows/ci-build-mysql.yml
@@ -1,0 +1,69 @@
+name: MySql CI build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  config: Release
+  disable_test_parallelization: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: 1
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  db_pwd: P@55w0rd
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    strategy:
+        matrix:
+            mysql-image:
+                - mysql:8.0
+            framework:
+                - net8.0
+                - net9.0
+                - net10.0
+
+    name: MySql ${{ matrix.mysql-image }} ${{ matrix.framework }}
+
+    services:
+      mysql:
+        image: ${{ matrix.mysql-image }}
+        ports:
+          - 3306:3306
+        env:
+          MYSQL_ROOT_PASSWORD: ${{ env.db_pwd }}
+          MYSQL_DATABASE: weasel_testing
+          MYSQL_USER: weasel
+          MYSQL_PASSWORD: ${{ env.db_pwd }}
+        options: >-
+          --health-cmd="mysqladmin ping -h localhost"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Install .NET
+      uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: |
+            8.0.x
+            9.0.x
+            10.0.x
+
+    - name: Restore dependencies
+      run: dotnet restore
+
+    - name: Build
+      run: dotnet build --no-restore
+
+    - name: Test
+      env:
+        weasel_mysql_testing_database: "Server=localhost;Port=3306;Database=weasel_testing;Uid=weasel;Pwd=${{ env.db_pwd }};"
+      run: dotnet test src/Weasel.MySql.Tests/Weasel.MySql.Tests.csproj --no-build --verbosity normal --framework ${{ matrix.framework }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,4 +25,13 @@ services:
           - "ORACLE_PASSWORD=P@55w0rd"
           - "APP_USER=weasel"
           - "APP_USER_PASSWORD=P@55w0rd"
+  mysql:
+      image: "mysql:8.0"
+      ports:
+          - "3306:3306"
+      environment:
+          - "MYSQL_ROOT_PASSWORD=P@55w0rd"
+          - "MYSQL_DATABASE=weasel_testing"
+          - "MYSQL_USER=weasel"
+          - "MYSQL_PASSWORD=P@55w0rd"
 

--- a/src/Weasel.MySql.Tests/ConnectionSource.cs
+++ b/src/Weasel.MySql.Tests/ConnectionSource.cs
@@ -1,0 +1,22 @@
+using MySqlConnector;
+
+namespace Weasel.MySql.Tests;
+
+public static class ConnectionSource
+{
+    public static readonly string ConnectionString =
+        Environment.GetEnvironmentVariable("weasel_mysql_testing_database")
+        ?? "Server=localhost;Port=3306;Database=weasel_testing;Uid=weasel;Pwd=P@55w0rd;";
+
+    public static MySqlConnection Create()
+    {
+        return new MySqlConnection(ConnectionString);
+    }
+
+    public static async Task<MySqlConnection> CreateOpenConnectionAsync(CancellationToken ct = default)
+    {
+        var conn = Create();
+        await conn.OpenAsync(ct).ConfigureAwait(false);
+        return conn;
+    }
+}

--- a/src/Weasel.MySql.Tests/IntegrationContext.cs
+++ b/src/Weasel.MySql.Tests/IntegrationContext.cs
@@ -1,0 +1,87 @@
+using MySqlConnector;
+using Weasel.Core;
+using Xunit;
+
+namespace Weasel.MySql.Tests;
+
+[Collection("integration")]
+public abstract class IntegrationContext: IAsyncLifetime
+{
+    protected MySqlConnection theConnection = default!;
+
+    public async Task InitializeAsync()
+    {
+        theConnection = await ConnectionSource.CreateOpenConnectionAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await theConnection.CloseAsync();
+        await theConnection.DisposeAsync();
+    }
+
+    protected async Task ResetSchemaAsync(string schemaName)
+    {
+        await DropSchemaAsync(schemaName);
+        await CreateSchemaAsync(schemaName);
+    }
+
+    protected async Task CreateSchemaAsync(string schemaName)
+    {
+        await using var cmd = theConnection.CreateCommand($"CREATE DATABASE IF NOT EXISTS `{schemaName}`");
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    protected async Task DropSchemaAsync(string schemaName)
+    {
+        await using var cmd = theConnection.CreateCommand($"DROP DATABASE IF EXISTS `{schemaName}`");
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    protected async Task CreateTableAsync(string sql)
+    {
+        await using var cmd = theConnection.CreateCommand(sql);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    protected async Task DropTableAsync(string tableName)
+    {
+        await using var cmd = theConnection.CreateCommand($"DROP TABLE IF EXISTS {tableName}");
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    protected async Task<T> ExecuteScalarAsync<T>(string sql)
+    {
+        await using var cmd = theConnection.CreateCommand(sql);
+        var result = await cmd.ExecuteScalarAsync();
+        return (T)Convert.ChangeType(result!, typeof(T));
+    }
+}
+
+[CollectionDefinition("integration")]
+public class IntegrationCollection: ICollectionFixture<IntegrationFixture>
+{
+}
+
+public class IntegrationFixture: IAsyncLifetime
+{
+    public async Task InitializeAsync()
+    {
+        // Ensure database exists
+        var builder = new MySqlConnectionStringBuilder(ConnectionSource.ConnectionString);
+        var database = builder.Database;
+        builder.Database = "";
+
+        await using var conn = new MySqlConnection(builder.ConnectionString);
+        await conn.OpenAsync();
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"CREATE DATABASE IF NOT EXISTS `{database}`";
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    public Task DisposeAsync()
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/src/Weasel.MySql.Tests/MySqlObjectNameTests.cs
+++ b/src/Weasel.MySql.Tests/MySqlObjectNameTests.cs
@@ -1,0 +1,94 @@
+using Shouldly;
+using Xunit;
+
+namespace Weasel.MySql.Tests;
+
+public class MySqlObjectNameTests
+{
+    [Fact]
+    public void qualified_name_with_schema()
+    {
+        var name = new MySqlObjectName("mydb", "users");
+        name.QualifiedName.ShouldBe("`mydb`.`users`");
+    }
+
+    [Fact]
+    public void qualified_name_without_schema()
+    {
+        var name = new MySqlObjectName("", "users");
+        name.QualifiedName.ShouldBe("`users`");
+    }
+
+    [Fact]
+    public void to_string_returns_qualified_name()
+    {
+        var name = new MySqlObjectName("mydb", "users");
+        name.ToString().ShouldBe("`mydb`.`users`");
+    }
+
+    [Fact]
+    public void name_comparison_is_case_insensitive()
+    {
+        var name1 = new MySqlObjectName("mydb", "Users");
+        var name2 = new MySqlObjectName("mydb", "users");
+
+        name1.Equals(name2).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void schema_comparison_is_case_insensitive()
+    {
+        var name1 = new MySqlObjectName("MyDb", "users");
+        var name2 = new MySqlObjectName("mydb", "users");
+
+        name1.Equals(name2).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void to_temp_copy_table_appends_temp_suffix()
+    {
+        var name = new MySqlObjectName("mydb", "users");
+        var temp = name.ToTempCopyTable();
+
+        temp.Name.ShouldBe("users_temp");
+        temp.Schema.ShouldBe("mydb");
+    }
+
+    [Fact]
+    public void to_index_name_generates_valid_name()
+    {
+        var name = new MySqlObjectName("mydb", "users");
+        var indexName = name.ToIndexName("idx", "email", "name");
+
+        indexName.ShouldBe("idx_users_email_name");
+    }
+
+    [Fact]
+    public void to_index_name_truncates_long_names()
+    {
+        var name = new MySqlObjectName("mydb", "very_long_table_name_that_exceeds_normal_limits");
+        var indexName = name.ToIndexName("idx", "very_long_column_name_one", "very_long_column_name_two");
+
+        indexName.Length.ShouldBeLessThanOrEqualTo(64);
+    }
+
+    [Fact]
+    public void parse_qualified_name()
+    {
+        var name = MySqlObjectName.Parse(MySqlProvider.Instance, "mydb.users") as MySqlObjectName;
+
+        name.ShouldNotBeNull();
+        name.Schema.ShouldBe("mydb");
+        name.Name.ShouldBe("users");
+    }
+
+    [Fact]
+    public void parse_unqualified_name_uses_default_schema()
+    {
+        var name = MySqlObjectName.Parse(MySqlProvider.Instance, "users") as MySqlObjectName;
+
+        name.ShouldNotBeNull();
+        name.Schema.ShouldBe("public");
+        name.Name.ShouldBe("users");
+    }
+}

--- a/src/Weasel.MySql.Tests/MySqlProviderTests.cs
+++ b/src/Weasel.MySql.Tests/MySqlProviderTests.cs
@@ -1,0 +1,134 @@
+using MySqlConnector;
+using Shouldly;
+using Weasel.Core;
+using Xunit;
+
+namespace Weasel.MySql.Tests;
+
+public class MySqlProviderTests
+{
+    [Fact]
+    public void engine_name_is_mysql()
+    {
+        MySqlProvider.EngineName.ShouldBe("MySql");
+    }
+
+    [Fact]
+    public void has_singleton_instance()
+    {
+        MySqlProvider.Instance.ShouldNotBeNull();
+    }
+
+    [Theory]
+    [InlineData(typeof(string), "VARCHAR(255)")]
+    [InlineData(typeof(bool), "TINYINT(1)")]
+    [InlineData(typeof(int), "INT")]
+    [InlineData(typeof(long), "BIGINT")]
+    [InlineData(typeof(short), "SMALLINT")]
+    [InlineData(typeof(byte), "TINYINT UNSIGNED")]
+    [InlineData(typeof(decimal), "DECIMAL(18,2)")]
+    [InlineData(typeof(double), "DOUBLE")]
+    [InlineData(typeof(float), "FLOAT")]
+    [InlineData(typeof(DateTime), "DATETIME")]
+    [InlineData(typeof(DateTimeOffset), "DATETIME")]
+    [InlineData(typeof(TimeSpan), "TIME")]
+    [InlineData(typeof(Guid), "CHAR(36)")]
+    [InlineData(typeof(byte[]), "BLOB")]
+    public void maps_clr_type_to_database_type(Type clrType, string expectedDbType)
+    {
+        var dbType = MySqlProvider.Instance.GetDatabaseType(clrType, EnumStorage.AsInteger);
+        dbType.ShouldBe(expectedDbType);
+    }
+
+    [Theory]
+    [InlineData(typeof(int?), "INT")]
+    [InlineData(typeof(bool?), "TINYINT(1)")]
+    [InlineData(typeof(long?), "BIGINT")]
+    public void maps_nullable_types_to_underlying_type(Type clrType, string expectedDbType)
+    {
+        var dbType = MySqlProvider.Instance.GetDatabaseType(clrType, EnumStorage.AsInteger);
+        dbType.ShouldBe(expectedDbType);
+    }
+
+    [Fact]
+    public void enum_as_integer_returns_int()
+    {
+        var dbType = MySqlProvider.Instance.GetDatabaseType(typeof(DayOfWeek), EnumStorage.AsInteger);
+        dbType.ShouldBe("INT");
+    }
+
+    [Fact]
+    public void enum_as_string_returns_varchar()
+    {
+        var dbType = MySqlProvider.Instance.GetDatabaseType(typeof(DayOfWeek), EnumStorage.AsString);
+        dbType.ShouldBe("VARCHAR(100)");
+    }
+
+    [Theory]
+    [InlineData("INTEGER", "INT")]
+    [InlineData("BOOLEAN", "TINYINT(1)")]
+    [InlineData("BOOL", "TINYINT(1)")]
+    [InlineData("TEXT", "VARCHAR(255)")]
+    [InlineData("STRING", "VARCHAR(255)")]
+    [InlineData("REAL", "FLOAT")]
+    public void convert_synonyms(string input, string expected)
+    {
+        MySqlProvider.Instance.ConvertSynonyms(input).ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("CASCADE", CascadeAction.Cascade)]
+    [InlineData("NO ACTION", CascadeAction.NoAction)]
+    [InlineData("SET NULL", CascadeAction.SetNull)]
+    [InlineData("RESTRICT", CascadeAction.Restrict)]
+    public void read_cascade_action(string input, CascadeAction expected)
+    {
+        MySqlProvider.ReadAction(input).ShouldBe(expected);
+    }
+
+    [Fact]
+    public void parse_creates_mysql_object_name()
+    {
+        var name = MySqlProvider.Instance.Parse("mydb", "mytable");
+        name.ShouldBeOfType<MySqlObjectName>();
+        name.Schema.ShouldBe("mydb");
+        name.Name.ShouldBe("mytable");
+    }
+
+    [Fact]
+    public void add_application_name_to_connection_string()
+    {
+        var connectionString = "Server=localhost;Database=test;";
+        var result = MySqlProvider.Instance.AddApplicationNameToConnectionString(connectionString, "MyApp");
+
+        result.ShouldContain("Application Name=MyApp");
+    }
+
+    [Fact]
+    public void to_parameter_type_for_known_type()
+    {
+        var dbType = MySqlProvider.Instance.ToParameterType(typeof(int));
+        dbType.ShouldBe(MySqlDbType.Int32);
+    }
+
+    [Fact]
+    public void to_parameter_type_for_string()
+    {
+        var dbType = MySqlProvider.Instance.ToParameterType(typeof(string));
+        dbType.ShouldBe(MySqlDbType.VarChar);
+    }
+
+    [Fact]
+    public void to_parameter_type_for_guid()
+    {
+        var dbType = MySqlProvider.Instance.ToParameterType(typeof(Guid));
+        dbType.ShouldBe(MySqlDbType.Guid);
+    }
+
+    [Fact]
+    public void arrays_throw_not_supported()
+    {
+        Should.Throw<NotSupportedException>(() =>
+            MySqlProvider.Instance.GetDatabaseType(typeof(int[]), EnumStorage.AsInteger));
+    }
+}

--- a/src/Weasel.MySql.Tests/Tables/ForeignKeyTests.cs
+++ b/src/Weasel.MySql.Tests/Tables/ForeignKeyTests.cs
@@ -1,0 +1,290 @@
+using Shouldly;
+using Weasel.MySql.Tables;
+using Xunit;
+
+namespace Weasel.MySql.Tests.Tables;
+
+public class ForeignKeyTests
+{
+    [Fact]
+    public void create_with_name()
+    {
+        var fk = new ForeignKey("fk_orders_customer");
+        fk.Name.ShouldBe("fk_orders_customer");
+    }
+
+    [Fact]
+    public void default_cascade_actions_are_no_action()
+    {
+        var fk = new ForeignKey("fk_test");
+        fk.OnDelete.ShouldBe(CascadeAction.NoAction);
+        fk.OnUpdate.ShouldBe(CascadeAction.NoAction);
+    }
+
+    [Fact]
+    public void set_column_names()
+    {
+        var fk = new ForeignKey("fk_test")
+        {
+            ColumnNames = new[] { "customer_id" }
+        };
+
+        fk.ColumnNames.ShouldBe(new[] { "customer_id" });
+    }
+
+    [Fact]
+    public void set_linked_names()
+    {
+        var fk = new ForeignKey("fk_test")
+        {
+            LinkedNames = new[] { "id" }
+        };
+
+        fk.LinkedNames.ShouldBe(new[] { "id" });
+    }
+
+    [Fact]
+    public void link_columns()
+    {
+        var fk = new ForeignKey("fk_test");
+        fk.LinkColumns("customer_id", "id");
+
+        fk.ColumnNames.ShouldBe(new[] { "customer_id" });
+        fk.LinkedNames.ShouldBe(new[] { "id" });
+    }
+
+    [Fact]
+    public void link_multiple_columns()
+    {
+        var fk = new ForeignKey("fk_test");
+        fk.LinkColumns("tenant_id", "id");
+        fk.LinkColumns("customer_id", "customer_id");
+
+        fk.ColumnNames.ShouldBe(new[] { "tenant_id", "customer_id" });
+        fk.LinkedNames.ShouldBe(new[] { "id", "customer_id" });
+    }
+
+    [Fact]
+    public void to_ddl_basic()
+    {
+        var orders = new Table("weasel_testing.orders");
+        var customers = new Table("weasel_testing.customers");
+
+        var fk = new ForeignKey("fk_orders_customer")
+        {
+            LinkedTable = customers.Identifier,
+            ColumnNames = new[] { "customer_id" },
+            LinkedNames = new[] { "id" }
+        };
+
+        var ddl = fk.ToDDL(orders);
+
+        ddl.ShouldContain("ALTER TABLE `weasel_testing`.`orders`");
+        ddl.ShouldContain("ADD CONSTRAINT `fk_orders_customer`");
+        ddl.ShouldContain("FOREIGN KEY (`customer_id`)");
+        ddl.ShouldContain("REFERENCES `weasel_testing`.`customers` (`id`)");
+    }
+
+    [Fact]
+    public void to_ddl_with_cascade_delete()
+    {
+        var orders = new Table("weasel_testing.orders");
+        var customers = new Table("weasel_testing.customers");
+
+        var fk = new ForeignKey("fk_orders_customer")
+        {
+            LinkedTable = customers.Identifier,
+            ColumnNames = new[] { "customer_id" },
+            LinkedNames = new[] { "id" },
+            OnDelete = CascadeAction.Cascade
+        };
+
+        var ddl = fk.ToDDL(orders);
+
+        ddl.ShouldContain("ON DELETE CASCADE");
+    }
+
+    [Fact]
+    public void to_ddl_with_cascade_update()
+    {
+        var orders = new Table("weasel_testing.orders");
+        var customers = new Table("weasel_testing.customers");
+
+        var fk = new ForeignKey("fk_orders_customer")
+        {
+            LinkedTable = customers.Identifier,
+            ColumnNames = new[] { "customer_id" },
+            LinkedNames = new[] { "id" },
+            OnUpdate = CascadeAction.Cascade
+        };
+
+        var ddl = fk.ToDDL(orders);
+
+        ddl.ShouldContain("ON UPDATE CASCADE");
+    }
+
+    [Fact]
+    public void to_ddl_with_set_null()
+    {
+        var orders = new Table("weasel_testing.orders");
+        var customers = new Table("weasel_testing.customers");
+
+        var fk = new ForeignKey("fk_orders_customer")
+        {
+            LinkedTable = customers.Identifier,
+            ColumnNames = new[] { "customer_id" },
+            LinkedNames = new[] { "id" },
+            OnDelete = CascadeAction.SetNull
+        };
+
+        var ddl = fk.ToDDL(orders);
+
+        ddl.ShouldContain("ON DELETE SET NULL");
+    }
+
+    [Fact]
+    public void to_ddl_with_restrict()
+    {
+        var orders = new Table("weasel_testing.orders");
+        var customers = new Table("weasel_testing.customers");
+
+        var fk = new ForeignKey("fk_orders_customer")
+        {
+            LinkedTable = customers.Identifier,
+            ColumnNames = new[] { "customer_id" },
+            LinkedNames = new[] { "id" },
+            OnDelete = CascadeAction.Restrict
+        };
+
+        var ddl = fk.ToDDL(orders);
+
+        ddl.ShouldContain("ON DELETE RESTRICT");
+    }
+
+    [Fact]
+    public void to_ddl_multi_column()
+    {
+        var orders = new Table("weasel_testing.orders");
+        var customers = new Table("weasel_testing.customers");
+
+        var fk = new ForeignKey("fk_orders_customer")
+        {
+            LinkedTable = customers.Identifier,
+            ColumnNames = new[] { "tenant_id", "customer_id" },
+            LinkedNames = new[] { "tenant_id", "id" }
+        };
+
+        var ddl = fk.ToDDL(orders);
+
+        ddl.ShouldContain("FOREIGN KEY (`tenant_id`, `customer_id`)");
+        ddl.ShouldContain("REFERENCES `weasel_testing`.`customers` (`tenant_id`, `id`)");
+    }
+
+    [Fact]
+    public void throws_if_linked_table_not_set()
+    {
+        var orders = new Table("weasel_testing.orders");
+
+        var fk = new ForeignKey("fk_test")
+        {
+            ColumnNames = new[] { "customer_id" },
+            LinkedNames = new[] { "id" }
+        };
+
+        Should.Throw<InvalidOperationException>(() => fk.ToDDL(orders));
+    }
+
+    [Fact]
+    public void read_referential_actions()
+    {
+        var fk = new ForeignKey("fk_test");
+        fk.ReadReferentialActions("CASCADE", "SET NULL");
+
+        fk.OnDelete.ShouldBe(CascadeAction.Cascade);
+        fk.OnUpdate.ShouldBe(CascadeAction.SetNull);
+    }
+
+    [Fact]
+    public void is_equivalent_same_fk()
+    {
+        var fk1 = new ForeignKey("fk_test")
+        {
+            LinkedTable = new MySqlObjectName("db", "customers"),
+            ColumnNames = new[] { "customer_id" },
+            LinkedNames = new[] { "id" },
+            OnDelete = CascadeAction.Cascade
+        };
+
+        var fk2 = new ForeignKey("fk_test")
+        {
+            LinkedTable = new MySqlObjectName("db", "customers"),
+            ColumnNames = new[] { "customer_id" },
+            LinkedNames = new[] { "id" },
+            OnDelete = CascadeAction.Cascade
+        };
+
+        fk1.IsEquivalentTo(fk2).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void is_not_equivalent_different_name()
+    {
+        var fk1 = new ForeignKey("fk_test1")
+        {
+            LinkedTable = new MySqlObjectName("db", "customers"),
+            ColumnNames = new[] { "customer_id" },
+            LinkedNames = new[] { "id" }
+        };
+
+        var fk2 = new ForeignKey("fk_test2")
+        {
+            LinkedTable = new MySqlObjectName("db", "customers"),
+            ColumnNames = new[] { "customer_id" },
+            LinkedNames = new[] { "id" }
+        };
+
+        fk1.IsEquivalentTo(fk2).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void is_not_equivalent_different_linked_table()
+    {
+        var fk1 = new ForeignKey("fk_test")
+        {
+            LinkedTable = new MySqlObjectName("db", "customers"),
+            ColumnNames = new[] { "customer_id" },
+            LinkedNames = new[] { "id" }
+        };
+
+        var fk2 = new ForeignKey("fk_test")
+        {
+            LinkedTable = new MySqlObjectName("db", "users"),
+            ColumnNames = new[] { "customer_id" },
+            LinkedNames = new[] { "id" }
+        };
+
+        fk1.IsEquivalentTo(fk2).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void is_not_equivalent_different_cascade_action()
+    {
+        var fk1 = new ForeignKey("fk_test")
+        {
+            LinkedTable = new MySqlObjectName("db", "customers"),
+            ColumnNames = new[] { "customer_id" },
+            LinkedNames = new[] { "id" },
+            OnDelete = CascadeAction.Cascade
+        };
+
+        var fk2 = new ForeignKey("fk_test")
+        {
+            LinkedTable = new MySqlObjectName("db", "customers"),
+            ColumnNames = new[] { "customer_id" },
+            LinkedNames = new[] { "id" },
+            OnDelete = CascadeAction.SetNull
+        };
+
+        fk1.IsEquivalentTo(fk2).ShouldBeFalse();
+    }
+}

--- a/src/Weasel.MySql.Tests/Tables/IndexDefinitionTests.cs
+++ b/src/Weasel.MySql.Tests/Tables/IndexDefinitionTests.cs
@@ -1,0 +1,266 @@
+using Shouldly;
+using Weasel.MySql.Tables;
+using Xunit;
+
+namespace Weasel.MySql.Tests.Tables;
+
+public class IndexDefinitionTests
+{
+    [Fact]
+    public void create_index_with_name()
+    {
+        var index = new IndexDefinition("idx_test");
+        index.Name.ShouldBe("idx_test");
+    }
+
+    [Fact]
+    public void default_index_type_is_btree()
+    {
+        var index = new IndexDefinition("idx_test");
+        index.IndexType.ShouldBe(MySqlIndexType.BTree);
+    }
+
+    [Fact]
+    public void default_sort_order_is_asc()
+    {
+        var index = new IndexDefinition("idx_test");
+        index.SortOrder.ShouldBe(SortOrder.Asc);
+    }
+
+    [Fact]
+    public void default_is_not_unique()
+    {
+        var index = new IndexDefinition("idx_test");
+        index.IsUnique.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void set_columns()
+    {
+        var index = new IndexDefinition("idx_test")
+        {
+            Columns = new[] { "email", "name" }
+        };
+
+        index.Columns.ShouldBe(new[] { "email", "name" });
+    }
+
+    [Fact]
+    public void against_columns_fluent()
+    {
+        var index = new IndexDefinition("idx_test")
+            .AgainstColumns("email", "name");
+
+        index.Columns.ShouldBe(new[] { "email", "name" });
+    }
+
+    [Fact]
+    public void add_column()
+    {
+        var index = new IndexDefinition("idx_test");
+        index.AddColumn("email");
+        index.AddColumn("name");
+
+        index.Columns.ShouldBe(new[] { "email", "name" });
+    }
+
+    [Fact]
+    public void to_ddl_btree_index()
+    {
+        var table = new Table("weasel_testing.people");
+        table.AddColumn<string>("email");
+
+        var index = new IndexDefinition("idx_people_email")
+        {
+            Columns = new[] { "email" }
+        };
+
+        var ddl = index.ToDDL(table);
+
+        ddl.ShouldContain("CREATE INDEX `idx_people_email`");
+        ddl.ShouldContain("ON `weasel_testing`.`people`");
+        ddl.ShouldContain("(`email`)");
+    }
+
+    [Fact]
+    public void to_ddl_unique_index()
+    {
+        var table = new Table("weasel_testing.people");
+
+        var index = new IndexDefinition("idx_people_email")
+        {
+            Columns = new[] { "email" },
+            IsUnique = true
+        };
+
+        var ddl = index.ToDDL(table);
+
+        ddl.ShouldContain("CREATE UNIQUE INDEX");
+    }
+
+    [Fact]
+    public void to_ddl_hash_index()
+    {
+        var table = new Table("weasel_testing.people");
+
+        var index = new IndexDefinition("idx_people_email")
+        {
+            Columns = new[] { "email" },
+            IndexType = MySqlIndexType.Hash
+        };
+
+        var ddl = index.ToDDL(table);
+
+        ddl.ShouldContain("USING HASH");
+    }
+
+    [Fact]
+    public void to_ddl_fulltext_index()
+    {
+        var table = new Table("weasel_testing.articles");
+
+        var index = new IndexDefinition("ft_articles_content")
+        {
+            Columns = new[] { "content" },
+            IndexType = MySqlIndexType.Fulltext
+        };
+
+        var ddl = index.ToDDL(table);
+
+        ddl.ShouldContain("CREATE FULLTEXT INDEX");
+        ddl.ShouldNotContain("UNIQUE");
+    }
+
+    [Fact]
+    public void to_ddl_fulltext_with_parser()
+    {
+        var table = new Table("weasel_testing.articles");
+
+        var index = new IndexDefinition("ft_articles_content")
+        {
+            Columns = new[] { "content" },
+            IndexType = MySqlIndexType.Fulltext,
+            FulltextParser = "ngram"
+        };
+
+        var ddl = index.ToDDL(table);
+
+        ddl.ShouldContain("WITH PARSER ngram");
+    }
+
+    [Fact]
+    public void to_ddl_spatial_index()
+    {
+        var table = new Table("weasel_testing.locations");
+
+        var index = new IndexDefinition("sp_locations_coords")
+        {
+            Columns = new[] { "coords" },
+            IndexType = MySqlIndexType.Spatial
+        };
+
+        var ddl = index.ToDDL(table);
+
+        ddl.ShouldContain("CREATE SPATIAL INDEX");
+    }
+
+    [Fact]
+    public void to_ddl_descending()
+    {
+        var table = new Table("weasel_testing.people");
+
+        var index = new IndexDefinition("idx_people_email")
+        {
+            Columns = new[] { "email" },
+            SortOrder = SortOrder.Desc
+        };
+
+        var ddl = index.ToDDL(table);
+
+        ddl.ShouldContain("`email` DESC");
+    }
+
+    [Fact]
+    public void to_ddl_with_prefix_length()
+    {
+        var table = new Table("weasel_testing.people");
+
+        var index = new IndexDefinition("idx_people_email")
+        {
+            Columns = new[] { "email" },
+            PrefixLength = 10
+        };
+
+        var ddl = index.ToDDL(table);
+
+        ddl.ShouldContain("`email`(10)");
+    }
+
+    [Fact]
+    public void to_ddl_multi_column()
+    {
+        var table = new Table("weasel_testing.people");
+
+        var index = new IndexDefinition("idx_people_name_email")
+        {
+            Columns = new[] { "first_name", "last_name" }
+        };
+
+        var ddl = index.ToDDL(table);
+
+        ddl.ShouldContain("(`first_name`, `last_name`)");
+    }
+
+    [Fact]
+    public void throws_if_no_columns()
+    {
+        var table = new Table("weasel_testing.people");
+        var index = new IndexDefinition("idx_test");
+
+        Should.Throw<InvalidOperationException>(() => index.ToDDL(table));
+    }
+
+    [Fact]
+    public void matches_identical_indexes()
+    {
+        var table = new Table("weasel_testing.people");
+
+        var index1 = new IndexDefinition("idx_test") { Columns = new[] { "email" } };
+        var index2 = new IndexDefinition("idx_test") { Columns = new[] { "email" } };
+
+        index1.Matches(index2, table).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void does_not_match_different_columns()
+    {
+        var table = new Table("weasel_testing.people");
+
+        var index1 = new IndexDefinition("idx_test") { Columns = new[] { "email" } };
+        var index2 = new IndexDefinition("idx_test") { Columns = new[] { "name" } };
+
+        index1.Matches(index2, table).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void does_not_match_different_uniqueness()
+    {
+        var table = new Table("weasel_testing.people");
+
+        var index1 = new IndexDefinition("idx_test") { Columns = new[] { "email" }, IsUnique = true };
+        var index2 = new IndexDefinition("idx_test") { Columns = new[] { "email" }, IsUnique = false };
+
+        index1.Matches(index2, table).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void canonicize_ddl_removes_backticks()
+    {
+        var table = new Table("weasel_testing.people");
+        var index = new IndexDefinition("idx_test") { Columns = new[] { "email" } };
+
+        var canonical = IndexDefinition.CanonicizeDdl(index, table);
+
+        canonical.ShouldNotContain("`");
+    }
+}

--- a/src/Weasel.MySql.Tests/Tables/TableColumnTests.cs
+++ b/src/Weasel.MySql.Tests/Tables/TableColumnTests.cs
@@ -1,0 +1,181 @@
+using Shouldly;
+using Weasel.MySql.Tables;
+using Xunit;
+
+namespace Weasel.MySql.Tests.Tables;
+
+public class TableColumnTests
+{
+    [Fact]
+    public void create_column_with_name_and_type()
+    {
+        var column = new TableColumn("email", "VARCHAR(255)");
+
+        column.Name.ShouldBe("email");
+        column.Type.ShouldBe("VARCHAR(255)");
+    }
+
+    [Fact]
+    public void default_allows_nulls()
+    {
+        var column = new TableColumn("email", "VARCHAR(255)");
+        column.AllowNulls.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void quoted_name_uses_backticks()
+    {
+        var column = new TableColumn("email", "VARCHAR(255)");
+        column.QuotedName.ShouldBe("`email`");
+    }
+
+    [Fact]
+    public void raw_type_strips_size()
+    {
+        var column = new TableColumn("email", "VARCHAR(255)");
+        column.RawType().ShouldBe("VARCHAR");
+    }
+
+    [Fact]
+    public void raw_type_handles_type_without_size()
+    {
+        var column = new TableColumn("count", "INT");
+        column.RawType().ShouldBe("INT");
+    }
+
+    [Fact]
+    public void to_declaration_not_null()
+    {
+        var column = new TableColumn("email", "VARCHAR(255)") { AllowNulls = false };
+        var declaration = column.ToDeclaration();
+
+        declaration.ShouldContain("`email`");
+        declaration.ShouldContain("VARCHAR(255)");
+        declaration.ShouldContain("NOT NULL");
+    }
+
+    [Fact]
+    public void to_declaration_allows_null()
+    {
+        var column = new TableColumn("email", "VARCHAR(255)") { AllowNulls = true };
+        var declaration = column.ToDeclaration();
+
+        declaration.ShouldContain("NULL");
+        declaration.ShouldNotContain("NOT NULL");
+    }
+
+    [Fact]
+    public void to_declaration_auto_increment()
+    {
+        var column = new TableColumn("id", "INT") { IsAutoNumber = true, AllowNulls = false };
+        var declaration = column.ToDeclaration();
+
+        declaration.ShouldContain("AUTO_INCREMENT");
+    }
+
+    [Fact]
+    public void to_declaration_with_default()
+    {
+        var column = new TableColumn("status", "VARCHAR(50)")
+        {
+            DefaultExpression = "'active'"
+        };
+        var declaration = column.ToDeclaration();
+
+        declaration.ShouldContain("DEFAULT 'active'");
+    }
+
+    [Fact]
+    public void is_equivalent_same_name_and_type()
+    {
+        var column1 = new TableColumn("email", "VARCHAR(255)");
+        var column2 = new TableColumn("email", "VARCHAR(255)");
+
+        column1.IsEquivalentTo(column2).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void is_equivalent_different_name()
+    {
+        var column1 = new TableColumn("email", "VARCHAR(255)");
+        var column2 = new TableColumn("name", "VARCHAR(255)");
+
+        column1.IsEquivalentTo(column2).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void is_equivalent_different_base_type()
+    {
+        var column1 = new TableColumn("data", "TEXT");
+        var column2 = new TableColumn("data", "VARCHAR(255)");
+
+        column1.IsEquivalentTo(column2).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void is_equivalent_ignores_size_differences()
+    {
+        var column1 = new TableColumn("email", "VARCHAR(100)");
+        var column2 = new TableColumn("email", "VARCHAR(255)");
+
+        // RawType() comparison means they are equivalent
+        column1.IsEquivalentTo(column2).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void is_equivalent_different_nullability()
+    {
+        var column1 = new TableColumn("email", "VARCHAR(255)") { AllowNulls = true };
+        var column2 = new TableColumn("email", "VARCHAR(255)") { AllowNulls = false };
+
+        column1.IsEquivalentTo(column2).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void is_equivalent_case_insensitive_name()
+    {
+        var column1 = new TableColumn("Email", "VARCHAR(255)");
+        var column2 = new TableColumn("email", "VARCHAR(255)");
+
+        column1.IsEquivalentTo(column2).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void to_string_returns_name_and_type()
+    {
+        var column = new TableColumn("email", "VARCHAR(255)");
+        column.ToString().ShouldBe("email: VARCHAR(255)");
+    }
+
+    [Fact]
+    public void equals_uses_is_equivalent()
+    {
+        var column1 = new TableColumn("email", "VARCHAR(255)");
+        var column2 = new TableColumn("email", "VARCHAR(255)");
+
+        column1.Equals(column2).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void hash_code_ignores_size()
+    {
+        var column1 = new TableColumn("email", "VARCHAR(100)");
+        var column2 = new TableColumn("email", "VARCHAR(255)");
+
+        column1.GetHashCode().ShouldBe(column2.GetHashCode());
+    }
+
+    [Fact]
+    public void primary_key_forces_not_null()
+    {
+        var column = new TableColumn("id", "INT")
+        {
+            IsPrimaryKey = true,
+            AllowNulls = true // this should be overridden in declaration
+        };
+
+        // Primary key columns are always NOT NULL in declaration
+        var declaration = column.Declaration();
+        declaration.ShouldContain("NOT NULL");
+    }
+}

--- a/src/Weasel.MySql.Tests/Tables/TableDeltaTests.cs
+++ b/src/Weasel.MySql.Tests/Tables/TableDeltaTests.cs
@@ -1,0 +1,300 @@
+using Shouldly;
+using Weasel.Core;
+using Weasel.MySql.Tables;
+using Xunit;
+
+namespace Weasel.MySql.Tests.Tables;
+
+public class TableDeltaTests
+{
+    [Fact]
+    public void detect_create_when_no_actual_table()
+    {
+        var expected = new Table("weasel_testing.people");
+        expected.AddColumn<int>("id").AsPrimaryKey();
+
+        var delta = new TableDelta(expected, null);
+
+        delta.Difference.ShouldBe(SchemaPatchDifference.Create);
+    }
+
+    [Fact]
+    public void no_difference_when_tables_match()
+    {
+        var expected = new Table("weasel_testing.people");
+        expected.AddColumn<int>("id").AsPrimaryKey();
+        expected.AddColumn<string>("name");
+
+        var actual = new Table("weasel_testing.people");
+        actual.AddColumn<int>("id").AsPrimaryKey();
+        actual.AddColumn<string>("name");
+
+        var delta = new TableDelta(expected, actual);
+
+        delta.Difference.ShouldBe(SchemaPatchDifference.None);
+        delta.HasChanges().ShouldBeFalse();
+    }
+
+    [Fact]
+    public void detect_missing_column()
+    {
+        var expected = new Table("weasel_testing.people");
+        expected.AddColumn<int>("id").AsPrimaryKey();
+        expected.AddColumn<string>("name");
+        expected.AddColumn<string>("email");
+
+        var actual = new Table("weasel_testing.people");
+        actual.AddColumn<int>("id").AsPrimaryKey();
+        actual.AddColumn<string>("name");
+
+        var delta = new TableDelta(expected, actual);
+
+        delta.Difference.ShouldBe(SchemaPatchDifference.Update);
+        delta.Columns!.Missing.Count.ShouldBe(1);
+        delta.Columns.Missing[0].Name.ShouldBe("email");
+    }
+
+    [Fact]
+    public void detect_extra_column()
+    {
+        var expected = new Table("weasel_testing.people");
+        expected.AddColumn<int>("id").AsPrimaryKey();
+        expected.AddColumn<string>("name");
+
+        var actual = new Table("weasel_testing.people");
+        actual.AddColumn<int>("id").AsPrimaryKey();
+        actual.AddColumn<string>("name");
+        actual.AddColumn<string>("email");
+
+        var delta = new TableDelta(expected, actual);
+
+        delta.Difference.ShouldBe(SchemaPatchDifference.Update);
+        delta.Columns!.Extras.Count.ShouldBe(1);
+        delta.Columns.Extras[0].Name.ShouldBe("email");
+    }
+
+    [Fact]
+    public void detect_different_column_type()
+    {
+        var expected = new Table("weasel_testing.people");
+        expected.AddColumn<int>("id").AsPrimaryKey();
+        expected.AddColumn("name", "TEXT");
+
+        var actual = new Table("weasel_testing.people");
+        actual.AddColumn<int>("id").AsPrimaryKey();
+        actual.AddColumn("name", "VARCHAR(100)");
+
+        var delta = new TableDelta(expected, actual);
+
+        delta.Difference.ShouldBe(SchemaPatchDifference.Update);
+        delta.Columns!.Different.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void detect_missing_index()
+    {
+        var expected = new Table("weasel_testing.people");
+        expected.AddColumn<int>("id").AsPrimaryKey();
+        expected.AddColumn<string>("email").AddIndex();
+
+        var actual = new Table("weasel_testing.people");
+        actual.AddColumn<int>("id").AsPrimaryKey();
+        actual.AddColumn<string>("email");
+
+        var delta = new TableDelta(expected, actual);
+
+        delta.Difference.ShouldBe(SchemaPatchDifference.Update);
+        delta.Indexes!.Missing.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void detect_extra_index()
+    {
+        var expected = new Table("weasel_testing.people");
+        expected.AddColumn<int>("id").AsPrimaryKey();
+        expected.AddColumn<string>("email");
+
+        var actual = new Table("weasel_testing.people");
+        actual.AddColumn<int>("id").AsPrimaryKey();
+        actual.AddColumn<string>("email").AddIndex();
+
+        var delta = new TableDelta(expected, actual);
+
+        delta.Difference.ShouldBe(SchemaPatchDifference.Update);
+        delta.Indexes!.Extras.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void detect_missing_foreign_key()
+    {
+        var expected = new Table("weasel_testing.orders");
+        expected.AddColumn<int>("id").AsPrimaryKey();
+        expected.AddColumn<int>("customer_id").ForeignKeyTo(new Table("weasel_testing.customers"), "id");
+
+        var actual = new Table("weasel_testing.orders");
+        actual.AddColumn<int>("id").AsPrimaryKey();
+        actual.AddColumn<int>("customer_id");
+
+        var delta = new TableDelta(expected, actual);
+
+        delta.Difference.ShouldBe(SchemaPatchDifference.Update);
+        delta.ForeignKeys!.Missing.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void detect_extra_foreign_key()
+    {
+        var expected = new Table("weasel_testing.orders");
+        expected.AddColumn<int>("id").AsPrimaryKey();
+        expected.AddColumn<int>("customer_id");
+
+        var actual = new Table("weasel_testing.orders");
+        actual.AddColumn<int>("id").AsPrimaryKey();
+        actual.AddColumn<int>("customer_id").ForeignKeyTo(new Table("weasel_testing.customers"), "id");
+
+        var delta = new TableDelta(expected, actual);
+
+        delta.Difference.ShouldBe(SchemaPatchDifference.Update);
+        delta.ForeignKeys!.Extras.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void detect_primary_key_change()
+    {
+        var expected = new Table("weasel_testing.people");
+        expected.AddColumn<int>("id").AsPrimaryKey();
+        expected.AddColumn<string>("tenant_id").AsPrimaryKey();
+
+        var actual = new Table("weasel_testing.people");
+        actual.AddColumn<int>("id").AsPrimaryKey();
+        actual.AddColumn<string>("tenant_id");
+
+        var delta = new TableDelta(expected, actual);
+
+        delta.PrimaryKeyDifference.ShouldBe(SchemaPatchDifference.Update);
+        delta.HasChanges().ShouldBeTrue();
+    }
+
+    [Fact]
+    public void invalid_when_partition_strategy_changes()
+    {
+        var expected = new Table("weasel_testing.events");
+        expected.AddColumn<int>("id").AsPrimaryKey();
+        expected.PartitionByRange("created_at");
+
+        var actual = new Table("weasel_testing.events");
+        actual.AddColumn<int>("id").AsPrimaryKey();
+
+        var delta = new TableDelta(expected, actual);
+
+        delta.Difference.ShouldBe(SchemaPatchDifference.Invalid);
+    }
+
+    [Fact]
+    public void write_update_for_missing_column()
+    {
+        var expected = new Table("weasel_testing.people");
+        expected.AddColumn<int>("id").AsPrimaryKey();
+        expected.AddColumn<string>("email");
+
+        var actual = new Table("weasel_testing.people");
+        actual.AddColumn<int>("id").AsPrimaryKey();
+
+        var delta = new TableDelta(expected, actual);
+        var writer = new StringWriter();
+        delta.WriteUpdate(new MySqlMigrator(), writer);
+
+        var sql = writer.ToString();
+        sql.ShouldContain("ALTER TABLE `weasel_testing`.`people` ADD COLUMN `email`");
+    }
+
+    [Fact]
+    public void write_update_for_extra_column()
+    {
+        var expected = new Table("weasel_testing.people");
+        expected.AddColumn<int>("id").AsPrimaryKey();
+
+        var actual = new Table("weasel_testing.people");
+        actual.AddColumn<int>("id").AsPrimaryKey();
+        actual.AddColumn<string>("email");
+
+        var delta = new TableDelta(expected, actual);
+        var writer = new StringWriter();
+        delta.WriteUpdate(new MySqlMigrator(), writer);
+
+        var sql = writer.ToString();
+        sql.ShouldContain("ALTER TABLE `weasel_testing`.`people` DROP COLUMN `email`");
+    }
+
+    [Fact]
+    public void write_update_for_missing_index()
+    {
+        var expected = new Table("weasel_testing.people");
+        expected.AddColumn<int>("id").AsPrimaryKey();
+        expected.AddColumn<string>("email").AddIndex();
+
+        var actual = new Table("weasel_testing.people");
+        actual.AddColumn<int>("id").AsPrimaryKey();
+        actual.AddColumn<string>("email");
+
+        var delta = new TableDelta(expected, actual);
+        var writer = new StringWriter();
+        delta.WriteUpdate(new MySqlMigrator(), writer);
+
+        var sql = writer.ToString();
+        sql.ShouldContain("CREATE INDEX `idx_people_email`");
+    }
+
+    [Fact]
+    public void write_update_for_extra_index()
+    {
+        var expected = new Table("weasel_testing.people");
+        expected.AddColumn<int>("id").AsPrimaryKey();
+        expected.AddColumn<string>("email");
+
+        var actual = new Table("weasel_testing.people");
+        actual.AddColumn<int>("id").AsPrimaryKey();
+        actual.AddColumn<string>("email").AddIndex();
+
+        var delta = new TableDelta(expected, actual);
+        var writer = new StringWriter();
+        delta.WriteUpdate(new MySqlMigrator(), writer);
+
+        var sql = writer.ToString();
+        sql.ShouldContain("DROP INDEX `idx_people_email`");
+    }
+
+    [Fact]
+    public void write_update_for_primary_key_change()
+    {
+        var expected = new Table("weasel_testing.people");
+        expected.AddColumn<int>("id").AsPrimaryKey();
+        expected.AddColumn<string>("tenant_id").AsPrimaryKey();
+
+        var actual = new Table("weasel_testing.people");
+        actual.AddColumn<int>("id").AsPrimaryKey();
+        actual.AddColumn<string>("tenant_id");
+
+        var delta = new TableDelta(expected, actual);
+        var writer = new StringWriter();
+        delta.WriteUpdate(new MySqlMigrator(), writer);
+
+        var sql = writer.ToString();
+        sql.ShouldContain("DROP PRIMARY KEY");
+        sql.ShouldContain("ADD PRIMARY KEY");
+    }
+
+    [Fact]
+    public void write_rollback_for_create()
+    {
+        var expected = new Table("weasel_testing.people");
+        expected.AddColumn<int>("id").AsPrimaryKey();
+
+        var delta = new TableDelta(expected, null);
+        var writer = new StringWriter();
+        delta.WriteRollback(new MySqlMigrator(), writer);
+
+        var sql = writer.ToString();
+        sql.ShouldContain("DROP TABLE IF EXISTS `weasel_testing`.`people`");
+    }
+}

--- a/src/Weasel.MySql.Tests/Tables/TableTests.cs
+++ b/src/Weasel.MySql.Tests/Tables/TableTests.cs
@@ -1,0 +1,353 @@
+using Shouldly;
+using Weasel.Core;
+using Weasel.MySql.Tables;
+using Xunit;
+
+namespace Weasel.MySql.Tests.Tables;
+
+public class TableTests
+{
+    [Fact]
+    public void create_table_with_qualified_name()
+    {
+        var table = new Table("weasel_testing.people");
+        table.Identifier.Schema.ShouldBe("weasel_testing");
+        table.Identifier.Name.ShouldBe("people");
+    }
+
+    [Fact]
+    public void add_column_with_type()
+    {
+        var table = new Table("weasel_testing.people");
+        table.AddColumn("name", "VARCHAR(100)");
+
+        table.Columns.Count.ShouldBe(1);
+        table.Columns[0].Name.ShouldBe("name");
+        table.Columns[0].Type.ShouldBe("VARCHAR(100)");
+    }
+
+    [Fact]
+    public void add_column_with_generic_type()
+    {
+        var table = new Table("weasel_testing.people");
+        table.AddColumn<int>("id");
+        table.AddColumn<string>("name");
+
+        table.Columns.Count.ShouldBe(2);
+        table.Columns[0].Type.ShouldBe("INT");
+        table.Columns[1].Type.ShouldBe("VARCHAR(255)");
+    }
+
+    [Fact]
+    public void add_column_as_primary_key()
+    {
+        var table = new Table("weasel_testing.people");
+        table.AddColumn<int>("id").AsPrimaryKey();
+
+        table.Columns[0].IsPrimaryKey.ShouldBeTrue();
+        table.Columns[0].AllowNulls.ShouldBeFalse();
+        table.PrimaryKeyColumns.ShouldBe(new[] { "id" });
+    }
+
+    [Fact]
+    public void multi_column_primary_key()
+    {
+        var table = new Table("weasel_testing.people");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn<string>("tenant_id").AsPrimaryKey();
+
+        table.PrimaryKeyColumns.Count.ShouldBe(2);
+        table.PrimaryKeyColumns.ShouldContain("id");
+        table.PrimaryKeyColumns.ShouldContain("tenant_id");
+    }
+
+    [Fact]
+    public void primary_key_name_is_derived()
+    {
+        var table = new Table("weasel_testing.people");
+        table.AddColumn<int>("id").AsPrimaryKey();
+
+        table.PrimaryKeyName.ShouldBe("pk_people_id");
+    }
+
+    [Fact]
+    public void custom_primary_key_name()
+    {
+        var table = new Table("weasel_testing.people");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.PrimaryKeyName = "my_custom_pk";
+
+        table.PrimaryKeyName.ShouldBe("my_custom_pk");
+    }
+
+    [Fact]
+    public void has_column()
+    {
+        var table = new Table("weasel_testing.people");
+        table.AddColumn<string>("name");
+
+        table.HasColumn("name").ShouldBeTrue();
+        table.HasColumn("email").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void column_for()
+    {
+        var table = new Table("weasel_testing.people");
+        table.AddColumn<string>("name");
+
+        var column = table.ColumnFor("name");
+        column.ShouldNotBeNull();
+        column.Name.ShouldBe("name");
+
+        table.ColumnFor("nonexistent").ShouldBeNull();
+    }
+
+    [Fact]
+    public void remove_column()
+    {
+        var table = new Table("weasel_testing.people");
+        table.AddColumn<string>("name");
+        table.AddColumn<string>("email");
+
+        table.RemoveColumn("name");
+
+        table.Columns.Count.ShouldBe(1);
+        table.HasColumn("name").ShouldBeFalse();
+        table.HasColumn("email").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void modify_column()
+    {
+        var table = new Table("weasel_testing.people");
+        table.AddColumn<string>("name");
+
+        var expression = table.ModifyColumn("name");
+        expression.ShouldNotBeNull();
+        table.ColumnFor("name").ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void modify_nonexistent_column_throws()
+    {
+        var table = new Table("weasel_testing.people");
+
+        Should.Throw<ArgumentOutOfRangeException>(() => table.ModifyColumn("nonexistent"));
+    }
+
+    [Fact]
+    public void add_index()
+    {
+        var table = new Table("weasel_testing.people");
+        table.AddColumn<string>("email").AddIndex();
+
+        table.Indexes.Count.ShouldBe(1);
+        table.Indexes[0].Columns.ShouldBe(new[] { "email" });
+    }
+
+    [Fact]
+    public void add_index_with_configuration()
+    {
+        var table = new Table("weasel_testing.people");
+        table.AddColumn<string>("email").AddIndex(x =>
+        {
+            x.IsUnique = true;
+            x.SortOrder = SortOrder.Desc;
+        });
+
+        table.Indexes[0].IsUnique.ShouldBeTrue();
+        table.Indexes[0].SortOrder.ShouldBe(SortOrder.Desc);
+    }
+
+    [Fact]
+    public void add_fulltext_index()
+    {
+        var table = new Table("weasel_testing.articles");
+        table.AddColumn("content", "TEXT").AddFulltextIndex();
+
+        table.Indexes.Count.ShouldBe(1);
+        table.Indexes[0].IndexType.ShouldBe(MySqlIndexType.Fulltext);
+    }
+
+    [Fact]
+    public void add_hash_index()
+    {
+        var table = new Table("weasel_testing.people");
+        table.AddColumn<string>("email").AddIndex(x => x.IndexType = MySqlIndexType.Hash);
+
+        table.Indexes[0].IndexType.ShouldBe(MySqlIndexType.Hash);
+    }
+
+    [Fact]
+    public void has_index()
+    {
+        var table = new Table("weasel_testing.people");
+        table.AddColumn<string>("email").AddIndex();
+
+        table.HasIndex("idx_people_email").ShouldBeTrue();
+        table.HasIndex("nonexistent").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void index_for()
+    {
+        var table = new Table("weasel_testing.people");
+        table.AddColumn<string>("email").AddIndex();
+
+        var index = table.IndexFor("idx_people_email");
+        index.ShouldNotBeNull();
+
+        table.IndexFor("nonexistent").ShouldBeNull();
+    }
+
+    [Fact]
+    public void add_foreign_key()
+    {
+        var states = new Table("weasel_testing.states");
+        var table = new Table("weasel_testing.people");
+        table.AddColumn<int>("state_id").ForeignKeyTo(states, "id");
+
+        table.ForeignKeys.Count.ShouldBe(1);
+        table.ForeignKeys[0].ColumnNames.ShouldBe(new[] { "state_id" });
+        table.ForeignKeys[0].LinkedNames.ShouldBe(new[] { "id" });
+    }
+
+    [Fact]
+    public void add_foreign_key_with_cascade()
+    {
+        var states = new Table("weasel_testing.states");
+        var table = new Table("weasel_testing.people");
+        table.AddColumn<int>("state_id").ForeignKeyTo(states, "id", onDelete: CascadeAction.Cascade);
+
+        table.ForeignKeys[0].OnDelete.ShouldBe(CascadeAction.Cascade);
+    }
+
+    [Fact]
+    public void find_or_create_foreign_key()
+    {
+        var table = new Table("weasel_testing.people");
+
+        var fk1 = table.FindOrCreateForeignKey("fk_test");
+        var fk2 = table.FindOrCreateForeignKey("fk_test");
+
+        fk1.ShouldBeSameAs(fk2);
+        table.ForeignKeys.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void all_names_includes_table_indexes_and_foreign_keys()
+    {
+        var table = new Table("weasel_testing.people");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn<string>("email").AddIndex();
+        table.AddColumn<int>("state_id").ForeignKeyTo(new Table("weasel_testing.states"), "id");
+
+        var names = table.AllNames().ToList();
+        names.Count.ShouldBe(3);
+    }
+
+    [Fact]
+    public void partition_by_range()
+    {
+        var table = new Table("weasel_testing.events");
+        table.PartitionByRange("created_at");
+
+        table.PartitionStrategy.ShouldBe(PartitionStrategy.Range);
+        table.PartitionExpressions.ShouldContain("created_at");
+    }
+
+    [Fact]
+    public void partition_by_hash()
+    {
+        var table = new Table("weasel_testing.events");
+        table.PartitionByHash("id");
+
+        table.PartitionStrategy.ShouldBe(PartitionStrategy.Hash);
+        table.PartitionExpressions.ShouldContain("id");
+    }
+
+    [Fact]
+    public void partition_by_list()
+    {
+        var table = new Table("weasel_testing.events");
+        table.PartitionByList("region");
+
+        table.PartitionStrategy.ShouldBe(PartitionStrategy.List);
+        table.PartitionExpressions.ShouldContain("region");
+    }
+
+    [Fact]
+    public void partition_by_key()
+    {
+        var table = new Table("weasel_testing.events");
+        table.PartitionByKey("id");
+
+        table.PartitionStrategy.ShouldBe(PartitionStrategy.Key);
+        table.PartitionExpressions.ShouldContain("id");
+    }
+
+    [Fact]
+    public void clear_partitions()
+    {
+        var table = new Table("weasel_testing.events");
+        table.PartitionByRange("created_at");
+        table.ClearPartitions();
+
+        table.PartitionStrategy.ShouldBe(PartitionStrategy.None);
+        table.PartitionExpressions.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void auto_number_column()
+    {
+        var table = new Table("weasel_testing.people");
+        table.AddColumn<int>("id").AutoNumber();
+
+        table.Columns[0].IsAutoNumber.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void default_value_by_string()
+    {
+        var table = new Table("weasel_testing.people");
+        table.AddColumn<string>("status").DefaultValueByString("active");
+
+        table.Columns[0].DefaultExpression.ShouldBe("'active'");
+    }
+
+    [Fact]
+    public void default_value_by_int()
+    {
+        var table = new Table("weasel_testing.people");
+        table.AddColumn<int>("count").DefaultValue(0);
+
+        table.Columns[0].DefaultExpression.ShouldBe("0");
+    }
+
+    [Fact]
+    public void default_engine_is_innodb()
+    {
+        var table = new Table("weasel_testing.people");
+        table.Engine.ShouldBe("InnoDB");
+    }
+
+    [Fact]
+    public void can_set_custom_engine()
+    {
+        var table = new Table("weasel_testing.people");
+        table.Engine = "MyISAM";
+        table.Engine.ShouldBe("MyISAM");
+    }
+
+    [Fact]
+    public void can_set_charset_and_collation()
+    {
+        var table = new Table("weasel_testing.people");
+        table.Charset = "utf8mb4";
+        table.Collation = "utf8mb4_unicode_ci";
+
+        table.Charset.ShouldBe("utf8mb4");
+        table.Collation.ShouldBe("utf8mb4_unicode_ci");
+    }
+}

--- a/src/Weasel.MySql.Tests/Tables/creating_tables_in_database.cs
+++ b/src/Weasel.MySql.Tests/Tables/creating_tables_in_database.cs
@@ -1,0 +1,239 @@
+using Shouldly;
+using Weasel.Core;
+using Weasel.MySql.Tables;
+using Xunit;
+
+namespace Weasel.MySql.Tests.Tables;
+
+public class creating_tables_in_database: IntegrationContext
+{
+    [Fact]
+    public async Task create_simple_table()
+    {
+        await DropTableAsync("`weasel_testing`.`people`");
+
+        var table = new Table("weasel_testing.people");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn<string>("name").NotNull();
+
+        await table.CreateAsync(theConnection);
+
+        var exists = await table.ExistsInDatabaseAsync(theConnection);
+        exists.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task create_table_with_auto_increment()
+    {
+        await DropTableAsync("`weasel_testing`.`items`");
+
+        var table = new Table("weasel_testing.items");
+        table.AddColumn<int>("id").AsPrimaryKey().AutoNumber();
+        table.AddColumn<string>("name");
+
+        await table.CreateAsync(theConnection);
+
+        var exists = await table.ExistsInDatabaseAsync(theConnection);
+        exists.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task create_table_with_index()
+    {
+        await DropTableAsync("`weasel_testing`.`users`");
+
+        var table = new Table("weasel_testing.users");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn<string>("email").AddIndex(x => x.IsUnique = true);
+
+        await table.CreateAsync(theConnection);
+
+        var exists = await table.ExistsInDatabaseAsync(theConnection);
+        exists.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task create_table_with_fulltext_index()
+    {
+        await DropTableAsync("`weasel_testing`.`articles`");
+
+        var table = new Table("weasel_testing.articles");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn("content", "TEXT").AddFulltextIndex();
+
+        await table.CreateAsync(theConnection);
+
+        var exists = await table.ExistsInDatabaseAsync(theConnection);
+        exists.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task create_table_with_foreign_key()
+    {
+        await DropTableAsync("`weasel_testing`.`orders`");
+        await DropTableAsync("`weasel_testing`.`customers`");
+
+        var customers = new Table("weasel_testing.customers");
+        customers.AddColumn<int>("id").AsPrimaryKey();
+        customers.AddColumn<string>("name");
+        await customers.CreateAsync(theConnection);
+
+        var orders = new Table("weasel_testing.orders");
+        orders.AddColumn<int>("id").AsPrimaryKey();
+        orders.AddColumn<int>("customer_id").ForeignKeyTo(customers, "id");
+        await orders.CreateAsync(theConnection);
+
+        var exists = await orders.ExistsInDatabaseAsync(theConnection);
+        exists.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task create_table_with_cascade_delete()
+    {
+        await DropTableAsync("`weasel_testing`.`line_items`");
+        await DropTableAsync("`weasel_testing`.`invoices`");
+
+        var invoices = new Table("weasel_testing.invoices");
+        invoices.AddColumn<int>("id").AsPrimaryKey();
+        await invoices.CreateAsync(theConnection);
+
+        var lineItems = new Table("weasel_testing.line_items");
+        lineItems.AddColumn<int>("id").AsPrimaryKey();
+        lineItems.AddColumn<int>("invoice_id")
+            .ForeignKeyTo(invoices, "id", onDelete: CascadeAction.Cascade);
+        await lineItems.CreateAsync(theConnection);
+
+        var exists = await lineItems.ExistsInDatabaseAsync(theConnection);
+        exists.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task create_table_with_default_value()
+    {
+        await DropTableAsync("`weasel_testing`.`tasks`");
+
+        var table = new Table("weasel_testing.tasks");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn<string>("status").DefaultValueByString("pending");
+        table.AddColumn<int>("priority").DefaultValue(0);
+
+        await table.CreateAsync(theConnection);
+
+        var exists = await table.ExistsInDatabaseAsync(theConnection);
+        exists.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task create_table_with_multi_column_primary_key()
+    {
+        await DropTableAsync("`weasel_testing`.`tenant_users`");
+
+        var table = new Table("weasel_testing.tenant_users");
+        table.AddColumn<int>("tenant_id").AsPrimaryKey();
+        table.AddColumn<int>("user_id").AsPrimaryKey();
+        table.AddColumn<string>("role");
+
+        await table.CreateAsync(theConnection);
+
+        var exists = await table.ExistsInDatabaseAsync(theConnection);
+        exists.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task create_table_with_multi_column_index()
+    {
+        await DropTableAsync("`weasel_testing`.`products`");
+
+        var table = new Table("weasel_testing.products");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn<string>("category");
+        table.AddColumn<string>("name");
+
+        table.Indexes.Add(new IndexDefinition("idx_products_category_name")
+        {
+            Columns = new[] { "category", "name" }
+        });
+
+        await table.CreateAsync(theConnection);
+
+        var exists = await table.ExistsInDatabaseAsync(theConnection);
+        exists.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task create_table_with_charset_and_collation()
+    {
+        await DropTableAsync("`weasel_testing`.`messages`");
+
+        var table = new Table("weasel_testing.messages");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn<string>("content");
+        table.Charset = "utf8mb4";
+        table.Collation = "utf8mb4_unicode_ci";
+
+        await table.CreateAsync(theConnection);
+
+        var exists = await table.ExistsInDatabaseAsync(theConnection);
+        exists.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task drop_then_create_mode()
+    {
+        await DropTableAsync("`weasel_testing`.`recreate_test`");
+
+        // Create initial table
+        var table1 = new Table("weasel_testing.recreate_test");
+        table1.AddColumn<int>("id").AsPrimaryKey();
+        table1.AddColumn<string>("name");
+        await table1.CreateAsync(theConnection);
+
+        // Create with drop mode
+        var table2 = new Table("weasel_testing.recreate_test");
+        table2.AddColumn<int>("id").AsPrimaryKey();
+        table2.AddColumn<string>("different_column");
+
+        var writer = new StringWriter();
+        var migrator = new MySqlMigrator { TableCreation = CreationStyle.DropThenCreate };
+        table2.WriteCreateStatement(migrator, writer);
+
+        var sql = writer.ToString();
+        sql.ShouldContain("DROP TABLE IF EXISTS");
+        sql.ShouldContain("CREATE TABLE IF NOT EXISTS");
+    }
+
+    [Fact]
+    public async Task fetch_existing_table()
+    {
+        await DropTableAsync("`weasel_testing`.`fetch_test`");
+
+        var table = new Table("weasel_testing.fetch_test");
+        table.AddColumn<int>("id").AsPrimaryKey().AutoNumber();
+        table.AddColumn<string>("email").AddIndex(x => x.IsUnique = true);
+        table.AddColumn<string>("name").NotNull();
+
+        await table.CreateAsync(theConnection);
+
+        var existing = await table.FetchExistingAsync(theConnection);
+
+        existing.ShouldNotBeNull();
+        existing.Columns.Count.ShouldBe(3);
+        existing.HasColumn("id").ShouldBeTrue();
+        existing.HasColumn("email").ShouldBeTrue();
+        existing.HasColumn("name").ShouldBeTrue();
+        existing.Indexes.Count.ShouldBeGreaterThanOrEqualTo(1);
+    }
+
+    [Fact]
+    public async Task fetch_existing_returns_null_for_missing_table()
+    {
+        await DropTableAsync("`weasel_testing`.`nonexistent_table`");
+
+        var table = new Table("weasel_testing.nonexistent_table");
+        table.AddColumn<int>("id").AsPrimaryKey();
+
+        var existing = await table.FetchExistingAsync(theConnection);
+
+        existing.ShouldBeNull();
+    }
+}

--- a/src/Weasel.MySql.Tests/Tables/detecting_table_deltas.cs
+++ b/src/Weasel.MySql.Tests/Tables/detecting_table_deltas.cs
@@ -1,0 +1,247 @@
+using Shouldly;
+using Weasel.Core;
+using Weasel.MySql.Tables;
+using Xunit;
+
+namespace Weasel.MySql.Tests.Tables;
+
+public class detecting_table_deltas: IntegrationContext
+{
+    [Fact]
+    public async Task detect_no_changes()
+    {
+        await DropTableAsync("`weasel_testing`.`delta_test_1`");
+
+        var expected = new Table("weasel_testing.delta_test_1");
+        expected.AddColumn<int>("id").AsPrimaryKey();
+        expected.AddColumn<string>("name");
+
+        await expected.CreateAsync(theConnection);
+
+        var delta = await expected.FindDeltaAsync(theConnection);
+
+        delta.Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task detect_table_needs_creation()
+    {
+        await DropTableAsync("`weasel_testing`.`delta_test_2`");
+
+        var expected = new Table("weasel_testing.delta_test_2");
+        expected.AddColumn<int>("id").AsPrimaryKey();
+
+        var delta = await expected.FindDeltaAsync(theConnection);
+
+        delta.Difference.ShouldBe(SchemaPatchDifference.Create);
+    }
+
+    [Fact]
+    public async Task detect_missing_column()
+    {
+        await DropTableAsync("`weasel_testing`.`delta_test_3`");
+
+        // Create table with just id
+        var actual = new Table("weasel_testing.delta_test_3");
+        actual.AddColumn<int>("id").AsPrimaryKey();
+        await actual.CreateAsync(theConnection);
+
+        // Expected has additional column
+        var expected = new Table("weasel_testing.delta_test_3");
+        expected.AddColumn<int>("id").AsPrimaryKey();
+        expected.AddColumn<string>("email");
+
+        var delta = await expected.FindDeltaAsync(theConnection) as TableDelta;
+
+        delta!.Difference.ShouldBe(SchemaPatchDifference.Update);
+        delta.Columns!.Missing.Count.ShouldBe(1);
+        delta.Columns.Missing[0].Name.ShouldBe("email");
+    }
+
+    [Fact]
+    public async Task detect_extra_column()
+    {
+        await DropTableAsync("`weasel_testing`.`delta_test_4`");
+
+        // Create table with extra column
+        var actual = new Table("weasel_testing.delta_test_4");
+        actual.AddColumn<int>("id").AsPrimaryKey();
+        actual.AddColumn<string>("obsolete_column");
+        await actual.CreateAsync(theConnection);
+
+        // Expected doesn't have the column
+        var expected = new Table("weasel_testing.delta_test_4");
+        expected.AddColumn<int>("id").AsPrimaryKey();
+
+        var delta = await expected.FindDeltaAsync(theConnection) as TableDelta;
+
+        delta!.Difference.ShouldBe(SchemaPatchDifference.Update);
+        delta.Columns!.Extras.Count.ShouldBe(1);
+        delta.Columns.Extras[0].Name.ShouldBe("obsolete_column");
+    }
+
+    [Fact]
+    public async Task detect_missing_index()
+    {
+        await DropTableAsync("`weasel_testing`.`delta_test_5`");
+
+        // Create table without index
+        var actual = new Table("weasel_testing.delta_test_5");
+        actual.AddColumn<int>("id").AsPrimaryKey();
+        actual.AddColumn<string>("email");
+        await actual.CreateAsync(theConnection);
+
+        // Expected has index
+        var expected = new Table("weasel_testing.delta_test_5");
+        expected.AddColumn<int>("id").AsPrimaryKey();
+        expected.AddColumn<string>("email").AddIndex();
+
+        var delta = await expected.FindDeltaAsync(theConnection) as TableDelta;
+
+        delta!.Difference.ShouldBe(SchemaPatchDifference.Update);
+        delta.Indexes!.Missing.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task detect_extra_index()
+    {
+        await DropTableAsync("`weasel_testing`.`delta_test_6`");
+
+        // Create table with index
+        var actual = new Table("weasel_testing.delta_test_6");
+        actual.AddColumn<int>("id").AsPrimaryKey();
+        actual.AddColumn<string>("email").AddIndex();
+        await actual.CreateAsync(theConnection);
+
+        // Expected doesn't have index
+        var expected = new Table("weasel_testing.delta_test_6");
+        expected.AddColumn<int>("id").AsPrimaryKey();
+        expected.AddColumn<string>("email");
+
+        var delta = await expected.FindDeltaAsync(theConnection) as TableDelta;
+
+        delta!.Difference.ShouldBe(SchemaPatchDifference.Update);
+        delta.Indexes!.Extras.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task detect_missing_foreign_key()
+    {
+        await DropTableAsync("`weasel_testing`.`delta_orders`");
+        await DropTableAsync("`weasel_testing`.`delta_customers`");
+
+        // Create parent table
+        var customers = new Table("weasel_testing.delta_customers");
+        customers.AddColumn<int>("id").AsPrimaryKey();
+        await customers.CreateAsync(theConnection);
+
+        // Create table without FK
+        var actualOrders = new Table("weasel_testing.delta_orders");
+        actualOrders.AddColumn<int>("id").AsPrimaryKey();
+        actualOrders.AddColumn<int>("customer_id");
+        await actualOrders.CreateAsync(theConnection);
+
+        // Expected has FK
+        var expectedOrders = new Table("weasel_testing.delta_orders");
+        expectedOrders.AddColumn<int>("id").AsPrimaryKey();
+        expectedOrders.AddColumn<int>("customer_id").ForeignKeyTo(customers, "id");
+
+        var delta = await expectedOrders.FindDeltaAsync(theConnection) as TableDelta;
+
+        delta!.Difference.ShouldBe(SchemaPatchDifference.Update);
+        delta.ForeignKeys!.Missing.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task apply_changes_adds_missing_column()
+    {
+        await DropTableAsync("`weasel_testing`.`apply_test_1`");
+
+        // Create table without email
+        var actual = new Table("weasel_testing.apply_test_1");
+        actual.AddColumn<int>("id").AsPrimaryKey();
+        await actual.CreateAsync(theConnection);
+
+        // Expected has email
+        var expected = new Table("weasel_testing.apply_test_1");
+        expected.AddColumn<int>("id").AsPrimaryKey();
+        expected.AddColumn<string>("email");
+
+        await expected.ApplyChangesAsync(theConnection);
+
+        var afterDelta = await expected.FindDeltaAsync(theConnection);
+        afterDelta.Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task apply_changes_adds_missing_index()
+    {
+        await DropTableAsync("`weasel_testing`.`apply_test_2`");
+
+        // Create table without index
+        var actual = new Table("weasel_testing.apply_test_2");
+        actual.AddColumn<int>("id").AsPrimaryKey();
+        actual.AddColumn<string>("email");
+        await actual.CreateAsync(theConnection);
+
+        // Expected has index
+        var expected = new Table("weasel_testing.apply_test_2");
+        expected.AddColumn<int>("id").AsPrimaryKey();
+        expected.AddColumn<string>("email").AddIndex();
+
+        await expected.ApplyChangesAsync(theConnection);
+
+        var afterDelta = await expected.FindDeltaAsync(theConnection);
+        afterDelta.Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task apply_changes_creates_table_if_not_exists()
+    {
+        await DropTableAsync("`weasel_testing`.`apply_test_3`");
+
+        var expected = new Table("weasel_testing.apply_test_3");
+        expected.AddColumn<int>("id").AsPrimaryKey();
+        expected.AddColumn<string>("name");
+
+        await expected.ApplyChangesAsync(theConnection);
+
+        var exists = await expected.ExistsInDatabaseAsync(theConnection);
+        exists.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task fetch_and_compare_auto_increment()
+    {
+        await DropTableAsync("`weasel_testing`.`auto_inc_test`");
+
+        var expected = new Table("weasel_testing.auto_inc_test");
+        expected.AddColumn<int>("id").AsPrimaryKey().AutoNumber();
+        expected.AddColumn<string>("name");
+
+        await expected.CreateAsync(theConnection);
+
+        var existing = await expected.FetchExistingAsync(theConnection);
+
+        existing.ShouldNotBeNull();
+        existing.ColumnFor("id")!.IsAutoNumber.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task fetch_and_compare_unique_index()
+    {
+        await DropTableAsync("`weasel_testing`.`unique_idx_test`");
+
+        var expected = new Table("weasel_testing.unique_idx_test");
+        expected.AddColumn<int>("id").AsPrimaryKey();
+        expected.AddColumn<string>("email").AddIndex(x => x.IsUnique = true);
+
+        await expected.CreateAsync(theConnection);
+
+        var existing = await expected.FetchExistingAsync(theConnection);
+
+        existing.ShouldNotBeNull();
+        existing.Indexes.Count.ShouldBeGreaterThanOrEqualTo(1);
+        existing.Indexes.Any(i => i.IsUnique).ShouldBeTrue();
+    }
+}

--- a/src/Weasel.MySql.Tests/Weasel.MySql.Tests.csproj
+++ b/src/Weasel.MySql.Tests/Weasel.MySql.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+      <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+        <PackageReference Include="NSubstitute" Version="5.3.0" />
+        <PackageReference Include="Shouldly" Version="4.3.0" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="6.0.0">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Weasel.MySql\Weasel.MySql.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Weasel.MySql/CascadeAction.cs
+++ b/src/Weasel.MySql/CascadeAction.cs
@@ -1,0 +1,10 @@
+namespace Weasel.MySql;
+
+public enum CascadeAction
+{
+    NoAction,
+    Restrict,
+    Cascade,
+    SetNull,
+    SetDefault
+}

--- a/src/Weasel.MySql/CommandBuilder.cs
+++ b/src/Weasel.MySql/CommandBuilder.cs
@@ -1,0 +1,62 @@
+using System.Data.Common;
+using MySqlConnector;
+using Weasel.Core;
+
+namespace Weasel.MySql;
+
+public class CommandBuilder: CommandBuilderBase<MySqlCommand, MySqlParameter, MySqlDbType>
+{
+    public CommandBuilder(): this(new MySqlCommand())
+    {
+    }
+
+    public CommandBuilder(MySqlCommand command): base(MySqlProvider.Instance, '@', command)
+    {
+    }
+}
+
+public static class CommandBuilderExtensions
+{
+    public static Task<int> ExecuteNonQueryAsync(
+        this MySqlConnection connection,
+        CommandBuilder commandBuilder,
+        CancellationToken ct = default
+    ) => connection.ExecuteNonQueryAsync(commandBuilder, null, ct);
+
+    public static Task<int> ExecuteNonQueryAsync(
+        this MySqlConnection connection,
+        CommandBuilder commandBuilder,
+        MySqlTransaction? tx,
+        CancellationToken ct = default
+    ) => Weasel.Core.CommandBuilderExtensions.ExecuteNonQueryAsync(connection, commandBuilder, tx, ct);
+
+    public static Task<MySqlDataReader> ExecuteReaderAsync(
+        this MySqlConnection connection,
+        CommandBuilder commandBuilder,
+        CancellationToken ct = default
+    ) => connection.ExecuteReaderAsync(commandBuilder, null, ct);
+
+    public static async Task<MySqlDataReader> ExecuteReaderAsync(
+        this MySqlConnection connection,
+        CommandBuilder commandBuilder,
+        MySqlTransaction? tx,
+        CancellationToken ct = default
+    ) =>
+        (MySqlDataReader)await Weasel.Core.CommandBuilderExtensions
+            .ExecuteReaderAsync(connection, commandBuilder, tx, ct).ConfigureAwait(false);
+
+    public static Task<IReadOnlyList<T>> FetchListAsync<T>(
+        this MySqlConnection connection,
+        CommandBuilder commandBuilder,
+        Func<DbDataReader, CancellationToken, Task<T>> transform,
+        CancellationToken ct = default
+    ) => connection.FetchListAsync(commandBuilder, transform, null, ct);
+
+    public static Task<IReadOnlyList<T>> FetchListAsync<T>(
+        this MySqlConnection connection,
+        CommandBuilder commandBuilder,
+        Func<DbDataReader, CancellationToken, Task<T>> transform,
+        MySqlTransaction? tx,
+        CancellationToken ct = default
+    ) => Weasel.Core.CommandBuilderExtensions.FetchListAsync(connection, commandBuilder, transform, tx, ct);
+}

--- a/src/Weasel.MySql/CommandExtensions.cs
+++ b/src/Weasel.MySql/CommandExtensions.cs
@@ -1,0 +1,32 @@
+using MySqlConnector;
+
+namespace Weasel.MySql;
+
+public static class CommandExtensions
+{
+    public static MySqlCommand With(this MySqlCommand command, string name, object? value)
+    {
+        var parameter = command.CreateParameter();
+        parameter.ParameterName = name;
+        parameter.Value = value ?? DBNull.Value;
+        command.Parameters.Add(parameter);
+        return command;
+    }
+
+    public static MySqlCommand With(this MySqlCommand command, string name, object? value, MySqlDbType dbType)
+    {
+        var parameter = command.CreateParameter();
+        parameter.ParameterName = name;
+        parameter.Value = value ?? DBNull.Value;
+        parameter.MySqlDbType = dbType;
+        command.Parameters.Add(parameter);
+        return command;
+    }
+
+    public static MySqlCommand CreateCommand(this MySqlConnection conn, string sql)
+    {
+        var cmd = conn.CreateCommand();
+        cmd.CommandText = sql;
+        return cmd;
+    }
+}

--- a/src/Weasel.MySql/MySqlMigrator.cs
+++ b/src/Weasel.MySql/MySqlMigrator.cs
@@ -1,0 +1,117 @@
+using System.Data.Common;
+using JasperFx;
+using JasperFx.Core;
+using Weasel.Core;
+using Weasel.Core.Migrations;
+
+namespace Weasel.MySql;
+
+public class MySqlMigrator: Migrator
+{
+    public MySqlMigrator(): base(MySqlProvider.Instance.DefaultDatabaseSchemaName)
+    {
+    }
+
+    public override void WriteScript(TextWriter writer, Action<Migrator, TextWriter> writeStep)
+    {
+        writeStep(this, writer);
+    }
+
+    public override void WriteSchemaCreationSql(IEnumerable<string> schemaNames, TextWriter writer)
+    {
+        foreach (var schemaName in schemaNames)
+        {
+            writer.WriteLine(CreateDatabaseStatementFor(schemaName));
+        }
+    }
+
+    protected override async Task executeDelta(
+        SchemaMigration migration,
+        DbConnection conn,
+        AutoCreate autoCreate,
+        IMigrationLogger logger,
+        CancellationToken ct = default)
+    {
+        await createSchemas(migration, conn, logger, ct).ConfigureAwait(false);
+
+        foreach (var delta in migration.Deltas)
+        {
+            var writer = new StringWriter();
+            WriteUpdate(writer, delta);
+
+            if (writer.ToString().Trim().IsNotEmpty())
+            {
+                await executeCommand(conn, logger, writer, ct).ConfigureAwait(false);
+            }
+        }
+    }
+
+    public override string ToExecuteScriptLine(string scriptName)
+    {
+        return $"source {scriptName}";
+    }
+
+    public override void AssertValidIdentifier(string name)
+    {
+        // MySQL identifiers can be up to 64 characters
+        if (name.Length > 64)
+        {
+            throw new ArgumentException($"MySQL identifier '{name}' exceeds the 64 character limit.");
+        }
+    }
+
+    private static async Task createSchemas(
+        SchemaMigration migration,
+        DbConnection conn,
+        IMigrationLogger logger,
+        CancellationToken ct = default)
+    {
+        var writer = new StringWriter();
+
+        if (migration.Schemas.Any())
+        {
+            new MySqlMigrator().WriteSchemaCreationSql(migration.Schemas, writer);
+            if (writer.ToString().Trim().IsNotEmpty())
+            {
+                await executeCommand(conn, logger, writer, ct).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private static async Task executeCommand(DbConnection conn, IMigrationLogger logger, StringWriter writer, CancellationToken ct = default)
+    {
+        var sql = writer.ToString();
+
+        // Split on semicolons and execute each statement
+        var statements = sql.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+
+        foreach (var statement in statements)
+        {
+            var trimmed = statement.Trim();
+            if (trimmed.IsEmpty()) continue;
+
+            var cmd = conn.CreateCommand();
+            cmd.CommandText = trimmed;
+            logger.SchemaChange(cmd.CommandText);
+
+            try
+            {
+                await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                if (logger is DefaultMigrationLogger)
+                {
+                    throw;
+                }
+
+                logger.OnFailure(cmd, e);
+            }
+        }
+    }
+
+    public static string CreateDatabaseStatementFor(string databaseName)
+    {
+        return $"CREATE DATABASE IF NOT EXISTS `{databaseName}`;";
+    }
+}

--- a/src/Weasel.MySql/MySqlObjectName.cs
+++ b/src/Weasel.MySql/MySqlObjectName.cs
@@ -1,0 +1,60 @@
+using JasperFx.Core;
+using JasperFx.Core.Reflection;
+using Weasel.Core;
+
+namespace Weasel.MySql;
+
+public class MySqlObjectName: DbObjectName
+{
+    protected override string QuotedQualifiedName => Schema.IsEmpty()
+        ? $"`{Name}`"
+        : $"`{Schema}`.`{Name}`";
+
+    public MySqlObjectName(string schema, string name)
+        : base(schema, name, ComputeQualifiedName(schema, name))
+    {
+    }
+
+    private static string ComputeQualifiedName(string schema, string name)
+    {
+        return schema.IsEmpty()
+            ? $"`{name}`"
+            : $"`{schema}`.`{name}`";
+    }
+
+    private MySqlObjectName(DbObjectName dbObjectName): this(dbObjectName.Schema, dbObjectName.Name)
+    {
+    }
+
+    public static MySqlObjectName From(DbObjectName dbObjectName) =>
+        new MySqlObjectName(dbObjectName);
+
+    public string ToIndexName(string prefix, params string[] columnNames)
+    {
+        var name = $"{prefix}_{Name}_{string.Join("_", columnNames)}";
+        return name.Length > 64 ? name.Substring(0, 64) : name;
+    }
+
+    private new bool Equals(DbObjectName other)
+    {
+        return string.Equals(QualifiedName, other.QualifiedName, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is DbObjectName dbObjectName)
+        {
+            return Equals(dbObjectName);
+        }
+
+        return base.Equals(obj);
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            return (typeof(DbObjectName).GetHashCode() * 397) ^ QualifiedName.GetHashCode();
+        }
+    }
+}

--- a/src/Weasel.MySql/MySqlProvider.cs
+++ b/src/Weasel.MySql/MySqlProvider.cs
@@ -1,0 +1,212 @@
+using System.Data;
+using ImTools;
+using JasperFx.Core;
+using JasperFx.Core.Reflection;
+using MySqlConnector;
+using Weasel.Core;
+
+namespace Weasel.MySql;
+
+public class MySqlProvider: DatabaseProvider<MySqlCommand, MySqlParameter, MySqlDbType>
+{
+    public const string EngineName = "MySql";
+    public static readonly MySqlProvider Instance = new();
+
+    private MySqlProvider(): base("public")
+    {
+    }
+
+    protected override void storeMappings()
+    {
+        store<string>(MySqlDbType.VarChar, "VARCHAR(255)");
+        store<bool>(MySqlDbType.Bool, "TINYINT(1)");
+        store<byte>(MySqlDbType.UByte, "TINYINT UNSIGNED");
+        store<short>(MySqlDbType.Int16, "SMALLINT");
+        store<int>(MySqlDbType.Int32, "INT");
+        store<long>(MySqlDbType.Int64, "BIGINT");
+        store<byte[]>(MySqlDbType.Blob, "BLOB");
+        store<DateTime>(MySqlDbType.DateTime, "DATETIME");
+        store<DateTimeOffset>(MySqlDbType.DateTime, "DATETIME");
+        store<decimal>(MySqlDbType.Decimal, "DECIMAL(18,2)");
+        store<double>(MySqlDbType.Double, "DOUBLE");
+        store<float>(MySqlDbType.Float, "FLOAT");
+        store<TimeSpan>(MySqlDbType.Time, "TIME");
+        store<Guid>(MySqlDbType.Guid, "CHAR(36)");
+    }
+
+    private string? ResolveDatabaseType(Type type)
+    {
+        if (DatabaseTypeMemo.Value.TryFind(type, out var value))
+        {
+            return value;
+        }
+
+        if (!type.IsNullable() ||
+            !DatabaseTypeMemo.Value.TryFind(type.GetInnerTypeFromNullable(), out var databaseType))
+            throw new NotSupportedException(
+                $"Weasel.MySql does not (yet) support database type mapping to {type.FullNameInCode()}");
+
+        DatabaseTypeMemo.Swap(d => d.AddOrUpdate(type, databaseType));
+        return databaseType;
+    }
+
+    private MySqlDbType? ResolveMySqlDbType(Type type)
+    {
+        if (ParameterTypeMemo.Value.TryFind(type, out var value))
+        {
+            return value;
+        }
+
+        if (type.IsNullable() &&
+            ParameterTypeMemo.Value.TryFind(type.GetInnerTypeFromNullable(), out var parameterType))
+        {
+            ParameterTypeMemo.Swap(d => d.AddOrUpdate(type, parameterType));
+            return parameterType;
+        }
+
+        return MySqlDbType.VarChar;
+    }
+
+    protected override Type[] determineClrTypesForParameterType(MySqlDbType dbType)
+    {
+        return Type.EmptyTypes;
+    }
+
+    public override string ToQualifiedName(string objectName) =>
+        string.IsNullOrEmpty(objectName) ? objectName : $"`{objectName}`";
+
+    public override DbObjectName Parse(string schemaName, string objectName) =>
+        new MySqlObjectName(schemaName, objectName);
+
+    public override string AddApplicationNameToConnectionString(string connectionString, string applicationName)
+    {
+        var builder = new MySqlConnectionStringBuilder(connectionString);
+        builder.ApplicationName = applicationName;
+        return builder.ConnectionString;
+    }
+
+    public string ConvertSynonyms(string type)
+    {
+        switch (type.ToUpperInvariant())
+        {
+            case "INTEGER":
+                return "INT";
+            case "BOOLEAN":
+            case "BOOL":
+                return "TINYINT(1)";
+            case "TEXT":
+            case "STRING":
+                return "VARCHAR(255)";
+            case "REAL":
+                return "FLOAT";
+        }
+
+        return type.ToUpperInvariant();
+    }
+
+    protected override bool determineParameterType(Type type, out MySqlDbType dbType)
+    {
+        var mySqlDbType = ResolveMySqlDbType(type);
+        if (mySqlDbType != null)
+        {
+            dbType = mySqlDbType.Value;
+            return true;
+        }
+
+        if (type.IsNullable())
+        {
+            dbType = ToParameterType(type.GetInnerTypeFromNullable());
+            return true;
+        }
+
+        if (type.IsEnum)
+        {
+            dbType = MySqlDbType.Int32;
+            return true;
+        }
+
+        if (type.IsArray)
+        {
+            throw new NotSupportedException("MySql does not support arrays as parameters");
+        }
+
+        if (type == typeof(DBNull))
+        {
+            dbType = MySqlDbType.VarChar;
+            return true;
+        }
+
+        if (type.IsConstructedGenericType)
+        {
+            dbType = ToParameterType(type.GetGenericTypeDefinition());
+            return true;
+        }
+
+        dbType = MySqlDbType.VarChar;
+        return false;
+    }
+
+    public override string GetDatabaseType(Type memberType, EnumStorage enumStyle)
+    {
+        if (memberType.IsEnum)
+        {
+            return enumStyle == EnumStorage.AsInteger ? "INT" : "VARCHAR(100)";
+        }
+
+        if (memberType.IsNullable())
+        {
+            return GetDatabaseType(memberType.GetInnerTypeFromNullable(), enumStyle);
+        }
+
+        // Check memo first - this handles byte[] -> BLOB mapping
+        if (ResolveDatabaseType(memberType) is { } result)
+        {
+            return result;
+        }
+
+        // byte[] is already handled above by ResolveDatabaseType
+        if (memberType.IsArray)
+        {
+            throw new NotSupportedException("MySql does not support array column types");
+        }
+
+        if (memberType.IsConstructedGenericType)
+        {
+            return GetDatabaseType(memberType.GetGenericTypeDefinition(), enumStyle);
+        }
+
+        return "TEXT";
+    }
+
+    public override void AddParameter(MySqlCommand command, MySqlParameter parameter)
+    {
+        command.Parameters.Add(parameter);
+    }
+
+    public override void SetParameterType(MySqlParameter parameter, MySqlDbType dbType)
+    {
+        parameter.MySqlDbType = dbType;
+    }
+
+    public static CascadeAction ReadAction(string description)
+    {
+        switch (description.ToUpperInvariant().Trim())
+        {
+            case "CASCADE":
+                return CascadeAction.Cascade;
+            case "NO ACTION":
+            case "NO_ACTION":
+                return CascadeAction.NoAction;
+            case "SET NULL":
+            case "SET_NULL":
+                return CascadeAction.SetNull;
+            case "SET DEFAULT":
+            case "SET_DEFAULT":
+                return CascadeAction.SetDefault;
+            case "RESTRICT":
+                return CascadeAction.Restrict;
+        }
+
+        return CascadeAction.NoAction;
+    }
+}

--- a/src/Weasel.MySql/SchemaObjectsExtensions.cs
+++ b/src/Weasel.MySql/SchemaObjectsExtensions.cs
@@ -1,0 +1,53 @@
+using JasperFx;
+using MySqlConnector;
+using Weasel.Core;
+
+namespace Weasel.MySql;
+
+public static class SchemaObjectsExtensions
+{
+    public static async Task ApplyChangesAsync(
+        this ISchemaObject schemaObject,
+        MySqlConnection connection,
+        CancellationToken ct = default)
+    {
+        var migration = await SchemaMigration.DetermineAsync(connection, ct, schemaObject).ConfigureAwait(false);
+        await new MySqlMigrator().ApplyAllAsync(connection, migration, AutoCreate.CreateOrUpdate, ct: ct)
+            .ConfigureAwait(false);
+    }
+
+    public static async Task CreateAsync(
+        this ISchemaObject schemaObject,
+        MySqlConnection connection,
+        CancellationToken ct = default)
+    {
+        var writer = new StringWriter();
+        schemaObject.WriteCreateStatement(new MySqlMigrator(), writer);
+
+        var sql = writer.ToString();
+
+        // MySQL doesn't support multiple statements by default, split them
+        var statements = sql.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+        foreach (var statement in statements)
+        {
+            var trimmed = statement.Trim();
+            if (string.IsNullOrEmpty(trimmed)) continue;
+
+            await using var cmd = connection.CreateCommand(trimmed);
+            await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+        }
+    }
+
+    public static async Task DropAsync(
+        this ISchemaObject schemaObject,
+        MySqlConnection connection,
+        CancellationToken ct = default)
+    {
+        var writer = new StringWriter();
+        schemaObject.WriteDropStatement(new MySqlMigrator(), writer);
+
+        var sql = writer.ToString();
+        await using var cmd = connection.CreateCommand(sql);
+        await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+    }
+}

--- a/src/Weasel.MySql/SchemaUtils.cs
+++ b/src/Weasel.MySql/SchemaUtils.cs
@@ -1,0 +1,46 @@
+namespace Weasel.MySql;
+
+public static class SchemaUtils
+{
+    public static string QuoteName(string name)
+    {
+        return $"`{name}`";
+    }
+
+    public static string QuoteQualifiedName(string schema, string name)
+    {
+        return string.IsNullOrEmpty(schema)
+            ? QuoteName(name)
+            : $"{QuoteName(schema)}.{QuoteName(name)}";
+    }
+
+    public static bool IsReservedKeyword(string name)
+    {
+        return ReservedKeywords.Contains(name, StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static readonly HashSet<string> ReservedKeywords = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "ACCESSIBLE", "ADD", "ALL", "ALTER", "ANALYZE", "AND", "AS", "ASC",
+        "BEFORE", "BETWEEN", "BIGINT", "BINARY", "BLOB", "BOTH", "BY", "CALL",
+        "CASCADE", "CASE", "CHANGE", "CHAR", "CHARACTER", "CHECK", "COLLATE",
+        "COLUMN", "CONSTRAINT", "CONTINUE", "CREATE", "CROSS", "CURRENT_DATE",
+        "CURRENT_TIME", "CURRENT_TIMESTAMP", "CURRENT_USER", "CURSOR", "DATABASE",
+        "DATABASES", "DEFAULT", "DELETE", "DESC", "DESCRIBE", "DISTINCT", "DIV",
+        "DOUBLE", "DROP", "DUAL", "EACH", "ELSE", "ELSEIF", "ENCLOSED", "ESCAPED",
+        "EXISTS", "EXIT", "EXPLAIN", "FALSE", "FETCH", "FLOAT", "FOR", "FORCE",
+        "FOREIGN", "FROM", "FULLTEXT", "GRANT", "GROUP", "HAVING", "IF", "IGNORE",
+        "IN", "INDEX", "INFILE", "INNER", "INSERT", "INT", "INTEGER", "INTERVAL",
+        "INTO", "IS", "ITERATE", "JOIN", "KEY", "KEYS", "KILL", "LEADING", "LEAVE",
+        "LEFT", "LIKE", "LIMIT", "LINES", "LOAD", "LOCK", "LONG", "LOOP", "MATCH",
+        "NATURAL", "NOT", "NULL", "NUMERIC", "ON", "OPTIMIZE", "OPTION",
+        "OPTIONALLY", "OR", "ORDER", "OUT", "OUTER", "OUTFILE", "PRIMARY",
+        "PROCEDURE", "RANGE", "READ", "READS", "REAL", "REFERENCES", "REGEXP",
+        "RELEASE", "RENAME", "REPEAT", "REPLACE", "REQUIRE", "RESTRICT", "RETURN",
+        "REVOKE", "RIGHT", "SCHEMA", "SCHEMAS", "SELECT", "SET", "SHOW",
+        "SMALLINT", "SPATIAL", "SQL", "STARTING", "TABLE", "TERMINATED", "THEN",
+        "TINYINT", "TO", "TRAILING", "TRIGGER", "TRUE", "UNDO", "UNION", "UNIQUE",
+        "UNLOCK", "UNSIGNED", "UPDATE", "USAGE", "USE", "USING", "VALUES",
+        "VARBINARY", "VARCHAR", "WHEN", "WHERE", "WHILE", "WITH", "WRITE", "XOR"
+    };
+}

--- a/src/Weasel.MySql/Sequence.cs
+++ b/src/Weasel.MySql/Sequence.cs
@@ -1,0 +1,65 @@
+using System.Data.Common;
+using Weasel.Core;
+
+namespace Weasel.MySql;
+
+public class Sequence: ISchemaObject
+{
+    public Sequence(DbObjectName identifier)
+    {
+        Identifier = identifier;
+    }
+
+    public Sequence(string sequenceName): this(DbObjectName.Parse(MySqlProvider.Instance, sequenceName))
+    {
+    }
+
+    public DbObjectName Identifier { get; }
+
+    public long StartWith { get; set; } = 1;
+    public long IncrementBy { get; set; } = 1;
+
+    public void WriteCreateStatement(Migrator migrator, TextWriter writer)
+    {
+        // MySQL 8.0+ supports sequences, but older versions don't
+        // Using a table-based sequence for broader compatibility
+        writer.WriteLine($"CREATE TABLE IF NOT EXISTS {Identifier.QualifiedName} (");
+        writer.WriteLine("    id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,");
+        writer.WriteLine($"    current_value BIGINT NOT NULL DEFAULT {StartWith}");
+        writer.WriteLine(");");
+        writer.WriteLine($"INSERT IGNORE INTO {Identifier.QualifiedName} (current_value) VALUES ({StartWith});");
+    }
+
+    public void WriteDropStatement(Migrator migrator, TextWriter writer)
+    {
+        writer.WriteLine($"DROP TABLE IF EXISTS {Identifier.QualifiedName};");
+    }
+
+    public void ConfigureQueryCommand(Core.DbCommandBuilder builder)
+    {
+        var schemaParam = builder.AddParameter(Identifier.Schema).ParameterName;
+        var nameParam = builder.AddParameter(Identifier.Name).ParameterName;
+
+        builder.Append($@"
+SELECT COUNT(*) FROM information_schema.tables
+WHERE table_schema = @{schemaParam} AND table_name = @{nameParam};
+");
+    }
+
+    public async Task<ISchemaObjectDelta> CreateDeltaAsync(DbDataReader reader, CancellationToken ct = default)
+    {
+        var exists = false;
+
+        if (await reader.ReadAsync(ct).ConfigureAwait(false))
+        {
+            exists = await reader.GetFieldValueAsync<long>(0, ct).ConfigureAwait(false) > 0;
+        }
+
+        return new SchemaObjectDelta(this, exists ? SchemaPatchDifference.None : SchemaPatchDifference.Create);
+    }
+
+    public IEnumerable<DbObjectName> AllNames()
+    {
+        yield return Identifier;
+    }
+}

--- a/src/Weasel.MySql/Tables/Change.cs
+++ b/src/Weasel.MySql/Tables/Change.cs
@@ -1,0 +1,13 @@
+namespace Weasel.MySql.Tables;
+
+public class Change<T> where T : class
+{
+    public Change(T expected, T actual)
+    {
+        Expected = expected;
+        Actual = actual;
+    }
+
+    public T Expected { get; }
+    public T Actual { get; }
+}

--- a/src/Weasel.MySql/Tables/ForeignKey.cs
+++ b/src/Weasel.MySql/Tables/ForeignKey.cs
@@ -1,0 +1,122 @@
+using System.Text;
+using JasperFx.Core;
+using Weasel.Core;
+
+namespace Weasel.MySql.Tables;
+
+public class ForeignKey: INamed
+{
+    private readonly List<string> _columnNames = new();
+    private readonly List<string> _linkedNames = new();
+
+    public ForeignKey(string name)
+    {
+        Name = name;
+    }
+
+    public string Name { get; set; }
+    public DbObjectName? LinkedTable { get; set; }
+    public CascadeAction OnDelete { get; set; } = CascadeAction.NoAction;
+    public CascadeAction OnUpdate { get; set; } = CascadeAction.NoAction;
+
+    public string[] ColumnNames
+    {
+        get => _columnNames.ToArray();
+        set
+        {
+            _columnNames.Clear();
+            _columnNames.AddRange(value);
+        }
+    }
+
+    public string[] LinkedNames
+    {
+        get => _linkedNames.ToArray();
+        set
+        {
+            _linkedNames.Clear();
+            _linkedNames.AddRange(value);
+        }
+    }
+
+    public void LinkColumns(string columnName, string linkedName)
+    {
+        _columnNames.Add(columnName);
+        _linkedNames.Add(linkedName);
+    }
+
+    public string ToDDL(Table parent)
+    {
+        if (LinkedTable == null)
+        {
+            throw new InvalidOperationException("LinkedTable must be set before generating DDL");
+        }
+
+        var builder = new StringBuilder();
+        builder.Append($"ALTER TABLE {parent.Identifier.QualifiedName} ADD CONSTRAINT `{Name}` ");
+        builder.Append($"FOREIGN KEY ({_columnNames.Select(c => $"`{c}`").Join(", ")}) ");
+        builder.Append($"REFERENCES {LinkedTable.QualifiedName} ({_linkedNames.Select(c => $"`{c}`").Join(", ")})");
+
+        if (OnDelete != CascadeAction.NoAction)
+        {
+            builder.Append($" ON DELETE {GetCascadeActionSql(OnDelete)}");
+        }
+
+        if (OnUpdate != CascadeAction.NoAction)
+        {
+            builder.Append($" ON UPDATE {GetCascadeActionSql(OnUpdate)}");
+        }
+
+        builder.Append(";");
+
+        return builder.ToString();
+    }
+
+    private static string GetCascadeActionSql(CascadeAction action)
+    {
+        return action switch
+        {
+            CascadeAction.Cascade => "CASCADE",
+            CascadeAction.SetNull => "SET NULL",
+            CascadeAction.SetDefault => "SET DEFAULT",
+            CascadeAction.Restrict => "RESTRICT",
+            _ => "NO ACTION"
+        };
+    }
+
+    public void ReadReferentialActions(string onDelete, string onUpdate)
+    {
+        OnDelete = MySqlProvider.ReadAction(onDelete);
+        OnUpdate = MySqlProvider.ReadAction(onUpdate);
+    }
+
+    public bool IsEquivalentTo(ForeignKey other)
+    {
+        if (!Name.Equals(other.Name, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (LinkedTable?.QualifiedName != other.LinkedTable?.QualifiedName)
+        {
+            return false;
+        }
+
+        if (!_columnNames.SequenceEqual(other._columnNames, StringComparer.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (!_linkedNames.SequenceEqual(other._linkedNames, StringComparer.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (OnDelete != other.OnDelete || OnUpdate != other.OnUpdate)
+        {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Weasel.MySql/Tables/IndexDefinition.cs
+++ b/src/Weasel.MySql/Tables/IndexDefinition.cs
@@ -1,0 +1,192 @@
+using System.Text;
+using JasperFx.Core;
+using Weasel.Core;
+
+namespace Weasel.MySql.Tables;
+
+public class IndexDefinition: INamed
+{
+    private readonly IList<string> _columns = new List<string>();
+    private string? _indexName;
+
+    public IndexDefinition(string indexName)
+    {
+        _indexName = indexName;
+    }
+
+    protected IndexDefinition()
+    {
+    }
+
+    public MySqlIndexType IndexType { get; set; } = MySqlIndexType.BTree;
+    public SortOrder SortOrder { get; set; } = SortOrder.Asc;
+    public bool IsUnique { get; set; }
+
+    public string[] Columns
+    {
+        get => _columns.ToArray();
+        set
+        {
+            _columns.Clear();
+            _columns.AddRange(value);
+        }
+    }
+
+    /// <summary>
+    ///     The constraint expression for a partial index (WHERE clause).
+    ///     Note: MySQL doesn't support partial indexes natively in the same way as PostgreSQL.
+    /// </summary>
+    public string? Predicate { get; set; }
+
+    /// <summary>
+    ///     For FULLTEXT indexes, specify the parser to use (e.g., "ngram" or "mecab").
+    /// </summary>
+    public string? FulltextParser { get; set; }
+
+    /// <summary>
+    ///     Prefix length for string columns (e.g., VARCHAR(255) indexed with prefix of 10).
+    /// </summary>
+    public int? PrefixLength { get; set; }
+
+    public string Name
+    {
+        get
+        {
+            if (_indexName.IsNotEmpty())
+            {
+                return _indexName;
+            }
+
+            return deriveIndexName();
+        }
+        set => _indexName = value;
+    }
+
+    protected virtual string deriveIndexName()
+    {
+        throw new NotSupportedException();
+    }
+
+    /// <summary>
+    ///     Set the Index expression against the supplied columns
+    /// </summary>
+    public IndexDefinition AgainstColumns(params string[] columns)
+    {
+        _columns.Clear();
+        _columns.AddRange(columns);
+        return this;
+    }
+
+    public string ToDDL(Table parent)
+    {
+        var builder = new StringBuilder();
+
+        builder.Append("CREATE ");
+
+        switch (IndexType)
+        {
+            case MySqlIndexType.Fulltext:
+                builder.Append("FULLTEXT ");
+                break;
+            case MySqlIndexType.Spatial:
+                builder.Append("SPATIAL ");
+                break;
+            default:
+                if (IsUnique)
+                {
+                    builder.Append("UNIQUE ");
+                }
+                break;
+        }
+
+        builder.Append("INDEX ");
+        builder.Append($"`{Name}`");
+        builder.Append(" ON ");
+        builder.Append(parent.Identifier.QualifiedName);
+        builder.Append(" ");
+        builder.Append(correctedExpression());
+
+        // Add index type for non-fulltext/spatial
+        if (IndexType == MySqlIndexType.Hash)
+        {
+            builder.Append(" USING HASH");
+        }
+        else if (IndexType == MySqlIndexType.BTree && !IsUnique)
+        {
+            // BTree is default, only explicit if needed
+        }
+
+        if (IndexType == MySqlIndexType.Fulltext && FulltextParser.IsNotEmpty())
+        {
+            builder.Append($" WITH PARSER {FulltextParser}");
+        }
+
+        builder.Append(";");
+
+        return builder.ToString();
+    }
+
+    private string correctedExpression()
+    {
+        if (!Columns.Any())
+        {
+            throw new InvalidOperationException("IndexDefinition requires at least one column");
+        }
+
+        var columns = Columns.Select(c =>
+        {
+            var col = $"`{c}`";
+            if (PrefixLength.HasValue)
+            {
+                col += $"({PrefixLength.Value})";
+            }
+
+            // Fulltext and spatial indexes don't support ASC/DESC
+            if (IndexType != MySqlIndexType.Fulltext && IndexType != MySqlIndexType.Spatial)
+            {
+                if (SortOrder == SortOrder.Desc)
+                {
+                    col += " DESC";
+                }
+            }
+
+            return col;
+        });
+
+        return $"({columns.Join(", ")})";
+    }
+
+    public bool Matches(IndexDefinition actual, Table parent)
+    {
+        var expectedSql = CanonicizeDdl(this, parent);
+        var actualSql = CanonicizeDdl(actual, parent);
+
+        return expectedSql == actualSql;
+    }
+
+    public void AssertMatches(IndexDefinition actual, Table parent)
+    {
+        var expectedSql = CanonicizeDdl(this, parent);
+        var actualSql = CanonicizeDdl(actual, parent);
+
+        if (expectedSql != actualSql)
+        {
+            throw new Exception(
+                $"Index did not match, expected{Environment.NewLine}{expectedSql}{Environment.NewLine}but got:{Environment.NewLine}{actualSql}");
+        }
+    }
+
+    public static string CanonicizeDdl(IndexDefinition index, Table parent)
+    {
+        return index.ToDDL(parent)
+            .Replace("`", "")
+            .Replace("  ", " ")
+            .ToUpperInvariant()
+            .TrimEnd(';');
+    }
+
+    public void AddColumn(string columnName)
+    {
+        _columns.Add(columnName);
+    }
+}

--- a/src/Weasel.MySql/Tables/ItemDelta.cs
+++ b/src/Weasel.MySql/Tables/ItemDelta.cs
@@ -1,0 +1,49 @@
+using Weasel.Core;
+
+namespace Weasel.MySql.Tables;
+
+public class ItemDelta<T> where T : class, INamed
+{
+    public ItemDelta(IEnumerable<T> expected, IEnumerable<T> actual, Func<T, T, bool> comparison)
+    {
+        var expectedList = expected.ToList();
+        var actualList = actual.ToList();
+
+        foreach (var item in expectedList)
+        {
+            var match = actualList.FirstOrDefault(a =>
+                a.Name.Equals(item.Name, StringComparison.OrdinalIgnoreCase));
+
+            if (match == null)
+            {
+                Missing.Add(item);
+            }
+            else if (!comparison(item, match))
+            {
+                Different.Add(new Change<T>(item, match));
+            }
+            else
+            {
+                Matched.Add(item);
+            }
+        }
+
+        foreach (var item in actualList)
+        {
+            var match = expectedList.FirstOrDefault(e =>
+                e.Name.Equals(item.Name, StringComparison.OrdinalIgnoreCase));
+
+            if (match == null)
+            {
+                Extras.Add(item);
+            }
+        }
+    }
+
+    public List<T> Missing { get; } = new();
+    public List<T> Extras { get; } = new();
+    public List<T> Matched { get; } = new();
+    public List<Change<T>> Different { get; } = new();
+
+    public bool HasChanges() => Missing.Any() || Extras.Any() || Different.Any();
+}

--- a/src/Weasel.MySql/Tables/MySqlIndexType.cs
+++ b/src/Weasel.MySql/Tables/MySqlIndexType.cs
@@ -1,0 +1,9 @@
+namespace Weasel.MySql.Tables;
+
+public enum MySqlIndexType
+{
+    BTree,
+    Hash,
+    Fulltext,
+    Spatial
+}

--- a/src/Weasel.MySql/Tables/SortOrder.cs
+++ b/src/Weasel.MySql/Tables/SortOrder.cs
@@ -1,0 +1,7 @@
+namespace Weasel.MySql.Tables;
+
+public enum SortOrder
+{
+    Asc,
+    Desc
+}

--- a/src/Weasel.MySql/Tables/StringWriterExtensions.cs
+++ b/src/Weasel.MySql/Tables/StringWriterExtensions.cs
@@ -1,0 +1,13 @@
+namespace Weasel.MySql.Tables;
+
+internal static class StringWriterExtensions
+{
+    public static void WriteStatement(this StringWriter writer, string statement)
+    {
+        writer.WriteLine(statement);
+        if (!statement.TrimEnd().EndsWith(";"))
+        {
+            writer.WriteLine(";");
+        }
+    }
+}

--- a/src/Weasel.MySql/Tables/Table.Deltas.cs
+++ b/src/Weasel.MySql/Tables/Table.Deltas.cs
@@ -1,0 +1,20 @@
+using System.Data.Common;
+using MySqlConnector;
+using Weasel.Core;
+
+namespace Weasel.MySql.Tables;
+
+public partial class Table
+{
+    public async Task<ISchemaObjectDelta> CreateDeltaAsync(DbDataReader reader, CancellationToken ct = default)
+    {
+        var existing = await readExistingAsync(reader, ct).ConfigureAwait(false);
+        return new TableDelta(this, existing);
+    }
+
+    public async Task<TableDelta> FindDeltaAsync(MySqlConnection conn, CancellationToken ct = default)
+    {
+        var actual = await FetchExistingAsync(conn, ct).ConfigureAwait(false);
+        return new TableDelta(this, actual);
+    }
+}

--- a/src/Weasel.MySql/Tables/Table.FetchExisting.cs
+++ b/src/Weasel.MySql/Tables/Table.FetchExisting.cs
@@ -1,0 +1,232 @@
+using System.Data.Common;
+using MySqlConnector;
+using Weasel.Core;
+
+namespace Weasel.MySql.Tables;
+
+public partial class Table
+{
+    public void ConfigureQueryCommand(Core.DbCommandBuilder builder)
+    {
+        var schemaParam = builder.AddParameter(Identifier.Schema).ParameterName;
+        var nameParam = builder.AddParameter(Identifier.Name).ParameterName;
+
+        builder.Append($@"
+-- Columns
+SELECT
+    COLUMN_NAME,
+    COLUMN_TYPE,
+    IS_NULLABLE,
+    COLUMN_KEY,
+    COLUMN_DEFAULT,
+    EXTRA
+FROM information_schema.COLUMNS
+WHERE TABLE_SCHEMA = @{schemaParam} AND TABLE_NAME = @{nameParam}
+ORDER BY ORDINAL_POSITION;
+
+-- Primary Key
+SELECT
+    kcu.COLUMN_NAME,
+    tc.CONSTRAINT_NAME
+FROM information_schema.TABLE_CONSTRAINTS tc
+JOIN information_schema.KEY_COLUMN_USAGE kcu
+    ON tc.CONSTRAINT_NAME = kcu.CONSTRAINT_NAME
+    AND tc.TABLE_SCHEMA = kcu.TABLE_SCHEMA
+    AND tc.TABLE_NAME = kcu.TABLE_NAME
+WHERE tc.TABLE_SCHEMA = @{schemaParam}
+    AND tc.TABLE_NAME = @{nameParam}
+    AND tc.CONSTRAINT_TYPE = 'PRIMARY KEY'
+ORDER BY kcu.ORDINAL_POSITION;
+
+-- Foreign Keys
+SELECT
+    tc.CONSTRAINT_NAME,
+    kcu.COLUMN_NAME,
+    kcu.REFERENCED_TABLE_SCHEMA,
+    kcu.REFERENCED_TABLE_NAME,
+    kcu.REFERENCED_COLUMN_NAME,
+    rc.DELETE_RULE,
+    rc.UPDATE_RULE
+FROM information_schema.TABLE_CONSTRAINTS tc
+JOIN information_schema.KEY_COLUMN_USAGE kcu
+    ON tc.CONSTRAINT_NAME = kcu.CONSTRAINT_NAME
+    AND tc.TABLE_SCHEMA = kcu.TABLE_SCHEMA
+    AND tc.TABLE_NAME = kcu.TABLE_NAME
+JOIN information_schema.REFERENTIAL_CONSTRAINTS rc
+    ON tc.CONSTRAINT_NAME = rc.CONSTRAINT_NAME
+    AND tc.TABLE_SCHEMA = rc.CONSTRAINT_SCHEMA
+WHERE tc.TABLE_SCHEMA = @{schemaParam}
+    AND tc.TABLE_NAME = @{nameParam}
+    AND tc.CONSTRAINT_TYPE = 'FOREIGN KEY'
+ORDER BY tc.CONSTRAINT_NAME, kcu.ORDINAL_POSITION;
+
+-- Indexes (excluding primary key)
+SELECT
+    s.INDEX_NAME,
+    s.COLUMN_NAME,
+    s.NON_UNIQUE,
+    s.INDEX_TYPE,
+    s.SEQ_IN_INDEX
+FROM information_schema.STATISTICS s
+WHERE s.TABLE_SCHEMA = @{schemaParam}
+    AND s.TABLE_NAME = @{nameParam}
+    AND s.INDEX_NAME != 'PRIMARY'
+ORDER BY s.INDEX_NAME, s.SEQ_IN_INDEX;
+");
+    }
+
+    public async Task<Table?> FetchExistingAsync(MySqlConnection conn, CancellationToken ct = default)
+    {
+        var builder = new Core.DbCommandBuilder(conn);
+
+        ConfigureQueryCommand(builder);
+
+        await using var reader = await conn.ExecuteReaderAsync(builder, ct).ConfigureAwait(false);
+        var result = await readExistingAsync(reader, ct).ConfigureAwait(false);
+        await reader.CloseAsync().ConfigureAwait(false);
+        return result;
+    }
+
+    private async Task<Table?> readExistingAsync(DbDataReader reader, CancellationToken ct = default)
+    {
+        var existing = new Table(Identifier);
+
+        await readColumnsAsync(reader, existing, ct).ConfigureAwait(false);
+
+        var (pks, primaryKeyName) = await readPrimaryKeysAsync(reader, ct).ConfigureAwait(false);
+        foreach (var pkColumn in pks)
+        {
+            var col = existing.ColumnFor(pkColumn);
+            if (col != null)
+            {
+                col.IsPrimaryKey = true;
+            }
+        }
+
+        if (primaryKeyName != null)
+        {
+            existing.PrimaryKeyName = primaryKeyName;
+        }
+
+        await readForeignKeysAsync(reader, existing, ct).ConfigureAwait(false);
+
+        await readIndexesAsync(reader, existing, ct).ConfigureAwait(false);
+
+        return !existing.Columns.Any()
+            ? null
+            : existing;
+    }
+
+    private static async Task readColumnsAsync(DbDataReader reader, Table existing, CancellationToken ct = default)
+    {
+        while (await reader.ReadAsync(ct).ConfigureAwait(false))
+        {
+            var column = await readColumnAsync(reader, ct).ConfigureAwait(false);
+            existing._columns.Add(column);
+        }
+    }
+
+    private static async Task<TableColumn> readColumnAsync(DbDataReader reader, CancellationToken ct = default)
+    {
+        var columnName = await reader.GetFieldValueAsync<string>(0, ct).ConfigureAwait(false);
+        var columnType = await reader.GetFieldValueAsync<string>(1, ct).ConfigureAwait(false);
+        var isNullable = await reader.GetFieldValueAsync<string>(2, ct).ConfigureAwait(false);
+        var columnKey = await reader.GetFieldValueAsync<string>(3, ct).ConfigureAwait(false);
+        var extra = await reader.IsDBNullAsync(5, ct).ConfigureAwait(false)
+            ? ""
+            : await reader.GetFieldValueAsync<string>(5, ct).ConfigureAwait(false);
+
+        var column = new TableColumn(columnName, columnType.ToUpperInvariant())
+        {
+            AllowNulls = isNullable.Equals("YES", StringComparison.OrdinalIgnoreCase),
+            IsPrimaryKey = columnKey.Equals("PRI", StringComparison.OrdinalIgnoreCase),
+            IsAutoNumber = extra.Contains("auto_increment", StringComparison.OrdinalIgnoreCase)
+        };
+
+        if (!await reader.IsDBNullAsync(4, ct).ConfigureAwait(false))
+        {
+            column.DefaultExpression = await reader.GetFieldValueAsync<string>(4, ct).ConfigureAwait(false);
+        }
+
+        return column;
+    }
+
+    private static async Task<(List<string>, string?)> readPrimaryKeysAsync(
+        DbDataReader reader,
+        CancellationToken ct = default)
+    {
+        string? pkName = null;
+        var pks = new List<string>();
+
+        await reader.NextResultAsync(ct).ConfigureAwait(false);
+
+        while (await reader.ReadAsync(ct).ConfigureAwait(false))
+        {
+            pks.Add(await reader.GetFieldValueAsync<string>(0, ct).ConfigureAwait(false));
+            pkName = await reader.GetFieldValueAsync<string>(1, ct).ConfigureAwait(false);
+        }
+
+        return (pks, pkName);
+    }
+
+    private async Task readForeignKeysAsync(DbDataReader reader, Table existing, CancellationToken ct = default)
+    {
+        await reader.NextResultAsync(ct).ConfigureAwait(false);
+
+        while (await reader.ReadAsync(ct).ConfigureAwait(false))
+        {
+            var fkName = await reader.GetFieldValueAsync<string>(0, ct).ConfigureAwait(false);
+            var columnName = await reader.GetFieldValueAsync<string>(1, ct).ConfigureAwait(false);
+            var refSchema = await reader.GetFieldValueAsync<string>(2, ct).ConfigureAwait(false);
+            var refTable = await reader.GetFieldValueAsync<string>(3, ct).ConfigureAwait(false);
+            var refColumn = await reader.GetFieldValueAsync<string>(4, ct).ConfigureAwait(false);
+            var onDelete = await reader.GetFieldValueAsync<string>(5, ct).ConfigureAwait(false);
+            var onUpdate = await reader.GetFieldValueAsync<string>(6, ct).ConfigureAwait(false);
+
+            var fk = existing.FindOrCreateForeignKey(fkName);
+            fk.LinkedTable = new MySqlObjectName(refSchema, refTable);
+            fk.ReadReferentialActions(onDelete, onUpdate);
+            fk.LinkColumns(columnName, refColumn);
+        }
+    }
+
+    private async Task readIndexesAsync(DbDataReader reader, Table existing, CancellationToken ct = default)
+    {
+        await reader.NextResultAsync(ct).ConfigureAwait(false);
+
+        var indexes = new Dictionary<string, IndexDefinition>(StringComparer.OrdinalIgnoreCase);
+
+        while (await reader.ReadAsync(ct).ConfigureAwait(false))
+        {
+            var indexName = await reader.GetFieldValueAsync<string>(0, ct).ConfigureAwait(false);
+            var columnName = await reader.GetFieldValueAsync<string>(1, ct).ConfigureAwait(false);
+            var nonUnique = await reader.GetFieldValueAsync<long>(2, ct).ConfigureAwait(false);
+            var indexType = await reader.GetFieldValueAsync<string>(3, ct).ConfigureAwait(false);
+
+            if (!indexes.TryGetValue(indexName, out var index))
+            {
+                index = new IndexDefinition(indexName)
+                {
+                    IsUnique = nonUnique == 0,
+                    IndexType = ParseIndexType(indexType)
+                };
+
+                indexes.Add(indexName, index);
+                existing.Indexes.Add(index);
+            }
+
+            index.AddColumn(columnName);
+        }
+    }
+
+    private static MySqlIndexType ParseIndexType(string typeDesc)
+    {
+        return typeDesc.ToUpperInvariant() switch
+        {
+            "HASH" => MySqlIndexType.Hash,
+            "FULLTEXT" => MySqlIndexType.Fulltext,
+            "SPATIAL" => MySqlIndexType.Spatial,
+            _ => MySqlIndexType.BTree
+        };
+    }
+}

--- a/src/Weasel.MySql/Tables/Table.cs
+++ b/src/Weasel.MySql/Tables/Table.cs
@@ -1,0 +1,523 @@
+using System.Globalization;
+using JasperFx.Core;
+using MySqlConnector;
+using Weasel.Core;
+
+namespace Weasel.MySql.Tables;
+
+public enum PartitionStrategy
+{
+    None,
+    Range,
+    Hash,
+    List,
+    Key
+}
+
+public partial class Table: ITable
+{
+    private readonly List<TableColumn> _columns = new();
+    private string? _primaryKeyName;
+
+    public Table(DbObjectName name)
+    {
+        Identifier = name ?? throw new ArgumentNullException(nameof(name));
+    }
+
+    public Table(string tableName): this(DbObjectName.Parse(MySqlProvider.Instance, tableName))
+    {
+    }
+
+    ITableColumn ITable.AddColumn(string name, string columnType)
+    {
+        var expression = AddColumn(name, columnType);
+        return expression.Column;
+    }
+
+    ITableColumn ITable.AddColumn(string name, Type dotnetType)
+    {
+        var type = MySqlProvider.Instance.GetDatabaseType(dotnetType, EnumStorage.AsInteger);
+        var expression = AddColumn(name, type);
+        return expression.Column;
+    }
+
+    ITableColumn ITable.AddPrimaryKeyColumn(string name, string columnType)
+    {
+        var expression = AddColumn(name, columnType).AsPrimaryKey();
+        return expression.Column;
+    }
+
+    ITableColumn ITable.AddPrimaryKeyColumn(string name, Type dotnetType)
+    {
+        var type = MySqlProvider.Instance.GetDatabaseType(dotnetType, EnumStorage.AsInteger);
+        var expression = AddColumn(name, type).AsPrimaryKey();
+        return expression.Column;
+    }
+
+    public IReadOnlyList<TableColumn> Columns => _columns;
+
+    public IList<ForeignKey> ForeignKeys { get; } = new List<ForeignKey>();
+    public IList<IndexDefinition> Indexes { get; } = new List<IndexDefinition>();
+
+    public IReadOnlyList<string> PrimaryKeyColumns =>
+        _columns.Where(x => x.IsPrimaryKey).Select(x => x.Name).ToList();
+
+    public IList<string> PartitionExpressions { get; } = new List<string>();
+
+    public PartitionStrategy PartitionStrategy { get; set; } = PartitionStrategy.None;
+
+    /// <summary>
+    ///     Number of partitions for HASH or KEY partitioning.
+    /// </summary>
+    public int? PartitionCount { get; set; }
+
+    /// <summary>
+    ///     MySQL storage engine (InnoDB, MyISAM, etc.)
+    /// </summary>
+    public string Engine { get; set; } = "InnoDB";
+
+    /// <summary>
+    ///     Character set for the table.
+    /// </summary>
+    public string? Charset { get; set; }
+
+    /// <summary>
+    ///     Collation for the table.
+    /// </summary>
+    public string? Collation { get; set; }
+
+    public string PrimaryKeyName
+    {
+        get => _primaryKeyName.IsNotEmpty()
+            ? _primaryKeyName
+            : $"pk_{Identifier.Name}_{PrimaryKeyColumns.Join("_")}";
+        set => _primaryKeyName = value;
+    }
+
+    public void WriteCreateStatement(Migrator migrator, TextWriter writer)
+    {
+        if (migrator.TableCreation == CreationStyle.DropThenCreate)
+        {
+            writer.WriteLine($"DROP TABLE IF EXISTS {Identifier.QualifiedName};");
+        }
+
+        writer.WriteLine($"CREATE TABLE IF NOT EXISTS {Identifier.QualifiedName} (");
+
+        if (migrator.Formatting == SqlFormatting.Pretty)
+        {
+            var columnLength = Columns.Max(x => x.QuotedName.Length) + 4;
+            var typeLength = Columns.Max(x => x.Type.Length) + 4;
+
+            var lines = Columns.Select(column =>
+                    $"    {column.QuotedName.PadRight(columnLength)}{column.Type.PadRight(typeLength)}{column.Declaration()}")
+                .ToList();
+
+            if (PrimaryKeyColumns.Any())
+            {
+                lines.Add(PrimaryKeyDeclaration());
+            }
+
+            for (var i = 0; i < lines.Count - 1; i++)
+            {
+                writer.WriteLine(lines[i] + ",");
+            }
+
+            writer.WriteLine(lines.Last());
+        }
+        else
+        {
+            var lines = Columns
+                .Select(column => column.ToDeclaration())
+                .ToList();
+
+            if (PrimaryKeyColumns.Any())
+            {
+                lines.Add(PrimaryKeyDeclaration());
+            }
+
+            for (var i = 0; i < lines.Count - 1; i++)
+            {
+                writer.WriteLine(lines[i] + ",");
+            }
+
+            writer.WriteLine(lines.Last());
+        }
+
+        writer.Write(")");
+
+        // Table options
+        var options = new List<string>();
+        options.Add($"ENGINE={Engine}");
+
+        if (Charset.IsNotEmpty())
+        {
+            options.Add($"DEFAULT CHARSET={Charset}");
+        }
+
+        if (Collation.IsNotEmpty())
+        {
+            options.Add($"COLLATE={Collation}");
+        }
+
+        if (options.Any())
+        {
+            writer.Write(" " + options.Join(" "));
+        }
+
+        // Partitioning
+        switch (PartitionStrategy)
+        {
+            case PartitionStrategy.Range:
+                writer.Write($" PARTITION BY RANGE ({PartitionExpressions.Join(", ")})");
+                break;
+            case PartitionStrategy.Hash:
+                writer.Write($" PARTITION BY HASH ({PartitionExpressions.Join(", ")})");
+                if (PartitionCount.HasValue)
+                {
+                    writer.Write($" PARTITIONS {PartitionCount}");
+                }
+
+                break;
+            case PartitionStrategy.List:
+                writer.Write($" PARTITION BY LIST ({PartitionExpressions.Join(", ")})");
+                break;
+            case PartitionStrategy.Key:
+                writer.Write($" PARTITION BY KEY ({PartitionExpressions.Join(", ")})");
+                if (PartitionCount.HasValue)
+                {
+                    writer.Write($" PARTITIONS {PartitionCount}");
+                }
+
+                break;
+        }
+
+        writer.WriteLine(";");
+
+        foreach (var foreignKey in ForeignKeys)
+        {
+            writer.WriteLine();
+            writer.WriteLine(foreignKey.ToDDL(this));
+        }
+
+        foreach (var index in Indexes)
+        {
+            writer.WriteLine();
+            writer.WriteLine(index.ToDDL(this));
+        }
+    }
+
+    public void WriteDropStatement(Migrator rules, TextWriter writer)
+    {
+        writer.WriteLine($"DROP TABLE IF EXISTS {Identifier.QualifiedName};");
+    }
+
+    public DbObjectName Identifier { get; }
+
+    public IEnumerable<DbObjectName> AllNames()
+    {
+        yield return Identifier;
+
+        foreach (var index in Indexes)
+        {
+            yield return new MySqlObjectName(Identifier.Schema, index.Name);
+        }
+
+        foreach (var fk in ForeignKeys)
+        {
+            yield return new MySqlObjectName(Identifier.Schema, fk.Name);
+        }
+    }
+
+    public string ToBasicCreateTableSql()
+    {
+        var writer = new StringWriter();
+        var rules = new MySqlMigrator { Formatting = SqlFormatting.Concise };
+        WriteCreateStatement(rules, writer);
+        return writer.ToString();
+    }
+
+    internal string PrimaryKeyDeclaration()
+    {
+        var columns = PrimaryKeyColumns.Select(c => $"`{c}`").Join(", ");
+        return $"    PRIMARY KEY ({columns})";
+    }
+
+    public TableColumn? ColumnFor(string columnName)
+    {
+        return Columns.FirstOrDefault(x => x.Name.EqualsIgnoreCase(columnName));
+    }
+
+    public bool HasColumn(string columnName)
+    {
+        return Columns.Any(x => x.Name.EqualsIgnoreCase(columnName));
+    }
+
+    public IndexDefinition? IndexFor(string indexName)
+    {
+        return Indexes.FirstOrDefault(x => x.Name.EqualsIgnoreCase(indexName));
+    }
+
+    public ColumnExpression AddColumn(TableColumn column)
+    {
+        _columns.Add(column);
+        column.Parent = this;
+        return new ColumnExpression(this, column);
+    }
+
+    public ColumnExpression AddColumn(string columnName, string columnType)
+    {
+        var column = new TableColumn(columnName, columnType) { Parent = this };
+        return AddColumn(column);
+    }
+
+    public ColumnExpression AddColumn<T>() where T : TableColumn, new()
+    {
+        var column = new T();
+        return AddColumn(column);
+    }
+
+    public ColumnExpression AddColumn<T>(string columnName)
+    {
+        if (typeof(T).IsEnum)
+        {
+            throw new InvalidOperationException(
+                "Database column types cannot be automatically derived for enums. Explicitly specify as varchar or integer");
+        }
+
+        var type = MySqlProvider.Instance.GetDatabaseType(typeof(T), EnumStorage.AsInteger);
+        return AddColumn(columnName, type);
+    }
+
+    public async Task<bool> ExistsInDatabaseAsync(MySqlConnection conn, CancellationToken ct = default)
+    {
+        var cmd = conn
+            .CreateCommand(
+                "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = @schema AND table_name = @table;")
+            .With("schema", Identifier.Schema)
+            .With("table", Identifier.Name);
+
+        var result = await cmd.ExecuteScalarAsync(ct).ConfigureAwait(false);
+        return Convert.ToInt64(result) > 0;
+    }
+
+    public void RemoveColumn(string columnName)
+    {
+        _columns.RemoveAll(x => x.Name.EqualsIgnoreCase(columnName));
+    }
+
+    public ColumnExpression ModifyColumn(string columnName)
+    {
+        var column = ColumnFor(columnName) ??
+                     throw new ArgumentOutOfRangeException(
+                         $"Column '{columnName}' does not exist in table {Identifier}");
+        return new ColumnExpression(this, column);
+    }
+
+    public bool HasIndex(string indexName)
+    {
+        return Indexes.Any(x => x.Name.EqualsIgnoreCase(indexName));
+    }
+
+    public void PartitionByRange(params string[] columnOrExpressions)
+    {
+        PartitionStrategy = PartitionStrategy.Range;
+        PartitionExpressions.Clear();
+        PartitionExpressions.AddRange(columnOrExpressions);
+    }
+
+    public void PartitionByHash(params string[] columnOrExpressions)
+    {
+        PartitionStrategy = PartitionStrategy.Hash;
+        PartitionExpressions.Clear();
+        PartitionExpressions.AddRange(columnOrExpressions);
+    }
+
+    public void PartitionByList(params string[] columnOrExpressions)
+    {
+        PartitionStrategy = PartitionStrategy.List;
+        PartitionExpressions.Clear();
+        PartitionExpressions.AddRange(columnOrExpressions);
+    }
+
+    public void PartitionByKey(params string[] columnOrExpressions)
+    {
+        PartitionStrategy = PartitionStrategy.Key;
+        PartitionExpressions.Clear();
+        PartitionExpressions.AddRange(columnOrExpressions);
+    }
+
+    public void ClearPartitions()
+    {
+        PartitionStrategy = PartitionStrategy.None;
+        PartitionExpressions.Clear();
+        PartitionCount = null;
+    }
+
+    public ForeignKey FindOrCreateForeignKey(string fkName)
+    {
+        var fk = ForeignKeys.FirstOrDefault(x => x.Name.EqualsIgnoreCase(fkName));
+        if (fk == null)
+        {
+            fk = new ForeignKey(fkName);
+            ForeignKeys.Add(fk);
+        }
+
+        return fk;
+    }
+
+    public class ColumnExpression
+    {
+        private readonly Table _parent;
+
+        public ColumnExpression(Table parent, TableColumn column)
+        {
+            _parent = parent;
+            Column = column;
+        }
+
+        internal TableColumn Column { get; }
+
+        public ColumnExpression ForeignKeyTo(string referencedTableName, string referencedColumnName,
+            string? fkName = null, CascadeAction onDelete = CascadeAction.NoAction,
+            CascadeAction onUpdate = CascadeAction.NoAction)
+        {
+            return ForeignKeyTo(DbObjectName.Parse(MySqlProvider.Instance, referencedTableName),
+                referencedColumnName, fkName, onDelete, onUpdate);
+        }
+
+        public ColumnExpression ForeignKeyTo(Table referencedTable, string referencedColumnName,
+            string? fkName = null, CascadeAction onDelete = CascadeAction.NoAction,
+            CascadeAction onUpdate = CascadeAction.NoAction)
+        {
+            return ForeignKeyTo(referencedTable.Identifier, referencedColumnName, fkName, onDelete, onUpdate);
+        }
+
+        public ColumnExpression ForeignKeyTo(DbObjectName referencedIdentifier, string referencedColumnName,
+            string? fkName = null, CascadeAction onDelete = CascadeAction.NoAction,
+            CascadeAction onUpdate = CascadeAction.NoAction)
+        {
+            var identifier = _parent.Identifier as MySqlObjectName ?? MySqlObjectName.From(_parent.Identifier);
+            var fk = new ForeignKey(fkName ?? identifier.ToIndexName("fk", Column.Name))
+            {
+                LinkedTable = referencedIdentifier,
+                ColumnNames = new[] { Column.Name },
+                LinkedNames = new[] { referencedColumnName },
+                OnDelete = onDelete,
+                OnUpdate = onUpdate
+            };
+
+            _parent.ForeignKeys.Add(fk);
+            return this;
+        }
+
+        public ColumnExpression AsPrimaryKey()
+        {
+            Column.IsPrimaryKey = true;
+            Column.AllowNulls = false;
+            return this;
+        }
+
+        public ColumnExpression AllowNulls()
+        {
+            Column.AllowNulls = true;
+            return this;
+        }
+
+        public ColumnExpression NotNull()
+        {
+            Column.AllowNulls = false;
+            return this;
+        }
+
+        public ColumnExpression AddIndex(Action<IndexDefinition>? configure = null)
+        {
+            var identifier = _parent.Identifier as MySqlObjectName ?? MySqlObjectName.From(_parent.Identifier);
+            var index = new IndexDefinition(identifier.ToIndexName("idx", Column.Name))
+            {
+                Columns = new[] { Column.Name }
+            };
+
+            _parent.Indexes.Add(index);
+            configure?.Invoke(index);
+
+            return this;
+        }
+
+        public ColumnExpression AddFulltextIndex(Action<IndexDefinition>? configure = null)
+        {
+            var identifier = _parent.Identifier as MySqlObjectName ?? MySqlObjectName.From(_parent.Identifier);
+            var index = new IndexDefinition(identifier.ToIndexName("ft", Column.Name))
+            {
+                Columns = new[] { Column.Name },
+                IndexType = MySqlIndexType.Fulltext
+            };
+
+            _parent.Indexes.Add(index);
+            configure?.Invoke(index);
+
+            return this;
+        }
+
+        public ColumnExpression AddSpatialIndex(Action<IndexDefinition>? configure = null)
+        {
+            var identifier = _parent.Identifier as MySqlObjectName ?? MySqlObjectName.From(_parent.Identifier);
+            var index = new IndexDefinition(identifier.ToIndexName("sp", Column.Name))
+            {
+                Columns = new[] { Column.Name },
+                IndexType = MySqlIndexType.Spatial
+            };
+
+            _parent.Indexes.Add(index);
+            configure?.Invoke(index);
+
+            return this;
+        }
+
+        public ColumnExpression AutoNumber()
+        {
+            Column.IsAutoNumber = true;
+            return this;
+        }
+
+        public ColumnExpression DefaultValueByString(string value)
+        {
+            return DefaultValueByExpression($"'{value}'");
+        }
+
+        public ColumnExpression DefaultValue(int value)
+        {
+            return DefaultValueByExpression(value.ToString());
+        }
+
+        public ColumnExpression DefaultValue(long value)
+        {
+            return DefaultValueByExpression(value.ToString());
+        }
+
+        public ColumnExpression DefaultValue(double value)
+        {
+            return DefaultValueByExpression(value.ToString(CultureInfo.InvariantCulture));
+        }
+
+        public ColumnExpression DefaultValueByExpression(string expression)
+        {
+            Column.DefaultExpression = expression;
+            return this;
+        }
+
+        public ColumnExpression PartitionByRange()
+        {
+            _parent.PartitionStrategy = PartitionStrategy.Range;
+            _parent.PartitionExpressions.Add(Column.Name);
+            Column.IsPrimaryKey = true;
+            return this;
+        }
+
+        public ColumnExpression PartitionByHash()
+        {
+            _parent.PartitionStrategy = PartitionStrategy.Hash;
+            _parent.PartitionExpressions.Add(Column.Name);
+            return this;
+        }
+    }
+}

--- a/src/Weasel.MySql/Tables/TableColumn.cs
+++ b/src/Weasel.MySql/Tables/TableColumn.cs
@@ -1,0 +1,112 @@
+using JasperFx.Core;
+using Weasel.Core;
+
+namespace Weasel.MySql.Tables;
+
+public class TableColumn: ITableColumn
+{
+    public TableColumn(string name, string type)
+    {
+        Name = name;
+        Type = type;
+    }
+
+    public string Name { get; }
+    public string Type { get; set; }
+    public bool AllowNulls { get; set; } = true;
+    public bool IsPrimaryKey { get; set; }
+    public bool IsAutoNumber { get; set; }
+    public string? DefaultExpression { get; set; }
+    public Table? Parent { get; set; }
+
+    public string QuotedName => $"`{Name}`";
+
+    public string RawType()
+    {
+        var type = Type.ToUpperInvariant();
+
+        // Remove size specifications for comparison
+        var parenIndex = type.IndexOf('(');
+        if (parenIndex > 0)
+        {
+            type = type.Substring(0, parenIndex);
+        }
+
+        return type;
+    }
+
+    public string ToDeclaration()
+    {
+        return $"{QuotedName} {Type} {Declaration()}".TrimEnd();
+    }
+
+    public string Declaration()
+    {
+        var parts = new List<string>();
+
+        if (!AllowNulls || IsPrimaryKey)
+        {
+            parts.Add("NOT NULL");
+        }
+        else
+        {
+            parts.Add("NULL");
+        }
+
+        if (IsAutoNumber)
+        {
+            parts.Add("AUTO_INCREMENT");
+        }
+
+        if (DefaultExpression.IsNotEmpty())
+        {
+            parts.Add($"DEFAULT {DefaultExpression}");
+        }
+
+        return parts.Join(" ");
+    }
+
+    public bool IsEquivalentTo(TableColumn other)
+    {
+        if (!Name.Equals(other.Name, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (RawType() != other.RawType())
+        {
+            return false;
+        }
+
+        // Compare nullability only for non-primary key columns
+        if (!IsPrimaryKey && !other.IsPrimaryKey)
+        {
+            if (AllowNulls != other.AllowNulls)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public override string ToString()
+    {
+        return $"{Name}: {Type}";
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is TableColumn other)
+        {
+            return IsEquivalentTo(other);
+        }
+
+        return false;
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(Name.ToUpperInvariant(), RawType());
+    }
+}

--- a/src/Weasel.MySql/Tables/TableDelta.cs
+++ b/src/Weasel.MySql/Tables/TableDelta.cs
@@ -1,0 +1,242 @@
+using JasperFx.Core;
+using Weasel.Core;
+
+namespace Weasel.MySql.Tables;
+
+public class TableDelta: ISchemaObjectDelta
+{
+    public TableDelta(Table expected, Table? actual)
+    {
+        Expected = expected;
+        Actual = actual;
+
+        if (actual == null)
+        {
+            Difference = SchemaPatchDifference.Create;
+            return;
+        }
+
+        Columns = new ItemDelta<TableColumn>(
+            expected.Columns,
+            actual.Columns,
+            (e, a) => e.IsEquivalentTo(a));
+
+        Indexes = new ItemDelta<IndexDefinition>(
+            expected.Indexes,
+            actual.Indexes,
+            (e, a) => e.Matches(a, expected));
+
+        ForeignKeys = new ItemDelta<ForeignKey>(
+            expected.ForeignKeys,
+            actual.ForeignKeys,
+            (e, a) => e.IsEquivalentTo(a));
+
+        // Check primary key differences
+        var expectedPks = expected.PrimaryKeyColumns.OrderBy(x => x).ToList();
+        var actualPks = actual.PrimaryKeyColumns.OrderBy(x => x).ToList();
+
+        if (!expectedPks.SequenceEqual(actualPks, StringComparer.OrdinalIgnoreCase))
+        {
+            PrimaryKeyDifference = SchemaPatchDifference.Update;
+        }
+
+        // Check partition differences
+        if (expected.PartitionStrategy != actual.PartitionStrategy)
+        {
+            Difference = SchemaPatchDifference.Invalid;
+            return;
+        }
+
+        // Determine overall difference
+        if (HasChanges())
+        {
+            Difference = SchemaPatchDifference.Update;
+        }
+        else
+        {
+            Difference = SchemaPatchDifference.None;
+        }
+    }
+
+    public Table Expected { get; }
+    public Table? Actual { get; }
+
+    public ItemDelta<TableColumn>? Columns { get; }
+    public ItemDelta<IndexDefinition>? Indexes { get; }
+    public ItemDelta<ForeignKey>? ForeignKeys { get; }
+
+    public SchemaPatchDifference PrimaryKeyDifference { get; } = SchemaPatchDifference.None;
+
+    public ISchemaObject SchemaObject => Expected;
+    public SchemaPatchDifference Difference { get; }
+
+    public bool HasChanges()
+    {
+        if (Actual == null) return true;
+
+        if (Columns?.HasChanges() == true) return true;
+        if (Indexes?.HasChanges() == true) return true;
+        if (ForeignKeys?.HasChanges() == true) return true;
+        if (PrimaryKeyDifference != SchemaPatchDifference.None) return true;
+
+        return false;
+    }
+
+    public void WriteUpdate(Migrator migrator, TextWriter writer)
+    {
+        if (Difference == SchemaPatchDifference.Create)
+        {
+            Expected.WriteCreateStatement(migrator, writer);
+            return;
+        }
+
+        if (Difference == SchemaPatchDifference.Invalid)
+        {
+            writer.WriteLine($"-- Cannot automatically migrate table {Expected.Identifier.QualifiedName}");
+            writer.WriteLine($"-- Partition strategy has changed and requires manual intervention");
+            return;
+        }
+
+        // Handle column changes
+        if (Columns != null)
+        {
+            foreach (var column in Columns.Missing)
+            {
+                writer.WriteLine(
+                    $"ALTER TABLE {Expected.Identifier.QualifiedName} ADD COLUMN {column.ToDeclaration()};");
+            }
+
+            foreach (var column in Columns.Extras)
+            {
+                writer.WriteLine($"ALTER TABLE {Expected.Identifier.QualifiedName} DROP COLUMN `{column.Name}`;");
+            }
+
+            foreach (var change in Columns.Different)
+            {
+                writer.WriteLine(
+                    $"ALTER TABLE {Expected.Identifier.QualifiedName} MODIFY COLUMN {change.Expected.ToDeclaration()};");
+            }
+        }
+
+        // Handle index changes - drop extras first, then add missing
+        if (Indexes != null)
+        {
+            foreach (var index in Indexes.Extras)
+            {
+                writer.WriteLine($"DROP INDEX `{index.Name}` ON {Expected.Identifier.QualifiedName};");
+            }
+
+            foreach (var change in Indexes.Different)
+            {
+                writer.WriteLine($"DROP INDEX `{change.Actual.Name}` ON {Expected.Identifier.QualifiedName};");
+                writer.WriteLine(change.Expected.ToDDL(Expected));
+            }
+
+            foreach (var index in Indexes.Missing)
+            {
+                writer.WriteLine(index.ToDDL(Expected));
+            }
+        }
+
+        // Handle foreign key changes - drop extras first, then add missing
+        if (ForeignKeys != null)
+        {
+            foreach (var fk in ForeignKeys.Extras)
+            {
+                writer.WriteLine(
+                    $"ALTER TABLE {Expected.Identifier.QualifiedName} DROP FOREIGN KEY `{fk.Name}`;");
+            }
+
+            foreach (var change in ForeignKeys.Different)
+            {
+                writer.WriteLine(
+                    $"ALTER TABLE {Expected.Identifier.QualifiedName} DROP FOREIGN KEY `{change.Actual.Name}`;");
+                writer.WriteLine(change.Expected.ToDDL(Expected));
+            }
+
+            foreach (var fk in ForeignKeys.Missing)
+            {
+                writer.WriteLine(fk.ToDDL(Expected));
+            }
+        }
+
+        // Handle primary key changes
+        if (PrimaryKeyDifference == SchemaPatchDifference.Update)
+        {
+            if (Actual?.PrimaryKeyColumns.Any() == true)
+            {
+                writer.WriteLine($"ALTER TABLE {Expected.Identifier.QualifiedName} DROP PRIMARY KEY;");
+            }
+
+            if (Expected.PrimaryKeyColumns.Any())
+            {
+                var pkColumns = Expected.PrimaryKeyColumns.Select(c => $"`{c}`").Join(", ");
+                writer.WriteLine($"ALTER TABLE {Expected.Identifier.QualifiedName} ADD PRIMARY KEY ({pkColumns});");
+            }
+        }
+    }
+
+    public void WriteRollback(Migrator migrator, TextWriter writer)
+    {
+        if (Actual == null)
+        {
+            Expected.WriteDropStatement(migrator, writer);
+            return;
+        }
+
+        // Rollback column changes
+        if (Columns != null)
+        {
+            foreach (var column in Columns.Missing)
+            {
+                writer.WriteLine($"ALTER TABLE {Expected.Identifier.QualifiedName} DROP COLUMN `{column.Name}`;");
+            }
+
+            foreach (var column in Columns.Extras)
+            {
+                writer.WriteLine(
+                    $"ALTER TABLE {Expected.Identifier.QualifiedName} ADD COLUMN {column.ToDeclaration()};");
+            }
+
+            foreach (var change in Columns.Different)
+            {
+                writer.WriteLine(
+                    $"ALTER TABLE {Expected.Identifier.QualifiedName} MODIFY COLUMN {change.Actual.ToDeclaration()};");
+            }
+        }
+
+        // Rollback index changes
+        if (Indexes != null)
+        {
+            foreach (var index in Indexes.Missing)
+            {
+                writer.WriteLine($"DROP INDEX `{index.Name}` ON {Expected.Identifier.QualifiedName};");
+            }
+
+            foreach (var index in Indexes.Extras)
+            {
+                writer.WriteLine(index.ToDDL(Expected));
+            }
+        }
+
+        // Rollback foreign key changes
+        if (ForeignKeys != null)
+        {
+            foreach (var fk in ForeignKeys.Missing)
+            {
+                writer.WriteLine(
+                    $"ALTER TABLE {Expected.Identifier.QualifiedName} DROP FOREIGN KEY `{fk.Name}`;");
+            }
+
+            foreach (var fk in ForeignKeys.Extras)
+            {
+                writer.WriteLine(fk.ToDDL(Expected));
+            }
+        }
+    }
+
+    public void WriteRestorationOfPreviousState(Migrator migrator, TextWriter writer)
+    {
+        Actual?.WriteCreateStatement(migrator, writer);
+    }
+}

--- a/src/Weasel.MySql/Weasel.MySql.csproj
+++ b/src/Weasel.MySql/Weasel.MySql.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Description>MySql support for Weasel</Description>
+    <PackageTags>mysql;ddl;schema;migration</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MySqlConnector" Version="2.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Weasel.Core\Weasel.Core.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
- Add MySqlProvider with MySQL type mappings (VARCHAR, INT, BIGINT, etc.)
- Add MySqlMigrator for MySQL-specific migration rules
- Add MySqlObjectName with backtick identifier quoting
- Add Table implementation with partitioning (Range, Hash, List, Key)
- Add index support for BTree, Hash, Fulltext, and Spatial indexes
- Add foreign key support with cascade options
- Add schema introspection via information_schema queries
- Add delta detection for schema migrations
- Add MySQL 8.0 to docker-compose.yml for testing
- Add CI workflow for MySQL testing
- Add comprehensive test suite (155 unit tests)