### PR TITLE
Fix marten#4713 — additive partition provisioning must restore IgnorePartitionsInMigration (9.1.4)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>9.1.3</Version>
+        <Version>9.1.4</Version>
         <LangVersion>13.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/src/Weasel.Postgresql.Tests/Tables/partitioning/managed_list_partitions.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/partitioning/managed_list_partitions.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Microsoft.Extensions.Logging.Abstractions;
 using Npgsql;
 using Weasel.Core;
@@ -274,6 +275,41 @@ public class managed_list_partitions : IntegrationContext
         // The child partition for the new value must physically exist on both managed tables.
         (await partitionExists("teams", suffix)).ShouldBeTrue($"teams_{suffix} partition should have been created");
         (await partitionExists("players", suffix)).ShouldBeTrue($"players_{suffix} partition should have been created");
+    }
+
+    [Fact]
+    public async Task additive_partition_provisioning_restores_ignore_partitions_flag()
+    {
+        // JasperFx/marten#4713: AddPartitionToAllTables temporarily clears IgnorePartitionsInMigration
+        // to reconcile the managed partitions, but it MUST restore it afterward. These Table objects are
+        // reused across schema applies — in a Marten consumer they are per-mapping singletons shared
+        // across every shard database. Leaving the flag cleared defeats the #4706 short-circuit on the
+        // shared instance, so a later ApplyAllConfiguredChangesToDatabaseAsync re-emits
+        // CREATE TABLE ... partition of for already-existing per-tenant partitions -> 42P07.
+        await dropManagedListsSchema();
+        var database = new ManagedListDatabase(ignorePartitionsInMigration: true);
+        var partitions = new Dictionary<string, string> { { "red", "red" } };
+        await database.Partitions.ResetValues(database, partitions, CancellationToken.None);
+        await database.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        // Provision a new tenant partition out-of-band — this is the call that clears the flag.
+        await database.Partitions.AddPartitionToAllTables(database, "green", "green", CancellationToken.None);
+
+        // The managed tables (the same instances the additive path operated on) must keep
+        // IgnorePartitionsInMigration set after the reconcile.
+        var managedTables = database.AllObjects().OfType<Table>()
+            .Where(t => t.Partitioning is ListPartitioning { PartitionManager: not null }).ToArray();
+        managedTables.ShouldNotBeEmpty();
+        foreach (var table in managedTables)
+        {
+            table.IgnorePartitionsInMigration.ShouldBeTrue(
+                $"{table.Identifier} must keep IgnorePartitionsInMigration after additive provisioning (#4713)");
+        }
+
+        // And a re-apply over the provisioned partitions stays a no-op (no 42P07 re-create).
+        var migration = await database.CreateMigrationAsync();
+        migration.Difference.ShouldBe(SchemaPatchDifference.None);
+        await database.ApplyAllConfiguredChangesToDatabaseAsync();
     }
 
     private static async Task dropManagedListsSchema()

--- a/src/Weasel.Postgresql/Tables/Partitioning/ManagedListPartitions.cs
+++ b/src/Weasel.Postgresql/Tables/Partitioning/ManagedListPartitions.cs
@@ -236,37 +236,51 @@ public class ManagedListPartitions : FeatureSchemaBase, IDatabaseInitializer<Npg
             // This is the explicit, out-of-band partition-management path (AddPartitionToAllTables).
             // Managed-partition tables set IgnorePartitionsInMigration so the GENERIC schema diff leaves
             // their partitions alone (JasperFx/marten#4706); here we are deliberately reconciling them,
-            // so clear the flag locally (these table objects are freshly built from AllObjects()) to let
-            // the delta compute the missing partitions to add.
+            // so clear the flag locally to let the delta compute the missing partitions to add.
+            //
+            // #4713: SAVE and RESTORE the flag. These Table objects are NOT throwaway clones — a Marten
+            // consumer reuses a per-mapping singleton Table across every shard database and across every
+            // schema apply. Leaving the flag at false permanently defeated the #4706 short-circuit on
+            // that shared instance, so a later ApplyAllConfiguredChangesToDatabaseAsync re-emitted
+            // CREATE TABLE ... partition of for already-existing per-tenant partitions (42P07) and could
+            // re-trigger the destructive rebuild. Restore it in a finally so this reconcile is the only
+            // thing that ever sees the flag cleared.
+            var priorIgnorePartitions = table.IgnorePartitionsInMigration;
             table.IgnorePartitionsInMigration = false;
-
-            var existing = await table.FetchExistingAsync(conn, token).ConfigureAwait(false);
-            var delta = new TableDelta(table, existing);
-            if (delta.PartitionDelta == PartitionDelta.Additive)
+            try
             {
-                try
+                var existing = await table.FetchExistingAsync(conn, token).ConfigureAwait(false);
+                var delta = new TableDelta(table, existing);
+                if (delta.PartitionDelta == PartitionDelta.Additive)
                 {
-                    await table.MigrateAsync(conn, token).ConfigureAwait(false);
-                    foreach (var partition in delta.MissingPartitions)
+                    try
                     {
-                        logger.LogInformation("Added partition {Partition} to table {TableName}", partition, table.Identifier);
-                    }
+                        await table.MigrateAsync(conn, token).ConfigureAwait(false);
+                        foreach (var partition in delta.MissingPartitions)
+                        {
+                            logger.LogInformation("Added partition {Partition} to table {TableName}", partition, table.Identifier);
+                        }
 
+                        list.Add(new TablePartitionStatus(table.Identifier, PartitionMigrationStatus.Complete));
+                    }
+                    catch (Exception e)
+                    {
+                        logger.LogError(e, "Error trying to add table partitions to {Table}", table.Identifier);
+                        list.Add(new TablePartitionStatus(table.Identifier, PartitionMigrationStatus.Failed));
+                    }
+                }
+                else if (delta.PartitionDelta == PartitionDelta.None)
+                {
                     list.Add(new TablePartitionStatus(table.Identifier, PartitionMigrationStatus.Complete));
                 }
-                catch (Exception e)
+                else
                 {
-                    logger.LogError(e, "Error trying to add table partitions to {Table}", table.Identifier);
-                    list.Add(new TablePartitionStatus(table.Identifier, PartitionMigrationStatus.Failed));
+                    list.Add(new TablePartitionStatus(table.Identifier, PartitionMigrationStatus.RequiresTableRebuild));
                 }
             }
-            else if (delta.PartitionDelta == PartitionDelta.None)
+            finally
             {
-                list.Add(new TablePartitionStatus(table.Identifier, PartitionMigrationStatus.Complete));
-            }
-            else
-            {
-                list.Add(new TablePartitionStatus(table.Identifier, PartitionMigrationStatus.RequiresTableRebuild));
+                table.IgnorePartitionsInMigration = priorIgnorePartitions;
             }
         }
 


### PR DESCRIPTION
Fixes the Weasel side of [JasperFx/marten#4713](https://github.com/JasperFx/marten/issues/4713). Bumps to **9.1.4**.

## Problem
`ApplyAllConfiguredChangesToDatabaseAsync` was not idempotent for per-tenant LIST partitions: after a tenant's partition was provisioned, a second apply re-emitted `CREATE TABLE <doc>_<tenant> partition of <doc>` (no `IF NOT EXISTS`) → `42P07: relation already exists`.

## Root cause
`additivelyMigrateTablesForNewPartitions` clears `IgnorePartitionsInMigration` on each managed table to reconcile its partitions out-of-band, but **never restored it**. The code comment assumed those `Table` objects were throwaway clones; in a Marten consumer they are **per-mapping singletons reused across every shard database and every schema apply**. So the first `AddPartitionToAllTables` / `AddTenantToShardAsync` permanently cleared the flag on the shared instance, defeating the #4706 short-circuit (`ListPartitioning.CreateDelta → None`). A later store-wide apply then computed a real partition delta and re-emitted the partition `CREATE` for already-existing partitions → 42P07 (and could re-trigger the #4706 destructive-rebuild branch).

## Fix
Wrap the per-table reconcile in `try/finally` and restore the prior `IgnorePartitionsInMigration` value, so the deliberate clear is scoped to the additive pass only. (The #4706 fix relied on this flag staying set; this restores that invariant.)

## Test
`additive_partition_provisioning_restores_ignore_partitions_flag` — after an additive `AddPartitionToAllTables`, the managed tables must keep `IgnorePartitionsInMigration`, and a re-apply must stay a no-op. RED before the fix (`teams must keep IgnorePartitionsInMigration`), green after. Full `managed_list_partitions` suite 12/12 per TFM.

> Note on `CREATE TABLE IF NOT EXISTS`: I deliberately did **not** add it to `ListPartition.WriteCreateStatement`. The save/restore fix removes the spurious re-emission at the source; `IF NOT EXISTS` on a `PARTITION OF` create would also trade a loud 42P07 for a silent missing-partition (later 23514) if a name ever collided, and would change DDL for all list partitions. Easy to add later if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)