### PR TITLE
fix(sqlite): emit composite primary keys as table-level constraint

### DIFF
--- a/src/Weasel.Sqlite.Tests/Tables/TableTests.cs
+++ b/src/Weasel.Sqlite.Tests/Tables/TableTests.cs
@@ -365,4 +365,112 @@ public class TableTests
         table.AddPrimaryKeyColumn("pk_id", "INTEGER").ShouldNotBeNull();
         table.AddPrimaryKeyColumn("pk_guid", typeof(Guid)).ShouldNotBeNull();
     }
+
+    /// <summary>
+    /// Regression for the bug surfaced by https://github.com/JasperFx/wolverine/issues/2680.
+    /// Two columns each calling <c>AsPrimaryKey()</c> used to emit two inline
+    /// <c>PRIMARY KEY</c> column definitions, which SQLite rejects with
+    /// <c>'table … has more than one primary key'</c>. The fix detects the
+    /// composite case in <see cref="Table.WriteCreateStatement"/> and emits a
+    /// single table-level <c>PRIMARY KEY (col1, col2)</c> constraint instead.
+    /// </summary>
+    [Fact]
+    public void composite_primary_key_emits_table_level_constraint_only()
+    {
+        var table = new Table("order_items");
+        table.AddColumn<int>("order_id").AsPrimaryKey();
+        table.AddColumn<int>("product_id").AsPrimaryKey();
+        table.AddColumn<int>("quantity").NotNull();
+
+        var migrator = new SqliteMigrator();
+        var writer = new StringWriter();
+        table.WriteCreateStatement(migrator, writer);
+        var ddl = writer.ToString();
+
+        // The table-level CONSTRAINT clause must be present, listing both PK columns.
+        // Identifier names that aren't reserved keywords are emitted unquoted by
+        // Weasel.Sqlite's QuoteName helper, so the expected form is `PRIMARY KEY (order_id, product_id)`.
+        ddl.ShouldContain("CONSTRAINT");
+        ddl.ShouldContain("PRIMARY KEY (order_id, product_id)");
+
+        // No column may carry an inline `PRIMARY KEY` token in its declaration —
+        // that is exactly what SQLite rejected. Match the column-line shape rather
+        // than just `PRIMARY KEY` substring (the table-level CONSTRAINT clause also
+        // contains `PRIMARY KEY`).
+        foreach (var line in ddl.Split('\n')
+                     .Where(l => l.TrimStart().StartsWith("order_id")
+                                 || l.TrimStart().StartsWith("product_id")))
+        {
+            line.ShouldNotContain(
+                "PRIMARY KEY",
+                customMessage: $"composite-PK columns must NOT emit inline PRIMARY KEY (column line: {line.Trim()})");
+        }
+
+        // PK columns must be NOT NULL — SQLite only auto-applies that for inline
+        // single-column PKs, so we explicitly emit it for the composite case.
+        ddl.ShouldContain("NOT NULL");
+    }
+
+    [Fact]
+    public void single_column_primary_key_still_emits_inline()
+    {
+        // Belt-and-braces: the composite-PK fix must not regress the historical
+        // shape for single-column PKs (which SQLite accepts inline, and the rest
+        // of the ecosystem expects).
+        var table = new Table("users");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn<string>("name").NotNull();
+
+        var migrator = new SqliteMigrator();
+        var writer = new StringWriter();
+        table.WriteCreateStatement(migrator, writer);
+        var ddl = writer.ToString();
+
+        // Single inline PK; no separate table-level CONSTRAINT clause.
+        ddl.ShouldContain("PRIMARY KEY");
+        ddl.ShouldNotContain("CONSTRAINT");
+        ddl.ShouldNotContain("PRIMARY KEY (id)");
+    }
+
+    [Fact]
+    public async Task composite_primary_key_ddl_executes_against_sqlite_in_memory()
+    {
+        // End-to-end repro of GH-2680: the broken DDL hit `'table ... has more
+        // than one primary key'` from SQLite itself. Run the produced statement
+        // against an in-memory connection so any future regression in the
+        // emission shape would surface even if the static-string assertions
+        // above drift.
+        var table = new Table("order_items");
+        table.AddColumn<int>("order_id").AsPrimaryKey();
+        table.AddColumn<int>("product_id").AsPrimaryKey();
+        table.AddColumn<int>("quantity").NotNull();
+
+        var migrator = new SqliteMigrator();
+        var writer = new StringWriter();
+        table.WriteCreateStatement(migrator, writer);
+        var ddl = writer.ToString();
+
+        await using var conn = new Microsoft.Data.Sqlite.SqliteConnection("Data Source=:memory:");
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = ddl;
+        await cmd.ExecuteNonQueryAsync();
+
+        // PRAGMA table_info reports the pk slot per column: 0 = not in PK,
+        // 1+ = position within the composite key. Verify both columns participate.
+        await using var pragma = conn.CreateCommand();
+        pragma.CommandText = "PRAGMA table_info(order_items);";
+        var pkColumns = new List<string>();
+        await using var reader = await pragma.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            var name = reader.GetString(1);
+            var pk = reader.GetInt32(5);
+            if (pk > 0) pkColumns.Add(name);
+        }
+
+        pkColumns.ShouldContain("order_id");
+        pkColumns.ShouldContain("product_id");
+        pkColumns.Count.ShouldBe(2);
+    }
 }

--- a/src/Weasel.Sqlite/Tables/Table.cs
+++ b/src/Weasel.Sqlite/Tables/Table.cs
@@ -107,6 +107,13 @@ public partial class Table: ITable
 
         var lines = new List<string>();
 
+        // SQLite rejects two inline PRIMARY KEY columns ("table ... has more than one primary
+        // key"), so for composite primary keys we suppress the inline emission on each column
+        // and rely on a single table-level CONSTRAINT ... PRIMARY KEY (col1, col2) clause
+        // below. Single-column PKs keep the historical inline-emission shape.
+        var hasCompositePrimaryKey = PrimaryKeyColumns.Count > 1;
+        var emitInlinePrimaryKey = !hasCompositePrimaryKey;
+
         // Add column definitions
         if (migrator.Formatting == SqlFormatting.Pretty)
         {
@@ -114,15 +121,17 @@ public partial class Table: ITable
             var typeLength = Columns.Any() ? Columns.Max(x => x.Type.Length) + 4 : 10;
 
             lines.AddRange(Columns.Select(column =>
-                $"    {column.QuotedName.PadRight(columnLength)}{column.Type.PadRight(typeLength)}{column.Declaration()}"));
+                $"    {column.QuotedName.PadRight(columnLength)}{column.Type.PadRight(typeLength)}{column.Declaration(emitInlinePrimaryKey)}"));
         }
         else
         {
-            lines.AddRange(Columns.Select(column => column.ToDeclaration()));
+            lines.AddRange(Columns.Select(column => column.ToDeclaration(emitInlinePrimaryKey)));
         }
 
-        // Add primary key if not already defined inline
-        if (PrimaryKeyColumns.Any() && !Columns.Any(c => c.IsPrimaryKey))
+        // Add primary key if not already defined inline. Either path emits the table-level
+        // constraint exactly once: composite PK case (we suppressed every inline emission above)
+        // or the legacy "registered via PrimaryKeyColumns without IsPrimaryKey set" case.
+        if (hasCompositePrimaryKey || (PrimaryKeyColumns.Any() && !Columns.Any(c => c.IsPrimaryKey)))
         {
             lines.Add(PrimaryKeyDeclaration());
         }

--- a/src/Weasel.Sqlite/Tables/TableColumn.cs
+++ b/src/Weasel.Sqlite/Tables/TableColumn.cs
@@ -59,18 +59,31 @@ public class TableColumn: ITableColumn
         return Type.Split('(')[0].Trim();
     }
 
-    public string Declaration()
+    public string Declaration() => Declaration(emitInlinePrimaryKey: true);
+
+    /// <summary>
+    /// Generate the column declaration. Pass <paramref name="emitInlinePrimaryKey"/> = false when
+    /// the table is responsible for emitting a table-level <c>PRIMARY KEY (...)</c> constraint
+    /// (e.g. composite primary keys on SQLite, where two inline <c>PRIMARY KEY</c> columns are
+    /// rejected with <c>'table ... has more than one primary key'</c>). When suppressed, the
+    /// column still emits <c>NOT NULL</c> on its own to match SQLite's implicit NOT NULL semantics
+    /// for primary-key columns.
+    /// </summary>
+    public string Declaration(bool emitInlinePrimaryKey)
     {
         var parts = new List<string>();
 
-        // NULL/NOT NULL constraint
-        if (!IsPrimaryKey && !AllowNulls)
+        // NULL/NOT NULL constraint. When we're suppressing the inline PRIMARY KEY (composite-PK
+        // case), explicitly emit NOT NULL so the column doesn't silently become nullable —
+        // SQLite only auto-applies NOT NULL to columns whose PRIMARY KEY is declared inline.
+        var inlinePk = IsPrimaryKey && emitInlinePrimaryKey;
+        if (!inlinePk && !AllowNulls)
         {
             parts.Add("NOT NULL");
         }
 
         // PRIMARY KEY with optional AUTOINCREMENT
-        if (IsPrimaryKey)
+        if (inlinePk)
         {
             if (IsAutoNumber)
             {
@@ -140,9 +153,11 @@ public class TableColumn: ITableColumn
         }
     }
 
-    public string ToDeclaration()
+    public string ToDeclaration() => ToDeclaration(emitInlinePrimaryKey: true);
+
+    public string ToDeclaration(bool emitInlinePrimaryKey)
     {
-        var declaration = Declaration();
+        var declaration = Declaration(emitInlinePrimaryKey);
 
         return declaration.IsEmpty()
             ? $"{QuotedName} {Type}"


### PR DESCRIPTION
## Summary
When a `Weasel.Sqlite.Tables.Table` has two or more columns each calling `.AsPrimaryKey()`, the generated DDL emitted an inline `PRIMARY KEY` on every PK column. SQLite rejects that with `'table … has more than one primary key'` and the migration aborts before the table is ever created. The fix detects the composite-PK case and emits a single table-level `CONSTRAINT pk_<table> PRIMARY KEY (col1, col2)` clause instead, suppressing the inline emission. Single-column PKs are unchanged — same inline `PRIMARY KEY` they've always emitted.

Surfaces downstream as JasperFx/wolverine#2680 — Wolverine's `MessageIdentity.IdAndDestination` mode marks both `id` and `received_at` as primary keys on `wolverine_incoming_envelopes`, and the failed migration cascades into the durability agent crashing on every poll. With this Weasel fix, no Wolverine code change is needed; bumping the WolverineFx.Sqlite Weasel dependency once this releases will quietly fix the bug.

### What changed

**`Weasel.Sqlite/Tables/TableColumn.cs`** — new `Declaration(bool emitInlinePrimaryKey)` overload (and a matching `ToDeclaration` overload). When the caller passes `false`, the inline `PRIMARY KEY` token is suppressed and the column instead emits `NOT NULL` on its own (SQLite only auto-applies NOT NULL to columns whose `PRIMARY KEY` is declared inline, so the composite-PK case must do it explicitly).

**`Weasel.Sqlite/Tables/Table.cs`** — `WriteCreateStatement` detects `PrimaryKeyColumns.Count > 1`, passes `emitInlinePrimaryKey: false` to each column declaration, and unconditionally appends `PrimaryKeyDeclaration()` for the table-level constraint. The pre-existing single-PK branch is preserved verbatim.

### Compatibility table

| Setup | Pre-fix DDL | Post-fix DDL |
|---|---|---|
| Single `.AsPrimaryKey()` column | `id INTEGER PRIMARY KEY` (inline) | `id INTEGER PRIMARY KEY` (inline, unchanged) |
| Two `.AsPrimaryKey()` columns | each column `PRIMARY KEY` inline → SQLite ERROR | inline tokens suppressed; one `CONSTRAINT pk_<table> PRIMARY KEY (col1, col2)` clause |
| `ReadPrimaryKeyColumns(...)` (no inline) | table-level constraint emitted | unchanged |

## Test plan
- [x] New `composite_primary_key_emits_table_level_constraint_only` — static-string assertions on the produced DDL, including a per-column line scan ensuring no PK column emits inline `PRIMARY KEY`.
- [x] New `single_column_primary_key_still_emits_inline` — guards the no-regression contract for single-PK tables.
- [x] New `composite_primary_key_ddl_executes_against_sqlite_in_memory` — end-to-end repro: the produced statement is executed against an in-memory SQLite connection (which used to throw `'table … has more than one primary key'`) and `PRAGMA table_info` confirms both columns participate in the PK. Verified to fail on master before the fix.
- [x] Full `Weasel.Sqlite.Tests` suite — **361/361 passed** on net8.0, net9.0, net10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)