### PR TITLE
Fix non-idempotent migration for a managed list partition whose suffix is "default"

### DIFF
--- a/src/Weasel.Postgresql.Tests/Tables/partitioning/managed_list_partitions.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/partitioning/managed_list_partitions.cs
@@ -66,6 +66,35 @@ public class managed_list_partitions : IntegrationContext
     }
 
     [Fact]
+    public async Task managed_partition_with_default_suffix_is_idempotent()
+    {
+        // Mirrors a managed partition whose suffix is "default" — e.g. Marten's *DEFAULT* tenant,
+        // registered as partition value "*DEFAULT*" with table suffix "default". Its partition table
+        // is named "<table>_default", which collided with the conventional PostgreSQL DEFAULT-partition
+        // name. The diff then perpetually reported it missing and re-issued CREATE TABLE ..._default,
+        // failing the SECOND migration with 42P07 "relation already exists". A regular value partition
+        // must be recognized by its bound expression, not its name.
+        var database = new ManagedListDatabase();
+        var partitions = new Dictionary<string, string> { { "tenant1", "tenant1" }, { "*DEFAULT*", "default" } };
+        await database.Partitions.ResetValues(database, partitions, CancellationToken.None);
+
+        await database.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        // The "<table>_default" partition is a value partition (FOR VALUES IN ('*DEFAULT*')), not the
+        // PostgreSQL DEFAULT partition.
+        var tables = await database.FetchExistingTablesAsync();
+        var teams = tables.Single(x => x.Identifier.Name == "teams");
+        var partitioning = teams.Partitioning.ShouldBeOfType<ListPartitioning>();
+        partitioning.HasExistingDefault.ShouldBeFalse();
+        partitioning.Partitions.Select(x => x.Suffix).OrderBy(x => x)
+            .ShouldBe(new []{"default", "tenant1"});
+
+        // No pending delta, and a second migration must NOT throw 42P07.
+        await database.AssertDatabaseMatchesConfigurationAsync();
+        await database.ApplyAllConfiguredChangesToDatabaseAsync();
+    }
+
+    [Fact]
     public async Task migrate_tables_smoke_test_with_variable_value_and_tenant_id()
     {
         var database = new ManagedListDatabase();

--- a/src/Weasel.Postgresql/Tables/Partitioning/ListPartitioning.cs
+++ b/src/Weasel.Postgresql/Tables/Partitioning/ListPartitioning.cs
@@ -117,13 +117,20 @@ public class ListPartitioning: IPartitionStrategy
 
     public async Task ReadPartitionsAsync(DbObjectName identifier, DbDataReader reader, CancellationToken ct)
     {
-        var expectedDefaultName = identifier.Name + "_default";
         while (await reader.ReadAsync(ct).ConfigureAwait(false))
         {
             var partitionName = await reader.GetFieldValueAsync<string>(0, ct).ConfigureAwait(false);
             var expression = await reader.GetFieldValueAsync<string>(1, ct).ConfigureAwait(false);
 
-            if (partitionName == expectedDefaultName)
+            // Classify by the partition's bound EXPRESSION, not its table name. PostgreSQL reports
+            // pg_get_expr(relpartbound, ...) == "DEFAULT" for the default partition. A regular value
+            // partition that merely happens to be named "<table>_default" — e.g. a managed list
+            // partition whose suffix is "default", such as Marten's *DEFAULT* tenant — reports
+            // "FOR VALUES IN (...)" and must be parsed as a normal partition. Classifying by name
+            // mistook it for the default partition and dropped it from the actual set, so CreateDelta
+            // perpetually reported it as missing and re-issued CREATE TABLE ..._default, failing the
+            // next migration with 42P07 "relation already exists".
+            if (expression.Trim() == "DEFAULT")
             {
                 HasExistingDefault = true;
             }


### PR DESCRIPTION
## Problem

`ListPartitioning.ReadPartitionsAsync` classified an existing partition as *the* PostgreSQL DEFAULT partition purely by **table name** (`<table>_default`):

```csharp
var expectedDefaultName = identifier.Name + "_default";
...
if (partitionName == expectedDefaultName) { HasExistingDefault = true; }   // <-- name-based
else { _partitions.Add(ListPartition.Parse(...)); }
```

A **managed list partition whose suffix is `"default"`** produces a table named `<table>_default` but is a regular value partition (`FOR VALUES IN (...)`), not the PG `DEFAULT` partition. This is exactly what Marten's per-tenant event partitioning does for the `*DEFAULT*` tenant (partition value `*DEFAULT*`, table suffix `default`).

Because the read classified `<table>_default` as the default partition, it dropped that partition from the actual set. `CreateDelta` then compared:
- expected (from `ManagedListPartitions.Partitions()`): includes the `default`-suffixed partition
- actual: excludes it (hidden behind `HasExistingDefault`)

→ it was perpetually reported as **missing** → re-issued `CREATE TABLE <table>_default …` → the **second** migration against the same schema throws `42P07: relation "<table>_default" already exists`.

This breaks any **clustered** deployment (each node runs resource setup) of a Marten store using `Events.UseTenantPartitionedEvents` together with any `MultiTenanted` document/projection — see JasperFx/wolverine#3037, where it surfaced.

## Fix

Classify by the partition's **bound expression**, not its name. `pg_get_expr(relpartbound, …)` (already selected in `Table.FetchExisting`) returns `"DEFAULT"` only for the real default partition; value partitions return `"FOR VALUES IN (…)"` and are parsed normally. `HasExistingDefault` is only ever set, never read by migration logic, so this is safe.

## Test

`managed_partition_with_default_suffix_is_idempotent` — a `ManagedListDatabase` with a `"default"`-suffixed partition now applies idempotently: `AssertDatabaseMatchesConfigurationAsync()` passes and a second `ApplyAllConfiguredChangesToDatabaseAsync()` no longer throws. Verified it **fails** with `42P07 "relation teams_default already exists"` without the fix. Full partitioning suite (57) + table-reading suite (10) green.

> Note: `RangePartitioning.ReadPartitionsAsync` has the same name-based default classification and likely the same latent issue, but list partitioning is what the Marten tenant case exercises — left out of this minimal fix.