### PR TITLE
Release Weasel 9.0.0 (Critter Stack 2026)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>9.0.0-rc.1</Version>
+        <Version>9.0.0</Version>
         <LangVersion>13.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,8 +8,8 @@
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.12.19" />
     <PackageVersion Include="DistributedLock.Postgres" Version="1.3.0" />
     <PackageVersion Include="DotNet.ReproducibleBuilds" Version="1.2.39" />
-    <PackageVersion Include="JasperFx" Version="2.0.0-alpha.20" />
-    <PackageVersion Include="JasperFx.Events" Version="2.0.0-alpha.19" />
+    <PackageVersion Include="JasperFx" Version="2.0.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.0.0" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="9.0.1" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />
     <!-- EF Core versions are framework-conditional - see below -->


### PR DESCRIPTION
Foundation upgrade + version bump rc.1 → final for the Weasel 9.0 release.

| Change | From | To |
|---|---|---|
| `JasperFx` | 2.0.0-alpha.20 | **2.0.0** |
| `JasperFx.Events` | 2.0.0-alpha.19 | **2.0.0** |
| Weasel.* (Core/Postgresql/SqlServer/Sqlite/MySql/Oracle/EFCore) | 9.0.0-rc.1 | **9.0.0** |

JasperFx 2.0.0 is published to nuget.org. Weasel builds clean against it (0 errors). Master plan #263 closed.

After merge: tag `9.0.0`, GitHub release, then trigger NuGet publish + docs deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)