### PR TITLE
feat(SqlServer): round-trip and migrate declarative RANGE partitions (#317)

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -91,6 +91,7 @@ export default withMermaid(
           items: [
             { text: 'Overview', link: '/sqlserver/' },
             { text: 'Tables', link: '/sqlserver/tables' },
+            { text: 'Partitioning', link: '/sqlserver/partitioning' },
             { text: 'Stored Procedures', link: '/sqlserver/procedures' },
             { text: 'Functions', link: '/sqlserver/functions' },
             { text: 'Sequences', link: '/sqlserver/sequences' },

--- a/docs/sqlserver/index.md
+++ b/docs/sqlserver/index.md
@@ -23,6 +23,8 @@ dotnet add package Weasel.SqlServer
 | Sequences | `Sequence` | `Weasel.SqlServer` |
 | Table Types | `TableType` | `Weasel.SqlServer.Tables` |
 
+Tables can also be [range or managed-tenant partitioned](/sqlserver/partitioning) via partition functions and schemes.
+
 ## Connection String
 
 Weasel.SqlServer uses standard SQL Server connection strings with `Microsoft.Data.SqlClient`:

--- a/docs/sqlserver/partitioning.md
+++ b/docs/sqlserver/partitioning.md
@@ -1,0 +1,120 @@
+# Table Partitioning
+
+Unlike PostgreSQL — which partitions a table into child tables — SQL Server partitioning is built from two
+server objects:
+
+* a **partition function** that defines the boundary values and the direction (`RANGE LEFT` / `RANGE RIGHT`), and
+* a **partition scheme** that maps the function's partitions onto filegroups.
+
+The table is then created *on* the partition scheme. Weasel models this through the
+`ISqlServerPartitioning` strategy on `Table`, with `RangePartitioning` for declarative date/numeric
+ranges and `ManagedTenantPartitions` for runtime, per-tenant partitioning.
+
+## Range Partitioning
+
+Use `PartitionByRange(column, sqlDataType)` and add the boundary values. The boundaries are the points at
+which a new partition begins; `N` boundaries produce `N + 1` partitions. The default direction is
+`RANGE RIGHT`, which is the natural choice for time-series data (each boundary is the *inclusive lower
+bound* of the next partition).
+
+```cs
+var table = new Table("metrics.metrics_sample");
+table.AddColumn<int>("id");
+table.AddColumn("bucket_end", "datetime").NotNull();
+table.AddColumn("data", "nvarchar(max)");
+
+// On SQL Server the partition column MUST participate in the primary key.
+table.ModifyColumn("id").AsPrimaryKey();
+table.ModifyColumn("bucket_end").AsPrimaryKey();
+
+var partitioning = table.PartitionByRange("bucket_end", "datetime");
+partitioning.AddBoundary(new DateTime(2026, 1, 1));
+partitioning.AddBoundary(new DateTime(2026, 2, 1));
+partitioning.AddBoundary(new DateTime(2026, 3, 1));
+```
+
+This generates a `CREATE PARTITION FUNCTION`, a `CREATE PARTITION SCHEME`, and a `CREATE TABLE ... ON` the
+scheme:
+
+```sql
+CREATE PARTITION FUNCTION [pf_metrics_sample_bucket_end] (datetime)
+    AS RANGE RIGHT FOR VALUES ('2026-01-01 00:00:00', '2026-02-01 00:00:00', '2026-03-01 00:00:00');
+CREATE PARTITION SCHEME [ps_metrics_sample_bucket_end]
+    AS PARTITION [pf_metrics_sample_bucket_end] ALL TO ([PRIMARY]);
+```
+
+::: tip
+Add boundaries with the strongly typed `AddBoundary<T>(value)` overload (e.g. a `DateTime`,
+`DateTimeOffset`, or `int`) rather than a raw SQL string. Weasel formats the value into a canonical SQL
+literal, which is what lets schema migration round-trip the boundaries back from the database without
+reporting a spurious change. See [Schema Migrations](#schema-migrations) below.
+:::
+
+`RangePartitioning` exposes a few knobs:
+
+| Member | Purpose |
+| --- | --- |
+| `IsRangeRight` | `true` (default) for `RANGE RIGHT`, `false` for `RANGE LEFT`. |
+| `Filegroup` | The filegroup all partitions are mapped to. Defaults to `PRIMARY`. |
+| `AddBoundary<T>(value)` | Add a typed boundary, formatted to a canonical SQL literal. |
+| `AddBoundary(string)` | Add a boundary as a raw SQL literal (advanced; opts out of round-trip matching). |
+
+## Schema Migrations
+
+`RangePartitioning` participates in Weasel's normal schema-diff machinery. When you fetch the existing
+table back from the database, Weasel reads the partition function, scheme, column, type, direction, and
+boundary values into `Table.PartitionInfo`, then compares them against what you declared:
+
+```cs
+var delta = await table.FindDeltaAsync(connection);
+
+// SchemaPatchDifference.None    -> the table matches the database
+// SchemaPatchDifference.Update  -> new boundaries can be rolled forward in place
+// SchemaPatchDifference.Invalid -> the partitioning must be rebuilt
+Console.WriteLine(delta.PartitioningDifference);
+```
+
+### Rolling new partitions forward
+
+Adding boundaries beyond what already exists is an **additive** change. Weasel migrates it in place with
+`ALTER PARTITION FUNCTION ... SPLIT RANGE` (preceded by `ALTER PARTITION SCHEME ... NEXT USED`), so no
+table rebuild or data movement is required:
+
+```cs
+// The database already has boundaries for Jan/Feb 2026. Declare March as well...
+var partitioning = table.PartitionByRange("bucket_end", "datetime");
+partitioning.AddBoundary(new DateTime(2026, 1, 1));
+partitioning.AddBoundary(new DateTime(2026, 2, 1));
+partitioning.AddBoundary(new DateTime(2026, 3, 1)); // new
+
+// ...and Weasel emits: ALTER PARTITION FUNCTION [...]() SPLIT RANGE ('2026-03-01 00:00:00');
+await table.ApplyChangesAsync(connection);
+```
+
+This is the recommended way to "roll forward" a time-series table month over month: keep extending the
+declared boundary list and let migration add the new partitions.
+
+### Rebuilds
+
+Changing the partition **column** or **data type**, or *removing* a boundary that exists in the database,
+cannot be done with an in-place `SPLIT`. Weasel reports these as `SchemaPatchDifference.Invalid` rather
+than silently rebuilding the table and moving every row. Trimming aged partitions for data retention is a
+runtime operation (`MERGE RANGE` / `SWITCH OUT`) rather than a declarative schema change.
+
+## Managed Tenant Partitioning
+
+For multi-tenant tables where each tenant gets its own physical partition, use
+`PartitionByManagedTenants(...)` with a shared `ManagedTenantPartitions` manager. Tenants are allocated
+integer ordinals at sign-up, the table is partitioned `RANGE RIGHT` on the ordinal column, and the
+partition function is split for each new tenant at runtime. See the manager's API for
+`AddPartitionToAllTables` / `DropPartitionFromAllTables`.
+
+```cs
+var manager = new ManagedTenantPartitions(
+    "tenant-partitions",
+    new DbObjectName("dbo", "tenant_partitions"));
+table.PartitionByManagedTenants(manager);
+```
+
+Managed strategies own their boundaries at runtime, so — unlike `RangePartitioning` — they are not
+diffed or migrated by `FindDeltaAsync`.

--- a/src/Weasel.SqlServer.Tests/Tables/partitioning/range_partitioning_round_trip.cs
+++ b/src/Weasel.SqlServer.Tests/Tables/partitioning/range_partitioning_round_trip.cs
@@ -1,0 +1,152 @@
+using Shouldly;
+using Weasel.Core;
+using Weasel.SqlServer.Tables;
+using Weasel.SqlServer.Tables.Partitioning;
+using Xunit;
+
+namespace Weasel.SqlServer.Tests.Tables.partitioning;
+
+[Collection("integration")]
+public class range_partitioning_round_trip : IntegrationContext
+{
+    public range_partitioning_round_trip() : base("partitioning")
+    {
+    }
+
+    private Table MetricsTable(params DateTime[] boundaries)
+    {
+        var table = new Table("partitioning.metrics_sample");
+        table.AddColumn<int>("id");
+        table.AddColumn("bucket_end", "datetime").NotNull();
+        table.AddColumn<string>("data");
+
+        // The partition column must participate in the primary key on SQL Server.
+        table.ModifyColumn("id").AsPrimaryKey();
+        table.ModifyColumn("bucket_end").AsPrimaryKey();
+
+        var partitioning = table.PartitionByRange("bucket_end", "datetime");
+        foreach (var boundary in boundaries)
+        {
+            partitioning.AddBoundary(boundary);
+        }
+
+        return table;
+    }
+
+    private async Task<int> PartitionCountAsync(string tableName)
+    {
+        var count = await theConnection.CreateCommand($"""
+            SELECT COUNT(*)
+            FROM sys.partitions p
+            JOIN sys.objects o ON p.object_id = o.object_id
+            JOIN sys.schemas s ON o.schema_id = s.schema_id
+            WHERE s.name = 'partitioning' AND o.name = '{tableName}' AND p.index_id IN (0, 1)
+            """).ExecuteScalarAsync();
+
+        return (int)count!;
+    }
+
+    [Fact]
+    public async Task fetch_existing_reads_partition_metadata()
+    {
+        await ResetSchema();
+
+        var table = MetricsTable(new DateTime(2026, 1, 1), new DateTime(2026, 2, 1));
+        await CreateSchemaObjectInDatabase(table);
+
+        var existing = await table.FetchExistingAsync(theConnection);
+
+        existing.ShouldNotBeNull();
+        existing!.PartitionInfo.ShouldNotBeNull();
+        existing.PartitionInfo!.Column.ShouldBe("bucket_end");
+        existing.PartitionInfo.SqlDataType.ShouldBe("datetime");
+        existing.PartitionInfo.IsRangeRight.ShouldBeTrue();
+        existing.PartitionInfo.BoundaryValues.ShouldBe(
+            ["'2026-01-01 00:00:00'", "'2026-02-01 00:00:00'"]);
+    }
+
+    [Fact]
+    public async Task no_delta_for_an_unchanged_range_partitioned_table()
+    {
+        await ResetSchema();
+
+        var table = MetricsTable(new DateTime(2026, 1, 1), new DateTime(2026, 2, 1));
+        await CreateSchemaObjectInDatabase(table);
+
+        var delta = await table.FindDeltaAsync(theConnection);
+
+        delta.PartitioningDifference.ShouldBe(SchemaPatchDifference.None);
+        delta.HasChanges().ShouldBeFalse();
+        delta.Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task additive_boundary_is_detected_and_applied_with_split_range()
+    {
+        await ResetSchema();
+
+        var initial = MetricsTable(new DateTime(2026, 1, 1), new DateTime(2026, 2, 1));
+        await CreateSchemaObjectInDatabase(initial);
+        (await PartitionCountAsync("metrics_sample")).ShouldBe(3); // 2 boundaries -> 3 partitions
+
+        // Roll a new month forward.
+        var rolledForward = MetricsTable(
+            new DateTime(2026, 1, 1), new DateTime(2026, 2, 1), new DateTime(2026, 3, 1));
+
+        var delta = await rolledForward.FindDeltaAsync(theConnection);
+        delta.PartitioningDifference.ShouldBe(SchemaPatchDifference.Update);
+        delta.HasChanges().ShouldBeTrue();
+
+        var writer = new StringWriter();
+        delta.WriteUpdate(new SqlServerMigrator(), writer);
+        writer.ToString().ShouldContain("SPLIT RANGE ('2026-03-01 00:00:00')");
+
+        await rolledForward.ApplyChangesAsync(theConnection);
+
+        // The new boundary added a partition...
+        (await PartitionCountAsync("metrics_sample")).ShouldBe(4);
+
+        // ...and the table now round-trips clean.
+        var after = await rolledForward.FindDeltaAsync(theConnection);
+        after.HasChanges().ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task removing_a_boundary_is_a_rebuild()
+    {
+        await ResetSchema();
+
+        var initial = MetricsTable(new DateTime(2026, 1, 1), new DateTime(2026, 2, 1));
+        await CreateSchemaObjectInDatabase(initial);
+
+        var fewerBoundaries = MetricsTable(new DateTime(2026, 2, 1));
+
+        var delta = await fewerBoundaries.FindDeltaAsync(theConnection);
+
+        delta.PartitioningDifference.ShouldBe(SchemaPatchDifference.Invalid);
+        delta.Difference.ShouldBe(SchemaPatchDifference.Invalid);
+    }
+
+    [Fact]
+    public async Task bit_archived_partitioning_round_trips_with_no_delta()
+    {
+        // Regression guard for the consumer pattern (Polecat/Marten archived-events tables): a bit
+        // column partitioned RANGE RIGHT at boundary 1 must read back identically and report no delta.
+        await ResetSchema();
+
+        var table = new Table("partitioning.archived_events");
+        table.AddColumn<int>("id");
+        table.AddColumn<bool>("is_archived").NotNull();
+        table.AddColumn<string>("data");
+        table.ModifyColumn("id").AsPrimaryKey();
+        table.ModifyColumn("is_archived").AsPrimaryKey();
+        table.PartitionByRange("is_archived", "bit").AddBoundary(1);
+
+        await CreateSchemaObjectInDatabase(table);
+
+        var delta = await table.FindDeltaAsync(theConnection);
+
+        delta.PartitioningDifference.ShouldBe(SchemaPatchDifference.None);
+        delta.HasChanges().ShouldBeFalse();
+    }
+}

--- a/src/Weasel.SqlServer/Tables/Partitioning/RangePartitioning.cs
+++ b/src/Weasel.SqlServer/Tables/Partitioning/RangePartitioning.cs
@@ -140,6 +140,24 @@ public class RangePartitioning : ISqlServerPartitioning
         }
     }
 
+    /// <summary>
+    ///     Write ALTER PARTITION FUNCTION ... MERGE RANGE statements that remove the boundaries
+    ///     <see cref="WriteSplitStatements" /> would add. Used to roll an additive partition migration back.
+    /// </summary>
+    public void WriteMergeStatements(TextWriter writer, Table parent, SqlServerPartitionInfo actual)
+    {
+        var pfName = PartitionFunctionName(parent);
+        var actualSet = new HashSet<string>(actual.BoundaryValues, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var boundary in _boundaryValues)
+        {
+            if (!actualSet.Contains(boundary))
+            {
+                writer.WriteLine($"ALTER PARTITION FUNCTION [{pfName}]() MERGE RANGE ({boundary});");
+            }
+        }
+    }
+
     internal static string FormatSqlValue<T>(T? value)
     {
         if (value == null) return "NULL";

--- a/src/Weasel.SqlServer/Tables/Table.FetchExisting.cs
+++ b/src/Weasel.SqlServer/Tables/Table.FetchExisting.cs
@@ -87,6 +87,25 @@ order by
     ic.index_column_id;
 
 
+select
+    pf.name as partition_function,
+    ps.name as partition_scheme,
+    pc.name as partition_column,
+    pt.name as partition_type,
+    pf.boundary_value_on_right,
+    prv.value as boundary_value
+from sys.tables tbl
+    inner join sys.schemas sch on tbl.schema_id = sch.schema_id
+    inner join sys.indexes idx on tbl.object_id = idx.object_id and idx.index_id in (0, 1)
+    inner join sys.partition_schemes ps on idx.data_space_id = ps.data_space_id
+    inner join sys.partition_functions pf on ps.function_id = pf.function_id
+    inner join sys.index_columns icp on icp.object_id = tbl.object_id and icp.index_id = idx.index_id and icp.partition_ordinal >= 1
+    inner join sys.columns pc on pc.object_id = tbl.object_id and pc.column_id = icp.column_id
+    inner join sys.partition_parameters pp on pp.function_id = pf.function_id
+    inner join sys.types pt on pt.user_type_id = pp.user_type_id
+    left join sys.partition_range_values prv on prv.function_id = pf.function_id
+where sch.name = @{schemaParam} and tbl.name = @{nameParam}
+order by prv.boundary_id;
 
 ");
     }
@@ -118,9 +137,44 @@ order by
 
         await readIndexesAsync(reader, existing, ct).ConfigureAwait(false);
 
+        await readPartitioningAsync(reader, existing, ct).ConfigureAwait(false);
+
         return !existing.Columns.Any()
             ? null
             : existing;
+    }
+
+    private async Task readPartitioningAsync(DbDataReader reader, Table existing, CancellationToken ct = default)
+    {
+        var hasResults = await reader.NextResultAsync(ct).ConfigureAwait(false);
+        if (!hasResults)
+        {
+            return;
+        }
+
+        Partitioning.SqlServerPartitionInfo? info = null;
+
+        while (await reader.ReadAsync(ct).ConfigureAwait(false))
+        {
+            info ??= new Partitioning.SqlServerPartitionInfo();
+
+            info.PartitionFunctionName = await reader.GetFieldValueAsync<string>(0, ct).ConfigureAwait(false);
+            info.PartitionSchemeName = await reader.GetFieldValueAsync<string>(1, ct).ConfigureAwait(false);
+            info.Column = await reader.GetFieldValueAsync<string>(2, ct).ConfigureAwait(false);
+            info.SqlDataType = await reader.GetFieldValueAsync<string>(3, ct).ConfigureAwait(false);
+            info.IsRangeRight = await reader.GetFieldValueAsync<bool>(4, ct).ConfigureAwait(false);
+
+            // sys.partition_range_values.value is a sql_variant carrying the boundary as its native CLR
+            // type (DateTime, DateTimeOffset, int, bool, ...). Format it through the SAME canonical
+            // formatter used to declare boundaries so a round-trip compares equal with no spurious rebuild.
+            if (!await reader.IsDBNullAsync(5, ct).ConfigureAwait(false))
+            {
+                var boundary = reader.GetValue(5);
+                info.BoundaryValues.Add(Partitioning.RangePartitioning.FormatSqlValue(boundary));
+            }
+        }
+
+        existing.PartitionInfo = info;
     }
 
     private async Task readForeignKeysAsync(DbDataReader reader, Table existing, CancellationToken ct = default)

--- a/src/Weasel.SqlServer/Tables/Table.cs
+++ b/src/Weasel.SqlServer/Tables/Table.cs
@@ -85,6 +85,14 @@ public partial class Table: TableBase<TableColumn, IndexDefinition, ForeignKey>
     public Partitioning.ISqlServerPartitioning? SqlServerPartitioning { get; set; }
 
     /// <summary>
+    ///     The actual RANGE partitioning metadata read back from the database by
+    ///     <see cref="FetchExistingAsync" />. Null when the table is not partitioned. Consumed by
+    ///     <see cref="TableDelta" /> to tell an additive boundary change (which migrates via
+    ///     <c>ALTER PARTITION FUNCTION ... SPLIT RANGE</c>) apart from a partitioning rebuild.
+    /// </summary>
+    public Partitioning.SqlServerPartitionInfo? PartitionInfo { get; set; }
+
+    /// <summary>
     ///     Configure SQL Server RANGE partitioning on a column.
     /// </summary>
     public Partitioning.RangePartitioning PartitionByRange(string column, string sqlDataType)

--- a/src/Weasel.SqlServer/Tables/TableDelta.cs
+++ b/src/Weasel.SqlServer/Tables/TableDelta.cs
@@ -16,6 +16,14 @@ public class TableDelta: SchemaObjectDelta<Table>
 
     public SchemaPatchDifference PrimaryKeyDifference { get; private set; }
 
+    /// <summary>
+    ///     Difference between the declared SQL Server RANGE partitioning and what is in the database.
+    ///     <see cref="SchemaPatchDifference.Update" /> means new boundaries can be added via
+    ///     <c>ALTER PARTITION FUNCTION ... SPLIT RANGE</c>; <see cref="SchemaPatchDifference.Invalid" />
+    ///     means the partitioning would have to be rebuilt (column/type change or boundaries removed).
+    /// </summary>
+    public SchemaPatchDifference PartitioningDifference { get; private set; } = SchemaPatchDifference.None;
+
     protected override SchemaPatchDifference compare(Table expected, Table? actual)
     {
         if (actual == null)
@@ -44,6 +52,19 @@ public class TableDelta: SchemaObjectDelta<Table>
         else if (!expected.PrimaryKeyColumns.SequenceEqual(actual.PrimaryKeyColumns))
         {
             PrimaryKeyDifference = SchemaPatchDifference.Update;
+        }
+
+        // Declarative RANGE partitioning round-trip. Only RangePartitioning is migrated here; managed
+        // strategies (e.g. ManagedTenantPartitions) own their boundaries at runtime and are left alone.
+        PartitioningDifference = SchemaPatchDifference.None;
+        if (expected.SqlServerPartitioning is Partitioning.RangePartitioning rangePartitioning)
+        {
+            PartitioningDifference = rangePartitioning.CreateDelta(actual.PartitionInfo) switch
+            {
+                Partitioning.PartitionDelta.None => SchemaPatchDifference.None,
+                Partitioning.PartitionDelta.Additive => SchemaPatchDifference.Update,
+                _ => SchemaPatchDifference.Invalid
+            };
         }
 
         return determinePatchDifference();
@@ -93,6 +114,14 @@ public class TableDelta: SchemaObjectDelta<Table>
 
         // Extra columns
         foreach (var column in Columns.Extras) writer.WriteLine(column.DropColumnSql(Expected));
+
+        // Additive RANGE partition boundaries -> ALTER PARTITION FUNCTION ... SPLIT RANGE
+        if (PartitioningDifference == SchemaPatchDifference.Update
+            && Expected.SqlServerPartitioning is Partitioning.RangePartitioning rangePartitioning
+            && Actual?.PartitionInfo != null)
+        {
+            rangePartitioning.WriteSplitStatements(writer, Expected, Actual.PartitionInfo);
+        }
 
         switch (PrimaryKeyDifference)
         {
@@ -166,6 +195,14 @@ public class TableDelta: SchemaObjectDelta<Table>
         foreach (var column in Columns.Missing) writer.WriteLine(column.DropColumnSql(Expected));
 
         foreach (var foreignKey in ForeignKeys.Extras) foreignKey.WriteAddStatement(Expected, writer);
+
+        // Roll an additive partition split back out -> ALTER PARTITION FUNCTION ... MERGE RANGE
+        if (PartitioningDifference == SchemaPatchDifference.Update
+            && Expected.SqlServerPartitioning is Partitioning.RangePartitioning rangePartitioning
+            && Actual?.PartitionInfo != null)
+        {
+            rangePartitioning.WriteMergeStatements(writer, Expected, Actual.PartitionInfo);
+        }
 
         switch (PrimaryKeyDifference)
         {
@@ -246,7 +283,8 @@ public class TableDelta: SchemaObjectDelta<Table>
 
         var differences = new[]
         {
-            Columns.Difference(), ForeignKeys.Difference(), Indexes.Difference(), PrimaryKeyDifference
+            Columns.Difference(), ForeignKeys.Difference(), Indexes.Difference(), PrimaryKeyDifference,
+            PartitioningDifference
         };
 
         return differences.Min();
@@ -267,7 +305,8 @@ public class TableDelta: SchemaObjectDelta<Table>
     public bool HasChanges()
     {
         return Columns.HasChanges() || Indexes.HasChanges() || ForeignKeys.HasChanges() ||
-               PrimaryKeyDifference != SchemaPatchDifference.None;
+               PrimaryKeyDifference != SchemaPatchDifference.None ||
+               PartitioningDifference != SchemaPatchDifference.None;
     }
 
     public override string ToString()


### PR DESCRIPTION
Closes #317.

Makes Weasel's existing declarative SQL Server RANGE partitioning a **fully managed** schema object instead of create-only. Previously `PartitionByRange(...)` could render a partitioned `CREATE TABLE`, but `FetchExisting` never read partition metadata back and `TableDelta` never diffed it — so boundaries could not be rolled forward by migration (`WriteSplitStatements` was dead code).

## What's in

- **`Table.FetchExisting`** now reads the partition function/scheme, partition column, data type, `RANGE LEFT/RIGHT` direction, and boundary values back into a new **`Table.PartitionInfo`**. Boundaries are read from `sys.partition_range_values` as their native CLR value and formatted through the *same* canonical formatter used to declare them, so a typed boundary round-trips with no spurious drift.
- **`TableDelta`** diffs `RangePartitioning` via the new **`PartitioningDifference`**:
  - added boundaries → `SchemaPatchDifference.Update`, migrated in place with `ALTER PARTITION SCHEME ... NEXT USED` + `ALTER PARTITION FUNCTION ... SPLIT RANGE` (roll-forward);
  - changed column/type or a **removed** boundary → `Invalid` (a rebuild — not silently rebuilt/data-moved).
- **`RangePartitioning.WriteMergeStatements`** rolls an additive split back out via `MERGE RANGE` (used by `WriteRollback`).
- Managed strategies (`ManagedTenantPartitions`) own their boundaries at runtime and are deliberately **excluded** from the declarative diff.

## Tests

New `range_partitioning_round_trip` integration tests (SQL Server): metadata read-back, no-delta on an unchanged table, additive boundary detected + applied via `SPLIT RANGE` (partition count grows, then round-trips clean), boundary removal reported as a rebuild, and a bit-archived regression guard mirroring the Polecat/Marten archived-events pattern. Full `Weasel.SqlServer.Tests` suite green locally (268 passed / 8 skipped) against SQL Server 2025.

## Docs

Adds `docs/sqlserver/partitioning.md` (range partitioning, roll-forward migrations, rebuild semantics, managed tenant partitioning) wired into the sidebar + overview.

## Scope note

This delivers the round-trip + declarative roll-forward half of #317. A runtime retention manager that *drops* aged partitions (`SWITCH OUT` + `MERGE RANGE`, the SQL Server analog of `ManagedTenantPartitions`) is the natural follow-up and is called out in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)