### PR TITLE
Make partition creation idempotent with CREATE TABLE IF NOT EXISTS

### DIFF
--- a/src/Weasel.Postgresql.Tests/KeywordIdentifierTests.cs
+++ b/src/Weasel.Postgresql.Tests/KeywordIdentifierTests.cs
@@ -127,7 +127,7 @@ public class KeywordIdentifierTests
 
         var expectedParent = QuoteQualifiedName(keyword, keyword);
         var expectedPartition = QuoteQualifiedName(keyword, keyword + "_" + suffixes[0]);
-        sql.ShouldContain($"create table {expectedPartition} partition of {expectedParent}");
+        sql.ShouldContain($"create table if not exists {expectedPartition} partition of {expectedParent}");
     }
 
     [Theory]
@@ -144,7 +144,7 @@ public class KeywordIdentifierTests
 
         var expectedParent = QuoteQualifiedName(keyword, keyword);
         var expectedPartition = QuoteQualifiedName(keyword, keyword + "_a");
-        sql.ShouldContain($"CREATE TABLE {expectedPartition} partition of {expectedParent}");
+        sql.ShouldContain($"CREATE TABLE IF NOT EXISTS {expectedPartition} partition of {expectedParent}");
     }
 
     [Theory]
@@ -161,7 +161,7 @@ public class KeywordIdentifierTests
 
         var expectedParent = QuoteQualifiedName(keyword, keyword);
         var expectedPartition = QuoteQualifiedName(keyword, keyword + "_a");
-        sql.ShouldContain($"CREATE TABLE {expectedPartition} PARTITION OF {expectedParent}");
+        sql.ShouldContain($"CREATE TABLE IF NOT EXISTS {expectedPartition} PARTITION OF {expectedParent}");
     }
 
     [Theory]
@@ -177,7 +177,7 @@ public class KeywordIdentifierTests
         var sql = writer.ToString();
         var expectedParent = QuoteQualifiedName(keyword, keyword);
         var expectedPartition = QuoteQualifiedName(keyword, keyword + "_default");
-        sql.ShouldContain($"CREATE TABLE {expectedPartition} PARTITION OF {expectedParent} DEFAULT;");
+        sql.ShouldContain($"CREATE TABLE IF NOT EXISTS {expectedPartition} PARTITION OF {expectedParent} DEFAULT;");
     }
 
     [Theory]

--- a/src/Weasel.Postgresql.Tests/Tables/partitioning/hash_partitions.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/partitioning/hash_partitions.cs
@@ -48,9 +48,9 @@ public class hash_partitions: IntegrationContext
 
         sql.ShouldContain("PARTITION BY HASH (role)");
 
-        sql.ShouldContain("create table partitions.people_one partition of partitions.people for values with (modulus 3, remainder 0);");
-        sql.ShouldContain("create table partitions.people_two partition of partitions.people for values with (modulus 3, remainder 1);");
-        sql.ShouldContain("create table partitions.people_three partition of partitions.people for values with (modulus 3, remainder 2);");
+        sql.ShouldContain("create table if not exists partitions.people_one partition of partitions.people for values with (modulus 3, remainder 0);");
+        sql.ShouldContain("create table if not exists partitions.people_two partition of partitions.people for values with (modulus 3, remainder 1);");
+        sql.ShouldContain("create table if not exists partitions.people_three partition of partitions.people for values with (modulus 3, remainder 2);");
 
         await tryToCreateTable();
     }

--- a/src/Weasel.Postgresql.Tests/Tables/partitioning/partition_creation_is_idempotent.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/partitioning/partition_creation_is_idempotent.cs
@@ -1,0 +1,94 @@
+using Weasel.Core;
+using Weasel.Postgresql.Tables;
+using Weasel.Postgresql.Tables.Partitioning;
+using Xunit;
+
+namespace Weasel.Postgresql.Tests.Tables.partitioning;
+
+// Partition creation must be idempotent (CREATE TABLE IF NOT EXISTS ... PARTITION OF): two concurrent
+// schema appliers (e.g. dynamic tenant provisioning racing an async daemon's storage check in a Marten
+// consumer) can both compute the same "missing" partition from a momentarily stale snapshot and both
+// emit the CREATE. Without IF NOT EXISTS the loser fails its whole migration batch with 42P07.
+[Collection("partitions")]
+public class partition_creation_is_idempotent: IntegrationContext
+{
+    public partition_creation_is_idempotent(): base("partitions")
+    {
+    }
+
+    private static string DdlOf(Action<TextWriter> write)
+    {
+        var writer = new StringWriter();
+        write(writer);
+        return writer.ToString();
+    }
+
+    [Fact]
+    public async Task reapplying_list_partition_ddl_of_an_existing_partition_does_not_throw()
+    {
+        await ResetSchema();
+
+        var table = new Table("partitions.people");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn<string>("role")
+            .PartitionByListValues()
+            .AddPartition("admin", "admin");
+
+        await table.CreateAsync(theConnection);
+
+        // Re-issue the same partition DDL as a racing second applier would.
+        var ddl = DdlOf(w => ((IPartition)new ListPartition("admin", "'admin'")).WriteCreateStatement(w, table));
+        await theConnection.CreateCommand(ddl).ExecuteNonQueryAsync(); // must not throw 42P07
+    }
+
+    [Fact]
+    public async Task reapplying_range_partition_ddl_of_an_existing_partition_does_not_throw()
+    {
+        await ResetSchema();
+
+        var table = new Table("partitions.people");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn<string>("role")
+            .PartitionByRange()
+            .AddRange("twenties", 20, 29);
+
+        await table.CreateAsync(theConnection);
+
+        var ddl = DdlOf(w => ((IPartition)new RangePartition("twenties", "20", "29")).WriteCreateStatement(w, table));
+        await theConnection.CreateCommand(ddl).ExecuteNonQueryAsync(); // must not throw 42P07
+    }
+
+    [Fact]
+    public async Task reapplying_hash_partition_ddl_of_an_existing_partition_does_not_throw()
+    {
+        await ResetSchema();
+
+        var table = new Table("partitions.people");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn<string>("role")
+            .PartitionByHash("one", "two", "three");
+
+        await table.CreateAsync(theConnection);
+
+        var ddl = DdlOf(w => new HashPartition("one", 3, 0).WriteCreateStatement(w, table));
+        await theConnection.CreateCommand(ddl).ExecuteNonQueryAsync(); // must not throw 42P07
+    }
+
+    [Fact]
+    public async Task reapplying_default_partition_ddl_of_an_existing_partition_does_not_throw()
+    {
+        await ResetSchema();
+
+        var table = new Table("partitions.people");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn<string>("role")
+            .PartitionByListValues()
+            .AddPartition("admin", "admin");
+
+        await table.CreateAsync(theConnection);
+
+        var ddl = DdlOf(w => w.WriteDefaultPartition(table.Identifier));
+        await theConnection.CreateCommand(ddl).ExecuteNonQueryAsync(); // first applier creates people_default
+        await theConnection.CreateCommand(ddl).ExecuteNonQueryAsync(); // racing applier must not throw 42P07
+    }
+}

--- a/src/Weasel.Postgresql/Tables/Partitioning/HashPartition.cs
+++ b/src/Weasel.Postgresql/Tables/Partitioning/HashPartition.cs
@@ -21,7 +21,8 @@ public record HashPartition
         var partitionName = PostgresqlObjectName.From(
             new DbObjectName(parent.Identifier.Schema, parent.Identifier.Name + "_" + Suffix));
         var parentName = PostgresqlObjectName.From(parent.Identifier);
-        writer.WriteLine($"create table {partitionName} partition of {parentName} for values with (modulus {Modulus}, remainder {Remainder});");
+        // IF NOT EXISTS: keep partition creation idempotent under concurrent schema application.
+        writer.WriteLine($"create table if not exists {partitionName} partition of {parentName} for values with (modulus {Modulus}, remainder {Remainder});");
     }
 
     public static HashPartition Parse(string suffix, string expression)

--- a/src/Weasel.Postgresql/Tables/Partitioning/ListPartition.cs
+++ b/src/Weasel.Postgresql/Tables/Partitioning/ListPartition.cs
@@ -52,7 +52,9 @@ public class ListPartition : IPartition
         var partitionName = PostgresqlObjectName.From(
             new DbObjectName(parent.Identifier.Schema, parent.Identifier.Name + "_" + Suffix));
         var parentName = PostgresqlObjectName.From(parent.Identifier);
-        writer.WriteLine($"CREATE TABLE {partitionName} partition of {parentName} for values in ({Values.Join(", ")});");
+        // IF NOT EXISTS: concurrent schema appliers (e.g. tenant provisioning racing an async daemon's
+        // storage check) may both compute the same missing partition; creation must be idempotent.
+        writer.WriteLine($"CREATE TABLE IF NOT EXISTS {partitionName} partition of {parentName} for values in ({Values.Join(", ")});");
     }
 
     internal static ListPartition Parse(DbObjectName dbObjectName, string partitionTableName, string postgresExpression)

--- a/src/Weasel.Postgresql/Tables/Partitioning/PartitionExtensions.cs
+++ b/src/Weasel.Postgresql/Tables/Partitioning/PartitionExtensions.cs
@@ -17,7 +17,8 @@ public static class PartitionExtensions
         var partitionName = PostgresqlObjectName.From(
             new DbObjectName(identifier.Schema, identifier.Name + "_default"));
         var parentName = PostgresqlObjectName.From(identifier);
-        writer.WriteLine($"CREATE TABLE {partitionName} PARTITION OF {parentName} DEFAULT;");
+        // IF NOT EXISTS: keep partition creation idempotent under concurrent schema application.
+        writer.WriteLine($"CREATE TABLE IF NOT EXISTS {partitionName} PARTITION OF {parentName} DEFAULT;");
     }
 
     /// <summary>

--- a/src/Weasel.Postgresql/Tables/Partitioning/RangePartition.cs
+++ b/src/Weasel.Postgresql/Tables/Partitioning/RangePartition.cs
@@ -33,7 +33,8 @@ public class RangePartition : IPartition
         var partitionName = PostgresqlObjectName.From(
             new DbObjectName(parent.Identifier.Schema, parent.Identifier.Name + "_" + Suffix));
         var parentName = PostgresqlObjectName.From(parent.Identifier);
-        writer.WriteLine($"CREATE TABLE {partitionName} PARTITION OF {parentName} FOR VALUES FROM ({From}) TO ({To});");
+        // IF NOT EXISTS: keep partition creation idempotent under concurrent schema application.
+        writer.WriteLine($"CREATE TABLE IF NOT EXISTS {partitionName} PARTITION OF {parentName} FOR VALUES FROM ({From}) TO ({To});");
     }
 
     protected bool Equals(RangePartition other)


### PR DESCRIPTION
## Problem

The partition-creation DDL emitted by `ListPartition`, `RangePartition`, `HashPartition` and `WriteDefaultPartition` uses plain `CREATE TABLE ... PARTITION OF ...`. When two schema appliers run concurrently, both can compute the same *missing* partition from a momentarily stale snapshot and both emit the CREATE — the loser then fails its whole 'All Configured Changes' batch with `42P07: relation already exists`.

This is not hypothetical: in a Marten consumer under `MultiTenantedWithShardedDatabases` + per-tenant list partitioning, dynamic tenant provisioning (`AddPartitionToAllTables`) racing the async daemon's storage check reliably produced exactly this failure while provisioning 500 tenants across 512 shard databases:

```
Marten.Exceptions.MartenSchemaException: DDL Execution for 'All Configured Changes' Failed!
...
CREATE TABLE public.mt_doc_claimlinebyreferencenumber_11_01008661 partition of public.mt_doc_claimlinebyreferencenumber_11 for values in ('01008661');
...
 ---> Npgsql.PostgresException (0x80004005): 42P07: relation "mt_doc_claimlinebyreferencenumber_11_01008661" already exists
```

The `IgnorePartitionsInMigration` flag guards the *sequential* re-apply case, but cannot help when two appliers race.

## Fix

Emit `CREATE TABLE IF NOT EXISTS ... PARTITION OF ...` (supported since PostgreSQL 10) for list, range, hash and default partitions, so the losing applier becomes a no-op instead of failing the batch.

Includes a new integration-test class `partition_creation_is_idempotent` that re-issues the partition DDL of an already-existing partition for all four partition kinds, plus updated DDL-string assertions.