### PR TITLE
Fix ListPartition bound round-trip drift for integer/date values (#320)

### DIFF
--- a/src/Weasel.Postgresql.Tests/Tables/partitioning/integer_list_partition_round_trip.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/partitioning/integer_list_partition_round_trip.cs
@@ -1,0 +1,58 @@
+using Shouldly;
+using Weasel.Core;
+using Weasel.Postgresql.Tables;
+using Weasel.Postgresql.Tables.Partitioning;
+using Xunit;
+
+namespace Weasel.Postgresql.Tests.Tables.partitioning;
+
+[Collection("partitions")]
+public class integer_list_partition_round_trip : IntegrationContext
+{
+    private readonly Table theTable;
+
+    public integer_list_partition_round_trip() : base("partitions")
+    {
+        theTable = new Table("partitions.people");
+        theTable.AddColumn<int>("id").AsPrimaryKey();
+        theTable.AddColumn<string>("first_name");
+        theTable.AddColumn<int>("age")
+            .PartitionByListValues()
+            .AddPartition("twenties", 20, 21, 22)
+            .AddPartition("thirties", 30, 31, 32);
+    }
+
+    private async Task tryToCreateTable()
+    {
+        await theConnection.OpenAsync();
+        await theConnection.ResetSchemaAsync("partitions");
+        await theTable.CreateAsync(theConnection);
+    }
+
+    [Fact]
+    public async Task no_delta_on_reapply_for_integer_list_values()
+    {
+        await tryToCreateTable();
+
+        // Before weasel#320: declared integer values (20) never string-matched PostgreSQL's quoted
+        // read-back ('20'), so every migration reported a spurious, destructive partition rebuild.
+        var delta = await theTable.FindDeltaAsync(theConnection);
+
+        delta.Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task fetch_existing_matches_declared_integer_list_partitions()
+    {
+        await tryToCreateTable();
+
+        var existing = await theTable.FetchExistingAsync(theConnection);
+
+        var partitioning = existing.Partitioning.ShouldBeOfType<ListPartitioning>();
+        partitioning.Columns.Single().ShouldBe("age");
+
+        // ShouldContain uses Equals, which normalizes the quoted read-back back to the declared form
+        partitioning.Partitions.ShouldContain(new ListPartition("twenties", "20", "21", "22"));
+        partitioning.Partitions.ShouldContain(new ListPartition("thirties", "30", "31", "32"));
+    }
+}

--- a/src/Weasel.Postgresql.Tests/Tables/partitioning/list_partition_equality.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/partitioning/list_partition_equality.cs
@@ -1,0 +1,64 @@
+using Shouldly;
+using Weasel.Postgresql.Tables.Partitioning;
+using Xunit;
+
+namespace Weasel.Postgresql.Tests.Tables.partitioning;
+
+public class list_partition_equality
+{
+    [Fact]
+    public void integer_value_matches_quoted_readback()
+    {
+        // declared unquoted (20) vs PostgreSQL read-back single-quoted ('20') — weasel#320
+        var declared = new ListPartition("twenties", "20");
+        var readBack = new ListPartition("twenties", "'20'");
+
+        declared.Equals(readBack).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void date_value_matches_quoted_readback_across_time_zones()
+    {
+        // Same instant, rendered by PostgreSQL in a non-UTC session time zone
+        var declared = new ListPartition("start", "'2026-01-01 00:00:00+00'");
+        var readBack = new ListPartition("start", "'2025-12-31 18:00:00-06'");
+
+        declared.Equals(readBack).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void not_equal_when_a_value_differs()
+    {
+        new ListPartition("twenties", "20")
+            .Equals(new ListPartition("twenties", "21"))
+            .ShouldBeFalse();
+    }
+
+    [Fact]
+    public void not_equal_when_suffix_differs()
+    {
+        new ListPartition("twenties", "20")
+            .Equals(new ListPartition("thirties", "20"))
+            .ShouldBeFalse();
+    }
+
+    [Fact]
+    public void get_hashcode_is_consistent_with_equals_across_quoting()
+    {
+        var declared = new ListPartition("twenties", "20");
+        var readBack = new ListPartition("twenties", "'20'");
+
+        declared.GetHashCode().ShouldBe(readBack.GetHashCode());
+    }
+
+    [Fact]
+    public void get_hashcode_hashes_element_values_not_the_array_reference()
+    {
+        // Old bug: HashCode.Combine(Values, Suffix) hashed the array reference, so two instances with
+        // identical contents hashed differently. The hash must be based on the element values.
+        var one = new ListPartition("admin", "'admin'", "'super'");
+        var two = new ListPartition("admin", "'admin'", "'super'");
+
+        one.GetHashCode().ShouldBe(two.GetHashCode());
+    }
+}

--- a/src/Weasel.Postgresql.Tests/Tables/partitioning/partitioning_deltas.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/partitioning/partitioning_deltas.cs
@@ -253,6 +253,24 @@ public class partitioning_deltas
     }
 
     [Fact]
+    public void integer_list_does_not_drift_against_quoted_readback()
+    {
+        // PostgreSQL echoes integer list values back single-quoted ('20'); the declared side is unquoted (20).
+        // Normalized comparison keeps these equal so no spurious rebuild is reported (weasel#320).
+        var table = new Table(new DbObjectName("partitions", "people"));
+
+        var declared = new ListPartitioning { Columns = ["age"] }
+            .AddPartition("twenties", 20, 21)
+            .AddPartition("thirties", 30, 31);
+
+        var readBack = new ListPartitioning { Columns = ["age"] }
+            .AddPartition("twenties", "'20'", "'21'")
+            .AddPartition("thirties", "'30'", "'31'").As<IPartitionStrategy>();
+
+        declared.As<IPartitionStrategy>().CreateDelta(table, readBack, out _).ShouldBe(PartitionDelta.None);
+    }
+
+    [Fact]
     public void timestamp_range_does_not_drift_against_readback_in_another_time_zone()
     {
         // Same monthly bounds, but PostgreSQL rendered the timestamptz read-back in a non-UTC session.

--- a/src/Weasel.Postgresql/Tables/Partitioning/ListPartition.cs
+++ b/src/Weasel.Postgresql/Tables/Partitioning/ListPartition.cs
@@ -65,10 +65,15 @@ public class ListPartition : IPartition
 
     protected bool Equals(ListPartition other)
     {
+        // Values hold raw SQL literals that differ between the declared side and what PostgreSQL
+        // echoes back (it single-quotes every literal, so a declared int 20 comes back as '20'), so
+        // compare on the normalized form to avoid spurious migration rebuilds. String values already
+        // match because FormatSqlValue quotes them on both sides; integer and date values would drift.
+        // See PartitionExtensions.NormalizePartitionValue (mirrors the RangePartition fix, weasel#318).
         if (Values.Length != other.Values.Length) return false;
         for (int i = 0; i < Values.Length; i++)
         {
-            if (!Values[i].Equals(other.Values[i]))
+            if (Values[i].NormalizePartitionValue() != other.Values[i].NormalizePartitionValue())
             {
                 return false;
             }
@@ -101,7 +106,16 @@ public class ListPartition : IPartition
 
     public override int GetHashCode()
     {
-        return HashCode.Combine(Values, Suffix);
+        // Combine the normalized element values (not the array reference) + Suffix so the hash is
+        // consistent with Equals and stable across the declared-vs-readback quoting difference.
+        var hash = new HashCode();
+        foreach (var value in Values)
+        {
+            hash.Add(value.NormalizePartitionValue());
+        }
+
+        hash.Add(Suffix);
+        return hash.ToHashCode();
     }
 
     public override string ToString()


### PR DESCRIPTION
Closes #320.

`ListPartition` had the same latent partition-bound drift that `RangePartition` had before #318 (shipped in 9.3.0). PostgreSQL single-quotes every bound literal on read-back via `pg_get_expr(relpartbound)` — a declared integer `20` comes back as `'20'` — and renders `timestamptz` in the session time zone. `ListPartition.Equals` compared the raw SQL strings directly, so **integer and date list partitions never matched their read-back form**, forcing a spurious, destructive rebuild on every migration. (String values already worked because `FormatSqlValue` quotes them on both sides.)

Separately, `GetHashCode` was `HashCode.Combine(Values, Suffix)`, which hashed the **array reference** rather than the element values — inconsistent with `Equals` and effectively random per instance.

## Fix (mirrors the #318 `RangePartition` change)

- `Equals` compares `Values` element-wise via the existing `PartitionExtensions.NormalizePartitionValue` helper (raw values are still kept for DDL emission).
- `GetHashCode` combines the **normalized element values** + `Suffix`, consistent with `Equals`.

## Tests

- `partitioning_deltas.integer_list_does_not_drift_against_quoted_readback` — declared integer list values (`20`) vs quoted read-back (`'20'`) → `PartitionDelta.None`.
- `list_partition_equality` — unit tests for integer/date normalized equality, suffix/value inequality, hashcode consistency with `Equals`, and that the hash is based on element values (not the array reference).
- `integer_list_partition_round_trip` — DB round-trip: creates an integer `LIST`-partitioned table, then asserts `FindDeltaAsync` reports `SchemaPatchDifference.None` on re-apply, and that `FetchExistingAsync` matches the declared partitions.

Full partitioning suite passes (88 tests) against PostgreSQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)