### PR TITLE
feat: use Guid.CreateVersion7() for shared sequential-Guid identity generation

### DIFF
--- a/src/Weasel.Core/Identity/SequentialGuidIdentification.cs
+++ b/src/Weasel.Core/Identity/SequentialGuidIdentification.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
-using JasperFx.Core;
 using JasperFx.Core.Reflection;
 using Weasel.Core.Sequences;
 
@@ -9,8 +8,8 @@ namespace Weasel.Core.Identity;
 
 /// <summary>
 ///     <see cref="IIdentification{TDoc,TId}" /> for documents whose id is a <see cref="Guid" />
-///     generated sequentially (comb) via <see cref="CombGuidIdGeneration" /> — no database
-///     round-trip.
+///     generated sequentially via <see cref="Guid.CreateVersion7()" /> (a time-ordered UUIDv7, for
+///     index locality) — no database round-trip.
 /// </summary>
 public sealed class SequentialGuidIdentification<TDoc> : IIdentification<TDoc, Guid>
     where TDoc : notnull
@@ -42,7 +41,7 @@ public sealed class SequentialGuidIdentification<TDoc> : IIdentification<TDoc, G
             return current;
         }
 
-        var assigned = CombGuidIdGeneration.NewGuid();
+        var assigned = Guid.CreateVersion7();
         _setter(document, assigned);
         return assigned;
     }

--- a/src/Weasel.Core/Identity/ValueTypeIdentification.cs
+++ b/src/Weasel.Core/Identity/ValueTypeIdentification.cs
@@ -15,8 +15,9 @@ namespace Weasel.Core.Identity;
 ///     int / long / string).
 /// </summary>
 /// <remarks>
-///     Generation strategy depends on the inner type: Guid → <see cref="Guid.NewGuid" />;
-///     int / long → per-document Hi-Lo sequence; string → externally assigned (throws on missing).
+///     Generation strategy depends on the inner type: Guid → <see cref="Guid.CreateVersion7()" />
+///     (time-ordered UUIDv7, for index locality); int / long → per-document Hi-Lo sequence;
+///     string → externally assigned (throws on missing).
 /// </remarks>
 public sealed class ValueTypeIdentification<TDoc, TWrapper, TInner> : IIdentification<TDoc, TWrapper>
     where TDoc : notnull
@@ -127,7 +128,7 @@ public sealed class ValueTypeIdentification<TDoc, TWrapper, TInner> : IIdentific
     {
         if (simpleType == typeof(Guid))
         {
-            return _ => (TInner)(object)Guid.NewGuid();
+            return _ => (TInner)(object)Guid.CreateVersion7();
         }
         if (simpleType == typeof(int))
         {


### PR DESCRIPTION
Follow-up to #321. The lifted closed-shape identity family inherited an inconsistency from Marten: plain `Guid` ids were generated **sequentially** (CombGuid) but strong-typed Guid-*wrapper* ids were generated **randomly** (`Guid.NewGuid()`).

This unifies the *sequential/default* Guid mechanism on **`Guid.CreateVersion7()`** (time-ordered UUIDv7) across both `SequentialGuidIdentification` and `ValueTypeIdentification`, so wrapped and unwrapped Guid ids get the same index-friendly, time-ordered generation. `GuidIdentification` (the explicit random strategy) keeps `Guid.NewGuid()`.

**Consumer note (Marten adoption / JasperFx/marten#4811):** this changes the default sequential-Guid algorithm from CombGuid to UUIDv7 — both are time-ordered / index-friendly, and v7 is the standard modern choice. Part of JasperFx/polecat#273.

Builds clean on net9.0/net10.0 (`Guid.CreateVersion7()` is .NET 9+).

🤖 Generated with [Claude Code](https://claude.com/claude-code)