### PR TITLE
Weasel.Storage: the closed-shape storage runtime contracts (marten#4821, increment 2)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>9.8.0</Version>
+        <Version>9.9.0</Version>
         <LangVersion>13.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/src/Weasel.Storage/ConcurrencyChecks.cs
+++ b/src/Weasel.Storage/ConcurrencyChecks.cs
@@ -1,0 +1,18 @@
+namespace Weasel.Storage;
+
+/// <summary>
+///     Whether a storage session honors optimistic concurrency checks when building document
+///     update/upsert operations.
+/// </summary>
+public enum ConcurrencyChecks
+{
+    /// <summary>
+    ///     Optimistic concurrency checks are enforced (Default)
+    /// </summary>
+    Enabled,
+
+    /// <summary>
+    ///     Optimistic concurrency checks are disabled for this session
+    /// </summary>
+    Disabled
+}

--- a/src/Weasel.Storage/DocumentProvider.cs
+++ b/src/Weasel.Storage/DocumentProvider.cs
@@ -1,0 +1,24 @@
+#nullable enable
+namespace Weasel.Storage;
+
+/// <summary>
+///     Bundles the four closed-shape storage variants for one document type. A store derives
+///     from this to attach store-specific services (e.g. a bulk loader) that are not part of the
+///     dialect-neutral contract.
+/// </summary>
+public class DocumentProvider<T> where T : notnull
+{
+    public DocumentProvider(IDocumentStorage<T> queryOnly, IDocumentStorage<T> lightweight,
+        IDocumentStorage<T> identityMap, IDocumentStorage<T> dirtyTracking)
+    {
+        QueryOnly = queryOnly;
+        Lightweight = lightweight;
+        IdentityMap = identityMap;
+        DirtyTracking = dirtyTracking;
+    }
+
+    public IDocumentStorage<T> QueryOnly { get; }
+    public IDocumentStorage<T> Lightweight { get; }
+    public IDocumentStorage<T> IdentityMap { get; }
+    public IDocumentStorage<T> DirtyTracking { get; }
+}

--- a/src/Weasel.Storage/IChangeTracker.cs
+++ b/src/Weasel.Storage/IChangeTracker.cs
@@ -1,0 +1,16 @@
+#nullable enable
+using System.Diagnostics.CodeAnalysis;
+
+namespace Weasel.Storage;
+
+/// <summary>
+///     Dirty-tracking seam: watches one loaded document and, at save time, detects whether it
+///     changed since load (producing the storage operation that persists the change) and resets
+///     its baseline after a successful commit.
+/// </summary>
+public interface IChangeTracker
+{
+    object Document { get; }
+    bool DetectChanges(IStorageSession session, [NotNullWhen(true)]out IStorageOperation? operation);
+    void Reset(IStorageSession session);
+}

--- a/src/Weasel.Storage/IDeletion.cs
+++ b/src/Weasel.Storage/IDeletion.cs
@@ -1,0 +1,12 @@
+#nullable enable
+namespace Weasel.Storage;
+
+/// <summary>
+///     A storage operation that deletes a document, exposing the document and/or identity it
+///     targets for unit-of-work bookkeeping. Deletions return no result set.
+/// </summary>
+public interface IDeletion: IStorageOperation, NoDataReturnedCall
+{
+    object Document { get; set; }
+    object Id { get; set; }
+}

--- a/src/Weasel.Storage/IDocumentStorage.cs
+++ b/src/Weasel.Storage/IDocumentStorage.cs
@@ -1,0 +1,135 @@
+#nullable enable
+using System.Data.Common;
+using JasperFx.Events.Aggregation;
+using JasperFx.MultiTenancy;
+using Weasel.Core;
+using Weasel.Core.SqlGeneration;
+
+namespace Weasel.Storage;
+
+/// <summary>
+///     Dialect-neutral contract for one closed-shape document storage variant (query-only,
+///     lightweight, identity-map, or dirty-tracking): identity/typing metadata, the delete
+///     fragments, tenancy style, and the query-filtering entry points the shared runtime and
+///     LINQ pipeline drive. Store-specific concerns (the LINQ member model, bulk loading,
+///     dialect-typed select clauses) live on derived interfaces in the owning store.
+/// </summary>
+public interface IDocumentStorage: ISelectClause
+{
+    Type SourceType { get; }
+
+    Type IdType { get; }
+
+    bool UseOptimisticConcurrency { get; }
+    IOperationFragment DeleteFragment { get; }
+    IOperationFragment HardDeleteFragment { get; }
+    IReadOnlyList<IDuplicatedField> DuplicatedFields { get; }
+    DbObjectName TableName { get; }
+    Type DocumentType { get; }
+
+    TenancyStyle TenancyStyle { get; }
+    Task TruncateDocumentStorageAsync(IStorageDatabase database, CancellationToken ct = default);
+
+    ISqlFragment FilterDocuments(ISqlFragment query, IStorageSession session);
+
+    ISqlFragment? DefaultWhereFragment();
+
+    bool UseNumericRevisions { get; }
+
+    object RawIdentityValue(object id);
+}
+
+/// <summary>
+///     Adds the document-typed store/eject/version members and the operation factory methods
+///     (update/insert/upsert/overwrite and their session-free projection variants) to
+///     <see cref="IDocumentStorage"/>.
+/// </summary>
+public interface IDocumentStorage<T>: IDocumentStorage where T : notnull
+{
+    object IdentityFor(T document);
+
+    Guid? VersionFor(T document, IStorageSession session);
+
+    void Store(IStorageSession session, T document);
+    void Store(IStorageSession session, T document, Guid? version);
+    void Store(IStorageSession session, T document, long revision);
+
+    void Eject(IStorageSession session, T document);
+
+    IStorageOperation Update(T document, IStorageSession session, string tenantId);
+    IStorageOperation Insert(T document, IStorageSession session, string tenantId);
+    IStorageOperation Upsert(T document, IStorageSession session, string tenantId);
+
+    IStorageOperation Overwrite(T document, IStorageSession session, string tenantId);
+
+    /// <summary>
+    ///     Lighter-weight overwrite for projection storage. Builds the same Overwrite operation
+    ///     but does NOT consult session-level version / revision tracking, so it is safe to call
+    ///     from parallel async-daemon slice handlers that share a session (the session is, by
+    ///     contract, not thread-safe; projections set the revision explicitly from the event and
+    ///     never read the session's version tracker back).
+    /// </summary>
+    IStorageOperation OverwriteProjected(T document, string tenantId);
+
+    /// <summary>
+    ///     Session-free Upsert for projection storage. Builds the same Upsert operation as
+    ///     <see cref="Upsert"/> but passes a null version/revision tracker so the projection path
+    ///     never touches the session's version tracking. Safe to call from parallel async-daemon
+    ///     slice handlers that share a session.
+    /// </summary>
+    IStorageOperation UpsertProjected(T document, string tenantId);
+
+    /// <summary>
+    ///     Session-free Insert for projection storage. See <see cref="UpsertProjected"/>.
+    /// </summary>
+    IStorageOperation InsertProjected(T document, string tenantId);
+
+    /// <summary>
+    ///     Session-free Update for projection storage. See <see cref="UpsertProjected"/>.
+    /// </summary>
+    IStorageOperation UpdateProjected(T document, string tenantId);
+
+    IDeletion DeleteForDocument(T document, string tenantId);
+
+    void EjectById(IStorageSession session, object id);
+    void RemoveDirtyTracker(IStorageSession session, object id);
+    IDeletion HardDeleteForDocument(T document, string tenantId);
+
+    void SetIdentityFromString(T document, string identityString);
+    void SetIdentityFromGuid(T document, Guid identityGuid);
+}
+
+/// <summary>
+///     The identity-typed closed shape: id-keyed load / delete / filter members plus the
+///     session-free projection load path (fresh connection off <see cref="IStorageDatabase"/>,
+///     no session-shared state).
+/// </summary>
+public interface IDocumentStorage<T, TId>: IDocumentStorage<T>, IIdentitySetter<T, TId> where T : notnull where TId : notnull
+{
+    IDeletion DeleteForId(TId id, string tenantId);
+
+    Task<T?> LoadAsync(TId id, IStorageSession session, CancellationToken token);
+
+    Task<IReadOnlyList<T>> LoadManyAsync(TId[] ids, IStorageSession session, CancellationToken token);
+
+    /// <summary>
+    ///     Session-free Load for projection storage. Opens a fresh connection from the database,
+    ///     executes the load SQL, and returns the deserialized document. Does not touch any
+    ///     session-shared state — no version/revision tracker writes, no ItemMap updates, no
+    ///     MarkAsDocumentLoaded, no ChangeTrackers writes. Safe to call from parallel
+    ///     async-daemon slice handlers that share a session.
+    /// </summary>
+    Task<T?> LoadProjectedAsync(TId id, IStorageDatabase database, string tenantId, CancellationToken token);
+
+    /// <summary>
+    ///     Session-free LoadMany for projection storage. See <see cref="LoadProjectedAsync"/>.
+    /// </summary>
+    Task<IReadOnlyList<T>> LoadManyProjectedAsync(TId[] ids, IStorageDatabase database, string tenantId, CancellationToken token);
+
+    TId AssignIdentity(T document, string tenantId, IStorageDatabase database);
+    ISqlFragment ByIdFilter(TId id);
+    IDeletion HardDeleteForId(TId id, string tenantId);
+    DbCommand BuildLoadCommand(TId id, string tenantId);
+    DbCommand BuildLoadManyCommand(TId[] ids, string tenantId);
+    object RawIdentityValue(TId id);
+}

--- a/src/Weasel.Storage/IDuplicatedField.cs
+++ b/src/Weasel.Storage/IDuplicatedField.cs
@@ -1,0 +1,23 @@
+#nullable enable
+using System.Reflection;
+
+namespace Weasel.Storage;
+
+/// <summary>
+///     Database-neutral view of a duplicated field that the closed-shape storage runtime
+///     consumes off <see cref="IDocumentStorage"/> — exposes only the members the storage /
+///     patch code needs (the resolved member chain, the column name, and the pre-rendered
+///     update fragment). A store's LINQ member model keeps its richer, dialect-typed duplicated
+///     field type and implements this view.
+/// </summary>
+public interface IDuplicatedField
+{
+    /// <summary>The resolved member chain the duplicated column is derived from.</summary>
+    MemberInfo[] Members { get; }
+
+    /// <summary>The duplicated column's name.</summary>
+    string ColumnName { get; }
+
+    /// <summary>The <c>"col" = ...</c> assignment fragment used when patch/update SQL refreshes the column.</summary>
+    string UpdateSqlFragment();
+}

--- a/src/Weasel.Storage/IOperationFragment.cs
+++ b/src/Weasel.Storage/IOperationFragment.cs
@@ -1,0 +1,14 @@
+#nullable enable
+using Weasel.Core;
+using Weasel.Core.SqlGeneration;
+
+namespace Weasel.Storage;
+
+/// <summary>
+///     A SQL fragment that also identifies the operation category it performs (delete, update,
+///     etc.) — used by the closed-shape document storage to describe its delete fragments.
+/// </summary>
+public interface IOperationFragment: ISqlFragment
+{
+    OperationRole Role();
+}

--- a/src/Weasel.Storage/IProviderGraph.cs
+++ b/src/Weasel.Storage/IProviderGraph.cs
@@ -1,0 +1,13 @@
+#nullable enable
+namespace Weasel.Storage;
+
+/// <summary>
+///     Registry of <see cref="DocumentProvider{T}"/> instances per document type — the
+///     document-provider lookup the closed-shape storage runtime resolves storages through.
+/// </summary>
+public interface IProviderGraph
+{
+    DocumentProvider<T> StorageFor<T>() where T : notnull;
+
+    void Append<T>(DocumentProvider<T> provider) where T : notnull;
+}

--- a/src/Weasel.Storage/ISelectClause.cs
+++ b/src/Weasel.Storage/ISelectClause.cs
@@ -1,0 +1,23 @@
+#nullable enable
+using Weasel.Core.SqlGeneration;
+
+namespace Weasel.Storage;
+
+/// <summary>
+///     Dialect-neutral select-clause contract for the closed-shape document storage runtime:
+///     where the document rows come from (<see cref="FromObject"/>), what is selected
+///     (<see cref="SelectFields"/> / <see cref="SelectedType"/>), and how rows are materialized
+///     (<see cref="BuildSelector"/>). A store's LINQ layer typically derives its own richer
+///     select-clause interface from this one, adding query-handler / statistics members that are
+///     specific to that store's query pipeline.
+/// </summary>
+public interface ISelectClause: ISqlFragment
+{
+    string FromObject { get; }
+
+    Type SelectedType { get; }
+
+    string[] SelectFields();
+
+    ISelector BuildSelector(IStorageSession session);
+}

--- a/src/Weasel.Storage/ISelector.cs
+++ b/src/Weasel.Storage/ISelector.cs
@@ -1,0 +1,23 @@
+#nullable enable
+using System.Data.Common;
+
+namespace Weasel.Storage;
+
+/// <summary>
+///     Marker base for the row-materialization selectors the closed-shape document storage
+///     runtime builds from a select clause (see <see cref="ISelectClause.BuildSelector"/>).
+/// </summary>
+public interface ISelector
+{
+}
+
+/// <summary>
+///     Materializes a <typeparamref name="T"/> from the current row of a
+///     <see cref="DbDataReader"/>.
+/// </summary>
+public interface ISelector<T>: ISelector
+{
+    T Resolve(DbDataReader reader);
+
+    Task<T> ResolveAsync(DbDataReader reader, CancellationToken token);
+}

--- a/src/Weasel.Storage/IStorageDatabase.cs
+++ b/src/Weasel.Storage/IStorageDatabase.cs
@@ -1,0 +1,31 @@
+#nullable enable
+using System.Data.Common;
+using Weasel.Core.Sequences;
+
+namespace Weasel.Storage;
+
+/// <summary>
+///     Dialect-neutral database accessor the closed-shape storage runtime targets: the
+///     <see cref="IProviderGraph"/> for document-provider lookup, the
+///     <see cref="ISequenceSource"/> Hi-Lo/sequence seam used by the Weasel.Core.Identity
+///     <c>AssignIfMissing</c> strategies, and a neutral connection/SQL surface for the
+///     session-free storage paths.
+/// </summary>
+public interface IStorageDatabase: ISequenceSource
+{
+    IProviderGraph Providers { get; }
+
+    /// <summary>
+    ///     Open a new database-neutral connection. The projection-safe closed-shape read path
+    ///     uses this to run its <see cref="DbCommand"/> off the session. (Distinct name from any
+    ///     dialect-typed <c>CreateConnection</c> a store's database exposes, to avoid a
+    ///     same-signature return-type clash.)
+    /// </summary>
+    DbConnection CreateStorageConnection();
+
+    /// <summary>
+    ///     Execute a single SQL statement against a fresh connection. Used by the closed-shape
+    ///     <c>TruncateDocumentStorageAsync</c> path.
+    /// </summary>
+    Task RunSqlAsync(string sql, CancellationToken ct = default);
+}

--- a/src/Weasel.Storage/IStorageOperation.cs
+++ b/src/Weasel.Storage/IStorageOperation.cs
@@ -1,0 +1,18 @@
+#nullable enable
+using Weasel.Core;
+
+namespace Weasel.Storage;
+
+/// <summary>
+///     Dialect-neutral storage operation: <see cref="Weasel.Core.IStorageOperation"/>
+///     (DocumentType / Role / PostprocessAsync) plus the command-configuration entry point the
+///     closed-shape unit of work drives against the neutral <see cref="ICommandBuilder"/>.
+///     A store's own operation contract typically derives from this and re-declares
+///     <c>ConfigureCommand</c> with its dialect-typed command builder, bridging back to this
+///     neutral slot with a default interface method (the same pattern the Weasel SQL-generation
+///     contracts use).
+/// </summary>
+public interface IStorageOperation: Core.IStorageOperation
+{
+    void ConfigureCommand(ICommandBuilder builder, IStorageSession session);
+}

--- a/src/Weasel.Storage/IStorageSession.cs
+++ b/src/Weasel.Storage/IStorageSession.cs
@@ -1,0 +1,57 @@
+#nullable enable
+using System.Data.Common;
+using JasperFx;
+
+namespace Weasel.Storage;
+
+/// <summary>
+///     Dialect-neutral operation/session context the closed-shape document storage, operation,
+///     and selector runtime targets — the gating seam for sharing that runtime across stores
+///     (JasperFx/marten#4810 / #4821). The unit-of-work metadata (tenant id / correlation /
+///     causation / user name / headers) comes from the <see cref="IMetadataContext"/> base.
+/// </summary>
+/// <remarks>
+///     Deliberately exposes only the subset of members the closed-shape document + event storage
+///     code actually consumes: the serializer/database/version seams, the identity-map and
+///     dirty-tracking state, and a database-neutral command execution entry point.
+/// </remarks>
+public interface IStorageSession: IMetadataContext
+{
+    IStorageSerializer Serializer { get; }
+
+    IStorageDatabase Database { get; }
+
+    IVersionTracker Versions { get; }
+
+    IList<IChangeTracker> ChangeTrackers { get; }
+
+    Dictionary<Type, object> ItemMap { get; }
+
+    /// <summary>
+    ///     Override whether or not this session honors optimistic concurrency checks
+    /// </summary>
+    ConcurrencyChecks Concurrency { get; }
+
+    IDocumentStorage StorageFor(Type documentType);
+
+    IDocumentStorage<T> StorageFor<T>() where T : notnull;
+
+    void MarkAsAddedForStorage(object id, object document);
+
+    void MarkAsDocumentLoaded(object id, object document);
+
+    /// <summary>
+    ///     Execute a single command against this session's connection and return the results.
+    ///     Database-neutral execution seam: the closed-shape read path (document LoadAsync /
+    ///     LoadManyAsync) targets <see cref="DbCommand"/> here instead of a dialect-typed
+    ///     command. The owning store's session implements this over its connection lifetime.
+    /// </summary>
+    Task<DbDataReader> ExecuteReaderAsync(DbCommand command, CancellationToken token = default);
+
+    /// <summary>
+    ///     Generates a unique temporary-table / CTE name scoped to this session. Used by LINQ
+    ///     statement compilers for include queries and chained sub-selects — a session-scoped
+    ///     concern any dialect performing include/CTE queries needs.
+    /// </summary>
+    string NextTempTableName();
+}

--- a/src/Weasel.Storage/NoDataReturnedCall.cs
+++ b/src/Weasel.Storage/NoDataReturnedCall.cs
@@ -1,0 +1,9 @@
+namespace Weasel.Storage;
+
+/// <summary>
+///     Marker interface for storage operations whose SQL returns no result set, telling the
+///     unit-of-work callback walker not to advance the batched reader for this operation.
+/// </summary>
+public interface NoDataReturnedCall
+{
+}

--- a/src/Weasel.Storage/Weasel.Storage.csproj
+++ b/src/Weasel.Storage/Weasel.Storage.csproj
@@ -14,6 +14,9 @@
     </PropertyGroup>
     <ItemGroup>
         <ProjectReference Include="..\Weasel.Core\Weasel.Core.csproj"/>
+        <!-- IDocumentStorage<T,TId> derives IIdentitySetter<T,TId> (JasperFx.Events.Aggregation) so
+             closed-shape storages plug straight into the event-projection aggregation APIs. -->
+        <PackageReference Include="JasperFx.Events"/>
     </ItemGroup>
     <Import Project="../../Analysis.Build.props"/>
 </Project>


### PR DESCRIPTION
Second Weasel.Storage increment for the Marten **W2 storage-extraction epic** (JasperFx/marten#4821): the dialect-neutral closed-shape document storage contracts, lifted from Marten now that its five gatekeeper refactors (marten#4850/#4851/#4858/#4859/#4860) made the dependency closure bounded.

### New contracts (all `namespace Weasel.Storage`)
- `IStorageSession` (: JasperFx `IMetadataContext`) — the operation/session context the storage runtime targets
- `IStorageDatabase` (: `ISequenceSource`, + `CreateStorageConnection()` / `RunSqlAsync`) and `IProviderGraph`
- `IDocumentStorage` / `IDocumentStorage<T>` / `IDocumentStorage<T,TId>` (: neutral `ISelectClause`; the id-typed one derives `IIdentitySetter<T,TId>` — hence a new **JasperFx.Events** package reference)
- `DocumentProvider<T>` — the four storage variants; store-specific services (e.g. Marten's COPY bulk loader) live on store-side subclasses
- `IChangeTracker`, `IDuplicatedField`, `ConcurrencyChecks`
- `IStorageOperation` (: `Weasel.Core.IStorageOperation` + neutral `ConfigureCommand(ICommandBuilder, IStorageSession)`), `IDeletion`, `NoDataReturnedCall`, `IOperationFragment`
- `ISelectClause` (neutral subset: FromObject / SelectedType / SelectFields / BuildSelector), `ISelector` / `ISelector<T>`

All SQL-generation references target the shared Weasel.Core contracts (`ISqlFragment` / `ICommandBuilder`, weasel#327); stores derive richer dialect-typed interfaces and bridge via default interface methods — the same pattern the Postgresql/SqlServer fragments already use.

Bumps to **9.9.0**.

Validated downstream (locally packed): Marten consumes these with all seven test suites green, and Wolverine.Marten + Wolverine.Http.Marten compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)