### PR TITLE
Add Migrator.EnsureDatabaseExistsAsync() for lightweight database creation

### DIFF
--- a/src/Weasel.Core/Migrator.cs
+++ b/src/Weasel.Core/Migrator.cs
@@ -233,4 +233,17 @@ public abstract class
     /// </summary>
     /// <param name="name"></param>
     public abstract void AssertValidIdentifier(string name);
+
+    /// <summary>
+    ///     Ensures that the database referenced by the supplied connection's connection string exists,
+    ///     creating it if necessary. This is a lightweight operation that only creates the database --
+    ///     it does not run any schema migrations or DDL.
+    /// </summary>
+    /// <param name="connection">A connection whose ConnectionString identifies the target database</param>
+    /// <param name="ct">Cancellation token</param>
+    public virtual Task EnsureDatabaseExistsAsync(DbConnection connection, CancellationToken ct = default)
+    {
+        throw new NotSupportedException(
+            $"EnsureDatabaseExistsAsync is not supported by {GetType().Name}. Override this method in a provider-specific migrator.");
+    }
 }

--- a/src/Weasel.MySql.Tests/MySqlMigratorTests.cs
+++ b/src/Weasel.MySql.Tests/MySqlMigratorTests.cs
@@ -27,4 +27,54 @@ public class MySqlMigratorTests
         table.ShouldBeOfType<Table>();
         table.Identifier.ShouldBe(identifier);
     }
+
+    [Fact]
+    public async Task can_ensure_database_that_does_not_exist()
+    {
+        var migrator = new MySqlMigrator();
+        var databaseName = $"weasel_ensure_{Guid.NewGuid():N}";
+
+        // Use root credentials for CREATE DATABASE privileges
+        var rootBuilder = new MySqlConnectionStringBuilder(ConnectionSource.ConnectionString)
+        {
+            UserID = "root",
+            Password = "P@55w0rd",
+            Database = databaseName
+        };
+
+        try
+        {
+            await using var targetConn = new MySqlConnection(rootBuilder.ConnectionString);
+            await migrator.EnsureDatabaseExistsAsync(targetConn);
+
+            // Verify the database was created by opening a connection to it
+            await using var verifyConn = new MySqlConnection(rootBuilder.ConnectionString);
+            await verifyConn.OpenAsync();
+        }
+        finally
+        {
+            var adminBuilder = new MySqlConnectionStringBuilder(ConnectionSource.ConnectionString)
+            {
+                UserID = "root",
+                Password = "P@55w0rd",
+                Database = ""
+            };
+            await using var adminConn = new MySqlConnection(adminBuilder.ConnectionString);
+            await adminConn.OpenAsync();
+
+            var cmd = adminConn.CreateCommand();
+            cmd.CommandText = $"DROP DATABASE IF EXISTS `{databaseName}`";
+            await cmd.ExecuteNonQueryAsync();
+        }
+    }
+
+    [Fact]
+    public async Task ensure_database_is_idempotent()
+    {
+        var migrator = new MySqlMigrator();
+
+        // Use the existing test database - should not throw
+        await using var connection = new MySqlConnection(ConnectionSource.ConnectionString);
+        await migrator.EnsureDatabaseExistsAsync(connection);
+    }
 }

--- a/src/Weasel.Oracle.Tests/OracleMigratorTests.cs
+++ b/src/Weasel.Oracle.Tests/OracleMigratorTests.cs
@@ -27,4 +27,14 @@ public class OracleMigratorTests
         table.ShouldBeOfType<Table>();
         table.Identifier.ShouldBe(identifier);
     }
+
+    [Fact]
+    public async Task ensure_database_is_idempotent()
+    {
+        var migrator = new OracleMigrator();
+
+        // Use the existing test connection/schema - should not throw
+        await using var connection = new OracleConnection(ConnectionSource.ConnectionString);
+        await migrator.EnsureDatabaseExistsAsync(connection);
+    }
 }

--- a/src/Weasel.SqlServer.Tests/SqlServerMigratorTests.cs
+++ b/src/Weasel.SqlServer.Tests/SqlServerMigratorTests.cs
@@ -27,4 +27,54 @@ public class SqlServerMigratorTests
         table.ShouldBeOfType<Table>();
         table.Identifier.ShouldBe(identifier);
     }
+
+    [Fact]
+    public async Task can_ensure_database_that_does_not_exist()
+    {
+        var migrator = new SqlServerMigrator();
+        var databaseName = $"weasel_ensure_{Guid.NewGuid():N}";
+
+        var builder = new SqlConnectionStringBuilder(ConnectionSource.ConnectionString)
+        {
+            InitialCatalog = databaseName
+        };
+
+        try
+        {
+            await using var targetConn = new SqlConnection(builder.ConnectionString);
+            await migrator.EnsureDatabaseExistsAsync(targetConn);
+
+            // Verify the database was created by opening a connection to it
+            await using var verifyConn = new SqlConnection(builder.ConnectionString);
+            await verifyConn.OpenAsync();
+        }
+        finally
+        {
+            var adminBuilder = new SqlConnectionStringBuilder(ConnectionSource.ConnectionString)
+            {
+                InitialCatalog = "master"
+            };
+            await using var adminConn = new SqlConnection(adminBuilder.ConnectionString);
+            await adminConn.OpenAsync();
+
+            var cmd = adminConn.CreateCommand();
+            cmd.CommandText = $@"
+                IF DB_ID('{databaseName}') IS NOT NULL
+                BEGIN
+                    ALTER DATABASE [{databaseName}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
+                    DROP DATABASE [{databaseName}];
+                END";
+            await cmd.ExecuteNonQueryAsync();
+        }
+    }
+
+    [Fact]
+    public async Task ensure_database_is_idempotent()
+    {
+        var migrator = new SqlServerMigrator();
+
+        // Use the existing test database - should not throw
+        await using var connection = new SqlConnection(ConnectionSource.ConnectionString);
+        await migrator.EnsureDatabaseExistsAsync(connection);
+    }
 }

--- a/src/Weasel.Sqlite.Tests/SqliteMigratorTests.cs
+++ b/src/Weasel.Sqlite.Tests/SqliteMigratorTests.cs
@@ -104,4 +104,37 @@ public class SqliteMigratorTests
 
         Should.Throw<InvalidOperationException>(() => migrator.AssertValidIdentifier(longName));
     }
+
+    [Fact]
+    public async Task ensure_database_exists_is_noop_for_memory()
+    {
+        var migrator = new SqliteMigrator();
+        await using var connection = new Microsoft.Data.Sqlite.SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+
+        // Should not throw - SQLite databases are auto-created
+        await migrator.EnsureDatabaseExistsAsync(connection);
+    }
+
+    [Fact]
+    public async Task ensure_database_exists_is_noop_for_file()
+    {
+        var migrator = new SqliteMigrator();
+        var tempFile = Path.Combine(Path.GetTempPath(), $"weasel_test_{Guid.NewGuid():N}.db");
+
+        try
+        {
+            await using var connection = new Microsoft.Data.Sqlite.SqliteConnection($"Data Source={tempFile}");
+
+            // Should not throw - SQLite databases are auto-created
+            await migrator.EnsureDatabaseExistsAsync(connection);
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+            {
+                File.Delete(tempFile);
+            }
+        }
+    }
 }

--- a/src/Weasel.Sqlite/SqliteMigrator.cs
+++ b/src/Weasel.Sqlite/SqliteMigrator.cs
@@ -114,6 +114,14 @@ public class SqliteMigrator: Migrator
         }
     }
 
+    /// <summary>
+    ///     No-op for SQLite. SQLite databases are automatically created when the connection is opened.
+    /// </summary>
+    public override Task EnsureDatabaseExistsAsync(DbConnection connection, CancellationToken ct = default)
+    {
+        return Task.CompletedTask;
+    }
+
     public override IDatabaseWithTables CreateDatabase(DbConnection connection, string? identifier = null)
     {
         if (connection is not Microsoft.Data.Sqlite.SqliteConnection)


### PR DESCRIPTION
## Summary

- Adds `Migrator.EnsureDatabaseExistsAsync(DbConnection, CancellationToken)` as a virtual method on the base `Migrator` class, with provider-specific overrides for all five database providers
- Enables Wolverine multi-tenancy to create databases without relying on EF Core's `EnsureCreatedAsync()`, which does extra work that interferes with Wolverine (addresses #211)
- Each provider uses the lightest-weight approach: SQLite is a no-op, PostgreSQL checks via `DatabaseExists()` + `DatabaseSpecification`, SQL Server uses `DB_ID()` + `CREATE DATABASE`, MySQL uses atomic `CREATE DATABASE IF NOT EXISTS`, and Oracle runs the existing idempotent `CreateSchemaStatementFor()` PL/SQL block

## Test plan

- [x] SQLite tests pass (`ensure_database_exists_is_noop_for_memory`, `ensure_database_exists_is_noop_for_file`)
- [x] Core tests pass
- [ ] PostgreSQL integration tests (`can_ensure_database_that_does_not_exist`, `ensure_database_is_idempotent`) — requires Docker
- [ ] SQL Server integration tests (`can_ensure_database_that_does_not_exist`, `ensure_database_is_idempotent`) — requires Docker
- [ ] MySQL integration tests (`can_ensure_database_that_does_not_exist`, `ensure_database_is_idempotent`) — requires Docker
- [ ] Oracle integration test (`ensure_database_is_idempotent`) — requires Docker

🤖 Generated with [Claude Code](https://claude.com/claude-code)