### PR TITLE
weasel#286: Lift serialization option enums into Weasel.Core

### DIFF
--- a/src/Weasel.Core/Casing.cs
+++ b/src/Weasel.Core/Casing.cs
@@ -1,0 +1,32 @@
+namespace Weasel.Core;
+
+/// <summary>
+///     Governs the JSON serialization behavior of how .Net
+///     member names are persisted in the JSON stored in
+///     the database.
+///     <para>
+///     Lifted into Weasel.Core in weasel#286 — byte-identical between Marten
+///     (<c>Marten.Casing</c>) and Polecat (<c>Polecat.Serialization.Casing</c>),
+///     and a natural neighbour of the already-canonical
+///     <see cref="EnumStorage" /> that both stores' serializers consume.
+///     </para>
+/// </summary>
+public enum Casing
+{
+    /// <summary>
+    ///     Exactly mimic the .Net member names in the JSON persisted to the database
+    /// </summary>
+    Default,
+
+    /// <summary>
+    ///     Force the .Net member names to camel casing when serialized to JSON in
+    ///     the database
+    /// </summary>
+    CamelCase,
+
+    /// <summary>
+    ///     Force the .Net member names to snake casing when serialized to JSON in
+    ///     the database
+    /// </summary>
+    SnakeCase
+}

--- a/src/Weasel.Core/CollectionStorage.cs
+++ b/src/Weasel.Core/CollectionStorage.cs
@@ -1,0 +1,23 @@
+namespace Weasel.Core;
+
+/// <summary>
+///     Governs .Net collection serialization.
+///     <para>
+///     Lifted into Weasel.Core in weasel#286 — byte-identical between Marten
+///     (<c>Marten.CollectionStorage</c>) and Polecat
+///     (<c>Polecat.Serialization.CollectionStorage</c>).
+///     </para>
+/// </summary>
+public enum CollectionStorage
+{
+    /// <summary>
+    ///     Use default serialization for collections according to the serializer
+    ///     being used
+    /// </summary>
+    Default,
+
+    /// <summary>
+    ///     Direct the underlying serializer to serialize collections as JSON arrays
+    /// </summary>
+    AsArray
+}

--- a/src/Weasel.Core/NonPublicMembersStorage.cs
+++ b/src/Weasel.Core/NonPublicMembersStorage.cs
@@ -1,0 +1,22 @@
+namespace Weasel.Core;
+
+/// <summary>
+///     Governs which non-public .Net members the serializer is allowed to use
+///     when reading documents back from the database (non-public setters,
+///     constructors, etc.).
+///     <para>
+///     Lifted into Weasel.Core in weasel#286 — byte-identical (including the
+///     <see cref="All" /> flag composition) between Marten
+///     (<c>Marten.NonPublicMembersStorage</c>) and Polecat
+///     (<c>Polecat.Serialization.NonPublicMembersStorage</c>).
+///     </para>
+/// </summary>
+[Flags]
+public enum NonPublicMembersStorage
+{
+    Default = 0,
+    NonPublicSetters = 1,
+    NonPublicDefaultConstructor = 2,
+    NonPublicConstructor = 4,
+    All = Default | NonPublicSetters | NonPublicDefaultConstructor | NonPublicConstructor
+}


### PR DESCRIPTION
Part of the Critter Stack 2026 dedupe pillar ([JasperFx/jasperfx#214](https://github.com/JasperFx/jasperfx/issues/214)). Addresses #286.

## Summary

Three serialization-option enums were byte-for-byte identical between Marten and Polecat and belong beside the already-canonical `Weasel.Core.EnumStorage` that both stores' serializers already consume. This lifts them verbatim into `Weasel.Core`.

| Enum | Source | Values |
|---|---|---|
| `Casing` | `Marten.Casing` (`ISerializer.cs`) / `Polecat.Serialization.Casing` | `Default` / `CamelCase` / `SnakeCase` |
| `CollectionStorage` | same | `Default` / `AsArray` |
| `NonPublicMembersStorage` | same | `[Flags]`: `Default=0`, `NonPublicSetters=1`, `NonPublicDefaultConstructor=2`, `NonPublicConstructor=4`, `All = 0\|1\|2\|4` |

Lifted exactly, including the `[Flags] All` composition.

## Notes

- Lowest-risk item from the audit — pure public config enums, zero dialect content, no reflection. `Weasel.Core` stays `IsAotCompatible`-clean (verified against the `Weasel.Core.AotSmoke` gate; full solution builds with 0 errors).
- Marten keeps its PG-Linq-specific `ValueCasting` local (explicitly out of scope per the issue).

## Downstream (separate repos, against this published surface)

- [ ] Marten consumes `Weasel.Core.{Casing,CollectionStorage,NonPublicMembersStorage}`; old names (`Marten.Casing` etc.) type-forwarded so downstream config keeps compiling
- [ ] Polecat consumes them; drops any redefined `EnumStorage` in favour of Weasel.Core's

## Refs

- JasperFx/jasperfx#214 (dedupe pillar) · JasperFx/jasperfx#217 (master)

🤖 Generated with [Claude Code](https://claude.com/claude-code)