### PR TITLE
fix(SqlServer): preserve user casing on TableColumn names

### DIFF
--- a/src/Weasel.SqlServer.Tests/Tables/TableColumnTests.cs
+++ b/src/Weasel.SqlServer.Tests/Tables/TableColumnTests.cs
@@ -137,21 +137,45 @@ public class TableColumnTests
     }
 
     [Fact]
-    public void column_name_normalization_is_culture_invariant()
+    public void column_name_preserves_user_casing()
     {
-        // In Turkish locale, "I".ToLower() produces dotless 'ı' (U+0131) instead of 'i',
-        // which would corrupt SQL identifiers like "INFORMATION_SCHEMA" → "ınformation_schema".
+        // SQL Server identifiers are case-insensitive by default, but legacy
+        // schemas and many SQL Server projects use PascalCase. Don't lowercase
+        // the user's column name (issue: JasperFx/polecat#45).
+        var column = new TableColumn("OrderId", "uniqueidentifier");
+        column.Name.ShouldBe("OrderId");
+    }
+
+    [Fact]
+    public void column_type_is_culture_invariant_lowercase()
+    {
+        // SQL types remain lowercased (e.g. "VARCHAR" → "varchar") and must
+        // be culture-invariant — Turkish locale would otherwise produce
+        // dotless 'ı' (U+0131) and corrupt the type string.
         var originalCulture = CultureInfo.CurrentCulture;
         try
         {
             CultureInfo.CurrentCulture = new CultureInfo("tr-TR");
             var column = new TableColumn("INFORMATION_SCHEMA", "VARCHAR");
-            column.Name.ShouldBe("information_schema");
-            column.Type.ShouldBe("varchar");
+            column.Name.ShouldBe("INFORMATION_SCHEMA");  // preserved
+            column.Type.ShouldBe("varchar");              // lowercased, culture-invariant
         }
         finally
         {
             CultureInfo.CurrentCulture = originalCulture;
         }
+    }
+
+    [Fact]
+    public void columns_compare_case_insensitively_on_name()
+    {
+        // SQL Server identifier comparison is case-insensitive in the default
+        // collation, so two TableColumn instances with the same name but
+        // different casing must compare equal (and produce the same hash).
+        var a = new TableColumn("Amount", "int");
+        var b = new TableColumn("amount", "int");
+
+        a.Equals(b).ShouldBeTrue();
+        a.GetHashCode().ShouldBe(b.GetHashCode());
     }
 }

--- a/src/Weasel.SqlServer/Tables/Table.cs
+++ b/src/Weasel.SqlServer/Tables/Table.cs
@@ -273,7 +273,7 @@ public partial class Table: ITable
 
     public bool HasColumn(string columnName)
     {
-        return Columns.Any(x => x.Name == columnName);
+        return Columns.Any(x => x.Name.EqualsIgnoreCase(columnName));
     }
 
     public IndexDefinition? IndexFor(string indexName)

--- a/src/Weasel.SqlServer/Tables/TableColumn.cs
+++ b/src/Weasel.SqlServer/Tables/TableColumn.cs
@@ -18,7 +18,11 @@ public class TableColumn: ITableColumn
             throw new ArgumentOutOfRangeException(nameof(type));
         }
 
-        Name = name.ToLowerInvariant().Trim().Replace(' ', '_');
+        // Preserve the user's casing — SQL Server identifiers are case-insensitive
+        // by default but legacy schemas often use PascalCase. Lowercasing here
+        // produced duplicate-column DDL when callers added the same logical column
+        // with different casings (issue: JasperFx/polecat#45).
+        Name = name.Trim().Replace(' ', '_');
         Type = type.ToLowerInvariant();
     }
 
@@ -62,7 +66,7 @@ public class TableColumn: ITableColumn
 
     protected bool Equals(TableColumn other)
     {
-        return string.Equals(QuotedName, other.QuotedName) &&
+        return string.Equals(QuotedName, other.QuotedName, StringComparison.OrdinalIgnoreCase) &&
                string.Equals(SqlServerProvider.Instance.ConvertSynonyms(RawType()),
                    SqlServerProvider.Instance.ConvertSynonyms(other.RawType()));
     }
@@ -91,7 +95,7 @@ public class TableColumn: ITableColumn
     {
         unchecked
         {
-            return (Name.GetHashCode() * 397) ^ Type.GetHashCode();
+            return (StringComparer.OrdinalIgnoreCase.GetHashCode(Name) * 397) ^ Type.GetHashCode();
         }
     }
 


### PR DESCRIPTION
Fixes JasperFx/polecat#45 — FlatTableProjection produced duplicate-column DDL when two events mapped to the same logical column with different casings (e.g. "Amount" vs "amount").

## What changed

- `TableColumn`: stop force-lowercasing `Name` (still trim and replace spaces). `Type` continues to be lowercased culture-invariantly.
- `TableColumn.Equals` / `GetHashCode`: case-insensitive on `Name` (matches SQL Server identifier semantics in default collations).
- `Table.HasColumn`: case-insensitive lookup, consistent with `ColumnFor`.

## Why

SQL Server identifiers are case-insensitive in the default collation, but legacy SQL Server schemas overwhelmingly use PascalCase. Lowercasing inside Weasel meant Polecat users could not preserve the casing the database expected — and worse, two `AddColumn("Amount", …)` / `AddColumn("amount", …)` calls would produce a duplicate-column DDL error at table creation time.

## Test coverage

Updated `TableColumnTests`:
- `column_name_preserves_user_casing` — round-trips PascalCase
- `column_type_is_culture_invariant_lowercase` — keeps the Turkish-locale protection on `Type` while allowing mixed-case `Name`
- `columns_compare_case_insensitively_on_name` — verifies `Equals`/`GetHashCode` case-insensitivity

All 244 `Weasel.SqlServer.Tests` pass on net10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)