### PR TITLE
Weasel 8.14.1: upgrade to JasperFx 1.26 + fix Spectre.Console 0.55 API break

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>8.14.0</Version>
+        <Version>8.14.1</Version>
         <LangVersion>13.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,7 @@
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.12.19" />
     <PackageVersion Include="DistributedLock.Postgres" Version="1.3.0" />
     <PackageVersion Include="DotNet.ReproducibleBuilds" Version="1.2.39" />
-    <PackageVersion Include="JasperFx" Version="1.24.0" />
+    <PackageVersion Include="JasperFx" Version="1.26.0" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="9.0.1" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />
     <!-- EF Core versions are framework-conditional - see below -->

--- a/src/Weasel.Core/CommandLine/AssertCommand.cs
+++ b/src/Weasel.Core/CommandLine/AssertCommand.cs
@@ -23,14 +23,14 @@ public class AssertCommand: JasperFxAsyncCommand<WeaselInput>
             {
                 await database.AssertDatabaseMatchesConfigurationAsync().ConfigureAwait(false);
                 AnsiConsole.MarkupLine(
-                    $"[green]No database differences detected for '{database.Identifier.EscapeMarkup()}'.[/]");
+                    $"[green]No database differences detected for '{Markup.Escape(database.Identifier)}'.[/]");
             }
             catch (DatabaseValidationException e)
             {
                 success = false;
 
                 AnsiConsole.MarkupLine(
-                    $"[red]Database '{database.Identifier.EscapeMarkup()}' does not match the configuration![/]");
+                    $"[red]Database '{Markup.Escape(database.Identifier)}' does not match the configuration![/]");
                 AnsiConsole.WriteException(e);
             }
         }


### PR DESCRIPTION
## Summary

Upgrades the Weasel dependency graph onto the latest JasperFx (1.24.0 → **1.26.0**), which transitively pulls Spectre.Console 0.53 → 0.55 for every downstream consumer. Patches the one spot in Weasel that called a Spectre API that 0.55 removed.

## The bug

Spectre.Console 0.55 removed the `StringExtensions.EscapeMarkup(string)` extension method — the static `Spectre.Console.Markup.Escape(string)` is the replacement. `Weasel.Core.CommandLine.AssertCommand` used the old extension form in two places:

```
public override async Task<bool> Execute(WeaselInput input)
{
    …
    AnsiConsole.MarkupLine(
        $"[green]No database differences detected for '{database.Identifier.EscapeMarkup()}'.[/]");
    …
    AnsiConsole.MarkupLine(
        $"[red]Database '{database.Identifier.EscapeMarkup()}' does not match the configuration![/]");
    …
}
```

Downstream in Marten this surfaced as:
```
System.MissingMethodException: Method not found:
  'System.String Spectre.Console.StringExtensions.EscapeMarkup(System.String)'
    at Weasel.Core.CommandLine.AssertCommand.Execute(WeaselInput input)
```
…on every `db-assert` / `resources` command that went through this code path (7 failing tests in `CoreTests.jasper_fx_mechanics.*` on [marten#4269](https://github.com/JasperFx/marten/pull/4269)).

## The fix

- `Directory.Packages.props`: `JasperFx` 1.24.0 → 1.26.0 (transitively moves Spectre.Console to 0.55)
- `src/Weasel.Core/CommandLine/AssertCommand.cs`: `database.Identifier.EscapeMarkup()` → `Markup.Escape(database.Identifier)`
- `Directory.Build.props`: Version 8.14.0 → **8.14.1**

## Test plan
- [x] `dotnet build Weasel.sln` — 0 errors (357 pre-existing warnings)
- [ ] CI across net8 / net9 / net10

## Downstream
Unblocks [JasperFx/marten#4269](https://github.com/JasperFx/marten/pull/4269), which needs a JasperFx 1.26.0 floor for its `JasperFx.Events` 1.29.0 uptake. Once Weasel 8.14.1 ships I'll bump Marten to consume it and drop the standalone Spectre.Console pin in Marten's `Directory.Packages.props`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)