### PR TITLE
Fix RANGE partition bound round-trip drift for date/quoted literals

### DIFF
--- a/src/Weasel.Postgresql.Tests/Tables/partitioning/detecting_table_deltas_with_partitions.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/partitioning/detecting_table_deltas_with_partitions.cs
@@ -206,6 +206,31 @@ public class detecting_table_deltas_with_partitions : IndexDeltasDetectionContex
     }
 
     [Fact]
+    public async Task apply_migration_to_range_partitioned_by_timestamptz_in_non_utc_session()
+    {
+        // Regression for monthly time-series partitioning on a timestamptz column. PostgreSQL renders
+        // the partition bounds back in the session time zone, so without value-aware comparison the
+        // second pass reports a spurious rebuild. Force a non-UTC session to prove the bounds still match.
+        await theConnection.CreateCommand("set timezone to 'America/Chicago'").ExecuteNonQueryAsync();
+
+        await CreateSchemaObjectInDatabase(theTable);
+
+        theTable.ModifyColumn("created_datetime_offset").AsPrimaryKey();
+
+        theTable.PartitionByRange("created_datetime_offset")
+            .AddRange("2026_01", new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                new DateTimeOffset(2026, 2, 1, 0, 0, 0, TimeSpan.Zero))
+            .AddRange("2026_02", new DateTimeOffset(2026, 2, 1, 0, 0, 0, TimeSpan.Zero),
+                new DateTimeOffset(2026, 3, 1, 0, 0, 0, TimeSpan.Zero));
+
+        var delta = await theTable.FindDeltaAsync(theConnection);
+        delta.Difference.ShouldBe(SchemaPatchDifference.Update);
+        delta.HasChanges().ShouldBeTrue();
+
+        await AssertNoDeltasAfterPatching();
+    }
+
+    [Fact]
     public async Task apply_migration_to_range_partitioned_with_other_table_changes()
     {
         await CreateSchemaObjectInDatabase(theTable);

--- a/src/Weasel.Postgresql.Tests/Tables/partitioning/partitioning_deltas.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/partitioning/partitioning_deltas.cs
@@ -236,5 +236,38 @@ public class partitioning_deltas
         range1.CreateDelta(table, range1, out partitions).ShouldBe(PartitionDelta.None);
     }
 
+    [Fact]
+    public void integer_range_does_not_drift_against_quoted_readback()
+    {
+        // PostgreSQL echoes integer bounds back single-quoted ('20'); the declared side is unquoted (20).
+        // Normalized comparison keeps these equal so no spurious rebuild is reported.
+        var table = new Table(new DbObjectName("partitions", "people"));
+
+        var declared = new RangePartitioning { Columns = ["age"] }
+            .AddRange("twenties", 20, 29);
+
+        var readBack = new RangePartitioning { Columns = ["age"] }
+            .AddRange("twenties", "'20'", "'29'").As<IPartitionStrategy>();
+
+        declared.As<IPartitionStrategy>().CreateDelta(table, readBack, out _).ShouldBe(PartitionDelta.None);
+    }
+
+    [Fact]
+    public void timestamp_range_does_not_drift_against_readback_in_another_time_zone()
+    {
+        // Same monthly bounds, but PostgreSQL rendered the timestamptz read-back in a non-UTC session.
+        var table = new Table(new DbObjectName("partitions", "people"));
+
+        var declared = new RangePartitioning { Columns = ["bucket_end"] }
+            .AddRange("2026_01", new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                new DateTimeOffset(2026, 2, 1, 0, 0, 0, TimeSpan.Zero));
+
+        var readBack = new RangePartitioning { Columns = ["bucket_end"] }
+            .AddRange("2026_01", "'2025-12-31 18:00:00-06'", "'2026-01-31 18:00:00-06'")
+            .As<IPartitionStrategy>();
+
+        declared.As<IPartitionStrategy>().CreateDelta(table, readBack, out _).ShouldBe(PartitionDelta.None);
+    }
+
 
 }

--- a/src/Weasel.Postgresql.Tests/Tables/partitioning/range_partition_value_formatting.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/partitioning/range_partition_value_formatting.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Globalization;
+using System.Threading;
+using Shouldly;
+using Weasel.Postgresql.Tables.Partitioning;
+using Xunit;
+
+namespace Weasel.Postgresql.Tests.Tables.partitioning;
+
+public class range_partition_value_formatting
+{
+    [Fact]
+    public void format_integer_value_unquoted()
+    {
+        20.FormatSqlValue().ShouldBe("20");
+    }
+
+    [Fact]
+    public void format_string_value_quoted()
+    {
+        "a".FormatSqlValue().ShouldBe("'a'");
+    }
+
+    [Fact]
+    public void format_date_time_offset_is_canonical_and_invariant()
+    {
+        var value = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        value.FormatSqlValue().ShouldBe("'2026-01-01 00:00:00+00:00'");
+    }
+
+    [Fact]
+    public void format_date_time_is_canonical()
+    {
+        var value = new DateTime(2026, 2, 1, 0, 0, 0);
+        value.FormatSqlValue().ShouldBe("'2026-02-01 00:00:00'");
+    }
+
+    [Fact]
+    public void format_date_time_offset_does_not_depend_on_current_culture()
+    {
+        var original = Thread.CurrentThread.CurrentCulture;
+        try
+        {
+            // A culture whose default DateTimeOffset.ToString() differs wildly from the invariant form
+            Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("de-DE");
+            var value = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            value.FormatSqlValue().ShouldBe("'2026-01-01 00:00:00+00:00'");
+        }
+        finally
+        {
+            Thread.CurrentThread.CurrentCulture = original;
+        }
+    }
+
+    [Fact]
+    public void normalize_strips_quotes_for_integers()
+    {
+        "20".NormalizePartitionValue().ShouldBe("20");
+        "'20'".NormalizePartitionValue().ShouldBe("20");
+    }
+
+    [Fact]
+    public void normalize_strips_quotes_for_text()
+    {
+        "'a'".NormalizePartitionValue().ShouldBe("a");
+    }
+
+    [Fact]
+    public void normalize_text_with_leading_dash_is_not_treated_as_a_date()
+    {
+        // would only be misparsed if LooksLikeTimestamp were too loose
+        "'role-a'".NormalizePartitionValue().ShouldBe("role-a");
+    }
+
+    [Fact]
+    public void normalize_timestamps_to_the_same_instant_regardless_of_rendered_offset()
+    {
+        // Same instant, rendered by PostgreSQL in different session time zones
+        var utc = "'2026-01-01 00:00:00+00'".NormalizePartitionValue();
+        var central = "'2025-12-31 18:00:00-06'".NormalizePartitionValue();
+
+        central.ShouldBe(utc);
+    }
+}

--- a/src/Weasel.Postgresql/Tables/Partitioning/PartitionExtensions.cs
+++ b/src/Weasel.Postgresql/Tables/Partitioning/PartitionExtensions.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using JasperFx.Core.Reflection;
 using Weasel.Core;
 using Weasel.Postgresql;
@@ -27,6 +28,20 @@ public static class PartitionExtensions
     /// <returns></returns>
     public static string FormatSqlValue<T>(this T value)
     {
+        // DateTimeOffset/DateTime have to be rendered with an invariant, canonical format so that the
+        // generated partition bound DDL is a) valid PostgreSQL and b) deterministic regardless of the
+        // current thread culture (the default ToString() is culture sensitive). The round-trip comparison
+        // against what PostgreSQL echoes back is handled separately via NormalizePartitionValue.
+        if (value is DateTimeOffset dto)
+        {
+            return $"'{dto.ToString("yyyy-MM-dd HH:mm:ss.FFFFFFzzz", CultureInfo.InvariantCulture)}'";
+        }
+
+        if (value is DateTime dt)
+        {
+            return $"'{dt.ToString("yyyy-MM-dd HH:mm:ss.FFFFFF", CultureInfo.InvariantCulture)}'";
+        }
+
         if (typeof(T).IsNumeric()) return value.ToString();
 
         if (value is bool b) return b.ToString().ToLowerInvariant();
@@ -34,6 +49,44 @@ public static class PartitionExtensions
         if (value is string v && v.StartsWith("'") && v.EndsWith("'")) return v;
 
         return $"'{value.ToString()}'";
+    }
+
+    /// <summary>
+    /// Normalize a partition bound literal (either a declared value produced by <see cref="FormatSqlValue{T}"/>
+    /// or a value echoed back by PostgreSQL via <c>pg_get_expr(relpartbound)</c>) into a stable, comparable
+    /// form. PostgreSQL single-quotes every bound literal on read-back (so a declared <c>20</c> comes back as
+    /// <c>'20'</c>) and renders <c>timestamptz</c> bounds in the session time zone (so <c>'2026-01-01 00:00:00+00'</c>
+    /// can come back as <c>'2025-12-31 18:00:00-06'</c>). Both would otherwise produce spurious migration
+    /// rebuilds when compared as raw strings.
+    /// </summary>
+    internal static string NormalizePartitionValue(this string? raw)
+    {
+        if (raw is null) return string.Empty;
+
+        var value = raw.Trim();
+        if (value.Length >= 2 && value[0] == '\'' && value[^1] == '\'')
+        {
+            value = value.Substring(1, value.Length - 2);
+        }
+
+        if (LooksLikeTimestamp(value)
+            && DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var moment))
+        {
+            return moment.ToString("yyyy-MM-ddTHH:mm:ss.fffffffzzz", CultureInfo.InvariantCulture);
+        }
+
+        return value;
+    }
+
+    private static bool LooksLikeTimestamp(string value)
+    {
+        // Cheap guard so plain integers ('20') and text values ('role-a') are never misparsed as dates:
+        // a timestamp/date literal starts with a four digit year followed by a '-' separator.
+        return value.Length >= 8
+            && value.IndexOf('-') >= 4
+            && char.IsDigit(value[0]) && char.IsDigit(value[1])
+            && char.IsDigit(value[2]) && char.IsDigit(value[3]);
     }
 
     /// <summary>

--- a/src/Weasel.Postgresql/Tables/Partitioning/RangePartition.cs
+++ b/src/Weasel.Postgresql/Tables/Partitioning/RangePartition.cs
@@ -38,7 +38,12 @@ public class RangePartition : IPartition
 
     protected bool Equals(RangePartition other)
     {
-        return Suffix == other.Suffix && From == other.From && To == other.To;
+        // From/To hold raw SQL literals that differ between the declared side and what PostgreSQL
+        // echoes back (quoting, time-zone rendering of timestamptz), so compare on the normalized
+        // form to avoid spurious migration rebuilds. See PartitionExtensions.NormalizePartitionValue.
+        return Suffix == other.Suffix
+            && From.NormalizePartitionValue() == other.From.NormalizePartitionValue()
+            && To.NormalizePartitionValue() == other.To.NormalizePartitionValue();
     }
 
     public override bool Equals(object? obj)
@@ -68,7 +73,7 @@ public class RangePartition : IPartition
 
     public override int GetHashCode()
     {
-        return HashCode.Combine(Suffix, From, To);
+        return HashCode.Combine(Suffix, From.NormalizePartitionValue(), To.NormalizePartitionValue());
     }
 
     internal static RangePartition Parse(DbObjectName tableName, string partitionName, string postgresExpression)


### PR DESCRIPTION
## Problem

A `RANGE`-partitioned table keyed on a `timestamptz` (or any `DateTime`/`DateTimeOffset`) column reports a **spurious, destructive partition rebuild on every migration**, even when nothing changed.

Two things conspire:

1. PostgreSQL echoes every partition bound literal back **single-quoted** via `pg_get_expr(relpartbound)` (so a declared `20` reads back as `'20'`), and renders `timestamptz` bounds **in the session time zone** (so `'2026-01-01 00:00:00+00'` can read back as `'2025-12-31 18:00:00-06'`).
2. `PartitionExtensions.FormatSqlValue<T>` rendered `DateTimeOffset`/`DateTime` as `'{value.ToString()}'` — culture-sensitive and non-canonical.

So the declared bounds never string-matched the database read-back, and `RangePartitioning.CreateDelta` returned `Rebuild`. The same quote mismatch latently affected **integer** bounds too (declared `20` vs read-back `'20'`), though no existing test compared a declared partition against a DB read-back.

## Fix

- `FormatSqlValue` renders `DateTime`/`DateTimeOffset` with an invariant, canonical format so the generated DDL is valid PostgreSQL and deterministic regardless of thread culture.
- New `NormalizePartitionValue` helper: strips the surrounding quotes and, for timestamp-like values, parses to a single UTC instant so comparison is **quote- and time-zone independent**.
- `RangePartition.Equals`/`GetHashCode` compare on the normalized `From`/`To`. The raw literals are still used verbatim for DDL emission, so generated `CREATE TABLE ... FOR VALUES FROM (...) TO (...)` is unchanged.

Scope is intentionally limited to `RangePartition` (the reported case). `ListPartition` has the same latent integer-quote drift and can follow separately.

## Tests

- `range_partition_value_formatting.cs` — unit coverage for the canonical formatting (incl. a culture-independence check) and the normalization rules.
- `partitioning_deltas.cs` — declared-vs-readback delta equivalence: integer bounds (`20` vs `'20'`) and timestamptz bounds rendered in a different time zone both yield `PartitionDelta.None`.
- `detecting_table_deltas_with_partitions.cs` — DB round-trip that creates monthly `timestamptz` partitions under a **non-UTC session** (`America/Chicago`) and asserts no delta on re-apply. Verified to **fail** without the normalized comparison.

All 81 partitioning tests pass (net10).

## Downstream

Unblocks Marten [#4779](https://github.com/JasperFx/marten/issues/4779) (declaratively range-partition a non-tenant document table by a duplicated date column for time-series retention).