### PR TITLE
Add Weasel.Storage library + release 9.8.0

### DIFF
--- a/.claude/chips/README.md
+++ b/.claude/chips/README.md
@@ -1,0 +1,30 @@
+# Pre-staged chip prompts for Weasel
+
+The coordinator session (rooted in `jasperfx`) drops `mcp__ccd_session__spawn_task`
+chips off whatever repo the *coordinator's* conversation is rooted in. Chips
+intended for Weasel can't be spawned directly from the jasperfx coordinator
+without the resulting sub-agent landing in a jasperfx worktree it can't escape.
+
+Workaround: the coordinator stashes the chip prompt here as a markdown file,
+and a Claude Code session opened from this repo (`/Users/jeremymiller/code/weasel`)
+drops the chip locally. The spawned sub-agent then gets a Weasel-rooted
+worktree, which is what we want.
+
+## How to use
+
+From a Weasel-rooted Claude Code session:
+
+> Please drop a chip from `.claude/chips/<name>.md` — title, tldr, and prompt
+> are all in the file.
+
+Each chip file has three sections (`# Title`, `## TL;DR`, then `## Prompt`).
+The session reads the file and calls `spawn_task` with each section mapped to
+the corresponding parameter.
+
+## Conventions
+
+- One file per chip, named `<short-slug>.md`.
+- Delete the file after the chip's PR merges — these are ephemeral.
+- `.claude/chips/` is gitignored — these don't get committed.
+
+This pattern is mirrored in CritterWatch, Wolverine, and Polecat's `.claude/chips/`.

--- a/.claude/chips/weasel-aot-smoke-and-provider-audit.md
+++ b/.claude/chips/weasel-aot-smoke-and-provider-audit.md
@@ -1,0 +1,100 @@
+# Title
+
+Weasel#263: Add Weasel.Core.AotSmoke consumer project + per-provider IsAotCompatible audit
+
+## TL;DR
+
+Add a CI-gated AOT smoke-test project that references Weasel.Core in Static mode and fails the build on IL2026/IL3050 (and siblings). Also do the per-provider AOT-flag audit: confirm IsAotCompatible state on each Weasel.* provider project (Postgresql/SqlServer/Oracle/MySql/Sqlite/EntityFrameworkCore); annotate the wrapper for AOT-hostile ADO.NET surfaces rather than chase upstream providers.
+
+## Prompt
+
+**Repo: Weasel** (https://github.com/JasperFx/weasel). Root: `/Users/jeremymiller/code/weasel`. Base branch: `main`. Open PR against `JasperFx/weasel`.
+
+If your worktree is rooted anywhere other than the Weasel repo, STOP and report — do not attempt cross-repo edits.
+
+Master plan: **Weasel#263** ([Master] Weasel 9.0). This chip ticks off two boxes:
+- "For database-specific Weasel.* projects (Postgresql, SqlServer, Oracle, MySql, Sqlite, EntityFrameworkCore): evaluate per-project AOT-cleanness."
+- The missing AOT smoke-test consumer project (parallel to `JasperFx.AotSmoke` in jasperfx).
+
+## Context
+
+`Weasel.Core.csproj` already sets `<IsAotCompatible>true</IsAotCompatible>`. The reflective surface in Weasel.Core is clean (no live `MakeGenericType` / `Activator.CreateInstance` outside annotated paths). Migration guide for 8→9 already shipped (#276 / `dd1c81a`).
+
+What's missing: (1) a consumer-side smoke-test project that gates regressions on Weasel.Core's already-AOT-clean state, and (2) the per-provider `Weasel.*` audit — each provider project needs `IsAotCompatible=true` if its surface is clean, OR the AOT-hostile ADO.NET surfaces need `[RequiresDynamicCode]` / `[RequiresUnreferencedCode]` annotations on the Weasel wrapper.
+
+The pattern to mirror is **`src/JasperFx.AotSmoke/`** in the jasperfx repo (commit `d4077d8`). Inspect that project before starting — same shape, just adapted for Weasel.Core's surface.
+
+## Scope
+
+### Part 1 — Weasel.Core.AotSmoke project
+
+1. **New project: `src/Weasel.Core.AotSmoke/Weasel.Core.AotSmoke.csproj`**
+   - Console app SDK (`Microsoft.NET.Sdk`), `<OutputType>Exe</OutputType>`.
+   - `<IsAotCompatible>true</IsAotCompatible>`, `<TrimMode>full</TrimMode>`.
+   - Mirror JasperFx.AotSmoke's `WarningsAsErrors` list: `IL2026;IL2046;IL2055;IL2065;IL2067;IL2070;IL2072;IL2075;IL2090;IL2091;IL2111;IL3050;IL3051`.
+   - Target framework matches the rest of the solution.
+   - ProjectReference to `Weasel.Core`.
+   - **No** reference to any database-specific Weasel.* provider — that's intentionally separate (the per-provider audit in Part 2).
+
+2. **Realistic surface in `Program.cs`:**
+   - Exercise a few `Weasel.Core` surfaces: build a simple `Table` definition with columns, get a `CreateStatement` from it, exercise `DdlSyntaxStrategy` (or whatever the AOT-relevant primitives are post-#270 consolidation).
+   - Goal: cover the consolidation surfaces from #270 (`SchemaObjectBase`, `TableBase`, `IDdlSyntaxStrategy`, unified `ColumnExpression`, `ForeignKeyBase`).
+   - Exit immediately after the surface is touched (`return 0`).
+
+3. **Solution + CI integration:**
+   - Add the new project to the Weasel solution (`dotnet sln add`).
+   - Verify `.github/workflows/*.yml` builds it as part of the standard build.
+   - Don't add it as a test target.
+
+### Part 2 — Per-provider IsAotCompatible audit
+
+For **each** of `Weasel.Postgresql`, `Weasel.SqlServer`, `Weasel.Oracle`, `Weasel.MySql`, `Weasel.Sqlite`, `Weasel.EntityFrameworkCore`:
+
+1. Inspect the provider's csproj for current `IsAotCompatible` state.
+2. Try setting `<IsAotCompatible>true</IsAotCompatible>` if not already on.
+3. Build the project. If it builds clean → leave the flag on, commit.
+4. If it surfaces IL2026/IL2075/IL3050 etc.:
+   - If the warnings are from the **Weasel wrapper code itself**, annotate the call sites at the wrapper layer (`[RequiresDynamicCode]` / `[RequiresUnreferencedCode]` with a justification).
+   - If the warnings are from **upstream ADO.NET provider code** (e.g. Npgsql, Microsoft.Data.SqlClient, Oracle.ManagedDataAccess), per the issue body: "annotate the Weasel wrapper rather than chase upstream." Add a comment explaining which upstream surface caused the wrapper-level annotation.
+   - If a provider is genuinely AOT-hostile through and through, leave `IsAotCompatible` off (or set it but with `<NoWarn>` listing the specific upstream-driven warnings) and add a comment block explaining why.
+5. **Document the outcome per provider in the PR body** — a small table:
+
+   | Provider | IsAotCompatible | Notes |
+   |---|---|---|
+   | Weasel.Postgresql | true | Clean, no annotations needed |
+   | Weasel.SqlServer | true (annotated) | `SqlBulkCopy.WriteToServer` requires DynamicCode — annotated at `BulkInserter` |
+   | ... | | |
+
+## Out of scope
+
+- Audit reflective call sites *inside* Weasel.Core (already clean per current state).
+- IStorageOperation migration (separate, bigger chip).
+- Hot-path GenericFactoryCache migration (separate, requires profiling).
+- Database-related enum dedupe (separate chip).
+
+## Acceptance
+
+- `dotnet build` clean with the new smoke-test project.
+- Per-provider state documented in the PR body's audit table.
+- Manually adding an unannotated `MakeGenericType` call somewhere in Weasel.Core surfaces a warning when the smoke-test compiles (revert before commit, note in PR body).
+- The smoke-test project's `Program.cs` exits cleanly when run.
+
+## Commit shape
+
+2-4 commits in one PR:
+1. `Add Weasel.Core.AotSmoke project + Static-mode bootstrap`
+2. `Audit IsAotCompatible across Weasel.* provider projects`
+3. (per-provider, optional) `Annotate Weasel.<Provider> wrapper for AOT-hostile upstream surfaces`
+
+## PR
+
+Title: `Weasel#263: Add Weasel.Core.AotSmoke + per-provider IsAotCompatible audit`
+Body: include the per-provider audit table. Reference `#263` (not "Closes" — master plan).
+
+## Don't
+
+- Don't pull in JasperFx.RuntimeCompiler.
+- Don't make this an xUnit test project.
+- Don't lower `WarningsAsErrors` in the new project's csproj.
+- Don't modify upstream ADO.NET provider code — annotate at the Weasel wrapper layer per the master plan's explicit guidance.
+- Don't make cross-repo edits.

--- a/.github/workflows/publish_nuget.yml
+++ b/.github/workflows/publish_nuget.yml
@@ -27,6 +27,9 @@ jobs:
     - name: Pack Weasel.Core
       run: dotnet pack ./src/Weasel.Core/Weasel.Core.csproj -o ./artifacts --configuration Release --no-build
 
+    - name: Pack Weasel.Storage
+      run: dotnet pack ./src/Weasel.Storage/Weasel.Storage.csproj -o ./artifacts --configuration Release --no-build
+
     - name: Pack Weasel.Postgresql
       run: dotnet pack ./src/Weasel.Postgresql/Weasel.Postgresql.csproj -o ./artifacts --configuration Release --no-build
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>9.7.0</Version>
+        <Version>9.8.0</Version>
         <LangVersion>13.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/Weasel.slnx
+++ b/Weasel.slnx
@@ -54,6 +54,9 @@
     <Project Path="src/Weasel.SqlServer.Tests/Weasel.SqlServer.Tests.csproj" />
     <Project Path="src/Weasel.SqlServer/Weasel.SqlServer.csproj" />
   </Folder>
+  <Folder Name="/src/">
+    <Project Path="src/Weasel.Storage/Weasel.Storage.csproj" />
+  </Folder>
   <Project Path="src/Weasel.Core.AotSmoke/Weasel.Core.AotSmoke.csproj" />
   <Project Path="src/Weasel.Core.Tests/Weasel.Core.Tests.csproj" />
   <Project Path="src/Weasel.Core/Weasel.Core.csproj" />

--- a/src/Weasel.Storage/BulkColumnValue.cs
+++ b/src/Weasel.Storage/BulkColumnValue.cs
@@ -1,0 +1,36 @@
+#nullable enable
+
+namespace Weasel.Storage;
+
+/// <summary>
+///     A single column's contribution to a bulk-load row — the value plus its dialect-neutral
+///     <see cref="StorageColumnType"/>. Returned by a metadata binder so a dialect-specific bulk
+///     loader can write it with its native mechanism, instead of the binder referencing a provider
+///     writer directly.
+/// </summary>
+/// <remarks>
+///     <see cref="Value"/> semantics:
+///     <list type="bullet">
+///         <item><c>null</c> → write an untyped SQL NULL.</item>
+///         <item><see cref="System.DBNull"/> → write a typed NULL of <see cref="Type"/>.</item>
+///         <item>otherwise → write the value as <see cref="Type"/>.</item>
+///     </list>
+/// </remarks>
+public readonly struct BulkColumnValue
+{
+    /// <summary>An untyped NULL (the loader writes a plain NULL, no provider type).</summary>
+    public static readonly BulkColumnValue Null = new(null, default);
+
+    public BulkColumnValue(object? value, StorageColumnType type)
+    {
+        Value = value;
+        Type = type;
+    }
+
+    public object? Value { get; }
+
+    public StorageColumnType Type { get; }
+
+    /// <summary>A typed NULL of the given column type (e.g. a JSONB null).</summary>
+    public static BulkColumnValue TypedNull(StorageColumnType type) => new(System.DBNull.Value, type);
+}

--- a/src/Weasel.Storage/IStorageDialect.cs
+++ b/src/Weasel.Storage/IStorageDialect.cs
@@ -1,0 +1,69 @@
+#nullable enable
+using System;
+using System.Data.Common;
+using Weasel.Core.SqlGeneration;
+
+namespace Weasel.Storage;
+
+/// <summary>
+///     The ADO/SQL-dialect strategy the shared document-storage runtime delegates its
+///     provider-specific concerns to, instead of constructing provider command/parameter types and
+///     emitting dialect SQL directly. One implementation is supplied per dialect (e.g. Marten's
+///     <c>PostgresStorageDialect</c>), keeping the storage runtime free of any direct provider
+///     reference so it can be shared.
+/// </summary>
+/// <remarks>
+///     Only the genuinely dialect-specific concerns live here — command/parameter materialization,
+///     the id-equality filter (which carries the provider parameter type), and provider error-code
+///     interpretation. Mechanical scalar parameter typing routes through Weasel's
+///     <c>IDatabaseProvider.ToParameterType</c>, and the document-body JSON parameter is
+///     dialect-polymorphic via <see cref="IStorageSerializer.WriteToParameter(DbParameter, object?)"/>.
+/// </remarks>
+public interface IStorageDialect
+{
+    /// <summary>
+    ///     Build a single-document load command over the storage's prebuilt loader SQL, binding the
+    ///     raw id and, for conjoined tenancy, the tenant id.
+    /// </summary>
+    DbCommand BuildLoadCommand(string loaderSql, object rawId, string? tenant);
+
+    /// <summary>
+    ///     Create the id-array parameter for a load-many command from the raw id values and the .NET
+    ///     type of a single raw id. A provider may bind a single array parameter (<c>= ANY($1)</c>) or
+    ///     shape it differently.
+    /// </summary>
+    DbParameter CreateIdArrayParameter(Array rawIds, Type rawSqlType);
+
+    /// <summary>
+    ///     Build a load-many command over the storage's prebuilt array-loader SQL, binding the
+    ///     id-array parameter (from <see cref="CreateIdArrayParameter"/>) and, for conjoined tenancy,
+    ///     the tenant id.
+    /// </summary>
+    DbCommand BuildLoadManyCommand(string loadArraySql, DbParameter idArrayParameter, string? tenant);
+
+    /// <summary>
+    ///     The id-equality <see cref="ISqlFragment"/> for a raw id — carries the dialect's parameter
+    ///     type so the emitted predicate binds correctly.
+    /// </summary>
+    ISqlFragment ByIdFilter(object rawId);
+
+    /// <summary>
+    ///     True when the exception represents an "undefined table" (e.g. truncating a table that
+    ///     hasn't been created yet) — the one provider error code the storage runtime swallows.
+    /// </summary>
+    bool IsUndefinedTable(Exception exception);
+
+    /// <summary>
+    ///     Set the provider parameter type on a write parameter for a fixed <see cref="StorageColumnType"/>,
+    ///     letting the storage runtime bind id/tenant/version/revision slots as <see cref="DbParameter"/>
+    ///     without naming a provider type.
+    /// </summary>
+    void SetParameterType(DbParameter parameter, StorageColumnType type);
+
+    /// <summary>
+    ///     Set the provider parameter type for a document id slot from the .NET type of the raw id
+    ///     value. Distinct from <see cref="SetParameterType"/> because an id can be any supported
+    ///     scalar / strong-typed-id inner type.
+    /// </summary>
+    void SetIdParameterType(DbParameter parameter, Type rawSqlType);
+}

--- a/src/Weasel.Storage/IStorageSerializer.cs
+++ b/src/Weasel.Storage/IStorageSerializer.cs
@@ -1,0 +1,62 @@
+#nullable enable
+using System;
+using System.Buffers;
+using System.Data.Common;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Weasel.Storage;
+
+/// <summary>
+///     Dialect-neutral serializer seam consumed by the shared document-storage runtime. Exposes only
+///     the JSON read/write members the storage / binders / selectors use, carrying no provider-typed
+///     members — the one write hook that binds a parameter is surfaced against the neutral
+///     <see cref="DbParameter"/>. The concrete implementation lives in the consuming library (e.g.
+///     Marten's serializer implements this over its provider's parameter type).
+/// </summary>
+public interface IStorageSerializer
+{
+    /// <summary>Serialize the document object into a JSON string.</summary>
+    string ToJson(object? document);
+
+    /// <summary>
+    ///     Serialize <paramref name="value"/> directly into the supplied buffer writer as UTF-8 JSON —
+    ///     the allocation-free append/write hot path.
+    /// </summary>
+    void WriteTo(IBufferWriter<byte> writer, object? value);
+
+    /// <summary>Serialize a document without any extra type-handling metadata.</summary>
+    string ToCleanJson(object? document);
+
+    /// <summary>
+    ///     Serialize <paramref name="value"/> as UTF-8 JSON and bind it to the supplied parameter as
+    ///     JSON/JSONB. The concrete implementation binds against its provider's parameter type.
+    /// </summary>
+    void WriteToParameter(DbParameter parameter, object? value);
+
+    /// <summary>Deserialize a JSON stream into an object of type T.</summary>
+    T FromJson<T>(Stream stream);
+
+    /// <summary>Deserialize the JSON at the reader's column index into an object of type T.</summary>
+    T FromJson<T>(DbDataReader reader, int index);
+
+    /// <summary>Deserialize a JSON stream into the supplied Type.</summary>
+    object FromJson(Type type, Stream stream);
+
+    /// <summary>Deserialize the JSON at the reader's column index into the supplied Type.</summary>
+    object FromJson(Type type, DbDataReader reader, int index);
+
+    /// <summary>Deserialize a JSON stream into an object of type T.</summary>
+    ValueTask<T> FromJsonAsync<T>(Stream stream, CancellationToken cancellationToken = default);
+
+    /// <summary>Deserialize the JSON at the reader's column index into an object of type T.</summary>
+    ValueTask<T> FromJsonAsync<T>(DbDataReader reader, int index, CancellationToken cancellationToken = default);
+
+    /// <summary>Deserialize a JSON stream into the supplied Type.</summary>
+    ValueTask<object> FromJsonAsync(Type type, Stream stream, CancellationToken cancellationToken = default);
+
+    /// <summary>Deserialize the JSON at the reader's column index into the supplied Type.</summary>
+    ValueTask<object> FromJsonAsync(Type type, DbDataReader reader, int index,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Weasel.Storage/IVersionTracker.cs
+++ b/src/Weasel.Storage/IVersionTracker.cs
@@ -1,0 +1,29 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+
+namespace Weasel.Storage;
+
+/// <summary>
+///     Dialect-neutral optimistic-concurrency version/revision tracker seam consumed by the shared
+///     document-storage runtime. Every member is database-neutral; the concrete implementation lives
+///     in the consuming library (e.g. Marten's <c>VersionTracker</c>).
+/// </summary>
+public interface IVersionTracker
+{
+    Dictionary<TId, long> RevisionsFor<TDoc, TId>() where TId : notnull;
+
+    Dictionary<TId, Guid> ForType<TDoc, TId>() where TId : notnull;
+
+    Guid? VersionFor<TDoc, TId>(TId id) where TId : notnull;
+
+    long? RevisionFor<TDoc, TId>(TId id) where TId : notnull;
+
+    void StoreVersion<TDoc, TId>(TId id, Guid guid) where TId : notnull;
+
+    void StoreRevision<TDoc, TId>(TId id, long revision) where TId : notnull;
+
+    void ClearVersion<TDoc, TId>(TId id) where TId : notnull;
+
+    void ClearRevision<TDoc, TId>(TId id) where TId : notnull;
+}

--- a/src/Weasel.Storage/StorageColumnType.cs
+++ b/src/Weasel.Storage/StorageColumnType.cs
@@ -1,0 +1,25 @@
+#nullable enable
+
+namespace Weasel.Storage;
+
+/// <summary>
+///     A small, dialect-neutral vocabulary of logical column types a metadata binder uses when
+///     contributing a value to the bulk-load path. A dialect maps each to its own provider parameter
+///     type (Postgres: <c>NpgsqlDbType</c>; SQL Server: <c>SqlDbType</c>). This is the seam that lets
+///     the fixed metadata binders drop their direct provider-writer dependency so they can be shared.
+/// </summary>
+/// <remarks>
+///     Deliberately covers only the fixed metadata columns' types. User-defined duplicated fields
+///     carry an arbitrary, user-overridable provider type that cannot be reduced to this set, so their
+///     bulk writing stays on the provider-native path.
+/// </remarks>
+public enum StorageColumnType
+{
+    String,
+    Guid,
+    Long,
+    Int,
+    Boolean,
+    Timestamp,
+    Json
+}

--- a/src/Weasel.Storage/Weasel.Storage.csproj
+++ b/src/Weasel.Storage/Weasel.Storage.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+        <Description>Dialect-neutral document-storage contracts (session/serializer/version-tracker/dialect seams) shared across the Critter Stack, spin off of Marten (JasperFx/marten#4821).</Description>
+        <GenerateAssemblyTitleAttribute>true</GenerateAssemblyTitleAttribute>
+        <GenerateAssemblyDescriptionAttribute>true</GenerateAssemblyDescriptionAttribute>
+        <GenerateAssemblyProductAttribute>true</GenerateAssemblyProductAttribute>
+        <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
+        <GenerateAssemblyVersionAttribute>true</GenerateAssemblyVersionAttribute>
+        <GenerateAssemblyFileVersionAttribute>true</GenerateAssemblyFileVersionAttribute>
+        <GenerateAssemblyInformationalVersionAttribute>true</GenerateAssemblyInformationalVersionAttribute>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <IsAotCompatible>true</IsAotCompatible>
+    </PropertyGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\Weasel.Core\Weasel.Core.csproj"/>
+    </ItemGroup>
+    <Import Project="../../Analysis.Build.props"/>
+</Project>


### PR DESCRIPTION
New **Weasel.Storage** library (on Weasel.Core) holding the dialect-neutral document-storage contracts extracted from Marten (JasperFx/marten#4821 Story 6): `IStorageDialect`, `StorageColumnType`, `BulkColumnValue`, `IStorageSerializer`, `IVersionTracker`. `IStorageDialect.ByIdFilter` uses the neutral `Weasel.Core.SqlGeneration.ISqlFragment` (weasel#327).

- `Weasel.Storage.csproj`: net9.0;net10.0, references `Weasel.Core`, `IsAotCompatible`. Added to `Weasel.slnx`.
- Bumps the release version 9.7.0 → **9.8.0**.
- `publish_nuget.yml`: adds the `Weasel.Storage` pack step.

Validated: Marten builds + its full test suites (Core/DocumentDb/EventSourcing) green against a local `Weasel.Storage` 9.8.0 pack; Wolverine.Marten compiles against a local Marten built on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)