### PR TITLE
Weasel.Storage descriptor core: the closed-shape runtime's shared vocabulary (marten#4821 INC-1)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>9.9.0</Version>
+        <Version>9.10.0</Version>
         <LangVersion>13.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/src/Weasel.Storage/ChangeTracker.cs
+++ b/src/Weasel.Storage/ChangeTracker.cs
@@ -1,0 +1,62 @@
+#nullable enable
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Nodes;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// The standard <see cref="IChangeTracker"/>: snapshots a loaded document's clean JSON and, at
+/// save time, detects changes by JSON comparison, producing the upsert/overwrite operation that
+/// persists the change.
+/// </summary>
+public class ChangeTracker<T>: IChangeTracker where T : notnull
+{
+    private readonly T _document;
+    private string _json;
+
+    public ChangeTracker(IStorageSession session, T document)
+    {
+        _document = document;
+        _json = session.Serializer.ToCleanJson(document);
+    }
+
+    public object Document => _document;
+
+    public bool DetectChanges(IStorageSession session, [NotNullWhen(true)]out IStorageOperation? operation)
+    {
+        var newJson = session.Serializer.ToCleanJson(_document);
+
+        // Fast path: if the JSON strings are identical, skip expensive parsing
+        if (string.Equals(_json, newJson, StringComparison.Ordinal))
+        {
+            operation = null;
+            return false;
+        }
+
+        // Slow path: parse and deep-compare to handle semantically equivalent JSON
+        // (whitespace, property ordering).
+        if (JsonNode.DeepEquals(JsonNode.Parse(_json), JsonNode.Parse(newJson)))
+        {
+            operation = null;
+            return false;
+        }
+
+        // When the session opts out of concurrency checks (Concurrency=Disabled) and the
+        // document uses optimistic versioning, route through Overwrite so the SQL drops the
+        // WHERE mt_version = ? guard — otherwise a stale version on the dirty-tracking copy
+        // turns into a no-op UPDATE and SaveChanges raises a concurrency exception despite the
+        // opt-out.
+        var storage = session.Database.Providers.StorageFor<T>().DirtyTracking;
+        operation = session.Concurrency == ConcurrencyChecks.Disabled
+                    && (storage.UseOptimisticConcurrency || storage.UseNumericRevisions)
+            ? storage.Overwrite(_document, session, session.TenantId)
+            : storage.Upsert(_document, session, session.TenantId);
+
+        return true;
+    }
+
+    public void Reset(IStorageSession session)
+    {
+        _json = session.Serializer.ToCleanJson(_document);
+    }
+}

--- a/src/Weasel.Storage/ClosedShapeProjectionLoader.cs
+++ b/src/Weasel.Storage/ClosedShapeProjectionLoader.cs
@@ -1,0 +1,111 @@
+#nullable enable
+using System.Data.Common;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Shared projection-safe load implementation for closed-shape document storages. Opens a
+/// fresh connection from the <see cref="IStorageDatabase"/>, executes the load SQL, and
+/// deserializes the data column directly via the <see cref="IStorageSerializer"/> — without
+/// any session reference, without writing to the version tracker / identity map / change
+/// trackers, and without marking documents as loaded.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The projection-safe selector path intentionally skips metadata binders (CreatedAt /
+/// LastModified / Headers / etc.). Projections care about the aggregate state encoded in the
+/// data column for their Apply/Evolve hot path; per-row metadata is not part of that contract.
+/// If a future projection scenario needs metadata it can be added here as a focused follow-up.
+/// </para>
+/// <para>
+/// Hierarchical storages dispatch deserialization through the descriptor's
+/// <see cref="DocumentStorageDescriptor{TDoc,TId}.ResolveDocumentType"/> alias-to-.NET-type
+/// lookup, mirroring the hierarchical query-only selector.
+/// </para>
+/// </remarks>
+public static class ClosedShapeProjectionLoader<TDoc, TId>
+    where TDoc : notnull
+    where TId : notnull
+{
+    // Column layout matches the writeable closed-shape selectors (Lightweight / IdentityMap /
+    // DirtyChecked) since LoadProjectedAsync is only reached from those storages. QueryOnly
+    // storage has a different layout (id excluded, data at col 0) but doesn't implement
+    // LoadProjectedAsync; it throws NotSupportedException instead.
+    private const int IdColumn = 0;
+    private const int DataColumn = 1;
+    private const int FirstMetadataColumn = 2;
+
+    public static async Task<TDoc?> LoadAsync(
+        DbCommand command,
+        DocumentStorageDescriptor<TDoc, TId> descriptor,
+        IStorageSerializer serializer,
+        IStorageDatabase database,
+        CancellationToken token)
+    {
+        await using var conn = database.CreateStorageConnection();
+        await conn.OpenAsync(token).ConfigureAwait(false);
+        try
+        {
+            command.Connection = conn;
+            await using var reader = await command.ExecuteReaderAsync(token).ConfigureAwait(false);
+            if (!await reader.ReadAsync(token).ConfigureAwait(false))
+            {
+                return default;
+            }
+
+            return await readOneAsync(reader, descriptor, serializer, token).ConfigureAwait(false);
+        }
+        finally
+        {
+            await conn.CloseAsync().ConfigureAwait(false);
+        }
+    }
+
+    public static async Task<IReadOnlyList<TDoc>> LoadManyAsync(
+        DbCommand command,
+        DocumentStorageDescriptor<TDoc, TId> descriptor,
+        IStorageSerializer serializer,
+        IStorageDatabase database,
+        CancellationToken token)
+    {
+        await using var conn = database.CreateStorageConnection();
+        await conn.OpenAsync(token).ConfigureAwait(false);
+        try
+        {
+            command.Connection = conn;
+            await using var reader = await command.ExecuteReaderAsync(token).ConfigureAwait(false);
+            var list = new List<TDoc>();
+            while (await reader.ReadAsync(token).ConfigureAwait(false))
+            {
+                var doc = await readOneAsync(reader, descriptor, serializer, token).ConfigureAwait(false);
+                if (doc is not null)
+                {
+                    list.Add(doc);
+                }
+            }
+            return list;
+        }
+        finally
+        {
+            await conn.CloseAsync().ConfigureAwait(false);
+        }
+    }
+
+    private static async ValueTask<TDoc> readOneAsync(
+        DbDataReader reader,
+        DocumentStorageDescriptor<TDoc, TId> descriptor,
+        IStorageSerializer serializer,
+        CancellationToken token)
+    {
+        // Hierarchical: dispatch via the doc-type alias just like the hierarchical query-only
+        // selector. Flat: straight deserialize.
+        if (descriptor.ResolveDocumentType is { } resolveType)
+        {
+            var docTypeOrdinal = FirstMetadataColumn + descriptor.DocTypeReadIndex;
+            var alias = await reader.GetFieldValueAsync<string>(docTypeOrdinal, token).ConfigureAwait(false);
+            return (TDoc)await serializer.FromJsonAsync(resolveType(alias), reader, DataColumn, token).ConfigureAwait(false);
+        }
+
+        return await serializer.FromJsonAsync<TDoc>(reader, DataColumn, token).ConfigureAwait(false);
+    }
+}

--- a/src/Weasel.Storage/DocumentStorageDescriptor.cs
+++ b/src/Weasel.Storage/DocumentStorageDescriptor.cs
@@ -1,0 +1,247 @@
+#nullable enable
+namespace Weasel.Storage;
+
+/// <summary>
+/// Which concurrency model the document mapping uses. Drives WHERE-clause additions on
+/// UPDATE/UPSERT, RETURNING column choice, and the Postprocess exception type. Encoded once on
+/// the descriptor so the operation classes can switch on it without reading mapping state per
+/// call.
+/// </summary>
+public enum ConcurrencyMode
+{
+    /// <summary>No optimistic concurrency. Updates use plain WHERE id = ?.</summary>
+    Off,
+
+    /// <summary>
+    /// Guid-based optimistic concurrency. Each write generates a fresh Guid version; UPDATE /
+    /// UPSERT add <c>and mt_version = ?</c> to the predicate and RETURN the new version for
+    /// postprocess validation. A miss (no row returned) raises a concurrency exception instead
+    /// of a missing-document exception.
+    /// </summary>
+    Optimistic,
+
+    /// <summary>
+    /// Monotonic-bigint revisions. Each write either auto-increments (caller passes
+    /// <c>Revision = 0</c>) or supplies an explicit revision that must be strictly greater than
+    /// the current row's version column.
+    /// </summary>
+    Numeric
+}
+
+/// <summary>
+/// Per-mapping descriptor that the closed-shape document storage class composes with at
+/// construction. Holds the pre-built SQL strings + the ordered metadata-binder arrays. Built
+/// once per document mapping by the owning store's descriptor builder; held as a
+/// <c>readonly</c> field on the storage instance.
+/// </summary>
+public sealed class DocumentStorageDescriptor<TDoc, TId>
+    where TDoc : notnull
+    where TId : notnull
+{
+    public DocumentStorageDescriptor(
+        Core.Identity.IIdentification<TDoc, TId> identification,
+        IStorageSerializer serializer,
+        IStorageDialect dialect,
+        IDocumentMetadataBinder<TDoc>[] clientSideWriteBinders,
+        IDocumentMetadataBinder<TDoc>[] writeBinders,
+        IDocumentMetadataBinder<TDoc>[] readBinders,
+        IDocumentMetadataBinder<TDoc>[] queryOnlyReadBinders,
+        string upsertSql,
+        string insertSql,
+        string updateSql,
+        string overwriteSql,
+        bool isConjoined,
+        ConcurrencyMode concurrencyMode,
+        IVersionMetadataBinder<TDoc>? versionBinder,
+        IRevisionMetadataBinder<TDoc>? revisionBinder,
+        int versionReadIndex,
+        Func<string, Type>? resolveDocumentType,
+        int docTypeReadIndex,
+        string tableName,
+        IDocumentMetadataBinder<TDoc>[]? partitionPkBinders = null,
+        bool useVersionFromMatchingStream = false)
+    {
+        Identification = identification;
+        Serializer = serializer;
+        Dialect = dialect;
+        ClientSideWriteBinders = clientSideWriteBinders;
+        WriteBinders = writeBinders;
+        ReadBinders = readBinders;
+        QueryOnlyReadBinders = queryOnlyReadBinders;
+        TableName = tableName;
+        UpsertSql = upsertSql;
+        InsertSql = insertSql;
+        UpdateSql = updateSql;
+        OverwriteSql = overwriteSql;
+        IsConjoined = isConjoined;
+        ConcurrencyMode = concurrencyMode;
+        VersionBinder = versionBinder;
+        RevisionBinder = revisionBinder;
+        VersionReadIndex = versionReadIndex;
+        ResolveDocumentType = resolveDocumentType;
+        DocTypeReadIndex = docTypeReadIndex;
+        PartitionPkBinders = partitionPkBinders ?? Array.Empty<IDocumentMetadataBinder<TDoc>>();
+        UseVersionFromMatchingStream = useVersionFromMatchingStream;
+    }
+
+    /// <summary>
+    /// When set, the closed-shape SQL pulls the revision from the matching row in the event
+    /// store's streams table (used by inline single-stream projections under quick event
+    /// append, where the in-memory event version hasn't been assigned yet). The Insert / Upsert
+    /// operations consult this flag to bind extra ? slots for the stream-lookup subquery's id
+    /// (and tenant_id under conjoined tenancy).
+    /// </summary>
+    public bool UseVersionFromMatchingStream { get; }
+
+    /// <summary>
+    /// Writers that bind the partition PK columns. For Update/Upsert on partitioned tables
+    /// whose PK includes the partition column (e.g. list-partitioned by a soft-delete flag,
+    /// range-partitioned by a duplicated date field) the WHERE clause needs to filter on those
+    /// columns too — otherwise UPDATE … WHERE id = ? targets every partition row with that id
+    /// and produces a PK violation when the new value moves it back into another row's slot.
+    /// Order matches the SQL emit.
+    /// </summary>
+    public IDocumentMetadataBinder<TDoc>[] PartitionPkBinders { get; }
+
+    public Core.Identity.IIdentification<TDoc, TId> Identification { get; }
+
+    /// <summary>
+    /// The store-global serializer, captured on the descriptor so the projection read path
+    /// (<c>LoadProjectedAsync</c>/<c>LoadManyProjectedAsync</c>) needs no store mapping
+    /// reference.
+    /// </summary>
+    public IStorageSerializer Serializer { get; }
+
+    /// <summary>
+    /// The ADO/SQL-dialect strategy for this document type. The owning store's builder supplies
+    /// its dialect singleton; the closed-shape storage classes expose it so the shared runtime
+    /// holds no direct provider reference.
+    /// </summary>
+    public IStorageDialect Dialect { get; }
+
+    /// <summary>
+    /// Subset of the metadata binders that consume a <c>?</c> parameter slot in the VALUES
+    /// list. Server-side binders (e.g. <c>transaction_timestamp()</c> for last-modified) are
+    /// excluded — their literal SQL is baked into <see cref="UpsertSql"/>.
+    /// </summary>
+    public IDocumentMetadataBinder<TDoc>[] ClientSideWriteBinders { get; }
+
+    /// <summary>
+    /// All write binders — client-side <em>and</em> server-side. The bulk-copy path uses this
+    /// because binary copy protocols can't run inline SQL literals, so each binder writes a
+    /// client-computed value via <see cref="IDocumentMetadataBinder{TDoc}.GetBulkValue"/> —
+    /// including LastModified, which computes UtcNow instead of emitting
+    /// <c>transaction_timestamp()</c>.
+    /// </summary>
+    public IDocumentMetadataBinder<TDoc>[] WriteBinders { get; }
+
+    /// <summary>
+    /// Unqualified table name (without schema prefix) — used by the exception-transform path to
+    /// detect when a unique-constraint violation belongs to this document type's table so it
+    /// can be surfaced as <see cref="JasperFx.DocumentAlreadyExistsException"/>.
+    /// </summary>
+    public string TableName { get; }
+
+    /// <summary>
+    /// All metadata binders applied on the read path, in column order. Includes both
+    /// client-side and server-side binders — on read they're symmetric (each binder consumes
+    /// one result column).
+    /// </summary>
+    public IDocumentMetadataBinder<TDoc>[] ReadBinders { get; }
+
+    /// <summary>
+    /// The read-binder set for the QueryOnly storage style. Identical to
+    /// <see cref="ReadBinders"/> except it omits the version/revision binder when that column
+    /// has no annotated member — the version column is absent from the QueryOnly SELECT in that
+    /// case and its binders would otherwise be offset by one. Same array instance as
+    /// <see cref="ReadBinders"/> when nothing is dropped.
+    /// </summary>
+    public IDocumentMetadataBinder<TDoc>[] QueryOnlyReadBinders { get; }
+
+    /// <summary>
+    /// Full upsert SQL with <c>?</c> placeholders for client-side parameters and inline
+    /// literals for server-side ones. Fed to the command builder's placeholder-expanding append
+    /// at write time; the returned <see cref="System.Data.Common.DbParameter"/> array is filled
+    /// by the operation in order: id, data, then each <see cref="ClientSideWriteBinders"/>
+    /// entry.
+    /// </summary>
+    public string UpsertSql { get; }
+
+    /// <summary>
+    /// SQL for the Insert path —
+    /// <c>"insert into … (id, data, …) values (?, ?, …) on conflict (id) do nothing returning id"</c>.
+    /// The trailing RETURNING is consumed by the insert operation's Postprocess so a missing
+    /// row (conflict) raises a document-already-exists exception. Parameter order matches
+    /// <see cref="UpsertSql"/>: id, data, then each client-side binder.
+    /// </summary>
+    public string InsertSql { get; }
+
+    /// <summary>
+    /// SQL for the Update path —
+    /// <c>"update … set data = ?, mt_version = ?, … where id = ? returning id"</c>.
+    /// Parameter order: data first, then each client-side binder, then id (the WHERE clause).
+    /// Postprocess raises a missing-document exception when no row comes back.
+    /// </summary>
+    public string UpdateSql { get; }
+
+    /// <summary>
+    /// SQL for the Overwrite path — identical to <see cref="UpsertSql"/> when
+    /// <see cref="ConcurrencyMode"/> is <c>Off</c>; under optimistic concurrency the trailing
+    /// WHERE filter on the version column is stripped so the write always wins.
+    /// </summary>
+    public string OverwriteSql { get; }
+
+    /// <summary>
+    /// When <c>true</c>, the document table is conjoined-multi-tenanted: <c>tenant_id</c> is
+    /// part of the primary key, INSERT carries it as the first parameter, UPDATE has
+    /// <c>and tenant_id = ?</c> appended to the WHERE clause, and ON CONFLICT references
+    /// <c>(tenant_id, id)</c>. The operations bind the tenant id directly from the tenant
+    /// argument the storage class receives.
+    /// </summary>
+    public bool IsConjoined { get; }
+
+    /// <summary>
+    /// Which concurrency model the mapping uses. <see cref="UpsertSql"/> / <see cref="UpdateSql"/>
+    /// are already baked for the selected mode; operation classes only read this property to
+    /// decide their postprocess branch and what extra parameter to bind.
+    /// </summary>
+    public ConcurrencyMode ConcurrencyMode { get; }
+
+    /// <summary>
+    /// The version binder, present whenever <see cref="ConcurrencyMode"/> is non-<c>Off</c> or
+    /// the mapping has a version-annotated member. Operations use it from <c>Postprocess</c> to
+    /// write the new version back onto the document without needing to re-walk
+    /// <see cref="ReadBinders"/>.
+    /// </summary>
+    public IVersionMetadataBinder<TDoc>? VersionBinder { get; }
+
+    /// <summary>
+    /// The numeric revision binder, present when <see cref="ConcurrencyMode"/> is
+    /// <see cref="ConcurrencyMode.Numeric"/> or the mapping has a version-annotated numeric
+    /// member. Operations use it from <c>Postprocess</c> to write the new revision back onto
+    /// the document.
+    /// </summary>
+    public IRevisionMetadataBinder<TDoc>? RevisionBinder { get; }
+
+    /// <summary>
+    /// Zero-based index of the version binder inside <see cref="ReadBinders"/>, or <c>-1</c>
+    /// when version isn't in the read set. Each selector adds its own first-metadata-column
+    /// offset to get the actual reader column ordinal.
+    /// </summary>
+    public int VersionReadIndex { get; }
+
+    /// <summary>
+    /// Store-agnostic document-type alias → .NET <see cref="Type"/> resolver, present when the
+    /// mapping is hierarchical, otherwise <c>null</c>. Selectors use it for polymorphic
+    /// deserialization; the owning store's builder captures its mapping's alias lookup as a
+    /// delegate.
+    /// </summary>
+    public Func<string, Type>? ResolveDocumentType { get; }
+
+    /// <summary>
+    /// Zero-based index of the document-type binder inside <see cref="ReadBinders"/>, or
+    /// <c>-1</c> when the mapping isn't hierarchical. Selectors translate it to a column
+    /// ordinal the same way as <see cref="VersionReadIndex"/>.
+    /// </summary>
+    public int DocTypeReadIndex { get; }
+}

--- a/src/Weasel.Storage/IDocumentMetadataBinder.cs
+++ b/src/Weasel.Storage/IDocumentMetadataBinder.cs
@@ -1,0 +1,112 @@
+#nullable enable
+using System.Data.Common;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Per-metadata-column seam for the closed-shape document storage runtime — every metadata
+/// column on the document table (version, .NET type, last-modified, tenant id, soft-delete
+/// flag, custom user-set metadata, etc.) gets one binder. The
+/// <see cref="DocumentStorageDescriptor{TDoc,TId}"/> holds them in ordered arrays; the storage
+/// operations loop over the client-side subset in <c>ConfigureCommand</c> and the selectors
+/// loop over the full array on read.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Per-call cost is one virtual <see cref="BindParameter"/> per active client-side metadata
+/// column on the write path. Server-side values (e.g. <c>transaction_timestamp()</c>) declare a
+/// non-<c>?</c> <see cref="ValueSql"/> fragment that goes directly into the VALUES list — they
+/// have no parameter slot to fill and <see cref="IsServerSide"/> is <c>true</c>.
+/// </para>
+/// </remarks>
+public interface IDocumentMetadataBinder<TDoc>
+    where TDoc : notnull
+{
+    /// <summary>
+    /// Stable column name used to compose the INSERT column list, the SELECT projection, and
+    /// the ON CONFLICT UPDATE clause. The descriptor builder threads these through to the SQL
+    /// strings in the same order as the binder array — parameter order matches column order.
+    /// </summary>
+    string ColumnName { get; }
+
+    /// <summary>
+    /// SQL fragment placed in the VALUES list at this binder's position. <c>"?"</c> for a bound
+    /// parameter (the common case); <c>"transaction_timestamp()"</c> / <c>"now()"</c> / similar
+    /// for a server-side computed value.
+    /// </summary>
+    string ValueSql { get; }
+
+    /// <summary>
+    /// True when <see cref="ValueSql"/> is something other than <c>"?"</c> — i.e. the value is
+    /// computed server-side and this binder has no parameter slot to fill on write. Server-side
+    /// binders skip <see cref="BindParameter"/> but may still implement <see cref="Apply"/> to
+    /// project the column's value back onto the document on read.
+    /// </summary>
+    bool IsServerSide => ValueSql != "?";
+
+    /// <summary>
+    /// Per-row write hook on the INSERT / UPSERT path. The storage operation pre-allocates the
+    /// parameter from the SQL's <c>?</c> placeholders and hands it to each client-side binder in
+    /// order. Server-side binders don't get called here — their <see cref="ValueSql"/> fragment
+    /// is in the SQL directly. The parameter is the db-neutral <see cref="DbParameter"/>; the
+    /// concrete dialect binders set the provider type on the underlying parameter.
+    /// </summary>
+    void BindParameter(DbParameter parameter, TDoc document, IStorageSession session);
+
+    /// <summary>
+    /// Optional pre-serialization hook. Called once per write before the document body is
+    /// serialized into the <c>data</c> parameter — gives session-derived binders (Correlation/
+    /// Causation/LastModifiedBy/Headers) a chance to project the session value onto the
+    /// document's mapped member so the value flows into the JSON data column too. Default
+    /// no-op; binders whose value isn't session-derived (Version, LastModified, soft-delete,
+    /// etc.) don't override.
+    /// </summary>
+    void ApplyToDocument(TDoc document, IStorageSession session) { }
+
+    /// <summary>
+    /// Per-row read hook on the SELECT path. Called from the selector after the document body
+    /// has been deserialized, with the metadata column's position in the result row. Binders
+    /// for columns whose values get projected onto the document (Version → version member,
+    /// LastModified → last-modified member) write through to the doc's annotated member;
+    /// binders whose stored values are purely informational no-op. The
+    /// <paramref name="session"/> is threaded through for binders that need to deserialize JSON
+    /// values (e.g. Headers) via the configured <see cref="IStorageSerializer"/>.
+    /// </summary>
+    void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IStorageSession session);
+
+    /// <summary>
+    /// The binder's contribution to a bulk-load row, as a dialect-neutral
+    /// <see cref="BulkColumnValue"/> (value + <see cref="StorageColumnType"/>). The
+    /// dialect-specific bulk loader maps the type to its provider and writes. Server-side
+    /// binders (e.g. <c>transaction_timestamp()</c>) compute a client-side value here since
+    /// bulk-copy protocols don't honor inline SQL literals. Any document mutation the value
+    /// implies (version writeback, LastModified) happens as a side effect of this call.
+    /// </summary>
+    BulkColumnValue GetBulkValue(TDoc document);
+}
+
+/// <summary>
+/// The version (e.g. <c>mt_version</c> Guid) metadata binder, surfaced on the
+/// <see cref="DocumentStorageDescriptor{TDoc,TId}"/> so the optimistic-concurrency operations
+/// can write the new version back onto the document from <c>Postprocess</c> without re-walking
+/// the read binders. The owning store's concrete binder implements this.
+/// </summary>
+public interface IVersionMetadataBinder<TDoc>: IDocumentMetadataBinder<TDoc>
+    where TDoc : notnull
+{
+    void ApplyVersionTo(TDoc document, Guid version);
+}
+
+/// <summary>
+/// The numeric-revision metadata binder (monotonic int/bigint revisions), surfaced on the
+/// <see cref="DocumentStorageDescriptor{TDoc,TId}"/> so the numeric-concurrency operations can
+/// write the new revision back onto the document and bind the revision parameter with the
+/// right column type. The owning store's concrete binder implements this.
+/// </summary>
+public interface IRevisionMetadataBinder<TDoc>: IDocumentMetadataBinder<TDoc>
+    where TDoc : notnull
+{
+    StorageColumnType RevisionColumnType { get; }
+
+    void ApplyRevisionTo(TDoc document, long revision);
+}


### PR DESCRIPTION
Third Weasel.Storage increment for the Marten **W2 storage-extraction epic** (JasperFx/marten#4821) — the neutral descriptor core the closed-shape document storage runtime types against:

- **`IDocumentMetadataBinder<TDoc>`** — the per-metadata-column bind/read/bulk seam (`DbParameter`/`DbDataReader`/`BulkColumnValue`, fully dialect-neutral), plus new **`IVersionMetadataBinder<TDoc>`** / **`IRevisionMetadataBinder<TDoc>`** so the descriptor no longer types its version/revision slots as a store's concrete binder classes.
- **`DocumentStorageDescriptor<TDoc,TId>` + `ConcurrencyMode`** — the per-mapping pre-built SQL strings + ordered binder arrays a store's descriptor builder compiles (Marten keeps its `DocumentStorageDescriptorBuilder`; Polecat writes its own).
- **`ClosedShapeProjectionLoader<TDoc,TId>`** — the session-free projection read path over `IStorageDatabase.CreateStorageConnection()`.
- **`ChangeTracker<T>`** — the standard `IChangeTracker` (clean-JSON diffing over `IStorageSession.Serializer`).

Bumps to **9.10.0**.

Validated downstream with local packs: Marten consumes these with five suites green (DocumentDb 1033 / Core 458 / EventSourcing 1421 / Daemon 198 / ValueType 339); Wolverine.Marten + Wolverine.Http.Marten compile unchanged.

Follows #331; next increments move the selectors, metadata binders, and operations (scoped, in order).

🤖 Generated with [Claude Code](https://claude.com/claude-code)