### PR TITLE
Shared Weasel.Core SQL-generation contract (#327)

### DIFF
--- a/src/Weasel.Core/ICommandBuilder.cs
+++ b/src/Weasel.Core/ICommandBuilder.cs
@@ -1,0 +1,86 @@
+using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Weasel.Core;
+
+/// <summary>
+///     Dialect-neutral, non-generic command-builder surface shared by every Weasel provider's
+///     command builders. Only exposes members whose signatures are identical across dialects —
+///     parameters flow through the ADO.NET-neutral <see cref="DbParameter" /> (see
+///     <see cref="AppendWithDbParameters(string)" />) rather than a provider-specific parameter type.
+///     <para>
+///     A database-agnostic consumer (e.g. a shared storage runtime) can build SQL and fill
+///     parameter slots against this interface without referencing <c>Weasel.Postgresql</c> or
+///     <c>Weasel.SqlServer</c>. Each provider's own <c>ICommandBuilder</c> derives from this and
+///     adds the provider-typed overloads (<c>AppendParameter</c> returning the native parameter,
+///     grouped parameter builders, etc.).
+///     </para>
+/// </summary>
+public interface ICommandBuilder
+{
+    /// <summary>
+    ///     It became so common, that it's turned out to be convenient to place
+    ///     this here
+    /// </summary>
+    string TenantId { get; set; }
+
+    /// <summary>
+    ///     Preview the parameter name of the last appended parameter
+    /// </summary>
+    string? LastParameterName { get; }
+
+    void Append(string sql);
+    void Append(char character);
+
+    void AppendParameters(params object[] parameters);
+
+    /// <summary>
+    ///     Append a SQL string with `?` placeholders for new parameters, and returns an
+    ///     array of the newly created parameters upcast to the dialect-neutral <see cref="DbParameter" />.
+    ///     Lets a database-agnostic consumer fill parameter slots without referencing the
+    ///     provider-specific parameter type.
+    /// </summary>
+    /// <param name="text"></param>
+    /// <returns></returns>
+    DbParameter[] AppendWithDbParameters(string text);
+
+    /// <summary>
+    ///     Append a SQL string with user defined placeholder characters for new parameters, and returns an
+    ///     array of the newly created parameters upcast to the dialect-neutral <see cref="DbParameter" />.
+    ///     Lets a database-agnostic consumer fill parameter slots without referencing the
+    ///     provider-specific parameter type.
+    /// </summary>
+    /// <param name="text"></param>
+    /// <param name="placeholder"></param>
+    /// <returns></returns>
+    DbParameter[] AppendWithDbParameters(string text, char placeholder);
+
+    void StartNewCommand();
+
+    /// <summary>
+    ///     Use an anonymous type to add named parameters.
+    ///     If a dictionary is passed in then its key-value pairs will be used as named parameters.
+    ///     <para>
+    ///     Annotated <see cref="RequiresUnreferencedCodeAttribute" /> to
+    ///     match <see cref="CommandBuilderBase{TCommand, TParameter, TParameterType}.AddParameters(object)" />
+    ///     — both reflect over the parameters object's public properties. AOT-trim-clean
+    ///     consumers should prefer the dictionary overloads below.
+    ///     </para>
+    /// </summary>
+    /// <param name="parameters"></param>
+    [RequiresUnreferencedCode(
+        "AddParameters(object) reflects on the parameters object's public properties via Type.GetProperties(). Use the IDictionary<string, T> overload when publishing AOT-trim-clean.")]
+    void AddParameters(object parameters);
+
+    /// <summary>
+    ///     Use a dictionary to add named parameters
+    /// </summary>
+    /// <param name="parameters"></param>
+    void AddParameters(IDictionary<string, object?> parameters);
+
+    /// <summary>
+    ///     Use a dictionary to add named parameters
+    /// </summary>
+    /// <param name="parameters"></param>
+    void AddParameters<T>(IDictionary<string, T> parameters);
+}

--- a/src/Weasel.Core/SqlGeneration/ISqlFragment.cs
+++ b/src/Weasel.Core/SqlGeneration/ISqlFragment.cs
@@ -1,0 +1,25 @@
+namespace Weasel.Core.SqlGeneration;
+
+/// <summary>
+///     Dialect-neutral SQL fragment. Applies itself to the shared, non-generic
+///     <see cref="ICommandBuilder" /> so a database-agnostic consumer can compose WHERE
+///     fragments, select clauses, and commands without referencing a specific Weasel provider.
+///     <para>
+///     Each provider's own <c>ISqlFragment</c> derives from this and keeps its dialect-typed
+///     <c>Apply</c> overload; the neutral <see cref="Apply" /> requirement is satisfied on the
+///     dialect interface via a default interface method that forwards to the dialect overload.
+///     </para>
+/// </summary>
+public interface ISqlFragment
+{
+    void Apply(ICommandBuilder builder);
+}
+
+/// <summary>
+///     Models a SQL fragment that may hold one or more other fragments.
+///     Used to search through a tree of fragments in a dialect-neutral way.
+/// </summary>
+public interface ICompoundFragment: ISqlFragment
+{
+    IEnumerable<ISqlFragment> Children { get; }
+}

--- a/src/Weasel.Postgresql.Tests/SqlGeneration/NeutralSqlGenerationTests.cs
+++ b/src/Weasel.Postgresql.Tests/SqlGeneration/NeutralSqlGenerationTests.cs
@@ -1,0 +1,77 @@
+using System.Data.Common;
+using System.Linq;
+using Shouldly;
+using Weasel.Postgresql.SqlGeneration;
+using Xunit;
+using CoreSql = Weasel.Core.SqlGeneration;
+
+namespace Weasel.Postgresql.Tests.SqlGeneration;
+
+/// <summary>
+///     Proves that the PostgreSQL SQL-generation types satisfy the shared, dialect-neutral
+///     Weasel.Core substrate (weasel#327) so a database-agnostic consumer can compose and apply
+///     fragments without referencing Weasel.Postgresql.
+/// </summary>
+public class NeutralSqlGenerationTests
+{
+    [Fact]
+    public void dialect_command_builders_are_core_command_builders()
+    {
+        new CommandBuilder().ShouldBeAssignableTo<Weasel.Core.ICommandBuilder>();
+        new BatchBuilder().ShouldBeAssignableTo<Weasel.Core.ICommandBuilder>();
+    }
+
+    [Fact]
+    public void dialect_command_builder_interface_derives_from_core()
+    {
+        typeof(Weasel.Core.ICommandBuilder)
+            .IsAssignableFrom(typeof(Weasel.Postgresql.ICommandBuilder)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void dialect_fragment_is_a_core_fragment()
+    {
+        new WhereFragment("id = 1").ShouldBeAssignableTo<CoreSql.ISqlFragment>();
+    }
+
+    [Fact]
+    public void apply_fragment_through_the_neutral_surface()
+    {
+        // Hold everything as the dialect-neutral Weasel.Core abstractions
+        CoreSql.ISqlFragment fragment = new WhereFragment("id = ?", 42);
+        var builder = new CommandBuilder();
+        Weasel.Core.ICommandBuilder neutral = builder;
+
+        // Neutral Apply is satisfied by the default interface method that forwards
+        // to the PostgreSQL-typed Apply(ICommandBuilder) overload
+        fragment.Apply(neutral);
+
+        var command = builder.Compile();
+        command.CommandText.Trim().ShouldBe("id = :p0");
+        command.Parameters[0].Value.ShouldBe(42);
+    }
+
+    [Fact]
+    public void compound_fragment_is_walkable_as_a_neutral_compound()
+    {
+        var compound = CompoundWhereFragment.And(
+            new WhereFragment("a = 1"),
+            new WhereFragment("b = 2"));
+
+        CoreSql.ICompoundFragment neutral = compound;
+        neutral.Children.Count().ShouldBe(2);
+    }
+
+    [Fact]
+    public void neutral_consumer_can_fill_parameter_slots_via_db_parameters()
+    {
+        var builder = new CommandBuilder();
+        Weasel.Core.ICommandBuilder neutral = builder;
+
+        DbParameter[] parameters = neutral.AppendWithDbParameters("id = ?");
+        parameters.Length.ShouldBe(1);
+        parameters[0].Value = 7;
+
+        builder.Compile().CommandText.Trim().ShouldBe("id = :p0");
+    }
+}

--- a/src/Weasel.Postgresql/CommandBuilder.cs
+++ b/src/Weasel.Postgresql/CommandBuilder.cs
@@ -56,7 +56,7 @@ public class CommandBuilder: CommandBuilderBase<NpgsqlCommand, NpgsqlParameter, 
         return _command.Parameters[^1];
     }
 
-    void ICommandBuilder.AppendParameters(params object[] parameters)
+    void Weasel.Core.ICommandBuilder.AppendParameters(params object[] parameters)
     {
         if (!parameters.Any())
             throw new ArgumentOutOfRangeException(nameof(parameters),

--- a/src/Weasel.Postgresql/ICommandBuilder.cs
+++ b/src/Weasel.Postgresql/ICommandBuilder.cs
@@ -1,30 +1,20 @@
-using System.Data.Common;
 using Npgsql;
 using NpgsqlTypes;
 
 namespace Weasel.Postgresql;
 
-public interface ICommandBuilder
+/// <summary>
+///     PostgreSQL command-builder surface. Derives from the dialect-neutral
+///     <see cref="Weasel.Core.ICommandBuilder" /> (which contributes <see cref="Weasel.Core.ICommandBuilder.Append(string)" />,
+///     <see cref="Weasel.Core.ICommandBuilder.AppendWithDbParameters(string)" />, <c>AddParameters</c>, tenant id, etc.)
+///     and adds the Npgsql-typed overloads that return <see cref="NpgsqlParameter" />.
+/// </summary>
+public interface ICommandBuilder: Weasel.Core.ICommandBuilder
 {
-    /// <summary>
-    /// It became so common, that it's turned out to be convenient to place
-    /// this here
-    /// </summary>
-    string TenantId { get; set; }
-
-    /// <summary>
-    /// Preview the parameter name of the last appended parameter
-    /// </summary>
-    string? LastParameterName { get; }
-
-    void Append(string sql);
-    void Append(char character);
-
     NpgsqlParameter AppendParameter<T>(T value);
     NpgsqlParameter AppendParameter<T>(T value, NpgsqlDbType dbType);
     NpgsqlParameter AppendParameter(object value);
     NpgsqlParameter AppendParameter(object? value, NpgsqlDbType? dbType);
-    void AppendParameters(params object[] parameters);
 
     IGroupedParameterBuilder CreateGroupedParameterBuilder(char? seperator = null);
 
@@ -33,7 +23,6 @@ public interface ICommandBuilder
     ///     array of the newly created parameters
     /// </summary>
     /// <param name="text"></param>
-    /// <param name="separator"></param>
     /// <returns></returns>
     NpgsqlParameter[] AppendWithParameters(string text);
 
@@ -42,55 +31,7 @@ public interface ICommandBuilder
     ///     array of the newly created parameters
     /// </summary>
     /// <param name="text"></param>
-    /// <param name="separator"></param>
-    /// <returns></returns>
-    NpgsqlParameter[] AppendWithParameters(string text, char placeholder);
-
-    /// <summary>
-    ///     Append a SQL string with `?` placeholders for new parameters, and returns an
-    ///     array of the newly created parameters upcast to the dialect-neutral <see cref="DbParameter" />.
-    ///     Lets a database-agnostic consumer fill parameter slots without referencing <see cref="NpgsqlParameter" />.
-    /// </summary>
-    /// <param name="text"></param>
-    /// <returns></returns>
-    DbParameter[] AppendWithDbParameters(string text);
-
-    /// <summary>
-    ///     Append a SQL string with user defined placeholder characters for new parameters, and returns an
-    ///     array of the newly created parameters upcast to the dialect-neutral <see cref="DbParameter" />.
-    ///     Lets a database-agnostic consumer fill parameter slots without referencing <see cref="NpgsqlParameter" />.
-    /// </summary>
-    /// <param name="text"></param>
     /// <param name="placeholder"></param>
     /// <returns></returns>
-    DbParameter[] AppendWithDbParameters(string text, char placeholder);
-
-    void StartNewCommand();
-
-    /// <summary>
-    ///     Use an anonymous type to add named parameters.
-    ///     If a dictionary is passed in then its key-value pairs will be used as named parameters.
-    ///     <para>
-    ///     Annotated <see cref="System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute" /> to
-    ///     match <see cref="Core.CommandBuilderBase{TCommand, TParameter, TParameterType}.AddParameters(object)" />
-    ///     — both reflect over the parameters object's public properties. AOT-trim-clean
-    ///     consumers should prefer the dictionary overloads below.
-    ///     </para>
-    /// </summary>
-    /// <param name="parameters"></param>
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(
-        "AddParameters(object) reflects on the parameters object's public properties via Type.GetProperties(). Use the IDictionary<string, T> overload when publishing AOT-trim-clean.")]
-    void AddParameters(object parameters);
-
-    /// <summary>
-    ///     Use a dictionary to add named parameters
-    /// </summary>
-    /// <param name="parameters"></param>
-    void AddParameters(IDictionary<string, object?> parameters);
-
-    /// <summary>
-    ///     Use a dictionary to add named parameters
-    /// </summary>
-    /// <param name="parameters"></param>
-    void AddParameters<T>(IDictionary<string, T> parameters);
+    NpgsqlParameter[] AppendWithParameters(string text, char placeholder);
 }

--- a/src/Weasel.Postgresql/SqlGeneration/ISqlFragment.cs
+++ b/src/Weasel.Postgresql/SqlGeneration/ISqlFragment.cs
@@ -1,16 +1,31 @@
 namespace Weasel.Postgresql.SqlGeneration;
 
-public interface ISqlFragment
+public interface ISqlFragment: Weasel.Core.SqlGeneration.ISqlFragment
 {
     void Apply(ICommandBuilder builder);
+
+    /// <summary>
+    ///     Satisfies the dialect-neutral <see cref="Weasel.Core.SqlGeneration.ISqlFragment" /> contract by
+    ///     forwarding to the PostgreSQL-typed <see cref="Apply(ICommandBuilder)" /> overload. Provided as a
+    ///     default interface method so existing implementers only need to implement the dialect overload.
+    /// </summary>
+    void Weasel.Core.SqlGeneration.ISqlFragment.Apply(Weasel.Core.ICommandBuilder builder)
+        => Apply((ICommandBuilder)builder);
 }
 
 /// <summary>
 /// Model a Sql fragment that may hold one or more other fragements
 /// Used to search through a tree of fragments
 /// </summary>
-public interface ICompoundFragment: ISqlFragment
+public interface ICompoundFragment: Weasel.Core.SqlGeneration.ICompoundFragment, ISqlFragment
 {
-    IEnumerable<ISqlFragment> Children { get; }
-}
+    new IEnumerable<ISqlFragment> Children { get; }
 
+    /// <summary>
+    ///     Bridges the neutral <see cref="Weasel.Core.SqlGeneration.ICompoundFragment.Children" /> to the
+    ///     PostgreSQL-typed <see cref="Children" />; the covariance of <see cref="IEnumerable{T}" /> makes the
+    ///     dialect children a valid neutral enumerable.
+    /// </summary>
+    IEnumerable<Weasel.Core.SqlGeneration.ISqlFragment> Weasel.Core.SqlGeneration.ICompoundFragment.Children
+        => Children;
+}

--- a/src/Weasel.SqlServer.Tests/SqlGeneration/NeutralSqlGenerationTests.cs
+++ b/src/Weasel.SqlServer.Tests/SqlGeneration/NeutralSqlGenerationTests.cs
@@ -1,0 +1,77 @@
+using System.Data.Common;
+using System.Linq;
+using Shouldly;
+using Weasel.SqlServer.SqlGeneration;
+using Xunit;
+using CoreSql = Weasel.Core.SqlGeneration;
+
+namespace Weasel.SqlServer.Tests.SqlGeneration;
+
+/// <summary>
+///     Proves that the SQL Server SQL-generation types satisfy the shared, dialect-neutral
+///     Weasel.Core substrate (weasel#327) so a database-agnostic consumer can compose and apply
+///     fragments without referencing Weasel.SqlServer.
+/// </summary>
+public class NeutralSqlGenerationTests
+{
+    [Fact]
+    public void dialect_command_builders_are_core_command_builders()
+    {
+        // The concrete CommandBuilder now also satisfies the neutral surface, matching BatchBuilder
+        new CommandBuilder().ShouldBeAssignableTo<Weasel.Core.ICommandBuilder>();
+        new BatchBuilder().ShouldBeAssignableTo<Weasel.Core.ICommandBuilder>();
+    }
+
+    [Fact]
+    public void dialect_command_builder_interface_derives_from_core()
+    {
+        typeof(Weasel.Core.ICommandBuilder)
+            .IsAssignableFrom(typeof(Weasel.SqlServer.ICommandBuilder)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void dialect_fragment_is_a_core_fragment()
+    {
+        new WhereFragment("id = 1").ShouldBeAssignableTo<CoreSql.ISqlFragment>();
+    }
+
+    [Fact]
+    public void apply_fragment_through_the_neutral_surface()
+    {
+        // Hold everything as the dialect-neutral Weasel.Core abstractions. SQL Server fragments are
+        // applied against the concrete CommandBuilder, so the neutral consumer supplies one.
+        CoreSql.ISqlFragment fragment = new WhereFragment("id = 1");
+        var builder = new CommandBuilder();
+        Weasel.Core.ICommandBuilder neutral = builder;
+
+        // Neutral Apply is satisfied by the default interface method that forwards
+        // to the SQL Server Apply(CommandBuilder) overload
+        fragment.Apply(neutral);
+
+        builder.Compile().CommandText.Trim().ShouldBe("id = 1");
+    }
+
+    [Fact]
+    public void compound_fragment_is_walkable_as_a_neutral_compound()
+    {
+        var compound = CompoundWhereFragment.And(
+            new WhereFragment("a = 1"),
+            new WhereFragment("b = 2"));
+
+        CoreSql.ICompoundFragment neutral = compound;
+        neutral.Children.Count().ShouldBe(2);
+    }
+
+    [Fact]
+    public void neutral_consumer_can_fill_parameter_slots_via_db_parameters()
+    {
+        var builder = new CommandBuilder();
+        Weasel.Core.ICommandBuilder neutral = builder;
+
+        DbParameter[] parameters = neutral.AppendWithDbParameters("id = ?");
+        parameters.Length.ShouldBe(1);
+        parameters[0].Value = 7;
+
+        builder.Compile().CommandText.Trim().ShouldBe("id = @p0");
+    }
+}

--- a/src/Weasel.SqlServer/CommandBuilder.cs
+++ b/src/Weasel.SqlServer/CommandBuilder.cs
@@ -5,7 +5,7 @@ using Weasel.Core;
 
 namespace Weasel.SqlServer;
 
-public class CommandBuilder: CommandBuilderBase<SqlCommand, SqlParameter, SqlDbType>
+public class CommandBuilder: CommandBuilderBase<SqlCommand, SqlParameter, SqlDbType>, Weasel.Core.ICommandBuilder
 {
     public CommandBuilder(): this(new SqlCommand())
     {
@@ -13,6 +13,37 @@ public class CommandBuilder: CommandBuilderBase<SqlCommand, SqlParameter, SqlDbT
 
     public CommandBuilder(SqlCommand command): base(SqlServerProvider.Instance, '@', command)
     {
+    }
+
+    /// <summary>
+    /// It became so common, that it's turned out to be convenient to place
+    /// this here
+    /// </summary>
+    public string TenantId { get; set; }
+
+    /// <summary>
+    ///     Append the supplied parameter values to the command, comma-separated, adding each to
+    ///     the underlying command's parameter collection and to the SQL text.
+    /// </summary>
+    /// <param name="parameters"></param>
+    public void AppendParameters(params object[] parameters)
+    {
+        if (!parameters.Any())
+            throw new ArgumentOutOfRangeException(nameof(parameters),
+                "Must be at least one parameter value, but got " + parameters.Length);
+
+        AppendParameter(parameters[0]);
+
+        for (var i = 1; i < parameters.Length; i++)
+        {
+            Append(", ");
+            AppendParameter(parameters[i]);
+        }
+    }
+
+    public void StartNewCommand()
+    {
+        // do nothing!
     }
 }
 

--- a/src/Weasel.SqlServer/ICommandBuilder.cs
+++ b/src/Weasel.SqlServer/ICommandBuilder.cs
@@ -1,30 +1,20 @@
 using System.Data;
-using System.Data.Common;
 using Microsoft.Data.SqlClient;
 
 namespace Weasel.SqlServer;
 
-public interface ICommandBuilder
+/// <summary>
+///     SQL Server command-builder surface. Derives from the dialect-neutral
+///     <see cref="Weasel.Core.ICommandBuilder" /> (which contributes <see cref="Weasel.Core.ICommandBuilder.Append(string)" />,
+///     <see cref="Weasel.Core.ICommandBuilder.AppendWithDbParameters(string)" />, <c>AddParameters</c>, tenant id, etc.)
+///     and adds the SqlClient-typed overloads that return <see cref="SqlParameter" />.
+/// </summary>
+public interface ICommandBuilder: Weasel.Core.ICommandBuilder
 {
-    /// <summary>
-    /// It became so common, that it's turned out to be convenient to place
-    /// this here
-    /// </summary>
-    string TenantId { get; set; }
-
-    /// <summary>
-    /// Preview the parameter name of the last appended parameter
-    /// </summary>
-    string? LastParameterName { get; }
-
-    void Append(string sql);
-    void Append(char character);
-
     SqlParameter AppendParameter<T>(T value);
     SqlParameter AppendParameter<T>(T value, SqlDbType dbType);
     SqlParameter AppendParameter(object value);
     SqlParameter AppendParameter(object? value, SqlDbType? dbType);
-    void AppendParameters(params object[] parameters);
 
     IGroupedParameterBuilder CreateGroupedParameterBuilder(char? seperator = null);
 
@@ -44,54 +34,6 @@ public interface ICommandBuilder
     /// <param name="placeholder"></param>
     /// <returns></returns>
     SqlParameter[] AppendWithParameters(string text, char placeholder);
-
-    /// <summary>
-    ///     Append a SQL string with `?` placeholders for new parameters, and returns an
-    ///     array of the newly created parameters upcast to the dialect-neutral <see cref="DbParameter" />.
-    ///     Lets a database-agnostic consumer fill parameter slots without referencing <see cref="SqlParameter" />.
-    /// </summary>
-    /// <param name="text"></param>
-    /// <returns></returns>
-    DbParameter[] AppendWithDbParameters(string text);
-
-    /// <summary>
-    ///     Append a SQL string with user defined placeholder characters for new parameters, and returns an
-    ///     array of the newly created parameters upcast to the dialect-neutral <see cref="DbParameter" />.
-    ///     Lets a database-agnostic consumer fill parameter slots without referencing <see cref="SqlParameter" />.
-    /// </summary>
-    /// <param name="text"></param>
-    /// <param name="placeholder"></param>
-    /// <returns></returns>
-    DbParameter[] AppendWithDbParameters(string text, char placeholder);
-
-    void StartNewCommand();
-
-    /// <summary>
-    ///     Use an anonymous type to add named parameters.
-    ///     If a dictionary is passed in then its key-value pairs will be used as named parameters.
-    ///     <para>
-    ///     Annotated <see cref="System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute" /> to
-    ///     match <see cref="Core.CommandBuilderBase{TCommand, TParameter, TParameterType}.AddParameters(object)" />
-    ///     — both reflect over the parameters object's public properties. AOT-trim-clean
-    ///     consumers should prefer the dictionary overloads below.
-    ///     </para>
-    /// </summary>
-    /// <param name="parameters"></param>
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(
-        "AddParameters(object) reflects on the parameters object's public properties via Type.GetProperties(). Use the IDictionary<string, T> overload when publishing AOT-trim-clean.")]
-    void AddParameters(object parameters);
-
-    /// <summary>
-    ///     Use a dictionary to add named parameters
-    /// </summary>
-    /// <param name="parameters"></param>
-    void AddParameters(IDictionary<string, object?> parameters);
-
-    /// <summary>
-    ///     Use a dictionary to add named parameters
-    /// </summary>
-    /// <param name="parameters"></param>
-    void AddParameters<T>(IDictionary<string, T> parameters);
 }
 
 public interface IGroupedParameterBuilder

--- a/src/Weasel.SqlServer/SqlGeneration/CompoundWhereFragment.cs
+++ b/src/Weasel.SqlServer/SqlGeneration/CompoundWhereFragment.cs
@@ -2,7 +2,7 @@ using JasperFx.Core;
 
 namespace Weasel.SqlServer.SqlGeneration;
 
-public class CompoundWhereFragment: ISqlFragment, IWhereFragmentHolder
+public class CompoundWhereFragment: ICompoundFragment, IWhereFragmentHolder
 {
     private readonly IList<ISqlFragment> _children = new List<ISqlFragment>();
 

--- a/src/Weasel.SqlServer/SqlGeneration/ISqlFragment.cs
+++ b/src/Weasel.SqlServer/SqlGeneration/ISqlFragment.cs
@@ -1,8 +1,38 @@
 namespace Weasel.SqlServer.SqlGeneration;
 
-public interface ISqlFragment
+public interface ISqlFragment: Weasel.Core.SqlGeneration.ISqlFragment
 {
     void Apply(CommandBuilder builder);
 
     bool Contains(string sqlText);
+
+    /// <summary>
+    ///     Satisfies the dialect-neutral <see cref="Weasel.Core.SqlGeneration.ISqlFragment" /> contract by
+    ///     forwarding to the SQL Server <see cref="Apply(CommandBuilder)" /> overload. Provided as a default
+    ///     interface method so existing implementers only need to implement the dialect overload.
+    ///     <para>
+    ///     SQL Server fragments are applied against the concrete <see cref="CommandBuilder" />; a neutral
+    ///     consumer must therefore supply a <see cref="CommandBuilder" /> (not a <c>BatchBuilder</c>) — the
+    ///     same constraint that already applied to the dialect <see cref="Apply(CommandBuilder)" /> overload.
+    ///     </para>
+    /// </summary>
+    void Weasel.Core.SqlGeneration.ISqlFragment.Apply(Weasel.Core.ICommandBuilder builder)
+        => Apply((CommandBuilder)builder);
+}
+
+/// <summary>
+/// Model a Sql fragment that may hold one or more other fragements
+/// Used to search through a tree of fragments
+/// </summary>
+public interface ICompoundFragment: Weasel.Core.SqlGeneration.ICompoundFragment, ISqlFragment
+{
+    new IEnumerable<ISqlFragment> Children { get; }
+
+    /// <summary>
+    ///     Bridges the neutral <see cref="Weasel.Core.SqlGeneration.ICompoundFragment.Children" /> to the
+    ///     SQL Server-typed <see cref="Children" />; the covariance of <see cref="IEnumerable{T}" /> makes the
+    ///     dialect children a valid neutral enumerable.
+    /// </summary>
+    IEnumerable<Weasel.Core.SqlGeneration.ISqlFragment> Weasel.Core.SqlGeneration.ICompoundFragment.Children
+        => Children;
 }


### PR DESCRIPTION
Closes #327.

Introduces a dialect-neutral SQL-generation substrate in **Weasel.Core** so a database-agnostic consumer (Marten/Polecat's shared storage runtime) can build WHERE fragments, select clauses, and commands **without referencing `Weasel.Postgresql` / `Weasel.SqlServer`** — unblocking the physical package move in JasperFx/marten#4830.

Per the requirement, this does **not** break the current public API of either provider: the existing types **subclass** the new Weasel.Core abstractions.

## What's new in Weasel.Core

- **`Weasel.Core.ICommandBuilder`** — non-generic, neutral command-builder surface. Contains only the members whose signatures are *already identical* across both dialects (`Append`, `AppendParameters`, `AddParameters`, `StartNewCommand`, `TenantId`, `LastParameterName`). Parameters flow through the ADO.NET-neutral `DbParameter` via `AppendWithDbParameters` (the weasel#324 shape); the provider-typed `AppendParameter`/`AppendWithParameters`/grouped-parameter overloads stay on each dialect interface.
- **`Weasel.Core.SqlGeneration.ISqlFragment` / `ICompoundFragment`** — neutral fragment contracts, `Apply(ICommandBuilder)`.

## How the dialects derive (non-breaking)

- `Weasel.Postgresql.ICommandBuilder` / `Weasel.SqlServer.ICommandBuilder` now derive from `Weasel.Core.ICommandBuilder`; the common members move *up* (same effective surface, now inherited).
- Each dialect `SqlGeneration.ISqlFragment` derives from the Core fragment, **keeps its existing dialect-typed `Apply` overload**, and satisfies the neutral `Apply(Weasel.Core.ICommandBuilder)` requirement via a **default interface method** that forwards to the dialect overload:
  ```csharp
  void Weasel.Core.SqlGeneration.ISqlFragment.Apply(Weasel.Core.ICommandBuilder builder)
      => Apply((DialectBuilder)builder);
  ```
  → existing fragment implementers (in-provider fragments **and** downstream ones like Marten's) need **zero** changes, and existing `.Apply(builder)` call sites still bind to the dialect overload (more-specific overload wins).

## SqlServer parity

- `Weasel.SqlServer.CommandBuilder` now also implements `Weasel.Core.ICommandBuilder` (adds three small members: `TenantId`, `AppendParameters(params object[])`, `StartNewCommand`) so a neutral consumer can pass it — previously only `BatchBuilder` implemented the interface.
- Added a SqlServer `ICompoundFragment` so `CompoundWhereFragment` participates in neutral tree-walks (parity with Postgres).
- SqlServer's per-fragment `Contains(string)` stays dialect-only (it can't move to Core without forcing it onto Postgres implementers).
- SqlServer fragments still require a concrete `CommandBuilder` (not `BatchBuilder`) — a **pre-existing** limitation, unchanged here.

Oracle/MySql/Sqlite have no fragment abstraction and are untouched.

## Testing

- New `NeutralSqlGenerationTests` in both providers exercise the neutral path end-to-end (hold a dialect fragment as `Core.ISqlFragment`, apply to a dialect builder held as `Core.ICommandBuilder`, verify SQL + params; walk a compound fragment as a `Core.ICompoundFragment`; fill slots via `AppendWithDbParameters`).
- Full suites pass: **Weasel.Postgresql 717 passed / 3 skipped**, **Weasel.SqlServer 276 passed / 8 skipped**, Weasel.Core 13 passed. 0 failures.

> Note: branched off `master` (which contains the prerequisite weasel#324 `AppendWithDbParameters`); the `release/9.5.0` line does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)