### PR TITLE
Bump Microsoft.Data.Sqlite to 10.0.9 and release 9.2.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>9.2.1</Version>
+        <Version>9.2.2</Version>
         <LangVersion>13.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,7 @@
     <PackageVersion Include="DotNet.ReproducibleBuilds" Version="1.2.39" />
     <PackageVersion Include="JasperFx" Version="2.13.1" />
     <PackageVersion Include="JasperFx.Events" Version="2.0.0" />
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />
     <!-- EF Core versions are framework-conditional - see below -->
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.0" />


### PR DESCRIPTION
## Summary
- Update `Microsoft.Data.Sqlite` from 9.0.1 to **10.0.9** (latest stable) in `Directory.Packages.props`
- Bump the NuGet patch (fix) version from 9.2.1 to **9.2.2** in `Directory.Build.props`

## Testing
- `dotnet build src/Weasel.Sqlite.Tests` — succeeds (pre-existing nullable warnings only)
- `dotnet test src/Weasel.Sqlite.Tests` — **361 passed** on both net9.0 and net10.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)