### PR TITLE
Retry transient catalog-concurrency errors in PostgreSQL migration DDL (closes #293)

### DIFF
--- a/src/Weasel.Postgresql.Tests/PostgresqlMigratorConcurrencyRetryTests.cs
+++ b/src/Weasel.Postgresql.Tests/PostgresqlMigratorConcurrencyRetryTests.cs
@@ -1,0 +1,80 @@
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Xunit;
+
+namespace Weasel.Postgresql.Tests;
+
+/// <summary>
+///     Unit coverage for the transient-catalog-concurrency predicate that drives
+///     the bounded retry in <see cref="PostgresqlMigrator" />.executeDelta
+///     (weasel#293, follow-up to #282). The retry itself races on the catalog and
+///     can't be exercised deterministically, but the classification of which
+///     SQLSTATEs are retry-safe is a pure function and is fully testable here.
+/// </summary>
+public class PostgresqlMigratorConcurrencyRetryTests
+{
+    [Fact]
+    public void serialization_failure_is_transient()
+    {
+        PostgresqlMigrator.IsTransientCatalogConcurrency(PostgresErrorCodes.SerializationFailure, "could not serialize access")
+            .ShouldBeTrue();
+    }
+
+    [Fact]
+    public void deadlock_detected_is_transient()
+    {
+        PostgresqlMigrator.IsTransientCatalogConcurrency(PostgresErrorCodes.DeadlockDetected, "deadlock detected")
+            .ShouldBeTrue();
+    }
+
+    [Fact]
+    public void internal_error_with_tuple_concurrently_updated_is_transient()
+    {
+        PostgresqlMigrator.IsTransientCatalogConcurrency(PostgresErrorCodes.InternalError, "tuple concurrently updated")
+            .ShouldBeTrue();
+    }
+
+    [Fact]
+    public void internal_error_matches_message_case_insensitively()
+    {
+        PostgresqlMigrator.IsTransientCatalogConcurrency(PostgresErrorCodes.InternalError, "Tuple Concurrently Updated")
+            .ShouldBeTrue();
+    }
+
+    [Fact]
+    public void internal_error_can_appear_inside_a_larger_message()
+    {
+        PostgresqlMigrator
+            .IsTransientCatalogConcurrency(PostgresErrorCodes.InternalError,
+                "XX000: tuple concurrently updated while creating function")
+            .ShouldBeTrue();
+    }
+
+    [Fact]
+    public void internal_error_with_an_unrelated_message_is_not_transient()
+    {
+        // XX000 is a catch-all internal_error — we must not blanket-retry it.
+        PostgresqlMigrator.IsTransientCatalogConcurrency(PostgresErrorCodes.InternalError, "some other internal error")
+            .ShouldBeFalse();
+    }
+
+    [Fact]
+    public void internal_error_with_null_message_is_not_transient()
+    {
+        PostgresqlMigrator.IsTransientCatalogConcurrency(PostgresErrorCodes.InternalError, null)
+            .ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData("42P06")] // duplicate_schema — handled by the #282 DO-block, not here
+    [InlineData("23505")] // unique_violation — ditto
+    [InlineData("42P01")] // undefined_table
+    [InlineData("23503")] // foreign_key_violation
+    [InlineData(null)]
+    public void unrelated_sqlstates_are_not_transient(string? sqlState)
+    {
+        PostgresqlMigrator.IsTransientCatalogConcurrency(sqlState, "tuple concurrently updated")
+            .ShouldBeFalse();
+    }
+}

--- a/src/Weasel.Postgresql/PostgresqlMigrator.cs
+++ b/src/Weasel.Postgresql/PostgresqlMigrator.cs
@@ -140,8 +140,7 @@ $$;
 
             try
             {
-                await cmd
-                    .ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+                await executeWithConcurrencyRetryAsync(cmd, ct).ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -153,6 +152,71 @@ $$;
                 logger.OnFailure(cmd, e);
             }
         }
+    }
+
+    /// <summary>
+    ///     Maximum number of attempts (including the first) for a single migration
+    ///     statement that fails with a transient catalog-concurrency error. The
+    ///     migration DDL Weasel emits is idempotent (<c>IF NOT EXISTS</c> /
+    ///     <c>CREATE OR REPLACE</c>) and each statement auto-commits independently,
+    ///     so re-running a statement that lost a catalog race is safe.
+    /// </summary>
+    private const int MaxConcurrencyRetries = 3;
+
+    /// <summary>
+    ///     Execute a single migration statement, retrying a bounded number of times
+    ///     on the transient PostgreSQL catalog-concurrency errors that surface when
+    ///     two sessions lazily ensure storage against the same database at once
+    ///     (weasel#293, follow-up to #282). A jittered backoff keeps two racers from
+    ///     retrying in lockstep.
+    /// </summary>
+    private static async Task executeWithConcurrencyRetryAsync(DbCommand cmd, CancellationToken ct)
+    {
+        for (var attempt = 1; ; attempt++)
+        {
+            try
+            {
+                await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+                return;
+            }
+            catch (PostgresException e)
+                when (attempt < MaxConcurrencyRetries && IsTransientCatalogConcurrency(e.SqlState, e.MessageText))
+            {
+                var delayMs = (50 * attempt) + Random.Shared.Next(0, 50);
+                await Task.Delay(delayMs, ct).ConfigureAwait(false);
+            }
+        }
+    }
+
+    /// <summary>
+    ///     True for the PostgreSQL SQLSTATEs that signal a transient, retry-safe
+    ///     concurrency conflict while applying idempotent migration DDL:
+    ///     <list type="bullet">
+    ///         <item><c>40001</c> serialization_failure</item>
+    ///         <item><c>40P01</c> deadlock_detected</item>
+    ///         <item>
+    ///             <c>XX000</c> internal_error <b>only</b> when the message is
+    ///             "tuple concurrently updated" — two backends updated the same
+    ///             system-catalog row (e.g. <c>pg_proc</c> under concurrent
+    ///             <c>CREATE OR REPLACE FUNCTION</c>). <c>XX000</c> is a catch-all,
+    ///             so the message guard prevents blanket-retrying unrelated
+    ///             internal errors.
+    ///         </item>
+    ///     </list>
+    ///     Pure over the two string inputs so it is unit-testable without
+    ///     constructing a <see cref="PostgresException" />.
+    /// </summary>
+    internal static bool IsTransientCatalogConcurrency(string? sqlState, string? messageText)
+    {
+        return sqlState switch
+        {
+            PostgresErrorCodes.SerializationFailure => true,
+            PostgresErrorCodes.DeadlockDetected => true,
+            PostgresErrorCodes.InternalError =>
+                messageText is not null
+                && messageText.Contains("tuple concurrently updated", StringComparison.OrdinalIgnoreCase),
+            _ => false
+        };
     }
 
     public override string ToExecuteScriptLine(string scriptName)


### PR DESCRIPTION
Closes #293. Follow-up to #282.

## Problem

#282 (`6b6d296`) made only `CREATE SCHEMA` concurrent-safe — a plpgsql sub-block catching `42P06`/`23505`. The rest of the migration DDL emitted by `migration.WriteAllUpdates(...)` (`CREATE OR REPLACE FUNCTION mt_immutable_*`, `CREATE TABLE IF NOT EXISTS`, …) stayed unguarded. When two sessions lazily `EnsureStorageExists` against the same database, the shared catalog DDL races and one backend gets:

```
Npgsql.PostgresException : XX000: tuple concurrently updated
```

That SQLSTATE isn't caught by #282, so it propagates. Surfaced as a Marten conjoined multi-tenant CI flake (`query_before_saving`, downstream JasperFx/marten#4552).

## Why retry is the right fix

Two properties of `PostgresqlMigrator.executeDelta` make a bounded retry both safe and minimal:

1. **The DDL is idempotent** — `IF NOT EXISTS` / `CREATE OR REPLACE` throughout.
2. **Each statement auto-commits independently** — `executeDelta` never sets `cmd.Transaction`, so a failed statement rolls back fully and a retry re-runs from a clean slate. (`CREATE INDEX CONCURRENTLY` is already split into its own chunk, so the main body is a transaction-safe block.)

A wider DO-block guard doesn't generalize — the post-schema DDL isn't in one catchable block, and `CONCURRENTLY` can't be. Retry is the issue's recommended option and the general fix.

## Change

Wrap each `cmd.ExecuteNonQueryAsync` in a bounded retry (3 attempts, jittered sub-100ms backoff), inside the existing try/catch so the established `logger.OnFailure` / rethrow path is untouched after exhaustion. Retry only on the transient, retry-safe SQLSTATEs:

| SQLSTATE | Meaning | Match |
|---|---|---|
| `40001` | serialization_failure | by code |
| `40P01` | deadlock_detected | by code |
| `XX000` | internal_error | **only** when message is `tuple concurrently updated` (XX000 is a catch-all) |

Kept PG-specific (these codes are PostgreSQL's; `executeDelta` is a per-provider override). The classification is a pure internal predicate `IsTransientCatalogConcurrency(sqlState, messageText)`.

## Test plan

- [x] `PostgresqlMigratorConcurrencyRetryTests` — 12 assertions on the predicate: 40001/40P01 by code; XX000 matches on message (case-insensitive, substring), rejects unrelated XX000 messages + null; unrelated SQLSTATEs (incl. the #282-handled 42P06/23505) not retried. The catalog race itself isn't deterministically testable, so the classification is what's covered.
- [x] Happy-path integration unchanged: migration-scenario / schema-creation / `DatabaseWithTables` / Bug983 suites 21/22 (1 pre-existing skip) against PostgreSQL.

Downstream JasperFx/marten#4552 stabilizes once Marten consumes a Weasel build with this (an rc.2 candidate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)