### PR TITLE
Embed PDBs into .dll; drop snupkg generation

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,6 +11,19 @@
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618</NoWarn>
         <PackageIconUrl>https://raw.githubusercontent.com/JasperFx/JasperFx.Core/main/jasperfx-logo.jpg?raw=true</PackageIconUrl>
+
+        <!--
+        Embed PDB data into the .dll so the main .nupkg ships with debug
+        symbols inline. Drop the separate .snupkg upload that was failing
+        on nuget.org as "The package does not contain any symbol (.pdb)
+        files." for Weasel.Oracle / Weasel.SqlServer / Weasel.Sqlite
+        during the 9.0.0-alpha.3 publish (the 3 csprojs had
+        IncludeSymbols=true + SymbolPackageFormat=snupkg but the snupkg
+        was being produced empty). Setting this in Directory.Build.props
+        applies uniformly to all 7 Weasel.* packages.
+        -->
+        <DebugType>embedded</DebugType>
+        <IncludeSymbols>false</IncludeSymbols>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="DotNet.ReproducibleBuilds" PrivateAssets="All"/>

--- a/src/Weasel.Oracle/Weasel.Oracle.csproj
+++ b/src/Weasel.Oracle/Weasel.Oracle.csproj
@@ -11,8 +11,6 @@
         <GenerateAssemblyFileVersionAttribute>true</GenerateAssemblyFileVersionAttribute>
         <GenerateAssemblyInformationalVersionAttribute>true</GenerateAssemblyInformationalVersionAttribute>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <IncludeSymbols>true</IncludeSymbols>
-        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Weasel.SqlServer/Weasel.SqlServer.csproj
+++ b/src/Weasel.SqlServer/Weasel.SqlServer.csproj
@@ -11,8 +11,6 @@
         <GenerateAssemblyFileVersionAttribute>true</GenerateAssemblyFileVersionAttribute>
         <GenerateAssemblyInformationalVersionAttribute>true</GenerateAssemblyInformationalVersionAttribute>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <IncludeSymbols>true</IncludeSymbols>
-        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Weasel.Sqlite/Weasel.Sqlite.csproj
+++ b/src/Weasel.Sqlite/Weasel.Sqlite.csproj
@@ -11,8 +11,6 @@
         <GenerateAssemblyFileVersionAttribute>true</GenerateAssemblyFileVersionAttribute>
         <GenerateAssemblyInformationalVersionAttribute>true</GenerateAssemblyInformationalVersionAttribute>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <IncludeSymbols>true</IncludeSymbols>
-        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Fix the publish-workflow noise from the Weasel.* 9.0.0-alpha.3 release where 3 snupkg uploads failed with `400 BadRequest: The package does not contain any symbol (.pdb) files.`:

```
Pushing Weasel.Oracle.9.0.0-alpha.3.snupkg to .../symbolpackage
  BadRequest ... 400 (The package does not contain any symbol (.pdb) files.)
Pushing Weasel.SqlServer.9.0.0-alpha.3.snupkg to .../symbolpackage
  BadRequest ... 400 (The package does not contain any symbol (.pdb) files.)
Pushing Weasel.Sqlite.9.0.0-alpha.3.snupkg to .../symbolpackage
  BadRequest ... 400 (The package does not contain any symbol (.pdb) files.)
```

## Root cause

`Weasel.Oracle` / `Weasel.SqlServer` / `Weasel.Sqlite` each set `<IncludeSymbols>true</IncludeSymbols>` + `<SymbolPackageFormat>snupkg</SymbolPackageFormat>` but the resulting `.snupkg` was emitted without any `.pdb` entries — likely because nothing in the build pipeline was producing portable PDBs that matched what `dotnet pack` expected to package as a separate snupkg.

## Fix

Set `<DebugType>embedded</DebugType>` + `<IncludeSymbols>false</IncludeSymbols>` in `Directory.Build.props` so all 7 Weasel.* projects get consistent treatment — debug info embedded into the `.dll`, no separate `.snupkg` upload. Remove the per-csproj `IncludeSymbols` / `SymbolPackageFormat` in the 3 affected projects.

## Verification

```
$ dotnet pack src/Weasel.Sqlite/Weasel.Sqlite.csproj -c Release -o /tmp/weasel-pack-test
  Successfully created package '/tmp/weasel-pack-test/Weasel.Sqlite.9.0.0-alpha.3.nupkg'.

$ ls /tmp/weasel-pack-test/
Weasel.Sqlite.9.0.0-alpha.3.nupkg          (no .snupkg)

$ # Embedded PDB marker check: MPDB magic present in the lib/net10.0/Weasel.Sqlite.dll → confirmed
```

All 7 projects build clean in Release.

## Trade-off

- ✅ Symbols ship with the package; consumers debugging into Weasel.* get them automatically via the `.nupkg` reference. No second nuget.org upload.
- ⚠️ SourceLink / VS auto-fetch via the nuget.org symbol server is no longer the path (we don't push to it). SourceLink via GitHub still works for users who have it configured.
- ℹ️ Slightly larger `.dll` on disk (~5-10% typical for embedded portable PDB).

## Next publish

Fix lands as part of the existing `9.0.0-alpha.3` version (already published; the .nupkg side was fine). Next Weasel publish will be a clean run — no snupkg attempts, no 400 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)