### PR TITLE
Fix Guid[] and int[] array column delta detection

### DIFF
--- a/src/Weasel.Postgresql.Tests/PostgresqlProviderTests.cs
+++ b/src/Weasel.Postgresql.Tests/PostgresqlProviderTests.cs
@@ -96,6 +96,49 @@ public class PostgresqlProviderTests
         inputString.ReplaceMultiSpace(" ").ShouldBe(expectedString);
     }
 
+    [Theory]
+    [InlineData(typeof(Guid[]), "uuid[]")]
+    [InlineData(typeof(int[]), "integer[]")]
+    [InlineData(typeof(long[]), "bigint[]")]
+    [InlineData(typeof(short[]), "smallint[]")]
+    [InlineData(typeof(float[]), "real[]")]
+    [InlineData(typeof(double[]), "double precision[]")]
+    [InlineData(typeof(string[]), "varchar[]")]
+    [InlineData(typeof(bool[]), "boolean[]")]
+    [InlineData(typeof(decimal[]), "decimal[]")]
+    public void get_database_type_for_array_types(Type type, string expected)
+    {
+        PostgresqlProvider.Instance.GetDatabaseType(type, EnumStorage.AsInteger).ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData(typeof(Guid[]), NpgsqlDbType.Array | NpgsqlDbType.Uuid)]
+    [InlineData(typeof(int[]), NpgsqlDbType.Array | NpgsqlDbType.Integer)]
+    [InlineData(typeof(long[]), NpgsqlDbType.Array | NpgsqlDbType.Bigint)]
+    [InlineData(typeof(short[]), NpgsqlDbType.Array | NpgsqlDbType.Smallint)]
+    [InlineData(typeof(float[]), NpgsqlDbType.Array | NpgsqlDbType.Real)]
+    [InlineData(typeof(double[]), NpgsqlDbType.Array | NpgsqlDbType.Double)]
+    [InlineData(typeof(string[]), NpgsqlDbType.Array | NpgsqlDbType.Text)]
+    [InlineData(typeof(bool[]), NpgsqlDbType.Array | NpgsqlDbType.Boolean)]
+    public void to_parameter_type_for_array_types(Type type, NpgsqlDbType expected)
+    {
+        PostgresqlProvider.Instance.ToParameterType(type).ShouldBe(expected);
+    }
+
+    [Fact]
+    public void table_columns_should_match_for_uuid_array()
+    {
+        var uuidArray = new TableColumn("ids", "uuid[]");
+        uuidArray.ShouldBe(new TableColumn("ids", "uuid[]"));
+    }
+
+    [Fact]
+    public void table_columns_should_match_for_integer_array()
+    {
+        var intArray = new TableColumn("ids", "integer[]");
+        intArray.ShouldBe(new TableColumn("ids", "int[]"));
+    }
+
     [Fact]
     public void table_columns_should_match_raw_types()
     {
@@ -136,6 +179,17 @@ public class PostgresqlProviderTests
     [InlineData("character varying[]", "array")]
     [InlineData("varchar[]", "array")]
     [InlineData("text[]", "array")]
+    [InlineData("uuid[]", "uuid[]")]
+    [InlineData("boolean[]", "boolean[]")]
+    [InlineData("bool[]", "boolean[]")]
+    [InlineData("decimal[]", "decimal[]")]
+    [InlineData("numeric[]", "decimal[]")]
+    [InlineData("smallint[]", "smallint[]")]
+    [InlineData("bigint[]", "bigint[]")]
+    [InlineData("real[]", "real[]")]
+    [InlineData("double precision[]", "double precision[]")]
+    [InlineData("timestamp without time zone[]", "timestamp[]")]
+    [InlineData("timestamp with time zone[]", "timestamptz[]")]
     public void convert_synonyms(string type, string synonym)
     {
         PostgresqlProvider.Instance.ConvertSynonyms(type).ShouldBe(synonym);

--- a/src/Weasel.Postgresql.Tests/Tables/detecting_table_deltas.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/detecting_table_deltas.cs
@@ -715,6 +715,59 @@ public class detecting_table_deltas(): IndexDeltasDetectionContext("deltas")
     }
 
     [Fact]
+    public async Task no_delta_with_guid_array_column()
+    {
+        var table = new Table("deltas.guid_array_test");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn<Guid[]>("guids");
+
+        await CreateSchemaObjectInDatabase(table);
+
+        var delta = await table.FindDeltaAsync(theConnection);
+        delta.HasChanges().ShouldBeFalse();
+
+        await AssertNoDeltasAfterPatching(table);
+    }
+
+    [Fact]
+    public async Task no_delta_with_int_array_column()
+    {
+        var table = new Table("deltas.int_array_test");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn<int[]>("numbers");
+
+        await CreateSchemaObjectInDatabase(table);
+
+        var delta = await table.FindDeltaAsync(theConnection);
+        delta.HasChanges().ShouldBeFalse();
+
+        await AssertNoDeltasAfterPatching(table);
+    }
+
+    [Fact]
+    public async Task no_delta_with_multiple_array_columns_using_generic_addcolumn()
+    {
+        var table = new Table("deltas.multi_array_test");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn<Guid[]>("guids");
+        table.AddColumn<int[]>("numbers");
+        table.AddColumn<long[]>("big_numbers");
+        table.AddColumn<short[]>("small_numbers");
+        table.AddColumn<float[]>("floats");
+        table.AddColumn<double[]>("doubles");
+        table.AddColumn<string[]>("strings");
+        table.AddColumn<bool[]>("flags");
+        table.AddColumn<decimal[]>("amounts");
+
+        await CreateSchemaObjectInDatabase(table);
+
+        var delta = await table.FindDeltaAsync(theConnection);
+        delta.HasChanges().ShouldBeFalse();
+
+        await AssertNoDeltasAfterPatching(table);
+    }
+
+    [Fact]
     public async Task no_change_with_jsonb_path_ops()
     {
         var table2 = new Table("deltas.people");

--- a/src/Weasel.Postgresql/PostgresqlProvider.cs
+++ b/src/Weasel.Postgresql/PostgresqlProvider.cs
@@ -121,6 +121,35 @@ public class PostgresqlProvider: DatabaseProvider<NpgsqlCommand, NpgsqlParameter
             case "integer[]":
                 return "int[]";
 
+            case "boolean[]":
+            case "bool[]":
+                return "boolean[]";
+
+            case "decimal[]":
+            case "numeric[]":
+                return "decimal[]";
+
+            case "uuid[]":
+                return "uuid[]";
+
+            case "smallint[]":
+                return "smallint[]";
+
+            case "bigint[]":
+                return "bigint[]";
+
+            case "real[]":
+                return "real[]";
+
+            case "double precision[]":
+                return "double precision[]";
+
+            case "timestamp without time zone[]":
+                return "timestamp[]";
+
+            case "timestamp with time zone[]":
+                return "timestamptz[]";
+
             case "decimal":
             case "numeric":
                 return "decimal";

--- a/src/Weasel.Postgresql/Tables/Table.FetchExisting.cs
+++ b/src/Weasel.Postgresql/Tables/Table.FetchExisting.cs
@@ -354,7 +354,18 @@ order by column_index;
             "_float4" => "real[]",
             "_float8" => "double precision[]",
             "_varchar" => "varchar[]",
-            _ => udtName
+            "_bool" => "boolean[]",
+            "_numeric" => "decimal[]",
+            "_text" => "text[]",
+            "_timestamp" => "timestamp without time zone[]",
+            "_timestamptz" => "timestamp with time zone[]",
+            "_date" => "date[]",
+            "_time" => "time without time zone[]",
+            "_timetz" => "time with time zone[]",
+            "_jsonb" => "jsonb[]",
+            "_json" => "json[]",
+            "_bytea" => "bytea[]",
+            _ => udtName.StartsWith('_') ? udtName.Substring(1) + "[]" : udtName
         };
     }
 }


### PR DESCRIPTION
## Summary
- Fixes #186 - `Guid[]` and `int[]` columns no longer produce spurious `ALTER TABLE ... ALTER COLUMN ... TYPE` statements on every startup
- Enhances `NormalizeArrayType` with 11 additional PostgreSQL internal array type mappings (`_bool`, `_numeric`, `_text`, `_timestamp`, `_timestamptz`, `_date`, `_time`, `_timetz`, `_jsonb`, `_json`, `_bytea`) plus a generic fallback for unknown `_xxx` types
- Adds `ConvertSynonyms` entries for array type synonyms (`boolean[]`/`bool[]`, `decimal[]`/`numeric[]`, `uuid[]`, `smallint[]`, `bigint[]`, `real[]`, `double precision[]`, timestamp arrays) to ensure consistent delta comparison
- Adds unit tests for `GetDatabaseType`, `ToParameterType`, `ConvertSynonyms`, and `TableColumn` equality with array types
- Adds integration tests verifying no false deltas when round-tripping `Guid[]`, `int[]`, and other array columns through the database

## Test plan
- [x] All 548 PostgreSQL tests pass (0 failures, 3 pre-existing skips)
- [x] 21 new unit tests for array type mapping, parameter type resolution, synonym conversion, and column equality
- [x] 3 new integration tests: `no_delta_with_guid_array_column`, `no_delta_with_int_array_column`, `no_delta_with_multiple_array_columns_using_generic_addcolumn`

🤖 Generated with [Claude Code](https://claude.com/claude-code)