### PR TITLE
Make CREATE SCHEMA migration DDL concurrent-safe against pg_namespace race

### DIFF
--- a/src/Weasel.Postgresql/PostgresqlMigrator.cs
+++ b/src/Weasel.Postgresql/PostgresqlMigrator.cs
@@ -94,16 +94,20 @@ $$;
 
     private static void WriteSql(string databaseSchemaName, TextWriter writer)
     {
+        // Neither the "IF NOT EXISTS(information_schema.schemata) THEN EXECUTE 'CREATE SCHEMA'"
+        // pattern nor PostgreSQL's own "CREATE SCHEMA IF NOT EXISTS" is concurrent-safe — both
+        // can have two sessions pass the existence check then race on the insert into pg_namespace,
+        // surfacing as "23505 duplicate key value violates unique constraint pg_namespace_nspname_index"
+        // / "42P06 schema X already exists". Wrap the create in a sub-block that swallows those two
+        // race exceptions specifically; any other error still propagates.
         writer.WriteLine(
             $"""
-                 IF NOT EXISTS(
-                     SELECT schema_name
-                       FROM information_schema.schemata
-                       WHERE schema_name = '{databaseSchemaName}'
-                   )
-                 THEN
-                   EXECUTE 'CREATE SCHEMA {PostgresqlProvider.Instance.ToQualifiedName(databaseSchemaName)}';
-                 END IF;
+                   BEGIN
+                     EXECUTE 'CREATE SCHEMA IF NOT EXISTS {PostgresqlProvider.Instance.ToQualifiedName(databaseSchemaName)}';
+                   EXCEPTION
+                     WHEN duplicate_schema THEN NULL;
+                     WHEN unique_violation THEN NULL;
+                   END;
 
              """);
     }


### PR DESCRIPTION
## Summary

- `PostgresqlMigrator.WriteSql` emitted `IF NOT EXISTS(information_schema.schemata) THEN EXECUTE 'CREATE SCHEMA …'`, which is not atomic against concurrent sessions: both sessions can pass the existence check, then race on the insert into `pg_namespace` and one loses with `23505 duplicate key value violates unique constraint pg_namespace_nspname_index`. PostgreSQL's own `CREATE SCHEMA IF NOT EXISTS` has the same window (see e.g. [pg-hackers thread](https://www.postgresql.org/message-id/CAEepm%3D0w_LH%2B5gAjQ_kpv0c2WMOmRhDC-2Sx_O88EWyEKHnsXg%40mail.gmail.com)).
- Wrap the create in a plpgsql sub-block that catches `duplicate_schema` (42P06) and `unique_violation` (23505) specifically, so the losing session treats the race as benign. Any other error still propagates.
- Tracked downstream as Marten flake [JasperFx/marten#4445](https://github.com/JasperFx/marten/issues/4445) — three `full_text_index` tests fail intermittently against the existing master with the exact 23505 symptom.

## Why this minimal form

The published DDL is wrapped in an outer `DO $$ BEGIN … END $$;` (one block per migration); each schema gets a nested `BEGIN … EXCEPTION … END;` sub-block so the EXCEPTION clause only suppresses the race for the current `CREATE SCHEMA`, not for the rest of the migration's DDL.

## Test plan

- [x] `dotnet build src/Weasel.Postgresql/Weasel.Postgresql.csproj` succeeds
- [x] Built a local 9.0.0-alpha.3-fix4445 nupkg, pointed Marten at it, ran `DocumentDbTests.Indexes.full_text_index` (31 tests, 5 currently `[Fact(Skip = "…#4445")]`) — unskipping all 5 and running 3× in a row with `DISABLE_TEST_PARALLELIZATION=true` is now `31/31 passed` deterministically (was `Failed: 3+/31` intermittently)
- [ ] Run existing `Weasel.Postgresql.Tests` suite (the Marten-side validation is the strongest signal because Weasel has no test asserting on the DDL emission text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)