### PR TITLE
Fix managed LIST partitions destructively rebuilt under multi-database apply (marten#4706)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>9.1.1</Version>
+        <Version>9.1.2</Version>
         <LangVersion>13.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>9.1.0</Version>
+        <Version>9.1.1</Version>
         <LangVersion>13.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/src/Weasel.Postgresql.Tests/Tables/partitioning/managed_list_partitions.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/partitioning/managed_list_partitions.cs
@@ -233,6 +233,66 @@ public class managed_list_partitions : IntegrationContext
         partitioning.Partitions.Select(x => x.Suffix).OrderBy(x => x)
             .ShouldBe(new []{"blue", "green", "purple", "red"});
     }
+
+    [Fact]
+    public async Task ignore_partitions_in_migration_no_destructive_rebuild_over_existing_partitions()
+    {
+        // JasperFx/marten#4706: a managed-partition table marked IgnorePartitionsInMigration must NOT be
+        // destructively rebuilt by the generic schema diff when it already has its managed partitions.
+        await dropManagedListsSchema();
+        var database = new ManagedListDatabase(ignorePartitionsInMigration: true);
+        var partitions = new Dictionary<string, string> { { "red", "red" }, { "green", "green" }, { "blue", "blue" }, };
+        await database.Partitions.ResetValues(database, partitions, CancellationToken.None);
+
+        await database.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        // Re-applying over the existing partitions is a no-op — no pending change, no rebuild.
+        var migration = await database.CreateMigrationAsync();
+        migration.Difference.ShouldBe(SchemaPatchDifference.None);
+
+        // And a second apply must not throw (pre-fix this rebuilt the table — CREATE _temp / copy).
+        await database.AssertDatabaseMatchesConfigurationAsync();
+        await database.ApplyAllConfiguredChangesToDatabaseAsync();
+    }
+
+    [Fact]
+    public async Task additive_partition_add_still_works_when_partitions_are_ignored_in_migration()
+    {
+        // The companion to the rebuild guard: the explicit AddPartitionToAllTables path must still
+        // create partitions even though the tables set IgnorePartitionsInMigration for the generic diff
+        // (the additive path clears the flag locally to compute the missing partitions to add).
+        await dropManagedListsSchema();
+        var database = new ManagedListDatabase(ignorePartitionsInMigration: true);
+        var partitions = new Dictionary<string, string> { { "red", "red" }, { "green", "green" }, };
+        await database.Partitions.ResetValues(database, partitions, CancellationToken.None);
+        await database.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        // Unique suffix so the assertion is independent of any partitions left by sibling tests.
+        var suffix = "added_" + Guid.NewGuid().ToString("N")[..8];
+        await database.Partitions.AddPartitionToAllTables(database, suffix, suffix, CancellationToken.None);
+
+        // The child partition for the new value must physically exist on both managed tables.
+        (await partitionExists("teams", suffix)).ShouldBeTrue($"teams_{suffix} partition should have been created");
+        (await partitionExists("players", suffix)).ShouldBeTrue($"players_{suffix} partition should have been created");
+    }
+
+    private static async Task dropManagedListsSchema()
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await conn.DropSchemaAsync("managed_lists");
+    }
+
+    private static async Task<bool> partitionExists(string parent, string suffix)
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        var count = (long)(await conn.CreateCommand(
+                "select count(*) from pg_class c join pg_namespace n on n.oid = c.relnamespace where n.nspname = 'managed_lists' and c.relname = :name")
+            .With("name", $"{parent}_{suffix}")
+            .ExecuteScalarAsync())!;
+        return count > 0;
+    }
 }
 
 public class ManagedListDatabase: PostgresqlDatabase
@@ -242,9 +302,9 @@ public class ManagedListDatabase: PostgresqlDatabase
 
     private readonly People _feature;
 
-    public ManagedListDatabase() : base(new DefaultMigrationLogger(), JasperFx.AutoCreate.CreateOrUpdate, new PostgresqlMigrator(), "Partitions", NpgsqlDataSource.Create(ConnectionSource.ConnectionString))
+    public ManagedListDatabase(bool ignorePartitionsInMigration = false) : base(new DefaultMigrationLogger(), JasperFx.AutoCreate.CreateOrUpdate, new PostgresqlMigrator(), "Partitions", NpgsqlDataSource.Create(ConnectionSource.ConnectionString))
     {
-        _feature = new People(Partitions);
+        _feature = new People(Partitions, ignorePartitionsInMigration);
     }
 
     public override IFeatureSchema[] BuildFeatureSchemas()
@@ -260,7 +320,7 @@ public class People: FeatureSchemaBase
     private readonly Table _teams;
     private readonly Table _players;
 
-    public People(ManagedListPartitions partitions) : base("People", new PostgresqlMigrator())
+    public People(ManagedListPartitions partitions, bool ignorePartitionsInMigration = false) : base("People", new PostgresqlMigrator())
     {
         _teams = new Table(new DbObjectName("managed_lists", "teams"));
         _teams.AddColumn<string>("name").AsPrimaryKey();
@@ -278,6 +338,10 @@ public class People: FeatureSchemaBase
             .PartitionByList("color")
             .UsePartitionManager(partitions);
 
+        // #4706: tables whose managed partitions are reconciled out-of-band exempt the generic schema
+        // diff from rebuilding them over their externally-added partitions.
+        _teams.IgnorePartitionsInMigration = ignorePartitionsInMigration;
+        _players.IgnorePartitionsInMigration = ignorePartitionsInMigration;
     }
 
     protected override IEnumerable<ISchemaObject> schemaObjects()

--- a/src/Weasel.Postgresql/Tables/Partitioning/ManagedListPartitions.cs
+++ b/src/Weasel.Postgresql/Tables/Partitioning/ManagedListPartitions.cs
@@ -26,16 +26,7 @@ public class ManagedListPartitions : FeatureSchemaBase, IDatabaseInitializer<Npg
 {
     private readonly Table _table;
     private Dictionary<string, string> _partitions = new();
-    // Identity of the database this manager last loaded its partition set from. A single manager
-    // instance is shared across every database in the store; under sharded multi-tenancy that means
-    // several physical databases, each with its OWN mt_tenant_partitions contents. Keying the
-    // "already loaded" state on the database (rather than a one-shot bool) makes InitializeAsync
-    // reload when it is pointed at a different database, so the partition set reflects the database
-    // actually being migrated. Without this the manager kept the first database's partitions and
-    // every other database's table diff falsely reported the existing partitions as "unexpected" ->
-    // destructive table rebuild (JasperFx/marten#4706). Single-database stores still load exactly
-    // once (the key never changes).
-    private string? _initializedFor;
+    private bool _hasInitialized;
     private readonly SemaphoreSlim _semaphoreSlim = new(1);
 
     public ManagedListPartitions(string identifier, DbObjectName tableName): base(identifier, new PostgresqlMigrator())
@@ -301,7 +292,7 @@ public class ManagedListPartitions : FeatureSchemaBase, IDatabaseInitializer<Npg
 
     public void ForceReload()
     {
-        _initializedFor = null;
+        _hasInitialized = false;
     }
 
     public async Task InitializeAsync(PostgresqlDatabase database, CancellationToken token)
@@ -316,14 +307,11 @@ public class ManagedListPartitions : FeatureSchemaBase, IDatabaseInitializer<Npg
 
     public async Task InitializeAsync(NpgsqlConnection conn, CancellationToken token)
     {
-        // Reload whenever this manager is pointed at a different database than it last loaded from
-        // (see _initializedFor). Same database => cached, no reload.
-        var key = $"{conn.DataSource}/{conn.Database}";
-        if (_initializedFor == key) return;
+        if (_hasInitialized) return;
         await _semaphoreSlim.WaitAsync(token).ConfigureAwait(false);
         try
         {
-            if (_initializedFor == key) return;
+            if (_hasInitialized) return;
 
             _partitions.Clear();
             await using var reader = await conn
@@ -343,14 +331,14 @@ public class ManagedListPartitions : FeatureSchemaBase, IDatabaseInitializer<Npg
                 _partitions[value] = suffix;
             }
 
-            _initializedFor = key;
+            _hasInitialized = true;
         }
         // 42P01: relation "public.mt_tenant_partitions" does not exist
         catch (NpgsqlException e)
         {
             if (e.SqlState == PostgresErrorCodes.UndefinedTable)
             {
-                _initializedFor = key;
+                _hasInitialized = true;
                 return;
             }
 

--- a/src/Weasel.Postgresql/Tables/Partitioning/ManagedListPartitions.cs
+++ b/src/Weasel.Postgresql/Tables/Partitioning/ManagedListPartitions.cs
@@ -26,7 +26,16 @@ public class ManagedListPartitions : FeatureSchemaBase, IDatabaseInitializer<Npg
 {
     private readonly Table _table;
     private Dictionary<string, string> _partitions = new();
-    private bool _hasInitialized;
+    // Identity of the database this manager last loaded its partition set from. A single manager
+    // instance is shared across every database in the store; under sharded multi-tenancy that means
+    // several physical databases, each with its OWN mt_tenant_partitions contents. Keying the
+    // "already loaded" state on the database (rather than a one-shot bool) makes InitializeAsync
+    // reload when it is pointed at a different database, so the partition set reflects the database
+    // actually being migrated. Without this the manager kept the first database's partitions and
+    // every other database's table diff falsely reported the existing partitions as "unexpected" ->
+    // destructive table rebuild (JasperFx/marten#4706). Single-database stores still load exactly
+    // once (the key never changes).
+    private string? _initializedFor;
     private readonly SemaphoreSlim _semaphoreSlim = new(1);
 
     public ManagedListPartitions(string identifier, DbObjectName tableName): base(identifier, new PostgresqlMigrator())
@@ -233,6 +242,13 @@ public class ManagedListPartitions : FeatureSchemaBase, IDatabaseInitializer<Npg
 
         foreach (var table in tables)
         {
+            // This is the explicit, out-of-band partition-management path (AddPartitionToAllTables).
+            // Managed-partition tables set IgnorePartitionsInMigration so the GENERIC schema diff leaves
+            // their partitions alone (JasperFx/marten#4706); here we are deliberately reconciling them,
+            // so clear the flag locally (these table objects are freshly built from AllObjects()) to let
+            // the delta compute the missing partitions to add.
+            table.IgnorePartitionsInMigration = false;
+
             var existing = await table.FetchExistingAsync(conn, token).ConfigureAwait(false);
             var delta = new TableDelta(table, existing);
             if (delta.PartitionDelta == PartitionDelta.Additive)
@@ -285,7 +301,7 @@ public class ManagedListPartitions : FeatureSchemaBase, IDatabaseInitializer<Npg
 
     public void ForceReload()
     {
-        _hasInitialized = true;
+        _initializedFor = null;
     }
 
     public async Task InitializeAsync(PostgresqlDatabase database, CancellationToken token)
@@ -300,11 +316,14 @@ public class ManagedListPartitions : FeatureSchemaBase, IDatabaseInitializer<Npg
 
     public async Task InitializeAsync(NpgsqlConnection conn, CancellationToken token)
     {
-        if (_hasInitialized) return;
+        // Reload whenever this manager is pointed at a different database than it last loaded from
+        // (see _initializedFor). Same database => cached, no reload.
+        var key = $"{conn.DataSource}/{conn.Database}";
+        if (_initializedFor == key) return;
         await _semaphoreSlim.WaitAsync(token).ConfigureAwait(false);
         try
         {
-            if (_hasInitialized) return;
+            if (_initializedFor == key) return;
 
             _partitions.Clear();
             await using var reader = await conn
@@ -324,14 +343,14 @@ public class ManagedListPartitions : FeatureSchemaBase, IDatabaseInitializer<Npg
                 _partitions[value] = suffix;
             }
 
-            _hasInitialized = true;
+            _initializedFor = key;
         }
         // 42P01: relation "public.mt_tenant_partitions" does not exist
         catch (NpgsqlException e)
         {
             if (e.SqlState == PostgresErrorCodes.UndefinedTable)
             {
-                _hasInitialized = true;
+                _initializedFor = key;
                 return;
             }
 


### PR DESCRIPTION
Fixes the Weasel side of [JasperFx/marten#4706](https://github.com/JasperFx/marten/issues/4706). Bumps to **9.1.1**.

## Problem
A single `ManagedListPartitions` instance is shared across every database in a store. Under sharded multi-tenancy each database has its own `mt_tenant_partitions` contents, and Marten's `ApplyAllConfiguredChangesToDatabaseAsync` runs the databases in **parallel**. The manager's one-shot `_hasInitialized` cache therefore held the *first* database's partition set, so every other database's table diff saw the existing per-tenant partitions as "unexpected" and **destructively rebuilt** the table (`create <t>_temp as select *` → drop → recreate → copy), failing with `23514: no partition of relation found for row`.

## Fix
- **Per-database load cache.** Replace the one-shot `_hasInitialized` bool with `_initializedFor`, keyed on the connection's `DataSource`/`Database`, so `InitializeAsync` reloads when pointed at a different database. Single-database stores still load exactly once. `ForceReload()` now clears the key.
- **Additive bypass.** `additivelyMigrateTablesForNewPartitions` clears `IgnorePartitionsInMigration` locally so the explicit `AddPartitionToAllTables` path still creates partitions even when a consumer (Marten) sets that flag on managed-partition tables to exempt them from the generic schema diff.

This is the Weasel half; the Marten side (marten#4706) sets `IgnorePartitionsInMigration` on its Marten-managed partitioned tables so the generic diff returns `None` for them (no rebuild), while partition creation continues through the additive path enabled here.

## Tests
`managed_list_partitions` gains:
- a **rebuild guard** — a managed table with `IgnorePartitionsInMigration` set is not destructively rebuilt by the generic diff over its existing partitions (`CreateMigrationAsync` → `None`);
- an **additive-bypass guard** — `AddPartitionToAllTables` still physically creates the child partition with the flag set.

Full partition + migration suite green (111).

🤖 Generated with [Claude Code](https://claude.com/claude-code)