### PR TITLE
weasel#287: Lift Hi-Lo sequence contracts + arithmetic base + exception into Weasel.Core

### DIFF
--- a/src/Weasel.Core.Tests/Sequences/HiloSequenceBaseTests.cs
+++ b/src/Weasel.Core.Tests/Sequences/HiloSequenceBaseTests.cs
@@ -1,0 +1,137 @@
+using Shouldly;
+using Weasel.Core.Sequences;
+using Xunit;
+
+namespace Weasel.Core.Tests.Sequences;
+
+public class HiloSequenceBaseTests
+{
+    /// <summary>
+    ///     Test double that supplies the "database I/O" the abstract base leaves
+    ///     open. Each "advance to next hi" just bumps an in-memory hi counter,
+    ///     matching what a real dialect does after a successful fetch.
+    /// </summary>
+    private class FakeHiloSequence: HiloSequenceBase
+    {
+        private long _nextHi;
+
+        public FakeHiloSequence(string entityName, IReadOnlyHiloSettings settings)
+            : base(entityName, settings)
+        {
+        }
+
+        public int AdvanceCount { get; private set; }
+
+        // Expose the protected hi-setter so a test can drive the "database
+        // returned a negative value, could not secure the next hi" branch.
+        public bool TrySetCurrentHiForTest(object? raw) => TrySetCurrentHi(raw);
+
+        public override Task AdvanceToNextHi(CancellationToken ct = default)
+        {
+            DoAdvance();
+            return Task.CompletedTask;
+        }
+
+        protected override void AdvanceToNextHiSync() => DoAdvance();
+
+        public override Task SetFloor(long floor)
+        {
+            // Mirror the dialect contract: ensure the next issued id clears the floor.
+            var pages = (long)Math.Ceiling((double)floor / MaxLo);
+            _nextHi = pages;
+            DoAdvance();
+            return Task.CompletedTask;
+        }
+
+        private void DoAdvance()
+        {
+            AdvanceCount++;
+            TrySetCurrentHi(_nextHi);
+            _nextHi++;
+        }
+    }
+
+    private static FakeHiloSequence Sequence(int maxLo = 3)
+        => new("things", new HiloSettings { MaxLo = maxLo });
+
+    [Fact]
+    public void initial_state_requires_a_hi_advance()
+    {
+        var seq = Sequence();
+        seq.CurrentHi.ShouldBe(-1);
+        seq.CurrentLo.ShouldBe(1);
+        seq.ShouldAdvanceHi().ShouldBeTrue();
+    }
+
+    [Fact]
+    public void next_long_issues_a_contiguous_run_within_a_single_hi()
+    {
+        var seq = Sequence(maxLo: 3);
+
+        // hi 0 -> ids 1,2,3   (CurrentHi*MaxLo + CurrentLo, lo running 1..MaxLo)
+        seq.NextLong().ShouldBe(1);
+        seq.NextLong().ShouldBe(2);
+        seq.NextLong().ShouldBe(3);
+
+        // Only one database advance was needed for the whole lo range.
+        seq.AdvanceCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void next_long_advances_hi_when_lo_range_is_exhausted()
+    {
+        var seq = Sequence(maxLo: 3);
+
+        seq.NextLong().ShouldBe(1);
+        seq.NextLong().ShouldBe(2);
+        seq.NextLong().ShouldBe(3);
+
+        // hi advances to 1 -> next id is (1*3)+1 = 4
+        seq.NextLong().ShouldBe(4);
+        seq.AdvanceCount.ShouldBe(2);
+    }
+
+    [Fact]
+    public void next_int_is_a_narrowing_cast_of_next_long()
+    {
+        var seq = Sequence(maxLo: 1000);
+        seq.NextInt().ShouldBe(1);
+        seq.NextInt().ShouldBe(2);
+    }
+
+    [Fact]
+    public void try_set_current_hi_accepts_non_negative_and_resets_lo()
+    {
+        var seq = Sequence(maxLo: 3);
+        seq.NextLong(); // advance lo off its initial value
+
+        seq.TrySetCurrentHiForTest(7L).ShouldBeTrue();
+        seq.CurrentHi.ShouldBe(7);
+        seq.CurrentLo.ShouldBe(1); // reset on a successful hi fetch
+    }
+
+    [Fact]
+    public void try_set_current_hi_rejects_negative_without_resetting_lo()
+    {
+        var seq = Sequence(maxLo: 3);
+        seq.NextLong();
+        seq.NextLong();
+        var loBefore = seq.CurrentLo;
+
+        // A negative scalar means the dialect couldn't secure the next hi — the
+        // caller should retry, so lo must be left untouched.
+        seq.TrySetCurrentHiForTest(-1L).ShouldBeFalse();
+        seq.CurrentLo.ShouldBe(loBefore);
+    }
+
+    [Fact]
+    public async Task set_floor_pushes_ids_past_the_floor()
+    {
+        var seq = Sequence(maxLo: 10);
+
+        await seq.SetFloor(95);
+
+        // 95 / 10 -> 10 pages, so the next hi is 10 -> first id (10*10)+1 = 101 > 95.
+        seq.NextLong().ShouldBeGreaterThan(95);
+    }
+}

--- a/src/Weasel.Core/Sequences/HiloSequenceAdvanceToNextHiAttemptsExceededException.cs
+++ b/src/Weasel.Core/Sequences/HiloSequenceAdvanceToNextHiAttemptsExceededException.cs
@@ -1,0 +1,22 @@
+namespace Weasel.Core.Sequences;
+
+/// <summary>
+///     Thrown when a Hi-Lo sequence exhausts
+///     <see cref="IReadOnlyHiloSettings.MaxAdvanceToNextHiAttempts" /> tries to
+///     atomically secure the next "hi" allocation from the database (typically
+///     because of sustained write contention on the hilo row).
+///     <para>
+///     Lifted into Weasel.Core in weasel#287 — previously duplicated with the
+///     same message and parameterless constructor in both Marten
+///     (<c>Marten.Exceptions</c>) and Polecat (<c>Polecat.Exceptions</c>).
+///     </para>
+/// </summary>
+public class HiloSequenceAdvanceToNextHiAttemptsExceededException: Exception
+{
+    private const string message =
+        "Advance to next hilo sequence retry limit exceeded. Unable to secure next hi sequence";
+
+    public HiloSequenceAdvanceToNextHiAttemptsExceededException(): base(message)
+    {
+    }
+}

--- a/src/Weasel.Core/Sequences/HiloSequenceBase.cs
+++ b/src/Weasel.Core/Sequences/HiloSequenceBase.cs
@@ -1,0 +1,142 @@
+namespace Weasel.Core.Sequences;
+
+/// <summary>
+///     Dialect-agnostic core of a Hi-Lo <see cref="ISequence" />: owns the
+///     <see cref="CurrentHi" /> / <see cref="CurrentLo" /> / <see cref="MaxLo" />
+///     state and the client-side id arithmetic (<see cref="AdvanceValue" />,
+///     <see cref="ShouldAdvanceHi" />, <see cref="NextInt" /> / <see cref="NextLong" />,
+///     <see cref="TrySetCurrentHi" />). Concrete subclasses supply only the
+///     database I/O — fetching the next "hi" allocation
+///     (<see cref="AdvanceToNextHi" /> / <see cref="AdvanceToNextHiSync" />) and
+///     resetting the floor (<see cref="SetFloor" />).
+///     <para>
+///     Lifted into Weasel.Core in weasel#287. The arithmetic was line-for-line
+///     identical between Marten's <c>HiLoSequence</c> (PostgreSQL, via the
+///     <c>mt_get_next_hi</c> stored function) and Polecat's <c>HiloSequence</c>
+///     (SQL Server, via an optimistic UPDATE on <c>pc_hilo</c>); only the I/O
+///     was dialect-forked, which is exactly the seam left abstract here.
+///     </para>
+/// </summary>
+public abstract class HiloSequenceBase: ISequence
+{
+    // System.Threading.Lock (net9+) — guards the lo-allocation / hi-advance
+    // critical section in NextLong so concurrent id requests don't hand out
+    // duplicates or race the hi advance.
+    private readonly Lock _lock = new();
+
+    protected HiloSequenceBase(string entityName, IReadOnlyHiloSettings settings)
+    {
+        EntityName = entityName;
+        CurrentHi = -1;
+        CurrentLo = 1;
+        MaxLo = settings.MaxLo;
+        Settings = settings;
+    }
+
+    /// <summary>
+    ///     The logical entity / document name this sequence allocates ids for.
+    ///     Used as the key into the database hilo row.
+    /// </summary>
+    public string EntityName { get; }
+
+    /// <summary>
+    ///     The current "hi" allocation. <c>-1</c> until the first database fetch.
+    /// </summary>
+    public long CurrentHi { get; protected set; }
+
+    /// <summary>
+    ///     The next "lo" offset within the current hi allocation (1-based).
+    /// </summary>
+    public int CurrentLo { get; protected set; }
+
+    /// <inheritdoc />
+    public int MaxLo { get; }
+
+    /// <summary>
+    ///     The configuration this sequence was created with, including
+    ///     <see cref="IReadOnlyHiloSettings.MaxAdvanceToNextHiAttempts" /> which
+    ///     the dialect <see cref="AdvanceToNextHi" /> retry loop should honor.
+    /// </summary>
+    protected IReadOnlyHiloSettings Settings { get; }
+
+    /// <inheritdoc />
+    public int NextInt()
+    {
+        return (int)NextLong();
+    }
+
+    /// <inheritdoc />
+    public long NextLong()
+    {
+        lock (_lock)
+        {
+            if (ShouldAdvanceHi())
+            {
+                AdvanceToNextHiSync();
+            }
+
+            return AdvanceValue();
+        }
+    }
+
+    /// <summary>
+    ///     Compute the next id from the current hi/lo state and advance the lo
+    ///     offset. Pure arithmetic — no I/O.
+    /// </summary>
+    public long AdvanceValue()
+    {
+        var result = (CurrentHi * MaxLo) + CurrentLo;
+        CurrentLo++;
+
+        return result;
+    }
+
+    /// <summary>
+    ///     True when the current lo allocation is exhausted (or the sequence has
+    ///     never fetched a hi), meaning a database round trip is needed before the
+    ///     next id can be issued.
+    /// </summary>
+    public bool ShouldAdvanceHi()
+    {
+        return CurrentHi < 0 || CurrentLo > MaxLo;
+    }
+
+    /// <summary>
+    ///     Apply a freshly-fetched "hi" value (the raw scalar from the dialect's
+    ///     database call). The database is expected to return a negative value
+    ///     when it could not atomically secure the next hi; in that case this
+    ///     returns false and the caller should retry. On success the lo offset is
+    ///     reset to 1.
+    /// </summary>
+    protected bool TrySetCurrentHi(object? raw)
+    {
+        CurrentHi = Convert.ToInt64(raw);
+
+        if (0 <= CurrentHi)
+        {
+            CurrentLo = 1;
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    ///     Fetch the next "hi" allocation from the database asynchronously, looping
+    ///     up to <see cref="IReadOnlyHiloSettings.MaxAdvanceToNextHiAttempts" /> and
+    ///     throwing <see cref="HiloSequenceAdvanceToNextHiAttemptsExceededException" />
+    ///     if it can't be secured. Dialect-specific (PostgreSQL stored function vs
+    ///     SQL Server optimistic update).
+    /// </summary>
+    public abstract Task AdvanceToNextHi(CancellationToken ct = default);
+
+    /// <summary>
+    ///     Synchronous counterpart to <see cref="AdvanceToNextHi" />, invoked from
+    ///     <see cref="NextLong" /> under the lock when the current lo allocation is
+    ///     exhausted.
+    /// </summary>
+    protected abstract void AdvanceToNextHiSync();
+
+    /// <inheritdoc />
+    public abstract Task SetFloor(long floor);
+}

--- a/src/Weasel.Core/Sequences/HiloSettings.cs
+++ b/src/Weasel.Core/Sequences/HiloSettings.cs
@@ -1,0 +1,38 @@
+namespace Weasel.Core.Sequences;
+
+/// <summary>
+///     Read-only view of the configuration for a Hi-Lo <see cref="ISequence" />.
+///     Lifted into Weasel.Core in weasel#287 (byte-identical between Marten and
+///     Polecat).
+/// </summary>
+public interface IReadOnlyHiloSettings
+{
+    /// <summary>
+    ///     Size of each client-side "lo" allocation. Defaults to 1000.
+    /// </summary>
+    int MaxLo { get; }
+
+    /// <summary>
+    ///     Optional override of the database sequence/row name. When null the
+    ///     consuming store derives a name from the entity.
+    /// </summary>
+    string? SequenceName { get; }
+
+    /// <summary>
+    ///     How many times to retry the dialect's "advance to next hi" operation
+    ///     before giving up with
+    ///     <see cref="HiloSequenceAdvanceToNextHiAttemptsExceededException" />.
+    ///     Defaults to 30.
+    /// </summary>
+    int MaxAdvanceToNextHiAttempts { get; }
+}
+
+/// <summary>
+///     Mutable configuration for a Hi-Lo <see cref="ISequence" />.
+/// </summary>
+public class HiloSettings: IReadOnlyHiloSettings
+{
+    public int MaxLo { get; set; } = 1000;
+    public string? SequenceName { get; set; } = null;
+    public int MaxAdvanceToNextHiAttempts { get; set; } = 30;
+}

--- a/src/Weasel.Core/Sequences/ISequence.cs
+++ b/src/Weasel.Core/Sequences/ISequence.cs
@@ -1,0 +1,40 @@
+namespace Weasel.Core.Sequences;
+
+/// <summary>
+///     A Hi-Lo identity sequence: hands out monotonically increasing 64-bit ids
+///     in client-side batches ("lo" values) drawn from a database-backed "hi"
+///     allocation, so the database is only contacted once per <see cref="MaxLo" />
+///     ids.
+///     <para>
+///     Lifted into Weasel.Core in weasel#287 — the contract was byte-identical
+///     between Marten (<c>Marten.Schema.Identity.Sequences.ISequence</c>) and
+///     Polecat. Concrete dialect implementations derive from
+///     <see cref="HiloSequenceBase" /> and supply only the database I/O.
+///     </para>
+/// </summary>
+public interface ISequence
+{
+    /// <summary>
+    ///     Size of each client-side allocation ("lo" range) drawn from a single
+    ///     database "hi" fetch. Larger values mean fewer database round trips at
+    ///     the cost of larger id gaps if the process restarts mid-batch.
+    /// </summary>
+    int MaxLo { get; }
+
+    /// <summary>
+    ///     The next id as a 32-bit integer (a narrowing cast of <see cref="NextLong" />).
+    /// </summary>
+    int NextInt();
+
+    /// <summary>
+    ///     The next id as a 64-bit integer.
+    /// </summary>
+    long NextLong();
+
+    /// <summary>
+    ///     Advance the sequence so that subsequently-issued ids are guaranteed to
+    ///     be greater than <paramref name="floor" />. Used to reset a sequence past
+    ///     externally-seeded data.
+    /// </summary>
+    Task SetFloor(long floor);
+}


### PR DESCRIPTION
Part of the Critter Stack 2026 dedupe pillar ([JasperFx/jasperfx#214](https://github.com/JasperFx/jasperfx/issues/214)). Addresses #287.

## Summary

The Hi-Lo id-allocation contracts, the client-side arithmetic core, and the overflow exception were duplicated between Marten (`src/Marten/Schema/Identity/Sequences/*`) and Polecat (`src/Polecat/Schema/Identity/Sequences/*`) with only the database I/O dialect-forked. This lifts the dialect-agnostic parts into `Weasel.Core.Sequences` so both stores derive from one source.

## New surface in `Weasel.Core.Sequences`

| Type | Notes |
|---|---|
| `ISequence` | `MaxLo` / `NextInt` / `NextLong` / `SetFloor`. Byte-identical between Marten & Polecat. |
| `IReadOnlyHiloSettings` + `HiloSettings` | `MaxLo` (1000), `SequenceName`, `MaxAdvanceToNextHiAttempts` (30). |
| `HiloSequenceBase : ISequence` | Owns `CurrentHi`/`CurrentLo`/`MaxLo`/`EntityName` + the arithmetic that was line-for-line identical in both stores (`AdvanceValue`, `ShouldAdvanceHi`, `NextInt`/`NextLong` under `System.Threading.Lock`, `TrySetCurrentHi`). |
| `HiloSequenceAdvanceToNextHiAttemptsExceededException` | Same const message + parameterless ctor both stores duplicated. |

## The seam

`HiloSequenceBase` leaves abstract exactly the pieces that genuinely differ per dialect — matching the issue's prescribed boundary:

- `AdvanceToNextHi` / `AdvanceToNextHiSync` — PostgreSQL `mt_get_next_hi` stored function (single connection, all retries) vs SQL Server optimistic `UPDATE` on `pc_hilo` (resilience pipeline, per-attempt connection)
- `SetFloor` — dialect-specific UPDATE SQL

The retry loop + `MaxAdvanceToNextHiAttempts` throw lives in those overrides because the connection lifetime differs materially between the two stores; the base exposes `Settings` and the exception type for them to use.

## Notes

- The Marten exception extended `MartenException`; the lifted copy extends `System.Exception` with the **same message**. Dropped the obsolete `SerializationInfo` ctor for AOT-cleanliness.
- `Weasel.Core` is `IsAotCompatible=true`; these are pure arithmetic + interfaces, so the build and the `Weasel.Core.AotSmoke` gate stay clean.

## Test plan

- [x] `Weasel.Core.Tests/Sequences/HiloSequenceBaseTests.cs` — 7 tests locking the lifted arithmetic (contiguous lo runs, hi advance on lo exhaustion, `NextInt` narrowing, `TrySetCurrentHi` accept/reject + lo-reset, `SetFloor` floor-clearing). The "no behavior change in id allocation" guard for the Weasel side.
- [x] Weasel.Core full suite: 13/13 (net9.0 + net10.0)
- [x] Weasel.Core.AotSmoke builds clean (no new IL warnings)

## Downstream (separate repos, against this published surface)

- [ ] Marten `HiLoSequence` derives from `HiloSequenceBase`, consumes the lifted contracts + exception
- [ ] Polecat `HiloSequence` likewise
- [ ] `HiloSequenceAttribute` in each store follows / type-forwards as needed

## Refs

- JasperFx/jasperfx#214 (dedupe pillar) · JasperFx/jasperfx#217 (master)

🤖 Generated with [Claude Code](https://claude.com/claude-code)