### PR TITLE
Dedupe IAdvisoryLock onto JasperFx.Events.Daemon (closes #284); bump alpha.7

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>9.0.0-alpha.6</Version>
+        <Version>9.0.0-alpha.7</Version>
         <LangVersion>13.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,8 +8,8 @@
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.12.19" />
     <PackageVersion Include="DistributedLock.Postgres" Version="1.3.0" />
     <PackageVersion Include="DotNet.ReproducibleBuilds" Version="1.2.39" />
-    <PackageVersion Include="JasperFx" Version="2.0.0-alpha.17" />
-    <PackageVersion Include="JasperFx.Events" Version="2.0.0-alpha.16" />
+    <PackageVersion Include="JasperFx" Version="2.0.0-alpha.20" />
+    <PackageVersion Include="JasperFx.Events" Version="2.0.0-alpha.19" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="9.0.1" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />
     <!-- EF Core versions are framework-conditional - see below -->

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -113,6 +113,26 @@ catch (MisconfiguredForeignKeyException ex) { ... }
 
 The PG-specific `InvalidForeignKeyException` and `TryToCorrectForLink` extension stay where they were.
 
+### `Weasel.Core.IAdvisoryLock` → `JasperFx.Events.Daemon.IAdvisoryLock`
+
+[#284](https://github.com/JasperFx/weasel/issues/284). The advisory-lock contract was a byte-identical duplicate of the one upstream JasperFx.Events lifted into `JasperFx.Events.Daemon` (jasperfx#316 / alpha.19) so the daemon contracts have a single canonical home. Weasel's duplicate has been removed; `Weasel.Postgresql.AdvisoryLock` and `Weasel.SqlServer.AdvisoryLock` now implement the lifted interface directly, satisfying the `lockFactory` closure that the lifted `*ProjectionDistributor` concretes accept.
+
+Update the `using` statement:
+
+```csharp
+// before (Weasel 8.x / 9.0.0-alpha.5 and earlier)
+using Weasel.Core;
+
+IAdvisoryLock lock = new Weasel.Postgresql.AdvisoryLock(...);
+
+// after (Weasel 9.0.0-alpha.7+)
+using JasperFx.Events.Daemon;
+
+IAdvisoryLock lock = new Weasel.Postgresql.AdvisoryLock(...);
+```
+
+The interface shape is unchanged (same three members: `HasLock` / `TryAttainLockAsync` / `ReleaseLockAsync`, with `IAsyncDisposable`). The two `AdvisoryLock` concretes' constructors and behaviour are also unchanged.
+
 ## API changes
 
 ### Canonical `AutoIncrement()` fluent API

--- a/src/Weasel.Core/IAdvisoryLock.cs
+++ b/src/Weasel.Core/IAdvisoryLock.cs
@@ -1,8 +1,0 @@
-namespace Weasel.Core;
-
-public interface IAdvisoryLock: IAsyncDisposable
-{
-    bool HasLock(int lockId);
-    Task<bool> TryAttainLockAsync(int lockId, CancellationToken token);
-    Task ReleaseLockAsync(int lockId);
-}

--- a/src/Weasel.Postgresql/AdvisoryLock.cs
+++ b/src/Weasel.Postgresql/AdvisoryLock.cs
@@ -1,8 +1,8 @@
 using JasperFx.Core;
+using JasperFx.Events.Daemon;
 using Medallion.Threading.Postgres;
 using Microsoft.Extensions.Logging;
 using Npgsql;
-using Weasel.Core;
 
 namespace Weasel.Postgresql;
 
@@ -14,6 +14,15 @@ public sealed class AdvisoryLockOptions
 }
 
 
+/// <summary>
+///     PostgreSQL implementation of <see cref="IAdvisoryLock" />. The contract was
+///     originally a duplicate in <c>Weasel.Core.IAdvisoryLock</c> (byte-identical
+///     to the upstream JasperFx.Events one); it was lifted into
+///     <c>JasperFx.Events.Daemon</c> in jasperfx alpha.19 / PR #319 so the daemon
+///     contracts have a single canonical home, and Weasel's duplicate was removed
+///     in weasel#284. Existing consumers should update their <c>using</c>
+///     statement from <c>Weasel.Core</c> to <c>JasperFx.Events.Daemon</c>.
+/// </summary>
 public class AdvisoryLock : IAdvisoryLock
 {
     private readonly string _databaseName;

--- a/src/Weasel.Postgresql/Weasel.Postgresql.csproj
+++ b/src/Weasel.Postgresql/Weasel.Postgresql.csproj
@@ -19,6 +19,10 @@
 
     <ItemGroup>
         <PackageReference Include="DistributedLock.Postgres" />
+        <!-- JasperFx.Events provides the canonical IAdvisoryLock contract (lifted
+             in jasperfx#316 / alpha.19, dedupe-aligned in weasel#284). AdvisoryLock
+             implements that interface directly. -->
+        <PackageReference Include="JasperFx.Events" />
         <PackageReference Include="Npgsql" />
         <PackageReference Include="Npgsql.NetTopologySuite" />
     </ItemGroup>

--- a/src/Weasel.SqlServer/AdvisoryLock.cs
+++ b/src/Weasel.SqlServer/AdvisoryLock.cs
@@ -1,11 +1,20 @@
 using System.Data;
 using JasperFx.Core;
+using JasperFx.Events.Daemon;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
-using Weasel.Core;
 
 namespace Weasel.SqlServer;
 
+/// <summary>
+///     SQL Server implementation of <see cref="IAdvisoryLock" />. The contract was
+///     originally a duplicate in <c>Weasel.Core.IAdvisoryLock</c> (byte-identical
+///     to the upstream JasperFx.Events one); it was lifted into
+///     <c>JasperFx.Events.Daemon</c> in jasperfx alpha.19 / PR #319 so the daemon
+///     contracts have a single canonical home, and Weasel's duplicate was removed
+///     in weasel#284. Existing consumers should update their <c>using</c>
+///     statement from <c>Weasel.Core</c> to <c>JasperFx.Events.Daemon</c>.
+/// </summary>
 public class AdvisoryLock : IAdvisoryLock
 {
     private readonly Func<SqlConnection> _source;

--- a/src/Weasel.SqlServer/Weasel.SqlServer.csproj
+++ b/src/Weasel.SqlServer/Weasel.SqlServer.csproj
@@ -17,6 +17,10 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <!-- JasperFx.Events provides the canonical IAdvisoryLock contract (lifted
+             in jasperfx#316 / alpha.19, dedupe-aligned in weasel#284). AdvisoryLock
+             implements that interface directly. -->
+        <PackageReference Include="JasperFx.Events" />
         <PackageReference Include="Microsoft.Data.SqlClient" />
     </ItemGroup>
 


### PR DESCRIPTION
Closes #284.

## Summary

JasperFx.Events alpha.19 (jasperfx#316 / PR #319) lifted \`IAdvisoryLock\` into \`JasperFx.Events.Daemon\` as the canonical contract for the lifted \`*ProjectionDistributor\` concretes' \`lockFactory\` closures. Weasel had its own byte-identical \`Weasel.Core.IAdvisoryLock\` — a Critter-Stack-2026 dedupe target.

This PR takes [option 3 from the issue](https://github.com/JasperFx/weasel/issues/284#issue-options): **delete the Weasel.Core duplicate and route the two concretes (\`Weasel.Postgresql.AdvisoryLock\`, \`Weasel.SqlServer.AdvisoryLock\`) at the lifted JFx interface directly**. Only three internal references touched (the interface declaration + the two concretes); no broader cascade. Aligns with the JFx-owns-daemon-contracts pillar.

The PG and SS provider csprojs now reference \`JasperFx.Events\` explicitly (it wasn't transitive through \`Weasel.Core\` since \`JasperFx\` alone doesn't carry the daemon contracts).

## Behaviour

Interface shape unchanged (same three members: \`HasLock\` / \`TryAttainLockAsync\` / \`ReleaseLockAsync\`, with \`IAsyncDisposable\`). \`AdvisoryLock\` concrete constructors and runtime behaviour unchanged.

## Breaking change for external consumers

Source-breaking for code that names \`Weasel.Core.IAdvisoryLock\` by type. The 9.0 alpha line is the window for that. Migration guide updated:

\`\`\`csharp
// before
using Weasel.Core;
IAdvisoryLock lock = new Weasel.Postgresql.AdvisoryLock(...);

// after
using JasperFx.Events.Daemon;
IAdvisoryLock lock = new Weasel.Postgresql.AdvisoryLock(...);
\`\`\`

## Also bumps

- \`JasperFx\` 2.0.0-alpha.17 → **alpha.20**
- \`JasperFx.Events\` 2.0.0-alpha.16 → **alpha.19** (the version that ships the lifted \`IAdvisoryLock\`)
- Weasel package version 9.0.0-alpha.6 → **9.0.0-alpha.7**

## Test plan

- [x] Advisory-lock suites specifically: PG 5/5, SS 5/5 against PostgreSQL 16 + Azure SQL Edge containers
- [x] PG full suite: 655/658 (3 pre-existing concurrent-index skips)
- [x] SS full suite: 244/252 (8 pre-existing skips)
- [x] SQLite full suite: 361/361
- [x] Weasel.Core: 6/6
- [x] \`dotnet build Weasel.slnx\` — 0 errors

## Refs

- jasperfx#316 — original lift issue
- jasperfx#319 — landed the lifted interface
- polecat#119 — first downstream adopter, was blocked here

🤖 Generated with [Claude Code](https://claude.com/claude-code)