### PR TITLE
Updated sqlite to allow composite primary keys via fluent API for pub…

### DIFF
--- a/src/Weasel.Sqlite.Tests/Tables/TableTests.cs
+++ b/src/Weasel.Sqlite.Tests/Tables/TableTests.cs
@@ -306,6 +306,64 @@ public class TableTests
     }
 
     [Fact]
+    public void composite_primary_key_renders_table_level_constraint_not_multiple_inline()
+    {
+        // SQLite rejects multiple inline PRIMARY KEY columns with "table has more than one primary key".
+        var table = new Table("order_items");
+        table.AddColumn<int>("order_id").AsPrimaryKey();
+        table.AddColumn<int>("product_id").AsPrimaryKey();
+        table.AddColumn<int>("quantity");
+
+        var ddl = table.ToBasicCreateTableSql();
+
+        System.Text.RegularExpressions.Regex.Matches(ddl, "PRIMARY KEY").Count.ShouldBe(1);
+        ddl.ShouldContain("PRIMARY KEY (order_id, product_id)");
+    }
+
+    [Fact]
+    public void single_primary_key_still_renders_inline()
+    {
+        // Preserves SQLite's INTEGER PRIMARY KEY rowid-alias optimization for existing consumers.
+        var table = new Table("users");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn<string>("name");
+
+        var ddl = table.ToBasicCreateTableSql();
+
+        ddl.ShouldContain("PRIMARY KEY");
+        ddl.ShouldNotContain("CONSTRAINT");
+    }
+
+    [Fact]
+    public void composite_primary_key_round_trips_through_sqlite()
+    {
+        var table = new Table("order_items");
+        table.AddColumn<int>("order_id").AsPrimaryKey();
+        table.AddColumn<int>("product_id").AsPrimaryKey();
+        table.AddColumn<int>("quantity");
+
+        var ddl = table.ToBasicCreateTableSql();
+
+        using var conn = new Microsoft.Data.Sqlite.SqliteConnection("Data Source=:memory:");
+        conn.Open();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = ddl;
+        cmd.ExecuteNonQuery();
+
+        using var pragma = conn.CreateCommand();
+        pragma.CommandText = "SELECT name, pk FROM pragma_table_info('order_items') WHERE pk > 0 ORDER BY pk";
+        using var reader = pragma.ExecuteReader();
+
+        var pkColumns = new List<string>();
+        while (reader.Read())
+        {
+            pkColumns.Add(reader.GetString(0));
+        }
+
+        pkColumns.ShouldBe(new[] { "order_id", "product_id" });
+    }
+
+    [Fact]
     public void set_primary_key_name()
     {
         var table = new Table("users");

--- a/src/Weasel.Sqlite/Tables/Table.cs
+++ b/src/Weasel.Sqlite/Tables/Table.cs
@@ -107,6 +107,8 @@ public partial class Table: ITable
 
         var lines = new List<string>();
 
+        var hasCompositePk = PrimaryKeyColumns.Count > 1;
+
         // Add column definitions
         if (migrator.Formatting == SqlFormatting.Pretty)
         {
@@ -114,15 +116,15 @@ public partial class Table: ITable
             var typeLength = Columns.Any() ? Columns.Max(x => x.Type.Length) + 4 : 10;
 
             lines.AddRange(Columns.Select(column =>
-                $"    {column.QuotedName.PadRight(columnLength)}{column.Type.PadRight(typeLength)}{column.Declaration()}"));
+                $"    {column.QuotedName.PadRight(columnLength)}{column.Type.PadRight(typeLength)}{column.Declaration(hasCompositePk)}"));
         }
         else
         {
-            lines.AddRange(Columns.Select(column => column.ToDeclaration()));
+            lines.AddRange(Columns.Select(column => column.ToDeclaration(hasCompositePk)));
         }
 
-        // Add primary key if not already defined inline
-        if (PrimaryKeyColumns.Any() && !Columns.Any(c => c.IsPrimaryKey))
+        // For composite primary keys, emit a single table-level constraint.
+        if (hasCompositePk)
         {
             lines.Add(PrimaryKeyDeclaration());
         }

--- a/src/Weasel.Sqlite/Tables/TableColumn.cs
+++ b/src/Weasel.Sqlite/Tables/TableColumn.cs
@@ -59,18 +59,28 @@ public class TableColumn: ITableColumn
         return Type.Split('(')[0].Trim();
     }
 
-    public string Declaration()
+    /// <summary>
+    /// Renders the inline column constraints (NOT NULL, PRIMARY KEY, DEFAULT, GENERATED, CHECKs)
+    /// that follow the column name and type in a CREATE TABLE statement.
+    /// </summary>
+    /// <param name="suppressInlinePrimaryKey">
+    /// When true, omits the inline PRIMARY KEY token even if <see cref="IsPrimaryKey"/> is set.
+    /// Used for composite primary keys, which are emitted as a single table-level CONSTRAINT.
+    /// </param>
+    /// <returns>Space-joined constraint tokens, or an empty string if none apply.</returns>
+    public string Declaration(bool suppressInlinePrimaryKey = false)
     {
         var parts = new List<string>();
+        var emitInlinePk = IsPrimaryKey && !suppressInlinePrimaryKey;
 
-        // NULL/NOT NULL constraint
-        if (!IsPrimaryKey && !AllowNulls)
+        // NOT NULL — inline PRIMARY KEY already implies it; otherwise honor AllowNulls.
+        if (!emitInlinePk && !AllowNulls)
         {
             parts.Add("NOT NULL");
         }
 
         // PRIMARY KEY with optional AUTOINCREMENT
-        if (IsPrimaryKey)
+        if (emitInlinePk)
         {
             if (IsAutoNumber)
             {
@@ -140,9 +150,9 @@ public class TableColumn: ITableColumn
         }
     }
 
-    public string ToDeclaration()
+    public string ToDeclaration(bool suppressInlinePrimaryKey = false)
     {
-        var declaration = Declaration();
+        var declaration = Declaration(suppressInlinePrimaryKey);
 
         return declaration.IsEmpty()
             ? $"{QuotedName} {Type}"


### PR DESCRIPTION
## Bug
Composite primary keys defined via the fluent API render as multiple inline `PRIMARY KEY` columns. SQLite rejects this with `table … has more than one primary key`.

Repro/Expected reported downstream: JasperFx/wolverine#2680

## Fix
 - `TableColumn.Declaration` / `ToDeclaration`: optional `suppressInlinePrimaryKey` parameter (default `false` → fully backward-compatible).
 - `Table.WriteCreateStatement`: when `PrimaryKeyColumns.Count > 1`, suppress inline tokens and emit a single table-level `CONSTRAINT`.
 - Single-column PK rendering unchanged → preserves SQLite's `INTEGER PRIMARY KEY` rowid-alias and `AUTOINCREMENT `semantics.

## Tests
3 new tests, including end-to-end round-trip via pragma_table_info.
All 361 existing tests pass on net8/net9/net10.