### PR TITLE
Clear SQLitePCLRaw advisory GHSA-2m69-gcr7-jv3q (override to 3.0.3), release 9.2.3

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>9.2.2</Version>
+        <Version>9.2.3</Version>
         <LangVersion>13.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,6 +11,9 @@
     <PackageVersion Include="JasperFx" Version="2.13.1" />
     <PackageVersion Include="JasperFx.Events" Version="2.0.0" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.9" />
+    <!-- Override the transitive SQLitePCLRaw 2.1.11 (vulnerable native lib,
+         GHSA-2m69-gcr7-jv3q) with 3.0.3, which ships the patched SQLite build. -->
+    <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />
     <!-- EF Core versions are framework-conditional - see below -->
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.0" />

--- a/src/Weasel.Sqlite/Weasel.Sqlite.csproj
+++ b/src/Weasel.Sqlite/Weasel.Sqlite.csproj
@@ -18,6 +18,9 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Data.Sqlite" />
+        <!-- Pull the patched native SQLite (3.0.3 / SQLite 3.50.x) instead of the
+             vulnerable transitive 2.1.11. See GHSA-2m69-gcr7-jv3q. -->
+        <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">


### PR DESCRIPTION
## Summary
`Microsoft.Data.Sqlite` 10.0.9 transitively pins `SQLitePCLRaw.bundle_e_sqlite3` **2.1.11**, whose native `SQLitePCLRaw.lib.e_sqlite3` 2.1.11 triggers the high-severity advisory **[GHSA-2m69-gcr7-jv3q](https://github.com/advisories/GHSA-2m69-gcr7-jv3q)** (surfaced as `NU1903` on every restore/build).

This adds a direct reference to **`SQLitePCLRaw.bundle_e_sqlite3` 3.0.3**, which restructures the native dependency to the patched **`SourceGear.sqlite3` 3.50.4.5** (SQLite 3.50.x) build and drops the vulnerable `lib.e_sqlite3` package entirely.

## Changes
- `Directory.Packages.props` — add `SQLitePCLRaw.bundle_e_sqlite3` 3.0.3
- `src/Weasel.Sqlite/Weasel.Sqlite.csproj` — direct `PackageReference` to force the override
- `Directory.Build.props` — bump NuGet fix version 9.2.2 → **9.2.3**

## Verification
- Resolved tree: `bundle/core/provider/config 3.0.3` + `SourceGear.sqlite3 3.50.4.5`; **`lib.e_sqlite3` 2.1.11 gone**
- `dotnet restore Weasel.slnx` — **no NU1903/NU1902**
- `dotnet list package --vulnerable --include-transitive` — **clean** across the solution
- `dotnet test src/Weasel.Sqlite.Tests` — **361 passed** on net9.0 and net10.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)