### PR TITLE
Sanitize LIST partition suffix to a valid Postgres identifier

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,7 @@
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.12.19" />
     <PackageVersion Include="DistributedLock.Postgres" Version="1.3.0" />
     <PackageVersion Include="DotNet.ReproducibleBuilds" Version="1.2.39" />
-    <PackageVersion Include="JasperFx" Version="2.13.0" />
+    <PackageVersion Include="JasperFx" Version="2.13.1" />
     <PackageVersion Include="JasperFx.Events" Version="2.0.0" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="9.0.1" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />

--- a/src/Weasel.Postgresql.Tests/Tables/partitioning/list_partition_suffix_sanitization.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/partitioning/list_partition_suffix_sanitization.cs
@@ -1,0 +1,47 @@
+using System.IO;
+using Shouldly;
+using Weasel.Postgresql.Tables;
+using Weasel.Postgresql.Tables.Partitioning;
+using Xunit;
+
+namespace Weasel.Postgresql.Tests.Tables.partitioning;
+
+// A partition table is named `{parent}_{suffix}` as an unquoted Postgres identifier. A suffix taken
+// straight from a tenant id can contain '-' (and other non-identifier characters), which produced
+// invalid DDL (`CREATE TABLE ..._tenant-a` → 42601). The suffix is now sanitized to [a-z0-9_] while
+// the partition VALUE keeps the exact tenant id. DB-free — exercises the rendered DDL directly.
+public class list_partition_suffix_sanitization
+{
+    [Theory]
+    [InlineData("tenant-a", "tenant_a")]
+    [InlineData("Tenant-A", "tenant_a")]
+    [InlineData("a.b:c@d", "a_b_c_d")]
+    [InlineData("already_valid", "already_valid")]
+    [InlineData("b_1", "b_1")]
+    public void suffix_is_normalized_to_a_valid_identifier(string input, string expected)
+    {
+        new ListPartition(input).Suffix.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void sanitization_is_idempotent_so_the_parse_round_trip_stays_symmetric()
+    {
+        var once = new ListPartition("tenant-a").Suffix;
+        new ListPartition(once).Suffix.ShouldBe(once);
+    }
+
+    [Fact]
+    public void create_statement_uses_a_valid_table_name_but_keeps_the_exact_partition_value()
+    {
+        var table = new Table("public.mt_streams");
+        table.AddColumn<string>("tenant_id");
+
+        var writer = new StringWriter();
+        ((IPartition)new ListPartition("tenant-a", "'tenant-a'")).WriteCreateStatement(writer, table);
+        var ddl = writer.ToString();
+
+        ddl.ShouldContain("mt_streams_tenant_a");        // sanitized, valid unquoted identifier
+        ddl.ShouldNotContain("mt_streams_tenant-a");     // the invalid hyphenated form is gone
+        ddl.ShouldContain("for values in ('tenant-a')"); // the partition VALUE is still the exact tenant id
+    }
+}

--- a/src/Weasel.Postgresql/Tables/Partitioning/ListPartition.cs
+++ b/src/Weasel.Postgresql/Tables/Partitioning/ListPartition.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using JasperFx.Core;
 using Weasel.Core;
 using Weasel.Postgresql;
@@ -8,8 +9,32 @@ public class ListPartition : IPartition
 {
     public ListPartition(string suffix, params string[] values)
     {
-        Suffix = suffix.ToLowerInvariant();
+        Suffix = SanitizeSuffix(suffix);
         Values = values;
+    }
+
+    /// <summary>
+    /// A partition table is named <c>{parent}_{suffix}</c> as an UNQUOTED Postgres identifier, so the
+    /// suffix may only contain identifier-safe characters. Tenant ids are frequently used directly as
+    /// the suffix and can contain '-' (and other non-identifier characters), which produced invalid DDL
+    /// (<c>CREATE TABLE ..._tenant-a ...</c> → <c>42601 syntax error at or near "-"</c>). Lower-case and
+    /// replace any character outside <c>[a-z0-9_]</c> with '_'. The partition VALUES keep the exact
+    /// tenant id, so partition routing is unaffected — only the internal table name is normalized.
+    /// Idempotent, so the <see cref="Parse"/> round-trip (which re-reads the suffix from the table name)
+    /// stays symmetric. NOTE: distinct suffixes that normalize to the same string (e.g. <c>a-b</c> and
+    /// <c>a_b</c>) collide on the same partition table; callers needing both must supply already-distinct
+    /// suffixes.
+    /// </summary>
+    internal static string SanitizeSuffix(string suffix)
+    {
+        var lower = suffix.ToLowerInvariant();
+        var builder = new StringBuilder(lower.Length);
+        foreach (var c in lower)
+        {
+            builder.Append((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_' ? c : '_');
+        }
+
+        return builder.ToString();
     }
 
     /// <summary>


### PR DESCRIPTION
## Problem

A LIST partition table is named `{parent}_{suffix}` and emitted as an **unquoted** Postgres identifier. The suffix is only `.ToLowerInvariant()`'d, so when it comes straight from a tenant id (a common pattern with `UseTenantPartitionedEvents` / managed list partitions) it can contain `-` and other non-identifier characters, producing invalid DDL:

```sql
CREATE TABLE schema.mt_streams_tenant-a partition of schema.mt_streams for values in ('tenant-a');
-- 42601: syntax error at or near "-"
```

That one bad statement fails the whole "All Configured Changes" batch for any store sharing the schema.

## Fix

Sanitize the suffix in the `ListPartition` constructor: lower-case (unchanged) **plus** replace any character outside `[a-z0-9_]` with `_`.

- The partition **VALUES** keep the exact tenant id, so partition routing is unaffected — only the internal table name is normalized.
- Centralized in the ctor and **idempotent**, so the `Parse()` round-trip (which re-reads the suffix from the existing table name) stays symmetric and schema-diffing doesn't churn.
- Existing valid suffixes (`admin`, `b_1`, …) are unchanged (no-op).

```csharp
// "tenant-a" -> table mt_streams_tenant_a, values in ('tenant-a')
```

### No migration risk
A hyphenated partition table name is invalid DDL, so such a table could never have been created — only *new* partition creation is affected.

### Caveat (documented on the method)
Distinct suffixes that normalize to the same string (e.g. `a-b` and `a_b`) collide on the same partition table; callers needing both must supply already-distinct suffixes.

## Verification

- New unit tests `list_partition_suffix_sanitization` (normalization, idempotency, valid-table-name-with-exact-value).
- Full `Weasel.Postgresql.Tests` partitioning suite **69/69 green**, including the round-trip / migration-diff tests (`managed_list_partitions`, `partitioning_deltas`, `detect_happy_path_difference_with_partitions`) — so the symmetry is clean.

## Context
Found downstream while a partitioned multi-tenant Marten store (CritterWatch monitoring) hit `42601` on a hyphenated tenant id. Marten delegates partition DDL entirely to this `ListPartition`, so the fix belongs here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)