### PR TITLE
Port Marten Bug 983 schema-validation regression to Weasel.Postgresql.Tests (#278)

### DIFF
--- a/src/Weasel.Postgresql.Tests/Bug983_AutoCreateNoneStillValidatesSchema.cs
+++ b/src/Weasel.Postgresql.Tests/Bug983_AutoCreateNoneStillValidatesSchema.cs
@@ -1,0 +1,46 @@
+using JasperFx;
+using Shouldly;
+using Weasel.Core.Migrations;
+using Xunit;
+
+namespace Weasel.Postgresql.Tests;
+
+/// <summary>
+///     Regression test for the original Marten Bug 983
+///     (<c>Bug_983_autocreate_none_is_disabling_schema_validation</c>) — ported to
+///     Weasel as part of #278 because the underlying
+///     <see cref="IDatabase.AssertDatabaseMatchesConfigurationAsync" /> logic now
+///     lives in <c>Weasel.Core.Migrations</c>, not Marten.
+///     <para>
+///     The original bug: <c>AutoCreate.None</c> was short-circuiting schema
+///     validation, so a database missing tables that the application configured
+///     silently passed <c>AssertDatabaseMatchesConfigurationAsync</c>. The fix
+///     made the assertion run regardless of <c>AutoCreate</c> — the autocreate
+///     setting controls whether <c>ApplyAllConfiguredChangesToDatabaseAsync</c>
+///     will <em>apply</em> changes, not whether the assert detects them.
+///     </para>
+/// </summary>
+[Collection("bug983")]
+public class Bug983_AutoCreateNoneStillValidatesSchema: IntegrationContext
+{
+    public Bug983_AutoCreateNoneStillValidatesSchema(): base("bug983")
+    {
+    }
+
+    [Fact]
+    public async Task assert_throws_when_table_is_missing_even_with_autocreate_none()
+    {
+        // Make sure the schema is empty so the configured table is genuinely missing.
+        await ResetSchema();
+
+        // Configure a database with one table that we deliberately don't apply, and
+        // turn auto-create off. Pre-fix, AutoCreate.None caused the assert to be a
+        // silent no-op; post-fix, the assert must still detect the missing table.
+        var db = new DatabaseWithTables("bug983", theDataSource, AutoCreate.None);
+        var table = db.AddTable(new PostgresqlObjectName(SchemaName, "documents"));
+        table.AddPrimaryKeyColumn("id", typeof(int));
+
+        await Should.ThrowAsync<DatabaseValidationException>(
+            () => db.AssertDatabaseMatchesConfigurationAsync());
+    }
+}


### PR DESCRIPTION
Closes #278.

## Summary

Marten has a regression test `Bug_983_autocreate_none_is_disabling_schema_validation` asserting that `AssertDatabaseMatchesConfigurationAsync()` must still throw `DatabaseValidationException` when `AutoCreate.None` is configured and the database doesn't match the configured schema. Because the underlying logic now lives in Weasel (`Weasel.Core.Migrations.IDatabase`), the test belongs in Weasel's own suite. The Marten copy is marked `[Obsolete("This should be in Weasel")]`.

This PR adds the equivalent test in `Weasel.Postgresql.Tests`:

- Uses the existing `DatabaseWithTables` test harness with its `AutoCreate` constructor overload.
- Resets the schema, adds a table that's never applied to the database, configures `AutoCreate.None`.
- Asserts that `AssertDatabaseMatchesConfigurationAsync()` throws `DatabaseValidationException`.

The point of the regression: `AutoCreate.None` must control whether `ApplyAllConfiguredChangesToDatabaseAsync` *applies* changes, not whether the assert *detects* them. Pre-fix the autocreate setting was short-circuiting the assertion, so missing tables silently passed.

## Test plan

- [x] Test passes against PostgreSQL 12 locally (`Passed: 1, Total time: 0.59s`)
- [x] Once merged, the Marten `Bug_983_autocreate_none_is_disabling_schema_validation` test can be deleted (it's already flagged `[Obsolete]` upstream)

🤖 Generated with [Claude Code](https://claude.com/claude-code)