### PR TITLE
Fix #307: guard against torn concurrent catalog read in Table.readExistingAsync

### DIFF
--- a/src/Weasel.Postgresql.Tests/Tables/marking_primary_key_columns.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/marking_primary_key_columns.cs
@@ -1,0 +1,41 @@
+using Shouldly;
+using Weasel.Postgresql.Tables;
+using Xunit;
+
+namespace Weasel.Postgresql.Tests.Tables;
+
+public class marking_primary_key_columns
+{
+    // #307: under concurrent DDL the multi-result-set catalog read in Table.readExistingAsync can be
+    // torn, so the primary-key query returns a column name the columns query did not (yet) include.
+    // markPrimaryKeyColumns must skip the missing column instead of dereferencing null and throwing a
+    // NullReferenceException.
+    [Fact]
+    public void ignores_pk_names_with_no_matching_column()
+    {
+        var table = new Table("public.mt_thing");
+        table.AddColumn("id", "uuid");
+        table.AddColumn("tenant_id", "varchar");
+
+        // "ghost" has no matching column — pre-fix this threw a NullReferenceException.
+        Should.NotThrow(() =>
+            Table.markPrimaryKeyColumns(table, new[] { "id", "tenant_id", "ghost" }));
+
+        table.ColumnFor("id")!.IsPrimaryKey.ShouldBeTrue();
+        table.ColumnFor("tenant_id")!.IsPrimaryKey.ShouldBeTrue();
+        table.ColumnFor("ghost").ShouldBeNull();
+    }
+
+    [Fact]
+    public void marks_only_the_present_primary_key_columns()
+    {
+        var table = new Table("public.mt_thing");
+        table.AddColumn("id", "uuid");
+        table.AddColumn("name", "varchar");
+
+        Table.markPrimaryKeyColumns(table, new[] { "id" });
+
+        table.ColumnFor("id")!.IsPrimaryKey.ShouldBeTrue();
+        table.ColumnFor("name")!.IsPrimaryKey.ShouldBeFalse();
+    }
+}

--- a/src/Weasel.Postgresql/Tables/Table.FetchExisting.cs
+++ b/src/Weasel.Postgresql/Tables/Table.FetchExisting.cs
@@ -169,8 +169,7 @@ order by column_index;
         await readIndexesAsync(reader, existing, ct).ConfigureAwait(false);
         await readConstraintsAsync(reader, existing, ct).ConfigureAwait(false);
 
-        foreach (var pkColumn in pks)
-            existing.ColumnFor(pkColumn)!.IsPrimaryKey = true;
+        markPrimaryKeyColumns(existing, pks);
 
         await readMaxIdentifierLength(reader, existing, ct).ConfigureAwait(false);
         await readPartitionsAsync(reader, existing, ct).ConfigureAwait(false);
@@ -178,6 +177,23 @@ order by column_index;
         return !existing.Columns.Any()
             ? null
             : existing;
+    }
+
+    // #307: mark the primary-key columns of a table read back from the catalog. Under concurrent DDL
+    // (e.g. multiple replicas/threads creating the same managed partition at once) the multi-result-set
+    // catalog read in readExistingAsync can be torn: the primary-key query returns a column name that the
+    // columns query did not (yet) include, so ColumnFor returns null. Guard against that rather than
+    // dereferencing null and throwing a NullReferenceException — the caller re-reads and re-diffs anyway,
+    // so a momentarily-missing column on a racing read is harmless. Internal for direct regression testing.
+    internal static void markPrimaryKeyColumns(Table existing, IEnumerable<string> pks)
+    {
+        foreach (var pkColumn in pks)
+        {
+            if (existing.ColumnFor(pkColumn) is { } column)
+            {
+                column.IsPrimaryKey = true;
+            }
+        }
     }
 
     private static async Task readMaxIdentifierLength(


### PR DESCRIPTION
Closes #307.

## Problem

Under concurrent DDL (e.g. multiple replicas/threads creating the same managed partition at once), the multi-result-set catalog read in `Table.readExistingAsync` can be **torn**: the primary-key query returns a column name that the columns query did not (yet) include. `ColumnFor(pkColumn)` then returns null and this line NRE'd:

```csharp
foreach (var pkColumn in pks)
    existing.ColumnFor(pkColumn)!.IsPrimaryKey = true;
```

```
System.NullReferenceException
  at Weasel.Postgresql.Tables.Table.readExistingAsync ... Table.FetchExisting.cs:173
  at Weasel.Core.SchemaMigration.DetermineAsync ...
  at ...ManagedListPartitions.AddPartitionToAllTables ...
```

Surfaced from Marten via concurrent `AddMartenManagedTenantsAsync` for the **same** tenant ([JasperFx/marten `Bug_4596`](https://github.com/JasperFx/marten)); intermittent (~1 in 10 runs).

## Fix

Extract the primary-key marking into an internal `markPrimaryKeyColumns(table, pks)` helper that skips a PK name with no matching column instead of dereferencing null. The caller re-reads and re-diffs anyway, so a momentarily-missing column on a racing read is harmless.

## Tests

New deterministic unit tests (`marking_primary_key_columns`) cover the torn-read guard (a PK name with no matching column no longer throws) and the normal case. Existing `reading_existing_table_from_database` / `detecting_table_deltas` suites stay green (181 passed, net9.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)