### PR TITLE
feat: opt-in schema fingerprinting — skip unchanged full applies

### DIFF
--- a/docs/core/schema-migrations.md
+++ b/docs/core/schema-migrations.md
@@ -198,3 +198,31 @@ public interface IMigrationLogger_Sample
 <!-- endSnippet -->
 
 The default logger writes SQL to `Console.WriteLine` and rethrows exceptions.
+
+## Schema Fingerprinting
+
+For deployments with many databases and/or many replicas, repeated no-op applies (one per database, per
+process start, per rolling update) are measurably expensive: `ApplyAllConfiguredChangesToDatabaseAsync`
+introspects the catalog for every configured schema object even when nothing changed. Opt-in schema
+fingerprinting turns the no-op apply into a single `SELECT`:
+
+```cs
+migrator.UseSchemaFingerprinting = true;
+```
+
+With the flag enabled, a successful **full** apply stamps a SHA-256 fingerprint of the configured
+schema's expected DDL into `{DefaultSchemaName}.weasel_schema_fingerprint`. The next full apply
+recomputes the fingerprint in memory and, when it matches the stamp, returns immediately — no global
+lock, no catalog introspection. Any configuration change (a new table, column, index, or managed
+partition) changes the fingerprint and re-enables the real apply, which then refreshes the stamp.
+
+Semantics to be aware of:
+
+* A matching stamp is **trusted**. Schema drift applied outside Weasel (manual DDL, another tool) is not
+  detected while the stamp matches — exactly like an application that skips migrations altogether. Use
+  `AssertDatabaseMatchesConfigurationAsync` when you need verification; it is unaffected by the stamp.
+  Deleting the stamp row (or table) forces the next apply to run in full.
+* Only the **full** apply reads or writes the stamp. Feature-level applies
+  (`EnsureStorageExistsAsync`) behave exactly as before.
+* Concurrent appliers re-check the stamp after attaining the global migration lock, so replicas racing
+  through a rolling update do the introspection work at most once per configuration.

--- a/src/Weasel.Core/Migrations/DatabaseBase.cs
+++ b/src/Weasel.Core/Migrations/DatabaseBase.cs
@@ -319,11 +319,31 @@ public abstract class DatabaseBase<TConnection>: IDatabase<TConnection> where TC
             postProcessing.PostProcess(objects);
         }
 
+        // Opt-in fingerprint short-circuit (see Migrator.UseSchemaFingerprinting): computed AFTER
+        // post-processing so injected objects (e.g. managed partitions) participate in the hash.
+        var fingerprint = Migrator.UseSchemaFingerprinting
+            ? SchemaFingerprint.ComputeFingerprint(Migrator, objects)
+            : null;
+
         TConnection? conn = null;
         try
         {
             conn = CreateConnection();
             await conn.OpenAsync(ct).ConfigureAwait(false);
+
+            // Fast path: when the stamped fingerprint already matches the configured schema, skip the
+            // whole apply — no global lock, no catalog introspection. The stamp is only ever written
+            // after a successful full apply of this exact configuration.
+            if (fingerprint != null)
+            {
+                var stored = await SchemaFingerprint.TryReadAsync(conn, Migrator.DefaultSchemaName, ct)
+                    .ConfigureAwait(false);
+                if (fingerprint == stored)
+                {
+                    MarkAllFeaturesAsChecked();
+                    return SchemaPatchDifference.None;
+                }
+            }
 
             AttainLockResult attainLockResult;
 
@@ -346,12 +366,33 @@ public abstract class DatabaseBase<TConnection>: IDatabase<TConnection> where TC
 
             if (attainLockResult == AttainLockResult.Success)
             {
+                // Re-check the fingerprint now that we hold the lock: a concurrent applier (another
+                // replica racing this one) may have applied + stamped while we waited.
+                if (fingerprint != null)
+                {
+                    var stored = await SchemaFingerprint.TryReadAsync(conn, Migrator.DefaultSchemaName, ct)
+                        .ConfigureAwait(false);
+                    if (fingerprint == stored)
+                    {
+                        MarkAllFeaturesAsChecked();
+                        await globalLock.ReleaseLock(conn, ct).ConfigureAwait(false);
+                        return SchemaPatchDifference.None;
+                    }
+                }
+
                 await initializeSchema(conn, ct).ConfigureAwait(false);
                 var patch = await SchemaMigration.DetermineAsync(conn, ct, objects).ConfigureAwait(false);
 
                 if (patch.Difference != SchemaPatchDifference.None)
                 {
                     await Migrator.ApplyAllAsync(conn, patch, autoCreate, _logger, ct).ConfigureAwait(false);
+                }
+
+                if (fingerprint != null)
+                {
+                    // Stamp only after the apply succeeded, still under the global lock.
+                    await SchemaFingerprint.RecordAsync(conn, Migrator.DefaultSchemaName, fingerprint, ct)
+                        .ConfigureAwait(false);
                 }
 
                 MarkAllFeaturesAsChecked();

--- a/src/Weasel.Core/Migrations/SchemaFingerprint.cs
+++ b/src/Weasel.Core/Migrations/SchemaFingerprint.cs
@@ -1,0 +1,107 @@
+using System.Data.Common;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Weasel.Core.Migrations;
+
+/// <summary>
+/// Opt-in short-circuit for <see cref="DatabaseBase{TConnection}.ApplyAllConfiguredChangesToDatabaseAsync(Weasel.Core.MultiTenancy.IGlobalLock{TConnection}, JasperFx.AutoCreate?, ReconnectionOptions?, System.Threading.CancellationToken)"/>
+/// (see <see cref="Migrator.UseSchemaFingerprinting"/>): after a successful full apply, a SHA-256
+/// fingerprint of the configured schema's expected DDL is stamped into a one-row table in the migrator's
+/// default schema. The next full apply recomputes the fingerprint in memory and, when it matches the
+/// stamp, returns without any catalog introspection — turning the no-op apply into a single SELECT.
+///
+/// <para>
+/// The fingerprint covers everything the configuration would create — tables, indexes, functions,
+/// managed partitions, sequences — because it hashes each schema object's <c>WriteCreateStatement</c>
+/// output (sorted by identifier for stability). Any configuration change, including newly registered
+/// tenant partitions, changes the hash and re-enables the full apply.
+/// </para>
+///
+/// <para>
+/// TRUST SEMANTICS: a matching stamp is trusted. Schema drift applied outside Weasel (manual DDL,
+/// another tool) is not detected while the stamp matches — exactly like an application that skips
+/// migrations altogether. <c>AssertDatabaseMatchesConfigurationAsync</c> remains the verification
+/// route and is unaffected. Feature-level applies (<c>EnsureStorageExistsAsync</c>) neither read nor
+/// write the stamp: only the FULL apply computes the full fingerprint.
+/// </para>
+/// </summary>
+internal static class SchemaFingerprint
+{
+    public const string TableName = "weasel_schema_fingerprint";
+
+    public static string ComputeFingerprint(Migrator migrator, ISchemaObject[] objects)
+    {
+        var writer = new StringWriter();
+
+        // Sort for a stable hash regardless of feature registration order.
+        foreach (var schemaObject in objects.OrderBy(x => x.Identifier.QualifiedName, StringComparer.Ordinal))
+        {
+            writer.WriteLine(schemaObject.Identifier.QualifiedName);
+            schemaObject.WriteCreateStatement(migrator, writer);
+        }
+
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(writer.ToString()));
+        return Convert.ToHexString(bytes);
+    }
+
+    /// <summary>
+    /// Reads the stored fingerprint. A missing table (fresh database, feature never used) simply
+    /// reads as "no stamp".
+    /// </summary>
+    public static async Task<string?> TryReadAsync(DbConnection conn, string schemaName, CancellationToken ct)
+    {
+        try
+        {
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"select fingerprint from {schemaName}.{TableName} where id = 1";
+            return await cmd.ExecuteScalarAsync(ct).ConfigureAwait(false) as string;
+        }
+        catch (DbException)
+        {
+            // Table (or schema) does not exist yet — no stamp, run the full apply.
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Upserts the stamp after a successful full apply. Table creation is attempted first and an
+    /// "already exists" failure is swallowed — plain CREATE TABLE keeps this provider-neutral
+    /// (not every provider supports IF NOT EXISTS).
+    /// </summary>
+    public static async Task RecordAsync(DbConnection conn, string schemaName, string fingerprint,
+        CancellationToken ct)
+    {
+        try
+        {
+            await using var create = conn.CreateCommand();
+            create.CommandText =
+                $"create table {schemaName}.{TableName} (id int not null primary key, fingerprint varchar(128) not null, applied_at varchar(64) not null)";
+            await create.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+        }
+        catch (DbException)
+        {
+            // Already exists — fine.
+        }
+
+        await using var delete = conn.CreateCommand();
+        delete.CommandText = $"delete from {schemaName}.{TableName} where id = 1";
+        await delete.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+
+        await using var insert = conn.CreateCommand();
+        insert.CommandText =
+            $"insert into {schemaName}.{TableName} (id, fingerprint, applied_at) values (1, @fingerprint, @appliedAt)";
+
+        var fingerprintParam = insert.CreateParameter();
+        fingerprintParam.ParameterName = "@fingerprint";
+        fingerprintParam.Value = fingerprint;
+        insert.Parameters.Add(fingerprintParam);
+
+        var appliedAtParam = insert.CreateParameter();
+        appliedAtParam.ParameterName = "@appliedAt";
+        appliedAtParam.Value = DateTimeOffset.UtcNow.ToString("O");
+        insert.Parameters.Add(appliedAtParam);
+
+        await insert.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+    }
+}

--- a/src/Weasel.Core/Migrator.cs
+++ b/src/Weasel.Core/Migrator.cs
@@ -70,6 +70,23 @@ public abstract class
     public string DefaultSchemaName { get; }
 
     /// <summary>
+    ///     Opt-in: stamp a fingerprint of the configured schema's expected DDL into
+    ///     <c>{DefaultSchemaName}.weasel_schema_fingerprint</c> after every successful FULL
+    ///     <c>ApplyAllConfiguredChangesToDatabaseAsync</c>, and skip the apply entirely (a single
+    ///     SELECT instead of full catalog introspection) when the stamp already matches the current
+    ///     configuration. Any configuration change — including newly registered managed partitions —
+    ///     changes the fingerprint and re-enables the full apply.
+    ///     <para>
+    ///     A matching stamp is TRUSTED: schema drift applied outside Weasel is not detected while the
+    ///     stamp matches. <c>AssertDatabaseMatchesConfigurationAsync</c> remains the verification route.
+    ///     Feature-level applies (<c>EnsureStorageExistsAsync</c>) neither read nor write the stamp.
+    ///     Intended for deployments with many databases and/or many replicas, where repeated no-op
+    ///     applies (per pod start, per rolling update) are measurably expensive.
+    ///     </para>
+    /// </summary>
+    public bool UseSchemaFingerprinting { get; set; }
+
+    /// <summary>
     ///     Read [name].table and [name].function files from the named directory
     ///     to serve as templates for extra DDL (GRANT's probably)
     /// </summary>

--- a/src/Weasel.Postgresql.Tests/Migrations/schema_fingerprint_tests.cs
+++ b/src/Weasel.Postgresql.Tests/Migrations/schema_fingerprint_tests.cs
@@ -1,0 +1,124 @@
+using JasperFx;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Core.Migrations;
+using Xunit;
+
+namespace Weasel.Postgresql.Tests.Migrations;
+
+/// <summary>
+/// Opt-in schema fingerprinting (Migrator.UseSchemaFingerprinting): a successful FULL apply stamps a
+/// fingerprint of the configured schema's expected DDL; the next apply with an unchanged configuration
+/// skips all catalog introspection (a single SELECT). The stamp is TRUSTED — drift applied outside
+/// Weasel is not detected while it matches; AssertDatabaseMatchesConfigurationAsync remains the
+/// verification route. Any configuration change (new table/column/partition) changes the hash and
+/// re-enables the full apply.
+/// </summary>
+[Collection("fingerprint")]
+public class schema_fingerprint_tests: IntegrationContext, IAsyncLifetime
+{
+    private readonly TestDatabaseWithTables theDatabase;
+
+    public schema_fingerprint_tests(): base("fingerprint")
+    {
+        theDatabase = new TestDatabaseWithTables(AutoCreate.CreateOrUpdate, "Fingerprint", theDataSource);
+    }
+
+    public override async Task InitializeAsync()
+    {
+        await ResetSchema();
+
+        // The stamp lives in the migrator's default schema ('public') — clear it so tests are
+        // order-independent.
+        await theConnection.CreateCommand("drop table if exists public.weasel_schema_fingerprint")
+            .ExecuteNonQueryAsync();
+    }
+
+    private async Task<string?> readStampAsync()
+    {
+        try
+        {
+            return await theConnection
+                .CreateCommand("select fingerprint from public.weasel_schema_fingerprint where id = 1")
+                .ExecuteScalarAsync() as string;
+        }
+        catch (Npgsql.PostgresException e) when (e.SqlState == Npgsql.PostgresErrorCodes.UndefinedTable)
+        {
+            return null;
+        }
+    }
+
+    private async Task<bool> tableExistsAsync(string qualifiedName)
+    {
+        var result = await theConnection
+            .CreateCommand($"select to_regclass('{qualifiedName}') is not null")
+            .ExecuteScalarAsync();
+        return result is true;
+    }
+
+    [Fact]
+    public async Task full_apply_stamps_and_a_matching_stamp_skips_the_apply_entirely()
+    {
+        theDatabase.Migrator.UseSchemaFingerprinting = true;
+        theDatabase.Features["One"].AddTable(SchemaName, "one");
+
+        await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var stamp = await readStampAsync();
+        stamp.ShouldNotBeNull();
+        (await tableExistsAsync($"{SchemaName}.one")).ShouldBeTrue();
+
+        // Drift outside Weasel: drop the table manually. While the stamp matches the configuration,
+        // the next apply is a no-op single SELECT — the table must NOT come back. That is the proof
+        // the introspection was skipped, and the documented trust semantics of the stamp.
+        await theConnection.CreateCommand($"drop table {SchemaName}.one").ExecuteNonQueryAsync();
+
+        var difference = await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        difference.ShouldBe(SchemaPatchDifference.None);
+        (await tableExistsAsync($"{SchemaName}.one")).ShouldBeFalse();
+
+        // The verification route is unaffected: asserting the configuration still detects the drift.
+        await Should.ThrowAsync<DatabaseValidationException>(
+            () => theDatabase.AssertDatabaseMatchesConfigurationAsync());
+    }
+
+    [Fact]
+    public async Task a_configuration_change_invalidates_the_stamp_and_reapplies()
+    {
+        theDatabase.Migrator.UseSchemaFingerprinting = true;
+        theDatabase.Features["One"].AddTable(SchemaName, "one");
+
+        await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync();
+        var firstStamp = await readStampAsync();
+        firstStamp.ShouldNotBeNull();
+
+        // New object in the configuration -> different fingerprint -> the apply runs for real.
+        theDatabase.Features["One"].AddTable(SchemaName, "two");
+
+        await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        (await tableExistsAsync($"{SchemaName}.two")).ShouldBeTrue();
+        var secondStamp = await readStampAsync();
+        secondStamp.ShouldNotBeNull();
+        secondStamp.ShouldNotBe(firstStamp);
+    }
+
+    [Fact]
+    public async Task disabled_by_default_behavior_is_unchanged_and_nothing_is_stamped()
+    {
+        theDatabase.Migrator.UseSchemaFingerprinting.ShouldBeFalse();
+        theDatabase.Features["One"].AddTable(SchemaName, "one");
+
+        await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        (await readStampAsync()).ShouldBeNull();
+
+        // Without fingerprinting every apply introspects, so drift is repaired — the historical behavior.
+        await theConnection.CreateCommand($"drop table {SchemaName}.one").ExecuteNonQueryAsync();
+
+        await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        (await tableExistsAsync($"{SchemaName}.one")).ShouldBeTrue();
+    }
+}


### PR DESCRIPTION
## Problem

`ApplyAllConfiguredChangesToDatabaseAsync` introspects the catalog for every configured schema object on every call, even when nothing changed. On deployments with many databases and/or replicas that cost is paid **per database, per process start, per rolling update**. Field measurement (a Marten store under sharded multi-tenancy: 512 databases × ~55 partitioned tables × hundreds of tenant partitions): minutes of pure no-op apply per pod start, colliding with orchestrator probe budgets, and every rolling update re-paying the full cost per replica.

## Feature (opt-in, default OFF)

```cs
migrator.UseSchemaFingerprinting = true;
```

A successful **full** apply stamps a SHA-256 fingerprint of the configured schema's expected DDL (each object's `WriteCreateStatement` output, sorted by identifier for stability) into `{DefaultSchemaName}.weasel_schema_fingerprint`. The next full apply recomputes the fingerprint in memory and, on a match, returns without any catalog introspection — **a single SELECT per database**. Any configuration change — a new table, column, index, or managed partition (they are part of the create-SQL, so newly registered tenants invalidate the stamp automatically) — re-enables the real apply, which refreshes the stamp.

Design notes:

- The opt-in lives on `Migrator` so one flag covers every database of a store (Marten exposes the migrator via `StoreOptions.Advanced.Migrator`-style surfaces); `DefaultSchemaName` hosts the stamp table.
- **Trust semantics**: a matching stamp is trusted. Out-of-band drift (manual DDL) is not detected while the stamp matches — the same trade an application makes by skipping migrations at startup. `AssertDatabaseMatchesConfigurationAsync` remains the verification route and is unaffected; deleting the stamp row forces a full apply.
- Only the **full** apply reads/writes the stamp; feature-level applies (`EnsureStorageExistsAsync`) are unchanged.
- Concurrent appliers re-check the stamp **after** attaining the global migration lock, so replicas racing through a rolling update introspect at most once per configuration.
- Storage is provider-neutral (plain `CREATE TABLE` with an already-exists catch, delete+insert upsert, ISO-8601 varchar timestamp) and lives in `Weasel.Core`.

## Tests

`schema_fingerprint_tests` (Weasel.Postgresql.Tests): stamp + skip (a manually dropped table deliberately does NOT come back while the stamp matches — the proof of the skip — and the assert route still detects the drift), configuration change invalidating the stamp, and default-off behavior unchanged. Full Weasel.Postgresql.Tests suite green (720 passed, net10.0).

## Docs

New "Schema Fingerprinting" section in `docs/core/schema-migrations.md` covering the flag, the trust semantics, and the intended workloads.

Adjacent to the connection/startup-conservation goals of JasperFx/jasperfx#486 (WS2/WS4) — field findings from the same hardening cycle as marten#4852/#4853/#4854.