### PR TITLE
Enhanced Postgres keyword quote naming

### DIFF
--- a/src/Weasel.Postgresql.Tests/CommandExtensionsTests.cs
+++ b/src/Weasel.Postgresql.Tests/CommandExtensionsTests.cs
@@ -52,7 +52,7 @@ public class CommandExtensionsTests
         var command = new NpgsqlCommand();
         command.CallsSproc(new PostgresqlObjectName("foo", "proc")).ShouldBeSameAs(command);
         command.CommandType.ShouldBe(CommandType.StoredProcedure);
-        command.CommandText.ShouldBe(Instance.UseCaseSensitiveQualifiedNames ? "\"foo\".\"proc\"" : "foo.proc");
+        command.CommandText.ShouldBe("foo.proc");
     }
 
     [Fact]

--- a/src/Weasel.Postgresql.Tests/Functions/FunctionTests.cs
+++ b/src/Weasel.Postgresql.Tests/Functions/FunctionTests.cs
@@ -8,8 +8,6 @@ using Xunit;
 
 namespace Weasel.Postgresql.Tests.Functions;
 
-using static PostgresqlProvider;
-
 [Collection("functions")]
 public class FunctionTests: IntegrationContext
 {
@@ -93,7 +91,7 @@ $$ LANGUAGE plpgsql;
     {
         var function = Function.ForRemoval("functions.mt_hilo");
         function.IsRemoved.ShouldBeTrue();
-        function.Identifier.QualifiedName.ShouldBe(Instance.Parse("functions.mt_hilo").QualifiedName);
+        function.Identifier.QualifiedName.ShouldBe("functions.mt_hilo");
     }
 
     [Fact]

--- a/src/Weasel.Postgresql.Tests/KeywordIdentifierTests.cs
+++ b/src/Weasel.Postgresql.Tests/KeywordIdentifierTests.cs
@@ -1,0 +1,194 @@
+using Shouldly;
+using Weasel.Core;
+using Weasel.Postgresql.Functions;
+using Weasel.Postgresql.Tables;
+using Weasel.Postgresql.Tables.Partitioning;
+using Weasel.Postgresql.Views;
+using Xunit;
+
+namespace Weasel.Postgresql.Tests;
+
+public class KeywordIdentifierTests
+{
+    private static string QuoteName(string name,
+        SchemaUtils.IdentifierUsage usage = SchemaUtils.IdentifierUsage.General)
+    {
+        return SchemaUtils.QuoteName(name, usage);
+    }
+
+    private static string QuoteQualifiedName(string schema, string name,
+        SchemaUtils.IdentifierUsage usage = SchemaUtils.IdentifierUsage.General)
+    {
+        return $"{QuoteName(schema, usage)}.{QuoteName(name, usage)}";
+    }
+
+    [Fact]
+    public void function_time_identifier_is_quoted()
+    {
+        var function = new Function(new DbObjectName("time", "time"), "select 1;");
+        // "time" is a Category C keyword, quoting depends on Function context
+        var expected = QuoteQualifiedName("time", "time", SchemaUtils.IdentifierUsage.Function);
+        function.Identifier.QualifiedName.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("order")]
+    [InlineData("between")]
+    [InlineData("authorization")]
+    [InlineData("MyTable")]
+    public void table_ddl_quotes_keyword_schema_and_name(string keyword)
+    {
+        var table = new Table(new DbObjectName(keyword, keyword));
+        table.AddColumn<int>("id");
+
+        var ddl = table.ToBasicCreateTableSql();
+
+        ddl.ShouldContain($"CREATE TABLE IF NOT EXISTS {QuoteQualifiedName(keyword, keyword)}");
+    }
+
+    [Theory]
+    [InlineData("order")]
+    [InlineData("between")]
+    [InlineData("authorization")]
+    [InlineData("MyTable")]
+    public void view_ddl_quotes_keyword_schema_and_name(string keyword)
+    {
+        var view = new View(new DbObjectName(keyword, keyword), "SELECT 1 AS id");
+
+        var ddl = view.ToBasicCreateViewSql();
+
+        var expected = QuoteQualifiedName(keyword, keyword);
+        ddl.ShouldContain($"DROP VIEW IF EXISTS {expected};");
+        ddl.ShouldContain($"CREATE VIEW {expected} AS SELECT 1 AS id;");
+    }
+
+    [Theory]
+    [InlineData("order")]
+    [InlineData("between")]
+    [InlineData("authorization")]
+    [InlineData("MyTable")]
+    public void sequence_ddl_quotes_keyword_schema_and_name(string keyword)
+    {
+        var sequence = new Sequence(new DbObjectName(keyword, keyword));
+        var writer = new StringWriter();
+
+        sequence.WriteCreateStatement(new PostgresqlMigrator(), writer);
+
+        writer.ToString().ShouldContain($"CREATE SEQUENCE {QuoteQualifiedName(keyword, keyword)};");
+    }
+
+    [Theory]
+    [InlineData("order")]
+    [InlineData("between")]
+    [InlineData("authorization")]
+    [InlineData("MyTable")]
+    public void function_identifier_quotes_keyword_schema_and_name(string keyword)
+    {
+        var function = new Function(new DbObjectName(keyword, keyword), "select 1;");
+
+        var expected = QuoteQualifiedName(keyword, keyword, SchemaUtils.IdentifierUsage.Function);
+        function.Identifier.QualifiedName.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("order")]
+    [InlineData("between")]
+    [InlineData("authorization")]
+    [InlineData("MyTable")]
+    public void index_ddl_quotes_keyword_schema_and_name(string keyword)
+    {
+        var table = new Table(new DbObjectName(keyword, keyword));
+        table.AddColumn<int>("id");
+
+        var index = new IndexDefinition(keyword)
+        {
+            Columns = new[] { "id" }
+        };
+
+        var ddl = index.ToDDL(table);
+
+        var expectedIndexName = SchemaUtils.QuoteName(keyword);
+        var expectedTableName = QuoteQualifiedName(keyword, keyword);
+        ddl.ShouldContain($"CREATE INDEX {expectedIndexName} ON {expectedTableName}");
+    }
+
+    [Theory]
+    [InlineData("order", "one", "two")]
+    [InlineData("between", "one", "two")]
+    [InlineData("authorization", "one", "two")]
+    public void hash_partition_ddl_quotes_keyword_table_names(string keyword, params string[] suffixes)
+    {
+        var table = new Table(new DbObjectName(keyword, keyword));
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn<string>("role")
+            .PartitionByHash(suffixes);
+
+        var sql = table.ToCreateSql(new PostgresqlMigrator());
+
+        var expectedParent = QuoteQualifiedName(keyword, keyword);
+        var expectedPartition = QuoteQualifiedName(keyword, keyword + "_" + suffixes[0]);
+        sql.ShouldContain($"create table {expectedPartition} partition of {expectedParent}");
+    }
+
+    [Theory]
+    [InlineData("order")]
+    [InlineData("between")]
+    public void list_partition_ddl_quotes_keyword_table_names(string keyword)
+    {
+        var table = new Table(new DbObjectName(keyword, keyword));
+        table.AddColumn<int>("id").AsPrimaryKey();
+        var partitioning = table.PartitionByList("id");
+        partitioning.AddPartition("a", "'val1'");
+
+        var sql = table.ToCreateSql(new PostgresqlMigrator());
+
+        var expectedParent = QuoteQualifiedName(keyword, keyword);
+        var expectedPartition = QuoteQualifiedName(keyword, keyword + "_a");
+        sql.ShouldContain($"CREATE TABLE {expectedPartition} partition of {expectedParent}");
+    }
+
+    [Theory]
+    [InlineData("order")]
+    [InlineData("between")]
+    public void range_partition_ddl_quotes_keyword_table_names(string keyword)
+    {
+        var table = new Table(new DbObjectName(keyword, keyword));
+        table.AddColumn<int>("id").AsPrimaryKey();
+        var partitioning = table.PartitionByRange("id");
+        partitioning.AddRange("a", "1", "100");
+
+        var sql = table.ToCreateSql(new PostgresqlMigrator());
+
+        var expectedParent = QuoteQualifiedName(keyword, keyword);
+        var expectedPartition = QuoteQualifiedName(keyword, keyword + "_a");
+        sql.ShouldContain($"CREATE TABLE {expectedPartition} PARTITION OF {expectedParent}");
+    }
+
+    [Theory]
+    [InlineData("order")]
+    [InlineData("between")]
+    public void default_partition_ddl_quotes_keyword_table_names(string keyword)
+    {
+        var writer = new StringWriter();
+        var identifier = new DbObjectName(keyword, keyword);
+
+        writer.WriteDefaultPartition(identifier);
+
+        var sql = writer.ToString();
+        var expectedParent = QuoteQualifiedName(keyword, keyword);
+        var expectedPartition = QuoteQualifiedName(keyword, keyword + "_default");
+        sql.ShouldContain($"CREATE TABLE {expectedPartition} PARTITION OF {expectedParent} DEFAULT;");
+    }
+
+    [Theory]
+    [InlineData("order")]
+    [InlineData("between")]
+    public void partition_rebuild_temp_table_uses_correct_quoting(string keyword)
+    {
+        var tempName = PostgresqlObjectName.From(
+            new DbObjectName(keyword, keyword + "_temp"));
+
+        var expected = QuoteQualifiedName(keyword, keyword + "_temp");
+        tempName.ToString().ShouldBe(expected);
+    }
+}

--- a/src/Weasel.Postgresql.Tests/PostgresqlObjectNameTests.cs
+++ b/src/Weasel.Postgresql.Tests/PostgresqlObjectNameTests.cs
@@ -17,9 +17,8 @@ public class PostgresqlObjectNameTests
         //When
         var pgObjectName = PostgresqlObjectName.From(dbObjectName);
 
-        var expectedQualifiedName = PostgresqlProvider.Instance.UseCaseSensitiveQualifiedNames
-            ? $"\"{schema}\".\"{name}\""
-            : $"{schema}.{name}";
+        // Mixed-case identifiers are always quoted to preserve case
+        var expectedQualifiedName = $"\"{schema}\".\"{name}\"";
 
         pgObjectName.Schema.ShouldBe(schema);
         pgObjectName.Name.ShouldBe(name);

--- a/src/Weasel.Postgresql.Tests/Tables/ForeignKeyTests.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/ForeignKeyTests.cs
@@ -5,8 +5,6 @@ using Xunit;
 
 namespace Weasel.Postgresql.Tests.Tables;
 
-using static PostgresqlProvider;
-
 public class ForeignKeyTests
 {
     [Fact]
@@ -24,9 +22,9 @@ public class ForeignKeyTests
         ddl.ShouldNotContain("ON DELETE");
         ddl.ShouldNotContain("ON UPDATE");
 
-        ddl.ShouldContain($"ALTER TABLE {Instance.Parse("public.people")}");
+        ddl.ShouldContain("ALTER TABLE public.people");
         ddl.ShouldContain("ADD CONSTRAINT fk_state FOREIGN KEY(state_id)");
-        ddl.ShouldContain($"REFERENCES {Instance.Parse("public.states")}(id)");
+        ddl.ShouldContain("REFERENCES public.states(id)");
     }
 
     [Fact]
@@ -46,9 +44,9 @@ public class ForeignKeyTests
         ddl.ShouldNotContain("ON DELETE");
         ddl.ShouldNotContain("ON UPDATE");
 
-        ddl.ShouldContain($"ALTER TABLE {Instance.Parse("public.people")}");
+        ddl.ShouldContain("ALTER TABLE public.people");
         ddl.ShouldContain("ADD CONSTRAINT fk_state FOREIGN KEY(state_id)");
-        ddl.ShouldContain($"REFERENCES {Instance.Parse("public.states")}(id)");
+        ddl.ShouldContain("REFERENCES public.states(id)");
     }
 
     [Fact]
@@ -68,9 +66,9 @@ public class ForeignKeyTests
         ddl.ShouldNotContain("ON DELETE");
         ddl.ShouldNotContain("ON UPDATE");
 
-        ddl.ShouldContain($"ALTER TABLE {Instance.Parse("public.people")}");
+        ddl.ShouldContain("ALTER TABLE public.people");
         ddl.ShouldContain("ADD CONSTRAINT fk_state FOREIGN KEY(state_id)");
-        ddl.ShouldContain($"REFERENCES {Instance.Parse("public.states")}(id)");
+        ddl.ShouldContain("REFERENCES public.states(id)");
     }
 
     [Fact]
@@ -120,9 +118,9 @@ public class ForeignKeyTests
 
         var ddl = fk.ToDDL(table);
 
-        ddl.ShouldContain($"ALTER TABLE {Instance.Parse("public.people")}");
+        ddl.ShouldContain("ALTER TABLE public.people");
         ddl.ShouldContain("ADD CONSTRAINT fk_state FOREIGN KEY(state_id, tenant_id)");
-        ddl.ShouldContain($"REFERENCES {Instance.Parse("public.states")}(id, tenant_id)");
+        ddl.ShouldContain("REFERENCES public.states(id, tenant_id)");
     }
 
     [Theory]

--- a/src/Weasel.Postgresql.Tests/Tables/TableColumnTests.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/TableColumnTests.cs
@@ -4,7 +4,6 @@ using Weasel.Postgresql.Tables;
 using Xunit;
 
 namespace Weasel.Postgresql.Tests.Tables;
-using static PostgresqlProvider;
 
 public class TableColumnTests
 {
@@ -118,7 +117,7 @@ public class TableColumnTests
         var column = table.AddColumn<string>("name1").NotNull().Column;
 
         column.AddColumnSql(table)
-            .ShouldBe($"alter table {Instance.Parse("public.people")} add column name1 varchar NOT NULL;");
+            .ShouldBe("alter table public.people add column name1 varchar NOT NULL;");
     }
 
     [Fact]
@@ -128,6 +127,6 @@ public class TableColumnTests
         var column = table.AddColumn<Geometry>("geom").NotNull().Column;
 
         column.AddColumnSql(table)
-            .ShouldBe($"alter table {Instance.Parse("public.map")} add column geom geometry NOT NULL;");
+            .ShouldBe("alter table public.map add column geom geometry NOT NULL;");
     }
 }

--- a/src/Weasel.Postgresql.Tests/Tables/TableTests.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/TableTests.cs
@@ -121,8 +121,8 @@ public class TableTests
 
         var lines = ddl.ReadLines().ToArray();
 
-        lines.ShouldContain($"DROP TABLE IF EXISTS {Instance.Parse("public.people")} CASCADE;");
-        lines.ShouldContain($"CREATE TABLE {Instance.Parse("public.people")} (");
+        lines.ShouldContain("DROP TABLE IF EXISTS public.people CASCADE;");
+        lines.ShouldContain("CREATE TABLE public.people (");
     }
 
     [Fact]
@@ -144,7 +144,7 @@ public class TableTests
 
         var lines = ddl.ReadLines().ToArray();
 
-        lines.ShouldContain($"CREATE TABLE IF NOT EXISTS {Instance.Parse("public.people")} (");
+        lines.ShouldContain("CREATE TABLE IF NOT EXISTS public.people (");
     }
 
     [Fact]

--- a/src/Weasel.Postgresql.Tests/Tables/creating_tables_in_database.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/creating_tables_in_database.cs
@@ -218,7 +218,7 @@ public class creating_tables_in_database: IntegrationContext
 
         await theConnection.ResetSchemaAsync("tables");
 
-        var table = new Table("order");
+        var table = new Table("tables.order");
         table.AddColumn<int>("id").AsPrimaryKey();
         table.AddColumn<string>("first_name");
         table.AddColumn<string>("last_name");
@@ -230,7 +230,7 @@ public class creating_tables_in_database: IntegrationContext
             .ShouldBeTrue();
 
         await theConnection.CreateCommand(
-                "insert into \"order\" (id, first_name, last_name, \"order\") values (1, 'Elton', 'John',1)")
+                "insert into tables.\"order\" (id, first_name, last_name, \"order\") values (1, 'Elton', 'John',1)")
             .ExecuteNonQueryAsync();
     }
 }

--- a/src/Weasel.Postgresql.Tests/Tables/partitioning/range_partitions.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/partitioning/range_partitions.cs
@@ -6,7 +6,6 @@ using Xunit;
 
 namespace Weasel.Postgresql.Tests.Tables.partitioning;
 
-
 [Collection("partitions")]
 public class range_partitions: IntegrationContext
 {

--- a/src/Weasel.Postgresql.Tests/Views/ViewTests.cs
+++ b/src/Weasel.Postgresql.Tests/Views/ViewTests.cs
@@ -7,8 +7,6 @@ using Xunit.Abstractions;
 
 namespace Weasel.Postgresql.Tests.Views;
 
-using static PostgresqlProvider;
-
 public class ViewTests
 {
     private readonly ITestOutputHelper _output;
@@ -50,7 +48,7 @@ public class ViewTests
 
         var lines = ddl.ReadLines().ToArray();
 
-        lines.ShouldContain($"DROP VIEW IF EXISTS {Instance.Parse("public.people_view")};");
-        lines.ShouldContain($"CREATE VIEW {Instance.Parse("public.people_view")} AS SELECT 1 AS id;");
+        lines.ShouldContain("DROP VIEW IF EXISTS public.people_view;");
+        lines.ShouldContain("CREATE VIEW public.people_view AS SELECT 1 AS id;");
     }
 }

--- a/src/Weasel.Postgresql/Extension.cs
+++ b/src/Weasel.Postgresql/Extension.cs
@@ -26,7 +26,8 @@ public class Extension: ISchemaObject
         writer.WriteLine($"DROP EXTENSION IF EXISTS {ExtensionName} CASCADE;");
     }
 
-    public DbObjectName Identifier => new PostgresqlObjectName("public", ExtensionName);
+    public DbObjectName Identifier =>
+        PostgresqlObjectName.From(new DbObjectName("public", ExtensionName));
 
     public void ConfigureQueryCommand(DbCommandBuilder builder)
     {

--- a/src/Weasel.Postgresql/Functions/Function.cs
+++ b/src/Weasel.Postgresql/Functions/Function.cs
@@ -3,6 +3,7 @@ using System.Text;
 using JasperFx.Core;
 using Npgsql;
 using Weasel.Core;
+using Weasel.Postgresql;
 using DbCommandBuilder = Weasel.Core.DbCommandBuilder;
 
 namespace Weasel.Postgresql.Functions;
@@ -16,18 +17,18 @@ public class Function: ISchemaObject
     {
         _body = body;
         _dropStatements = dropStatements;
-        Identifier = identifier;
+        Identifier = PostgresqlObjectName.From(identifier, SchemaUtils.IdentifierUsage.Function);
     }
 
     public Function(DbObjectName identifier, string? body)
     {
         _body = body;
-        Identifier = identifier;
+        Identifier = PostgresqlObjectName.From(identifier, SchemaUtils.IdentifierUsage.Function);
     }
 
     protected Function(DbObjectName identifier)
     {
-        Identifier = identifier;
+        Identifier = PostgresqlObjectName.From(identifier, SchemaUtils.IdentifierUsage.Function);
     }
 
 

--- a/src/Weasel.Postgresql/Functions/FunctionBody.cs
+++ b/src/Weasel.Postgresql/Functions/FunctionBody.cs
@@ -1,5 +1,6 @@
 using JasperFx.Core;
 using Weasel.Core;
+using Weasel.Postgresql;
 
 namespace Weasel.Postgresql.Functions;
 
@@ -7,7 +8,7 @@ public class FunctionBody
 {
     public FunctionBody(DbObjectName identifier, string[] dropStatements, string body)
     {
-        Identifier = identifier;
+        Identifier = PostgresqlObjectName.From(identifier, SchemaUtils.IdentifierUsage.Function);
         DropStatements = dropStatements;
         Body = body;
     }

--- a/src/Weasel.Postgresql/PostgresqlMigrator.cs
+++ b/src/Weasel.Postgresql/PostgresqlMigrator.cs
@@ -148,8 +148,7 @@ $$;
 
     public static string CreateSchemaStatementFor(string schemaName)
     {
-        Console.WriteLine("I AM WRITING OUT SCHEMA CREATION FOR " + schemaName);
-        return $"create schema if not exists {schemaName};";
+        return $"create schema if not exists {PostgresqlProvider.Instance.ToQualifiedName(schemaName)};";
     }
 
     public override void AssertValidIdentifier(string name)

--- a/src/Weasel.Postgresql/PostgresqlObjectName.cs
+++ b/src/Weasel.Postgresql/PostgresqlObjectName.cs
@@ -4,24 +4,55 @@ namespace Weasel.Postgresql;
 
 public class PostgresqlObjectName: DbObjectName
 {
-    protected override string QuotedQualifiedName => $"{SchemaUtils.QuoteName(Schema)}.{SchemaUtils.QuoteName(Name)}";
+    private readonly SchemaUtils.IdentifierUsage _usage;
 
+    protected override string QuotedQualifiedName =>
+        $"{SchemaUtils.QuoteName(Schema, _usage)}.{SchemaUtils.QuoteName(Name, _usage)}";
+
+    [Obsolete("Use the constructor with IdentifierUsage parameter. This overload will be removed in a future version.")]
     public PostgresqlObjectName(string schema, string name)
+        : this(schema, name, SchemaUtils.IdentifierUsage.General)
+    {
+    }
+
+    public PostgresqlObjectName(string schema, string name, SchemaUtils.IdentifierUsage usage)
         : base(schema, name, PostgresqlProvider.Instance.ToQualifiedName(schema, name))
     {
+        _usage = usage;
     }
 
+    [Obsolete("Use the constructor with IdentifierUsage parameter. This overload will be removed in a future version.")]
     public PostgresqlObjectName(string schema, string name, string qualifiedName)
+        : this(schema, name, qualifiedName, SchemaUtils.IdentifierUsage.General)
+    {
+    }
+
+    public PostgresqlObjectName(string schema, string name, string qualifiedName,
+        SchemaUtils.IdentifierUsage usage)
         : base(schema, name, qualifiedName)
     {
+        _usage = usage;
     }
 
-    private PostgresqlObjectName(DbObjectName dbObjectName): this(dbObjectName.Schema, dbObjectName.Name)
+    private PostgresqlObjectName(DbObjectName dbObjectName, SchemaUtils.IdentifierUsage usage)
+        : this(dbObjectName.Schema, dbObjectName.Name, usage)
     {
     }
 
+    [Obsolete("Use From(DbObjectName, IdentifierUsage). This overload will be removed in a future version.")]
     public static PostgresqlObjectName From(DbObjectName dbObjectName) =>
-        new PostgresqlObjectName(dbObjectName);
+        From(dbObjectName, SchemaUtils.IdentifierUsage.General);
+
+    public static PostgresqlObjectName From(DbObjectName dbObjectName,
+        SchemaUtils.IdentifierUsage usage)
+    {
+        var schema = dbObjectName.Schema;
+        var name = dbObjectName.Name;
+        var qualifiedName =
+            $"{SchemaUtils.QuoteName(schema, usage)}.{SchemaUtils.QuoteName(name, usage)}";
+
+        return new PostgresqlObjectName(schema, name, qualifiedName, usage);
+    }
 
     private new bool Equals(DbObjectName other)
     {

--- a/src/Weasel.Postgresql/SchemaExistenceCheck.cs
+++ b/src/Weasel.Postgresql/SchemaExistenceCheck.cs
@@ -84,7 +84,7 @@ public class SchemaExistenceCheck : ISchemaObject
         {
             foreach (var schemaName in _missing)
             {
-                writer.WriteLine($"drop schema if exists {schemaName};");
+                writer.WriteLine($"drop schema if exists {PostgresqlProvider.Instance.ToQualifiedName(schemaName)};");
             }
         }
 

--- a/src/Weasel.Postgresql/SchemaUtils.cs
+++ b/src/Weasel.Postgresql/SchemaUtils.cs
@@ -1,9 +1,16 @@
+using System.Collections.Frozen;
 using Npgsql;
 
 namespace Weasel.Postgresql;
 
 public static class SchemaUtils
 {
+    public enum IdentifierUsage
+    {
+        General,
+        Function
+    }
+
     // TODO: This should probably go to Weasel
     public static async Task DropSchema(string connectionString, string schemaName)
     {
@@ -44,24 +51,86 @@ public static class SchemaUtils
         }
     }
 
-    public static string QuoteName(string name)
+    /// <summary>
+    /// Quotes a PostgreSQL identifier if it is a reserved or type-function keyword, or contains uppercase characters.
+    /// Equivalent to calling <c>QuoteName(name, IdentifierUsage.General)</c>.
+    /// </summary>
+    [Obsolete("Use QuoteName(string, IdentifierUsage) for context-aware quoting. This overload will be removed in a future version.")]
+    public static string QuoteName(string name) => QuoteName(name, IdentifierUsage.General);
+
+    /// <summary>
+    /// Quotes a PostgreSQL identifier if it is a keyword or contains uppercase characters.
+    /// Keywords are checked according to their PostgreSQL category:
+    /// - Reserved (catcode 'R'): always quoted
+    /// - Type/function name (catcode 'T'): quoted in General usage, not in Function usage
+    /// - Column name (catcode 'C'): quoted only in Function usage
+    /// Mixed-case identifiers are always quoted to preserve case.
+    /// </summary>
+    public static string QuoteName(string name, IdentifierUsage usage)
     {
-        return ReservedKeywords.Contains(name, StringComparer.InvariantCultureIgnoreCase) || name.Any(char.IsUpper) ? $"\"{name}\"" : name;
+        if (string.IsNullOrEmpty(name))
+            return name;
+
+        if (ReservedKeywords.Contains(name) ||
+            (usage == IdentifierUsage.Function && CategoryCKeywords.Contains(name)) ||
+            (usage == IdentifierUsage.General && CategoryTKeywords.Contains(name)) ||
+            name.Any(char.IsUpper))
+        {
+            return $"\"{name}\"";
+        }
+
+        return name;
     }
 
-    private static readonly string[] ReservedKeywords =
-    [
-        "ALL", "ANALYSE", "ANALYZE", "AND", "ANY", "ARRAY", "AS", "ASC", "ASYMMETRIC", "AUTHORIZATION",
-        "BINARY", "BOTH", "CASE", "CAST", "CHECK", "COLLATE", "COLUMN", "CONCURRENTLY", "CONSTRAINT",
-        "CREATE", "CROSS", "CURRENT_CATALOG", "CURRENT_DATE", "CURRENT_ROLE", "CURRENT_SCHEMA",
-        "CURRENT_TIME", "CURRENT_TIMESTAMP", "CURRENT_USER", "DEFAULT", "DEFERRABLE", "DESC", "DISTINCT",
-        "DO", "ELSE", "END", "EXCEPT", "FALSE", "FETCH", "FOR", "FOREIGN", "FREEZE", "FROM", "FULL",
-        "GRANT", "GROUP", "HAVING", "ILIKE", "IN", "INITIALLY", "INNER", "INTERSECT", "INTO", "IS",
-        "ISNULL", "JOIN", "LATERAL", "LEADING", "LEFT", "LIKE", "LIMIT", "LOCALTIME", "LOCALTIMESTAMP",
-        "NATURAL", "NOT", "NOTNULL", "NULL", "OFFSET", "ON", "ONLY", "OR", "ORDER", "OUTER", "OVERLAPS",
-        "PLACING", "PRIMARY", "REFERENCES", "RETURNING", "RIGHT", "SELECT", "SESSION_USER", "SIMILAR",
-        "SOME", "SYMMETRIC", "TABLE", "THEN", "TO", "TRAILING", "TRUE", "UNION", "UNIQUE", "USER",
-        "USING", "VARIADIC", "VERBOSE", "WHEN", "WHERE", "WINDOW", "WITH"
-    ];
-}
+    /// <summary>
+    /// PostgreSQL reserved keywords (catcode 'R').
+    /// These keywords are always reserved and must be quoted when used as identifiers.
+    /// Source: pg_get_keywords() from PostgreSQL 10-17
+    /// </summary>
+    private static readonly FrozenSet<string> ReservedKeywords = new[]
+    {
+        "ALL", "ANALYSE", "ANALYZE", "AND", "ANY", "ARRAY", "AS", "ASC", "ASYMMETRIC", "BOTH",
+        "CASE", "CAST", "CHECK", "COLLATE", "COLUMN", "CONSTRAINT", "CREATE", "CURRENT_CATALOG",
+        "CURRENT_DATE", "CURRENT_ROLE", "CURRENT_TIME", "CURRENT_TIMESTAMP", "CURRENT_USER",
+        "DEFAULT", "DEFERRABLE", "DESC", "DISTINCT", "DO", "ELSE", "END", "EXCEPT", "FALSE",
+        "FETCH", "FOR", "FOREIGN", "FROM", "GRANT", "GROUP", "HAVING", "IN", "INITIALLY",
+        "INTERSECT", "INTO", "LATERAL", "LEADING", "LIMIT", "LOCALTIME", "LOCALTIMESTAMP",
+        "NOT", "NULL", "OFFSET", "ON", "ONLY", "OR", "ORDER", "PLACING", "PRIMARY",
+        "REFERENCES", "RETURNING", "SELECT", "SESSION_USER", "SOME", "SYMMETRIC", "SYSTEM_USER",
+        "TABLE", "THEN", "TO", "TRAILING", "TRUE", "UNION", "UNIQUE", "USER", "USING",
+        "VARIADIC", "WHEN", "WHERE", "WINDOW", "WITH"
+    }.ToFrozenSet(StringComparer.InvariantCultureIgnoreCase);
 
+    /// <summary>
+    /// PostgreSQL column name keywords (catcode 'C').
+    /// These keywords can be used without quotes except for function or type names.
+    /// Source: pg_get_keywords() from PostgreSQL 10-17
+    /// </summary>
+    private static readonly FrozenSet<string> CategoryCKeywords = new[]
+    {
+        "BETWEEN", "BIGINT", "BIT", "BOOLEAN", "CHAR", "CHARACTER", "COALESCE", "DEC",
+        "DECIMAL", "EXISTS", "EXTRACT", "FLOAT", "GREATEST", "GROUPING", "INOUT", "INT",
+        "INTEGER", "INTERVAL", "JSON", "JSON_ARRAY", "JSON_ARRAYAGG", "JSON_EXISTS",
+        "JSON_OBJECT", "JSON_OBJECTAGG", "JSON_QUERY", "JSON_SCALAR", "JSON_SERIALIZE",
+        "JSON_TABLE", "JSON_VALUE", "LEAST", "MERGE_ACTION", "NATIONAL", "NCHAR", "NONE",
+        "NORMALIZE", "NULLIF", "NUMERIC", "OUT", "OVERLAY", "POSITION", "PRECISION",
+        "REAL", "ROW", "SETOF", "SMALLINT", "SUBSTRING", "TIME", "TIMESTAMP", "TREAT",
+        "TRIM", "VALUES", "VARCHAR", "XMLATTRIBUTES", "XMLCONCAT", "XMLELEMENT",
+        "XMLEXISTS", "XMLFOREST", "XMLNAMESPACES", "XMLPARSE", "XMLPI", "XMLROOT",
+        "XMLSERIALIZE", "XMLTABLE"
+    }.ToFrozenSet(StringComparer.InvariantCultureIgnoreCase);
+
+    /// <summary>
+    /// PostgreSQL type/function name keywords (catcode 'T').
+    /// These keywords can only be used for function or type names without quotes.
+    /// Anywhere else will need to be quoted.
+    /// Source: pg_get_keywords() from PostgreSQL 10-17
+    /// </summary>
+    private static readonly FrozenSet<string> CategoryTKeywords = new[]
+    {
+        "AUTHORIZATION", "BINARY", "COLLATION", "CONCURRENTLY", "CROSS",
+        "CURRENT_SCHEMA", "FREEZE", "FULL", "ILIKE", "INNER", "IS", "ISNULL", "JOIN",
+        "LEFT", "LIKE", "NATURAL", "NOTNULL", "OUTER", "OVERLAPS", "RIGHT", "SIMILAR",
+        "TABLESAMPLE", "VERBOSE"
+    }.ToFrozenSet(StringComparer.InvariantCultureIgnoreCase);
+}

--- a/src/Weasel.Postgresql/Sequence.cs
+++ b/src/Weasel.Postgresql/Sequence.cs
@@ -16,12 +16,12 @@ public class Sequence: ISchemaObject
 
     public Sequence(DbObjectName identifier)
     {
-        Identifier = identifier;
+        Identifier = PostgresqlObjectName.From(identifier);
     }
 
     public Sequence(DbObjectName identifier, long startWith)
     {
-        Identifier = identifier;
+        Identifier = PostgresqlObjectName.From(identifier);
         _startWith = startWith;
     }
 

--- a/src/Weasel.Postgresql/Tables/Partitioning/HashPartition.cs
+++ b/src/Weasel.Postgresql/Tables/Partitioning/HashPartition.cs
@@ -1,5 +1,8 @@
 namespace Weasel.Postgresql.Tables.Partitioning;
 
+using Weasel.Core;
+using Weasel.Postgresql;
+
 public record HashPartition
 {
     public HashPartition(string suffix, int modulus, int remainder)
@@ -15,7 +18,10 @@ public record HashPartition
 
     public void WriteCreateStatement(TextWriter writer, Table parent)
     {
-        writer.WriteLine($"create table {parent.Identifier}_{Suffix} partition of {parent.Identifier} for values with (modulus {Modulus}, remainder {Remainder});");
+        var partitionName = PostgresqlObjectName.From(
+            new DbObjectName(parent.Identifier.Schema, parent.Identifier.Name + "_" + Suffix));
+        var parentName = PostgresqlObjectName.From(parent.Identifier);
+        writer.WriteLine($"create table {partitionName} partition of {parentName} for values with (modulus {Modulus}, remainder {Remainder});");
     }
 
     public static HashPartition Parse(string suffix, string expression)

--- a/src/Weasel.Postgresql/Tables/Partitioning/ListPartition.cs
+++ b/src/Weasel.Postgresql/Tables/Partitioning/ListPartition.cs
@@ -1,5 +1,6 @@
 using JasperFx.Core;
 using Weasel.Core;
+using Weasel.Postgresql;
 
 namespace Weasel.Postgresql.Tables.Partitioning;
 
@@ -23,7 +24,10 @@ public class ListPartition : IPartition
 
     void IPartition.WriteCreateStatement(TextWriter writer, Table parent)
     {
-        writer.WriteLine($"CREATE TABLE {parent.Identifier}_{Suffix} partition of {parent.Identifier} for values in ({Values.Join(", ")});");
+        var partitionName = PostgresqlObjectName.From(
+            new DbObjectName(parent.Identifier.Schema, parent.Identifier.Name + "_" + Suffix));
+        var parentName = PostgresqlObjectName.From(parent.Identifier);
+        writer.WriteLine($"CREATE TABLE {partitionName} partition of {parentName} for values in ({Values.Join(", ")});");
     }
 
     internal static ListPartition Parse(DbObjectName dbObjectName, string partitionTableName, string postgresExpression)

--- a/src/Weasel.Postgresql/Tables/Partitioning/ManagedListPartitions.cs
+++ b/src/Weasel.Postgresql/Tables/Partitioning/ManagedListPartitions.cs
@@ -11,8 +11,11 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Npgsql;
 using Weasel.Core;
 using Weasel.Core.Migrations;
+using Weasel.Postgresql;
+using Weasel.Postgresql.Tables;
 
 namespace Weasel.Postgresql.Tables.Partitioning;
+
 
 public interface IListPartitionManager
 {
@@ -140,7 +143,8 @@ public class ManagedListPartitions : FeatureSchemaBase, IDatabaseInitializer<Npg
         {
             foreach (var suffixName in suffixNames)
             {
-                var partitionName = $"{table.Identifier}_{suffixName}";
+                var partitionName = PostgresqlObjectName.From(
+                    new DbObjectName(table.Identifier.Schema, table.Identifier.Name + "_" + suffixName));
 
                 try
                 {

--- a/src/Weasel.Postgresql/Tables/Partitioning/PartitionExtensions.cs
+++ b/src/Weasel.Postgresql/Tables/Partitioning/PartitionExtensions.cs
@@ -1,5 +1,6 @@
 using JasperFx.Core.Reflection;
 using Weasel.Core;
+using Weasel.Postgresql;
 
 namespace Weasel.Postgresql.Tables.Partitioning;
 
@@ -12,7 +13,10 @@ public static class PartitionExtensions
     /// <param name="identifier"></param>
     public static void WriteDefaultPartition(this TextWriter writer, DbObjectName identifier)
     {
-        writer.WriteLine($"CREATE TABLE {identifier}_default PARTITION OF {identifier} DEFAULT;");
+        var partitionName = PostgresqlObjectName.From(
+            new DbObjectName(identifier.Schema, identifier.Name + "_default"));
+        var parentName = PostgresqlObjectName.From(identifier);
+        writer.WriteLine($"CREATE TABLE {partitionName} PARTITION OF {parentName} DEFAULT;");
     }
 
     /// <summary>

--- a/src/Weasel.Postgresql/Tables/Partitioning/RangePartition.cs
+++ b/src/Weasel.Postgresql/Tables/Partitioning/RangePartition.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using Weasel.Core;
+using Weasel.Postgresql;
 
 namespace Weasel.Postgresql.Tables.Partitioning;
 
@@ -29,7 +30,10 @@ public class RangePartition : IPartition
 
     void IPartition.WriteCreateStatement(TextWriter writer, Table parent)
     {
-        writer.WriteLine($"CREATE TABLE {parent.Identifier}_{Suffix} PARTITION OF {parent.Identifier} FOR VALUES FROM ({From}) TO ({To});");
+        var partitionName = PostgresqlObjectName.From(
+            new DbObjectName(parent.Identifier.Schema, parent.Identifier.Name + "_" + Suffix));
+        var parentName = PostgresqlObjectName.From(parent.Identifier);
+        writer.WriteLine($"CREATE TABLE {partitionName} PARTITION OF {parentName} FOR VALUES FROM ({From}) TO ({To});");
     }
 
     protected bool Equals(RangePartition other)

--- a/src/Weasel.Postgresql/Tables/Table.cs
+++ b/src/Weasel.Postgresql/Tables/Table.cs
@@ -17,7 +17,12 @@ public partial class Table: ISchemaObjectWithPostProcessing, ITable
 
     public Table(DbObjectName name)
     {
-        Identifier = name ?? throw new ArgumentNullException(nameof(name));
+        if (name == null)
+        {
+            throw new ArgumentNullException(nameof(name));
+        }
+
+        Identifier = PostgresqlObjectName.From(name);
     }
 
     public Table(string tableName): this(DbObjectName.Parse(PostgresqlProvider.Instance, tableName))
@@ -220,8 +225,7 @@ public partial class Table: ISchemaObjectWithPostProcessing, ITable
     /// <param name="schemaName"></param>
     public void MoveToSchema(string schemaName)
     {
-        var identifier = new PostgresqlObjectName(schemaName, Identifier.Name);
-        Identifier = identifier;
+        Identifier = PostgresqlObjectName.From(new DbObjectName(schemaName, Identifier.Name));
     }
 
     /// <summary>

--- a/src/Weasel.Postgresql/Tables/TableDelta.cs
+++ b/src/Weasel.Postgresql/Tables/TableDelta.cs
@@ -1,5 +1,6 @@
 using JasperFx.Core;
 using Weasel.Core;
+using Weasel.Postgresql;
 using Weasel.Postgresql.Tables.Partitioning;
 
 namespace Weasel.Postgresql.Tables;
@@ -138,7 +139,8 @@ public class TableDelta: SchemaObjectDelta<Table>, ISchemaObjectDeltaWithPostPro
         {
             var columns = Expected.Columns.Select(x => x.Name).Join(", ");
 
-            var tempName = new DbObjectName(Expected.Identifier.Schema, Expected.Identifier.Name + "_temp");
+            var tempName = PostgresqlObjectName.From(
+                new DbObjectName(Expected.Identifier.Schema, Expected.Identifier.Name + "_temp"));
             writer.WriteLine($"create table {tempName} as select * from {Expected.Identifier};");
             writer.WriteLine($"drop table {Expected.Identifier} cascade;");
 

--- a/src/Weasel.Postgresql/Views/View.cs
+++ b/src/Weasel.Postgresql/Views/View.cs
@@ -14,7 +14,12 @@ public class View: ISchemaObject
 
     public View(DbObjectName name, string viewSql)
     {
-        Identifier = name ?? throw new ArgumentNullException(nameof(name));
+        if (name == null)
+        {
+            throw new ArgumentNullException(nameof(name));
+        }
+
+        Identifier = PostgresqlObjectName.From(name);
         this.viewSql = viewSql ?? throw new ArgumentNullException(nameof(viewSql));
     }
 
@@ -32,8 +37,7 @@ public class View: ISchemaObject
     /// <param name="schemaName"></param>
     public void MoveToSchema(string schemaName)
     {
-        var identifier = new PostgresqlObjectName(schemaName, Identifier.Name);
-        Identifier = identifier;
+        Identifier = PostgresqlObjectName.From(new DbObjectName(schemaName, Identifier.Name));
     }
 
     /// <summary>


### PR DESCRIPTION
- Replace keyword `string[]` with `FrozenSet<string>` for immutability and faster lookups
- Split keywords into PostgreSQL categories (Reserved/Type-Function/Column-Name) from pg_get_keywords()
- Add `IdentifierUsage` enum and `QuoteName(string, IdentifierUsage)` for context-aware quoting
- Mark `QuoteName(string)`, original `PostgresqlObjectName` constructors/From(), and `UseCaseSensitiveQualifiedNames` as [Obsolete] to preserve binary compatibility
- Thread `IdentifierUsage` through `PostgresqlObjectName`, callers, and `SchemaObjectsExtensions`
- Add `KeywordIdentifierTests` and keyword delta integration tests
- Replace computed assertions with hard-coded expected strings in tests

Fixes https://github.com/JasperFx/marten/issues/4069