### PR TITLE
Add NativeAdvisoryLock for LockMonitoringEnabled = false opt-out

### DIFF
--- a/src/Weasel.Postgresql.Tests/advisory_lock_usage.cs
+++ b/src/Weasel.Postgresql.Tests/advisory_lock_usage.cs
@@ -186,6 +186,115 @@ public class AdvisoryLockSpecs : IAsyncLifetime
 
 }
 
+public class NativeAdvisoryLockSpecs: IAsyncLifetime
+{
+    private NpgsqlDataSource _database = null!;
+    private NativeAdvisoryLock theLock = null!;
+
+    public Task InitializeAsync()
+    {
+        _database = NpgsqlDataSource.Create(ConnectionSource.ConnectionString);
+        theLock = new NativeAdvisoryLock(_database, NullLogger.Instance, "localhost");
+        return Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync()
+    {
+        await theLock.DisposeAsync();
+        await _database.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task acquire_and_release_a_session_lock()
+    {
+        await using var conn2 = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn2.OpenAsync();
+
+        theLock.HasLock(20).ShouldBeFalse();
+
+        (await theLock.TryAttainLockAsync(20, CancellationToken.None)).ShouldBeTrue();
+        theLock.HasLock(20).ShouldBeTrue();
+
+        // Cannot get the lock from another connection
+        (await conn2.TryGetGlobalLock(20)).Succeeded.ShouldBeFalse();
+
+        await theLock.ReleaseLockAsync(20);
+        theLock.HasLock(20).ShouldBeFalse();
+
+        for (var j = 0; j < 5; j++)
+        {
+            if ((await conn2.TryGetGlobalLock(20)).Succeeded) return;
+
+            await Task.Delay(250);
+        }
+
+        throw new Exception("Advisory lock was not released");
+    }
+
+    [Fact]
+    public async Task hold_multiple_locks_and_release_one()
+    {
+        (await theLock.TryAttainLockAsync(30, CancellationToken.None)).ShouldBeTrue();
+        (await theLock.TryAttainLockAsync(31, CancellationToken.None)).ShouldBeTrue();
+        (await theLock.TryAttainLockAsync(32, CancellationToken.None)).ShouldBeTrue();
+
+        await theLock.ReleaseLockAsync(31);
+
+        theLock.HasLock(30).ShouldBeTrue();
+        theLock.HasLock(31).ShouldBeFalse();
+        theLock.HasLock(32).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task acquire_returns_false_when_held_by_another_instance()
+    {
+        await using var second = NpgsqlDataSource.Create(ConnectionSource.ConnectionString);
+        await using var lock2 = new NativeAdvisoryLock(second, NullLogger.Instance, "localhost");
+
+        (await theLock.TryAttainLockAsync(40, CancellationToken.None)).ShouldBeTrue();
+        (await lock2.TryAttainLockAsync(40, CancellationToken.None)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task dispose_releases_held_locks()
+    {
+        await using (var owner = new NativeAdvisoryLock(_database, NullLogger.Instance, "localhost"))
+        {
+            (await owner.TryAttainLockAsync(60, CancellationToken.None)).ShouldBeTrue();
+            (await owner.TryAttainLockAsync(61, CancellationToken.None)).ShouldBeTrue();
+        }
+
+        await using var second = new NativeAdvisoryLock(_database, NullLogger.Instance, "localhost");
+
+        for (var j = 0; j < 5; j++)
+        {
+            if (await second.TryAttainLockAsync(60, CancellationToken.None)
+                && await second.TryAttainLockAsync(61, CancellationToken.None))
+            {
+                return;
+            }
+
+            await Task.Delay(250);
+        }
+
+        throw new Exception("Advisory locks were not released by dispose");
+    }
+
+    [Fact]
+    public async Task try_get_global_lock_does_not_emit_set_local_warning()
+    {
+        var notices = new List<string>();
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        conn.Notice += (_, args) => notices.Add(args.Notice.MessageText);
+        await conn.OpenAsync();
+
+        await conn.TryGetGlobalLock(70);
+        await conn.ReleaseGlobalLock(70);
+
+        notices.ShouldNotContain(n => n.Contains("SET LOCAL", StringComparison.OrdinalIgnoreCase));
+    }
+}
+
 public class SimplePostgresqlDatabase: PostgresqlDatabase
 {
     public SimplePostgresqlDatabase(NpgsqlDataSource dataSource) : base(new DefaultMigrationLogger(), JasperFx.AutoCreate.CreateOrUpdate, new PostgresqlMigrator(), "Simple", dataSource)

--- a/src/Weasel.Postgresql/AdvisoryLockFactory.cs
+++ b/src/Weasel.Postgresql/AdvisoryLockFactory.cs
@@ -1,0 +1,15 @@
+using Microsoft.Extensions.Logging;
+using Npgsql;
+using Weasel.Core;
+
+namespace Weasel.Postgresql;
+
+public static class AdvisoryLockFactory
+{
+    public static IAdvisoryLock Create(NpgsqlDataSource dataSource, ILogger logger, string databaseName, AdvisoryLockOptions options)
+    {
+        return options.LockMonitoringEnabled
+            ? new AdvisoryLock(dataSource, logger, databaseName, options)
+            : new NativeAdvisoryLock(dataSource, logger, databaseName);
+    }
+}

--- a/src/Weasel.Postgresql/NativeAdvisoryLock.cs
+++ b/src/Weasel.Postgresql/NativeAdvisoryLock.cs
@@ -1,0 +1,100 @@
+using System.Data;
+using JasperFx.Core;
+using Microsoft.Extensions.Logging;
+using Npgsql;
+using Weasel.Core;
+using Weasel.Core.Migrations;
+
+namespace Weasel.Postgresql;
+
+public class NativeAdvisoryLock: IAdvisoryLock
+{
+    private readonly NpgsqlDataSource _dataSource;
+    private readonly string _databaseName;
+    private readonly ILogger _logger;
+    private readonly HashSet<int> _locks = new();
+    private NpgsqlConnection? _conn;
+
+    public NativeAdvisoryLock(NpgsqlDataSource dataSource, ILogger logger, string databaseName)
+    {
+        _dataSource = EnsurePrimaryWhenMultiHost(dataSource);
+        _logger = logger;
+        _databaseName = databaseName;
+    }
+
+    private static NpgsqlDataSource EnsurePrimaryWhenMultiHost(NpgsqlDataSource source)
+    {
+        if (source is NpgsqlMultiHostDataSource multiHostDataSource)
+            return multiHostDataSource.WithTargetSession(TargetSessionAttributes.ReadWrite);
+
+        return source;
+    }
+
+    public bool HasLock(int lockId)
+    {
+        return _conn is { State: ConnectionState.Open } && _locks.Contains(lockId);
+    }
+
+    public async Task<bool> TryAttainLockAsync(int lockId, CancellationToken token)
+    {
+        _conn ??= await _dataSource.OpenConnectionAsync(token).ConfigureAwait(false);
+
+        if (_conn.State != ConnectionState.Open)
+        {
+            await _conn.DisposeAsync().ConfigureAwait(false);
+            _conn = null;
+            return false;
+        }
+
+        var attained = await _conn.TryGetGlobalLock(lockId, cancellation: token).ConfigureAwait(false);
+        if (attained == AttainLockResult.Success)
+        {
+            _locks.Add(lockId);
+            return true;
+        }
+
+        return false;
+    }
+
+    public async Task ReleaseLockAsync(int lockId)
+    {
+        if (!_locks.Remove(lockId)) return;
+
+        if (_conn is not { State: ConnectionState.Open }) return;
+
+        using var cancellation = new CancellationTokenSource(1.Seconds());
+
+        await _conn.ReleaseGlobalLock(lockId, cancellation: cancellation.Token).ConfigureAwait(false);
+
+        if (_locks.Count == 0)
+        {
+            await _conn.CloseAsync().ConfigureAwait(false);
+            await _conn.DisposeAsync().ConfigureAwait(false);
+            _conn = null;
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_conn is null) return;
+
+        try
+        {
+            foreach (var lockId in _locks)
+            {
+                await _conn.ReleaseGlobalLock(lockId, CancellationToken.None).ConfigureAwait(false);
+            }
+
+            await _conn.CloseAsync().ConfigureAwait(false);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error trying to dispose of advisory locks for database {Identifier}", _databaseName);
+        }
+        finally
+        {
+            await _conn.DisposeAsync().ConfigureAwait(false);
+            _conn = null;
+        }
+    }
+}


### PR DESCRIPTION
# Add `NativeAdvisoryLock` and `AdvisoryLockFactory` to honour `LockMonitoringEnabled = false`

Draft. Companion change for [JasperFx/marten#4195](https://github.com/JasperFx/marten/discussions/4195).

## Problem

`AdvisoryLockOptions.LockMonitoringEnabled` is consulted only inside `AdvisoryLock.HasLock()`. The acquisition path always goes through `Medallion.Threading.Postgres.PostgresDistributedLock`, which prepends `SET LOCAL statement_timeout = 0; SET LOCAL lock_timeout = 0` to every `pg_try_advisory_lock` call. Outside an explicit transaction PostgreSQL 18 warns `SET LOCAL can only be used in transaction blocks`, and consumers (Marten's async daemon in HotCold mode being the canonical case) cannot opt out of that path.

## Change

Additive only. Existing `AdvisoryLock` and `AdvisoryLockOptions` are untouched.

- `NativeAdvisoryLock` — `IAdvisoryLock` implementation that holds a single dedicated `NpgsqlConnection` and uses the existing `AdvisoryLockExtensions.TryGetGlobalLock` / `ReleaseGlobalLock` helpers. No `SET LOCAL`. No third-party dependency. No keep-alive: this is the documented trade-off for callers that want to opt out of monitoring.
- `AdvisoryLockFactory.Create(...)` — branches on `LockMonitoringEnabled`. Returns `AdvisoryLock` when `true` (default behaviour preserved), `NativeAdvisoryLock` when `false`.

## Tests

`NativeAdvisoryLockSpecs` in `advisory_lock_usage.cs`:
- `acquire_and_release_a_session_lock` — full lifecycle, asserts another connection cannot acquire while held and can after release.
- `hold_multiple_locks_and_release_one` — independent lock ids on the same instance.
- `acquire_returns_false_when_held_by_another_instance` — exclusivity across instances.
- `dispose_releases_held_locks` — locks are released on `DisposeAsync`.
- `try_get_global_lock_does_not_emit_set_local_warning` — regression test on the underlying extension to ensure the native path stays free of `SET LOCAL` notices.

## Compatibility

- `new AdvisoryLock(...)` and `new AdvisoryLockOptions()` continue to behave exactly as before.
- The flag's default stays `false` (existing direct callers using `new AdvisoryLockOptions()` keep the Medallion-backed `AdvisoryLock` because they instantiate it directly — only the new `AdvisoryLockFactory.Create` path branches).
- No public API removed or renamed.

## Follow-up

Marten PR will bump the `Weasel.Postgresql` reference, switch its projection distributors to `AdvisoryLockFactory.Create`, expand existing tests to cover both modes, and rewrite the `async-daemon.md` HotCold section so the documentation matches the implementation.
