### PR TITLE
Fix #308: ResourceMigrationFailureMode for the startup migration lock timeout (JasperFx 2.13)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,7 @@
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.12.19" />
     <PackageVersion Include="DistributedLock.Postgres" Version="1.3.0" />
     <PackageVersion Include="DotNet.ReproducibleBuilds" Version="1.2.39" />
-    <PackageVersion Include="JasperFx" Version="2.0.1" />
+    <PackageVersion Include="JasperFx" Version="2.13.0" />
     <PackageVersion Include="JasperFx.Events" Version="2.0.0" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="9.0.1" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />

--- a/src/Weasel.Core/Migrations/DatabaseBase.cs
+++ b/src/Weasel.Core/Migrations/DatabaseBase.cs
@@ -70,6 +70,18 @@ public abstract class DatabaseBase<TConnection>: IDatabase<TConnection> where TC
     public AutoCreate AutoCreate { get; set; }
     public Migrator Migrator { get; }
 
+    /// <summary>
+    /// #308: governs what happens when <see cref="ApplyAllConfiguredChangesToDatabaseAsync(IGlobalLock{TConnection}, JasperFx.AutoCreate?, ReconnectionOptions?, CancellationToken)"/>
+    /// cannot attain the global migration lock. With the default <see cref="ResourceMigrationFailureMode.FailFast"/>
+    /// it throws (aborting startup). With <see cref="ResourceMigrationFailureMode.ContinueOnFailures"/> it
+    /// returns <see cref="SchemaPatchDifference.None"/> instead — the lock holder is presumably applying the
+    /// migration, so the application can start up against the soon-to-be / already current schema rather than
+    /// crash-looping. Callers (e.g. the Critter Stack hosts) set this from
+    /// <c>JasperFxOptions.ActiveProfile.ResourceMigrationFailureMode</c>.
+    /// </summary>
+    public ResourceMigrationFailureMode ResourceMigrationFailureMode { get; set; } =
+        ResourceMigrationFailureMode.FailFast;
+
     public string Identifier { get; protected set; }
 
     /// <summary>
@@ -350,6 +362,16 @@ public abstract class DatabaseBase<TConnection>: IDatabase<TConnection> where TC
             }
 
             await conn.CloseAsync().ConfigureAwait(false);
+
+            // #308: the global migration lock could not be attained in time. On a multi-replica rolling
+            // deploy this is expected for the replicas that lose the race — the winner is applying (or has
+            // applied) the migration. ContinueOnFailures lets those replicas start up against the
+            // current/soon-to-be-current schema instead of crash-looping; FailFast (default) preserves the
+            // historical throw-and-abort behavior.
+            if (ResourceMigrationFailureMode == ResourceMigrationFailureMode.ContinueOnFailures)
+            {
+                return SchemaPatchDifference.None;
+            }
 
             throw new InvalidOperationException(
                 "Unable to attain a global lock in time order to apply database changes");

--- a/src/Weasel.Postgresql.Tests/Migrations/migration_scenario_tests.cs
+++ b/src/Weasel.Postgresql.Tests/Migrations/migration_scenario_tests.cs
@@ -117,6 +117,27 @@ public class SchemaMigrationTests : IntegrationContext, IAsyncLifetime
         connectionGlobalLock.Failed.ShouldBeTrue();
         connectionGlobalLock.Retried.ShouldBeFalse();
     }
+
+    [Fact]
+    public async Task continue_on_failures_returns_None_instead_of_throwing_when_lock_not_attained()
+    {
+        // #308: with ResourceMigrationFailureMode.ContinueOnFailures, a replica that cannot attain the
+        // global migration lock starts up against the (soon-to-be) current schema instead of crash-looping.
+        theDatabase.ResourceMigrationFailureMode = ResourceMigrationFailureMode.ContinueOnFailures;
+
+        var connectionGlobalLock = new FlakyConnectionGlobalLock();
+
+        theDatabase.Features["One"].AddTable(SchemaName, "one");
+
+        var difference = await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync(
+            connectionGlobalLock,
+            null,
+            new ReconnectionOptions(0)
+        );
+
+        difference.ShouldBe(SchemaPatchDifference.None);
+        connectionGlobalLock.Failed.ShouldBeTrue();
+    }
 }
 
 public class NamedTable: Table


### PR DESCRIPTION
Closes #308. Phase 2 of the multi-repo "wait-instead-of-crash" startup work for [marten#4750](https://github.com/JasperFx/marten/issues/4750). Phase 1 shipped the setting in JasperFx ([jasperfx#456](https://github.com/JasperFx/jasperfx/pull/456), now in **JasperFx 2.13.0**).

## What

- **Bump JasperFx `2.0.1` → `2.13.0`** to pick up the new `ResourceMigrationFailureMode` enum.
- `DatabaseBase` gains a `ResourceMigrationFailureMode` property (default `FailFast`). When `ApplyAllConfiguredChangesToDatabaseAsync` cannot attain the global migration lock:
  - **`FailFast`** (default): throws as before — behavior **unchanged** (the existing `assert_fails_with_InvalidOperationException...` test passes verbatim).
  - **`ContinueOnFailures`**: returns `SchemaPatchDifference.None` instead of throwing, so a replica that loses the lock race during a multi-replica rolling deploy starts up against the (soon-to-be) current schema rather than crash-looping — the lock holder is applying the migration.

Per the discussion on #308, this uses the **setting** rather than a typed exception: the policy lives behind the `ResourceMigrationFailureMode` value, which the Critter Stack hosts set from `JasperFxOptions.ActiveProfile.ResourceMigrationFailureMode`.

## Tests

- New `continue_on_failures_returns_None_instead_of_throwing_when_lock_not_attained` (uses the existing `FlakyConnectionGlobalLock`).
- Existing FailFast lock-timeout test unchanged and green.
- Full Weasel solution builds against JasperFx 2.13.0 across all providers (Postgresql/SqlServer/MySql/Oracle/Sqlite).

## Next (Phase 3, Marten)

After this publishes, bump Weasel in Marten and have `MartenActivator` set `database.ResourceMigrationFailureMode = JasperFxOptions.ActiveProfile.ResourceMigrationFailureMode` before applying, logging when it continues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)