### PR TITLE
Upgrade JasperFx 2.0.0 → 2.0.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,7 @@
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.12.19" />
     <PackageVersion Include="DistributedLock.Postgres" Version="1.3.0" />
     <PackageVersion Include="DotNet.ReproducibleBuilds" Version="1.2.39" />
-    <PackageVersion Include="JasperFx" Version="2.0.0" />
+    <PackageVersion Include="JasperFx" Version="2.0.1" />
     <PackageVersion Include="JasperFx.Events" Version="2.0.0" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="9.0.1" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />


### PR DESCRIPTION
Patch bump of the `JasperFx` dependency, `2.0.0` → `2.0.1`.

`JasperFx.Events` stays at `2.0.0` — there is no `2.0.1` published (the next `JasperFx.Events` is the `2.1.0` minor, out of scope here). Events `2.0.0` and JasperFx `2.0.1` coexist with no downgrade / NU1605 conflict.

## Test plan
- [x] `dotnet build Weasel.slnx` — 0 errors
- [x] Weasel.Core: 13/13
- [x] AOT smoke gate (`Weasel.Core.AotSmoke`): green
- [x] PostgreSQL migration / table-creation suites: 20/21 (1 pre-existing skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)