### PR TITLE
feat: DbParameter[]-returning AppendWithDbParameters on non-generic ICommandBuilder (#324)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>9.5.0</Version>
+        <Version>9.6.0</Version>
         <LangVersion>13.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/src/Weasel.Core/CommandBuilderBase.cs
+++ b/src/Weasel.Core/CommandBuilderBase.cs
@@ -434,6 +434,33 @@ public class CommandBuilderBase<TCommand, TParameter, TParameterType>: ICommandB
         return parameters;
     }
 #endif
+
+    /// <summary>
+    ///     Append a SQL string with `?` placeholders for new parameters, and returns an
+    ///     array of the newly created parameters upcast to the dialect-neutral <see cref="DbParameter" />.
+    ///     Use this from database-agnostic consumers that fill parameter slots without
+    ///     referencing the provider-specific parameter type.
+    /// </summary>
+    /// <param name="text"></param>
+    /// <returns></returns>
+    public DbParameter[] AppendWithDbParameters(string text)
+    {
+        return AppendWithParameters(text);
+    }
+
+    /// <summary>
+    ///     Append a SQL string with user defined placeholder characters for new parameters, and returns an
+    ///     array of the newly created parameters upcast to the dialect-neutral <see cref="DbParameter" />.
+    ///     Use this from database-agnostic consumers that fill parameter slots without
+    ///     referencing the provider-specific parameter type.
+    /// </summary>
+    /// <param name="text"></param>
+    /// <param name="placeholder"></param>
+    /// <returns></returns>
+    public DbParameter[] AppendWithDbParameters(string text, char placeholder)
+    {
+        return AppendWithParameters(text, placeholder);
+    }
 }
 
 // Note: Those methods are intentionally not written as extension methods

--- a/src/Weasel.Postgresql.Tests/CommandBuilderTests.cs
+++ b/src/Weasel.Postgresql.Tests/CommandBuilderTests.cs
@@ -1,3 +1,4 @@
+using System.Data.Common;
 using Npgsql;
 using Shouldly;
 using Xunit;
@@ -16,6 +17,44 @@ public class CommandBuilderTests
             .Length.ShouldBe(1);
 
         builder.ToString().ShouldBe("select data from table where foo = :p0");
+    }
+
+    [Fact]
+    public void append_with_db_parameters_returns_neutral_db_parameters()
+    {
+        ICommandBuilder builder = new CommandBuilder(new NpgsqlCommand());
+
+        builder.Append("select data from table where ");
+        DbParameter[] parameters = builder.AppendWithDbParameters("foo = ? and bar = ?");
+
+        parameters.Length.ShouldBe(2);
+        parameters.ShouldAllBe(x => x is NpgsqlParameter);
+
+        builder.ToString().ShouldBe("select data from table where foo = :p0 and bar = :p1");
+    }
+
+    [Fact]
+    public void append_with_db_parameters_honors_custom_placeholder()
+    {
+        ICommandBuilder builder = new CommandBuilder(new NpgsqlCommand());
+
+        builder.Append("select data from table where ");
+        DbParameter[] parameters = builder.AppendWithDbParameters("foo = ^ and bar = ^", '^');
+
+        parameters.Length.ShouldBe(2);
+        builder.ToString().ShouldBe("select data from table where foo = :p0 and bar = :p1");
+    }
+
+    [Fact]
+    public void batch_builder_append_with_db_parameters_returns_neutral_db_parameters()
+    {
+        ICommandBuilder builder = new BatchBuilder();
+
+        builder.Append("select data from table where ");
+        DbParameter[] parameters = builder.AppendWithDbParameters("foo = ? and bar = ?");
+
+        parameters.Length.ShouldBe(2);
+        parameters.ShouldAllBe(x => x is NpgsqlParameter);
     }
 
     [Fact]

--- a/src/Weasel.Postgresql/BatchBuilder.cs
+++ b/src/Weasel.Postgresql/BatchBuilder.cs
@@ -178,6 +178,17 @@ public class BatchBuilder: ICommandBuilder
         return parameters;
     }
 #endif
+
+    public System.Data.Common.DbParameter[] AppendWithDbParameters(string text)
+    {
+        return AppendWithParameters(text);
+    }
+
+    public System.Data.Common.DbParameter[] AppendWithDbParameters(string text, char placeholder)
+    {
+        return AppendWithParameters(text, placeholder);
+    }
+
     public void StartNewCommand()
     {
         if (_current != null)

--- a/src/Weasel.Postgresql/ICommandBuilder.cs
+++ b/src/Weasel.Postgresql/ICommandBuilder.cs
@@ -1,3 +1,4 @@
+using System.Data.Common;
 using Npgsql;
 using NpgsqlTypes;
 
@@ -44,6 +45,25 @@ public interface ICommandBuilder
     /// <param name="separator"></param>
     /// <returns></returns>
     NpgsqlParameter[] AppendWithParameters(string text, char placeholder);
+
+    /// <summary>
+    ///     Append a SQL string with `?` placeholders for new parameters, and returns an
+    ///     array of the newly created parameters upcast to the dialect-neutral <see cref="DbParameter" />.
+    ///     Lets a database-agnostic consumer fill parameter slots without referencing <see cref="NpgsqlParameter" />.
+    /// </summary>
+    /// <param name="text"></param>
+    /// <returns></returns>
+    DbParameter[] AppendWithDbParameters(string text);
+
+    /// <summary>
+    ///     Append a SQL string with user defined placeholder characters for new parameters, and returns an
+    ///     array of the newly created parameters upcast to the dialect-neutral <see cref="DbParameter" />.
+    ///     Lets a database-agnostic consumer fill parameter slots without referencing <see cref="NpgsqlParameter" />.
+    /// </summary>
+    /// <param name="text"></param>
+    /// <param name="placeholder"></param>
+    /// <returns></returns>
+    DbParameter[] AppendWithDbParameters(string text, char placeholder);
 
     void StartNewCommand();
 

--- a/src/Weasel.SqlServer.Tests/CommandBuilderTests.cs
+++ b/src/Weasel.SqlServer.Tests/CommandBuilderTests.cs
@@ -1,3 +1,4 @@
+using System.Data.Common;
 using Microsoft.Data.SqlClient;
 using Shouldly;
 using Xunit;
@@ -16,6 +17,29 @@ public class CommandBuilderTests
             .Length.ShouldBe(1);
 
         builder.ToString().ShouldBe("select data from table where foo = @p0");
+    }
+
+    [Fact]
+    public void append_with_db_parameters_returns_neutral_db_parameters()
+    {
+        ICommandBuilder builder = new BatchBuilder();
+
+        builder.Append("select data from table where ");
+        DbParameter[] parameters = builder.AppendWithDbParameters("foo = ? and bar = ?");
+
+        parameters.Length.ShouldBe(2);
+        parameters.ShouldAllBe(x => x is SqlParameter);
+    }
+
+    [Fact]
+    public void append_with_db_parameters_honors_custom_placeholder()
+    {
+        ICommandBuilder builder = new BatchBuilder();
+
+        builder.Append("select data from table where ");
+        DbParameter[] parameters = builder.AppendWithDbParameters("foo = ^ and bar = ^", '^');
+
+        parameters.Length.ShouldBe(2);
     }
 
     [Fact]

--- a/src/Weasel.SqlServer/BatchBuilder.cs
+++ b/src/Weasel.SqlServer/BatchBuilder.cs
@@ -202,6 +202,16 @@ public class BatchBuilder: ICommandBuilder
     }
 #endif
 
+    public System.Data.Common.DbParameter[] AppendWithDbParameters(string text)
+    {
+        return AppendWithParameters(text);
+    }
+
+    public System.Data.Common.DbParameter[] AppendWithDbParameters(string text, char placeholder)
+    {
+        return AppendWithParameters(text, placeholder);
+    }
+
     public void StartNewCommand()
     {
         if (_current != null)

--- a/src/Weasel.SqlServer/ICommandBuilder.cs
+++ b/src/Weasel.SqlServer/ICommandBuilder.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Data.Common;
 using Microsoft.Data.SqlClient;
 
 namespace Weasel.SqlServer;
@@ -43,6 +44,25 @@ public interface ICommandBuilder
     /// <param name="placeholder"></param>
     /// <returns></returns>
     SqlParameter[] AppendWithParameters(string text, char placeholder);
+
+    /// <summary>
+    ///     Append a SQL string with `?` placeholders for new parameters, and returns an
+    ///     array of the newly created parameters upcast to the dialect-neutral <see cref="DbParameter" />.
+    ///     Lets a database-agnostic consumer fill parameter slots without referencing <see cref="SqlParameter" />.
+    /// </summary>
+    /// <param name="text"></param>
+    /// <returns></returns>
+    DbParameter[] AppendWithDbParameters(string text);
+
+    /// <summary>
+    ///     Append a SQL string with user defined placeholder characters for new parameters, and returns an
+    ///     array of the newly created parameters upcast to the dialect-neutral <see cref="DbParameter" />.
+    ///     Lets a database-agnostic consumer fill parameter slots without referencing <see cref="SqlParameter" />.
+    /// </summary>
+    /// <param name="text"></param>
+    /// <param name="placeholder"></param>
+    /// <returns></returns>
+    DbParameter[] AppendWithDbParameters(string text, char placeholder);
 
     void StartNewCommand();
 


### PR DESCRIPTION
Closes #324.

## Context

Marten is extracting its closed-shape document-storage runtime toward a database-agnostic contract (JasperFx/marten#4821). The one remaining external boundary is the operation parameter layer, gated by Weasel's command-builder API: the non-generic `ICommandBuilder.AppendWithParameters` returns the provider-specific `NpgsqlParameter[]` / `SqlParameter[]`, tying every operation that fills parameter slots to Npgsql (or SqlClient).

## Change

Exposes a dialect-neutral `DbParameter[]`-returning `AppendWithDbParameters` on the neutral surface so a database-agnostic consumer can fill parameter slots as `DbParameter` (setting the provider type via its own dialect seam) without referencing the provider parameter type:

```csharp
DbParameter[] AppendWithDbParameters(string text);
DbParameter[] AppendWithDbParameters(string text, char placeholder);
```

Added to both `Weasel.Postgresql.ICommandBuilder` and `Weasel.SqlServer.ICommandBuilder`. Each implementation simply upcasts its existing provider-specific `AppendWithParameters` result via array covariance — the Postgres builder returns its `NpgsqlParameter[]`, the SQL Server builder its `SqlParameter[]`.

Implemented across all three implementers:
- `CommandBuilderBase<TCommand, TParameter, TParameterType>` (Weasel.Core) — inherited by every provider `CommandBuilder`
- `Weasel.Postgresql.BatchBuilder`
- `Weasel.SqlServer.BatchBuilder`

Because the methods live on `CommandBuilderBase`, the neutral surface is also available on the MySql, Oracle, and Sqlite command builders for free.

## Tests

New unit tests in `Weasel.Postgresql.Tests` and `Weasel.SqlServer.Tests` verifying `AppendWithDbParameters` returns the correct count, produces the expected parameterized SQL, honors custom placeholders, and yields the provider-specific parameter instances behind the `DbParameter` upcast. All passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)