### PR TITLE
Weasel.Storage: the closed-shape selectors (marten#4821 INC-2)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>9.10.0</Version>
+        <Version>9.11.0</Version>
         <LangVersion>13.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/src/Weasel.Storage/ClosedShapeDirtyTrackingSelector.cs
+++ b/src/Weasel.Storage/ClosedShapeDirtyTrackingSelector.cs
@@ -1,0 +1,102 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Abstract base for the per-<see cref="ConcurrencyMode"/> ×
+/// <see cref="DocumentStorageDescriptor{T,TId}.ResolveDocumentType"/>
+/// closed-shape DirtyTracking <see cref="ISelector{T}"/>. Identity-map
+/// writes (like <see cref="ClosedShapeIdentityMapSelector{T, TId}"/>)
+/// plus a <see cref="ChangeTracker{T}"/> registered on the session per
+/// loaded document. Sealed concurrency × hierarchy leaves provide
+/// monomorphic <c>CaptureVersion</c> + <c>ReadDocument</c> bodies
+/// (#4659).
+/// </summary>
+public abstract class ClosedShapeDirtyTrackingSelector<T, TId>: ISelector<T>, IDocumentSelector
+    where T : notnull
+    where TId : notnull
+{
+    protected const int IdColumn = 0;
+    protected const int DataColumn = 1;
+    protected const int FirstMetadataColumn = 2;
+
+    protected readonly IStorageSession _session;
+    protected readonly IStorageSerializer _serializer;
+    protected readonly DocumentStorageDescriptor<T, TId> _descriptor;
+    protected readonly Dictionary<TId, T> _identityMap;
+
+    protected ClosedShapeDirtyTrackingSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    {
+        _session = session;
+        _serializer = session.Serializer;
+        _descriptor = descriptor;
+
+        if (session.ItemMap.TryGetValue(typeof(T), out var existing))
+        {
+            _identityMap = (Dictionary<TId, T>)existing;
+        }
+        else
+        {
+            _identityMap = new Dictionary<TId, T>();
+            session.ItemMap[typeof(T)] = _identityMap;
+        }
+    }
+
+    public T Resolve(DbDataReader reader)
+    {
+        var id = _descriptor.Identification.ReadIdFromReader(reader, IdColumn);
+
+        if (_identityMap.TryGetValue(id, out var cached))
+        {
+            CaptureVersion(reader, id);
+            return cached;
+        }
+
+        var doc = ReadDocument(reader);
+        ApplyMetadata(reader, doc);
+        _identityMap[id] = doc;
+        _session.ChangeTrackers.Add(new ChangeTracker<T>(_session, doc));
+        CaptureVersion(reader, id);
+        _session.MarkAsDocumentLoaded(id, doc);
+        return doc;
+    }
+
+    public async Task<T> ResolveAsync(DbDataReader reader, CancellationToken token)
+    {
+        var id = _descriptor.Identification.ReadIdFromReader(reader, IdColumn);
+
+        if (_identityMap.TryGetValue(id, out var cached))
+        {
+            CaptureVersion(reader, id);
+            return cached;
+        }
+
+        var doc = await ReadDocumentAsync(reader, token).ConfigureAwait(false);
+        ApplyMetadata(reader, doc);
+        _identityMap[id] = doc;
+        _session.ChangeTrackers.Add(new ChangeTracker<T>(_session, doc));
+        CaptureVersion(reader, id);
+        _session.MarkAsDocumentLoaded(id, doc);
+        return doc;
+    }
+
+    protected abstract void CaptureVersion(DbDataReader reader, TId id);
+
+    protected abstract T ReadDocument(DbDataReader reader);
+
+    protected abstract ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token);
+
+    protected void ApplyMetadata(DbDataReader reader, T document)
+    {
+        var ordinal = FirstMetadataColumn;
+        foreach (var binder in _descriptor.ReadBinders)
+        {
+            binder.Apply(reader, ordinal, document, _session);
+            ordinal++;
+        }
+    }
+}

--- a/src/Weasel.Storage/ClosedShapeIdentityMapSelector.cs
+++ b/src/Weasel.Storage/ClosedShapeIdentityMapSelector.cs
@@ -1,0 +1,104 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Abstract base for the per-<see cref="ConcurrencyMode"/> ×
+/// <see cref="DocumentStorageDescriptor{T,TId}.ResolveDocumentType"/>
+/// closed-shape IdentityMap <see cref="ISelector{T}"/>. Owns the
+/// identity-map cache init + lookup; sealed concurrency × hierarchy
+/// leaves override <c>CaptureVersion</c> + <c>ReadDocument</c> so the
+/// per-row hot path doesn't branch on either descriptor field (#4659).
+/// </summary>
+public abstract class ClosedShapeIdentityMapSelector<T, TId>: ISelector<T>, IDocumentSelector
+    where T : notnull
+    where TId : notnull
+{
+    // Same column layout as Lightweight: id at 0, data at 1, metadata at 2+.
+    protected const int IdColumn = 0;
+    protected const int DataColumn = 1;
+    protected const int FirstMetadataColumn = 2;
+
+    protected readonly IStorageSession _session;
+    protected readonly IStorageSerializer _serializer;
+    protected readonly DocumentStorageDescriptor<T, TId> _descriptor;
+    protected readonly Dictionary<TId, T> _identityMap;
+
+    protected ClosedShapeIdentityMapSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    {
+        _session = session;
+        _serializer = session.Serializer;
+        _descriptor = descriptor;
+
+        if (session.ItemMap.TryGetValue(typeof(T), out var existing))
+        {
+            _identityMap = (Dictionary<TId, T>)existing;
+        }
+        else
+        {
+            _identityMap = new Dictionary<TId, T>();
+            session.ItemMap[typeof(T)] = _identityMap;
+        }
+    }
+
+    public T Resolve(DbDataReader reader)
+    {
+        var id = _descriptor.Identification.ReadIdFromReader(reader, IdColumn);
+
+        // Identity-map cache hit: return the previously loaded instance
+        // instead of deserializing again. Subsequent Load<T>(id) calls
+        // (including from CreateBatchQuery / batched LoadMany) get
+        // reference-equal results back. Mirrors the codegen
+        // DocumentSelectorWithIdentityMap.
+        if (_identityMap.TryGetValue(id, out var cached))
+        {
+            CaptureVersion(reader, id);
+            return cached;
+        }
+
+        var doc = ReadDocument(reader);
+        ApplyMetadata(reader, doc);
+        _identityMap[id] = doc;
+        CaptureVersion(reader, id);
+        _session.MarkAsDocumentLoaded(id, doc);
+        return doc;
+    }
+
+    public async Task<T> ResolveAsync(DbDataReader reader, CancellationToken token)
+    {
+        var id = _descriptor.Identification.ReadIdFromReader(reader, IdColumn);
+
+        if (_identityMap.TryGetValue(id, out var cached))
+        {
+            CaptureVersion(reader, id);
+            return cached;
+        }
+
+        var doc = await ReadDocumentAsync(reader, token).ConfigureAwait(false);
+        ApplyMetadata(reader, doc);
+        _identityMap[id] = doc;
+        CaptureVersion(reader, id);
+        _session.MarkAsDocumentLoaded(id, doc);
+        return doc;
+    }
+
+    protected abstract void CaptureVersion(DbDataReader reader, TId id);
+
+    protected abstract T ReadDocument(DbDataReader reader);
+
+    protected abstract ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token);
+
+    protected void ApplyMetadata(DbDataReader reader, T document)
+    {
+        var ordinal = FirstMetadataColumn;
+        foreach (var binder in _descriptor.ReadBinders)
+        {
+            binder.Apply(reader, ordinal, document, _session);
+            ordinal++;
+        }
+    }
+}

--- a/src/Weasel.Storage/ClosedShapeLightweightSelector.cs
+++ b/src/Weasel.Storage/ClosedShapeLightweightSelector.cs
@@ -1,0 +1,84 @@
+#nullable enable
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Abstract base for the per-<see cref="ConcurrencyMode"/> ×
+/// <see cref="DocumentStorageDescriptor{T,TId}.ResolveDocumentType"/>
+/// closed-shape Lightweight <see cref="ISelector{T}"/>. Owns the shared
+/// row-shape (id at col 0, data at col 1, metadata at 2+) plus
+/// metadata-apply. Sealed concurrency × hierarchy leaves provide
+/// monomorphic <c>CaptureVersion</c> + <c>ReadDocument</c> /
+/// <c>ReadDocumentAsync</c> bodies so the per-row hot path doesn't
+/// branch on either descriptor field (#4659).
+/// </summary>
+public abstract class ClosedShapeLightweightSelector<T, TId>: ISelector<T>, IDocumentSelector
+    where T : notnull
+    where TId : notnull
+{
+    // Lightweight column order from DocumentTable.SelectColumns:
+    //   id (col 0), data (col 1), then ShouldSelect metadata columns.
+    protected const int IdColumn = 0;
+    protected const int DataColumn = 1;
+    protected const int FirstMetadataColumn = 2;
+
+    protected readonly IStorageSession _session;
+    protected readonly IStorageSerializer _serializer;
+    protected readonly DocumentStorageDescriptor<T, TId> _descriptor;
+
+    protected ClosedShapeLightweightSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    {
+        _session = session;
+        _serializer = session.Serializer;
+        _descriptor = descriptor;
+    }
+
+    public T Resolve(DbDataReader reader)
+    {
+        var doc = ReadDocument(reader);
+        ApplyMetadata(reader, doc);
+        var id = _descriptor.Identification.ReadIdFromReader(reader, IdColumn);
+        CaptureVersion(reader, id);
+        _session.MarkAsDocumentLoaded(id, doc);
+        return doc;
+    }
+
+    public async Task<T> ResolveAsync(DbDataReader reader, CancellationToken token)
+    {
+        var doc = await ReadDocumentAsync(reader, token).ConfigureAwait(false);
+        ApplyMetadata(reader, doc);
+        var id = _descriptor.Identification.ReadIdFromReader(reader, IdColumn);
+        CaptureVersion(reader, id);
+        _session.MarkAsDocumentLoaded(id, doc);
+        return doc;
+    }
+
+    /// <summary>
+    /// Concurrency-specific per-row version capture. Off-mode subclasses
+    /// no-op; Optimistic / Numeric capture into their typed tracker.
+    /// </summary>
+    protected abstract void CaptureVersion(DbDataReader reader, TId id);
+
+    /// <summary>
+    /// Hierarchy-specific per-row deserialization. Flat subclasses
+    /// deserialize straight to <typeparamref name="T"/>; Hierarchical
+    /// subclasses read <c>mt_doc_type</c> and dispatch through the
+    /// hierarchy mapping. (#4659 Phase 2.)
+    /// </summary>
+    protected abstract T ReadDocument(DbDataReader reader);
+
+    protected abstract ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token);
+
+    protected void ApplyMetadata(DbDataReader reader, T document)
+    {
+        var ordinal = FirstMetadataColumn;
+        foreach (var binder in _descriptor.ReadBinders)
+        {
+            binder.Apply(reader, ordinal, document, _session);
+            ordinal++;
+        }
+    }
+}

--- a/src/Weasel.Storage/ClosedShapeQueryOnlySelector.cs
+++ b/src/Weasel.Storage/ClosedShapeQueryOnlySelector.cs
@@ -1,0 +1,66 @@
+#nullable enable
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Abstract base for the QueryOnly closed-shape <see cref="ISelector{T}"/>.
+/// QueryOnly storage excludes the id column from its SELECT projection
+/// (see <c>IdColumn.ShouldSelect</c> — false for QueryOnly), so the data
+/// column sits at index 0 and metadata starts at 1. No identity-map
+/// writes — QueryOnly sessions don't track loaded docs.
+/// Sealed subclasses provide a monomorphic <c>ReadDocument</c> /
+/// <c>ReadDocumentAsync</c> so the per-row hot path doesn't branch on
+/// <c>ResolveDocumentType</c> (#4659 Phase 2).
+/// </summary>
+public abstract class ClosedShapeQueryOnlySelector<T, TId>: ISelector<T>
+    where T : notnull
+    where TId : notnull
+{
+    protected const int DataColumn = 0;
+    protected const int FirstMetadataColumn = 1;
+
+    protected readonly IStorageSession _session;
+    protected readonly IStorageSerializer _serializer;
+    protected readonly DocumentStorageDescriptor<T, TId> _descriptor;
+
+    protected ClosedShapeQueryOnlySelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    {
+        _session = session;
+        _serializer = session.Serializer;
+        _descriptor = descriptor;
+    }
+
+    public T Resolve(DbDataReader reader)
+    {
+        var doc = ReadDocument(reader);
+        ApplyMetadata(reader, doc);
+        return doc;
+    }
+
+    public async Task<T> ResolveAsync(DbDataReader reader, CancellationToken token)
+    {
+        var doc = await ReadDocumentAsync(reader, token).ConfigureAwait(false);
+        ApplyMetadata(reader, doc);
+        return doc;
+    }
+
+    protected abstract T ReadDocument(DbDataReader reader);
+
+    protected abstract ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token);
+
+    private void ApplyMetadata(DbDataReader reader, T document)
+    {
+        // #4602: QueryOnlyReadBinders, not ReadBinders — the QueryOnly SELECT omits
+        // mt_version when the version/revision column has no member, so its binder
+        // set is narrower to keep ordinals aligned with the projection.
+        var ordinal = FirstMetadataColumn;
+        foreach (var binder in _descriptor.QueryOnlyReadBinders)
+        {
+            binder.Apply(reader, ordinal, document, _session);
+            ordinal++;
+        }
+    }
+}

--- a/src/Weasel.Storage/FlatClosedShapeQueryOnlySelector.cs
+++ b/src/Weasel.Storage/FlatClosedShapeQueryOnlySelector.cs
@@ -1,0 +1,27 @@
+#nullable enable
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Non-hierarchical QueryOnly selector. <c>ReadDocument</c> deserializes
+/// straight to <typeparamref name="T"/> — no per-row mt_doc_type
+/// inspection. #4659 Phase 2 leaf.
+/// </summary>
+public sealed class FlatClosedShapeQueryOnlySelector<T, TId>: ClosedShapeQueryOnlySelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    public FlatClosedShapeQueryOnlySelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+    }
+
+    protected override T ReadDocument(DbDataReader reader)
+        => _serializer.FromJson<T>(reader, DataColumn);
+
+    protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
+        => await _serializer.FromJsonAsync<T>(reader, DataColumn, token).ConfigureAwait(false);
+}

--- a/src/Weasel.Storage/FlatNumericClosedShapeDirtyTrackingSelector.cs
+++ b/src/Weasel.Storage/FlatNumericClosedShapeDirtyTrackingSelector.cs
@@ -1,0 +1,25 @@
+#nullable enable
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Non-hierarchical, Numeric DirtyTracking selector. #4659 Phase 2 leaf.
+/// </summary>
+public sealed class FlatNumericClosedShapeDirtyTrackingSelector<T, TId>: NumericClosedShapeDirtyTrackingSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    public FlatNumericClosedShapeDirtyTrackingSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+    }
+
+    protected override T ReadDocument(DbDataReader reader)
+        => _serializer.FromJson<T>(reader, DataColumn);
+
+    protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
+        => await _serializer.FromJsonAsync<T>(reader, DataColumn, token).ConfigureAwait(false);
+}

--- a/src/Weasel.Storage/FlatNumericClosedShapeIdentityMapSelector.cs
+++ b/src/Weasel.Storage/FlatNumericClosedShapeIdentityMapSelector.cs
@@ -1,0 +1,25 @@
+#nullable enable
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Non-hierarchical, Numeric IdentityMap selector. #4659 Phase 2 leaf.
+/// </summary>
+public sealed class FlatNumericClosedShapeIdentityMapSelector<T, TId>: NumericClosedShapeIdentityMapSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    public FlatNumericClosedShapeIdentityMapSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+    }
+
+    protected override T ReadDocument(DbDataReader reader)
+        => _serializer.FromJson<T>(reader, DataColumn);
+
+    protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
+        => await _serializer.FromJsonAsync<T>(reader, DataColumn, token).ConfigureAwait(false);
+}

--- a/src/Weasel.Storage/FlatNumericClosedShapeLightweightSelector.cs
+++ b/src/Weasel.Storage/FlatNumericClosedShapeLightweightSelector.cs
@@ -1,0 +1,25 @@
+#nullable enable
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Non-hierarchical, Numeric Lightweight selector. #4659 Phase 2 leaf.
+/// </summary>
+public sealed class FlatNumericClosedShapeLightweightSelector<T, TId>: NumericClosedShapeLightweightSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    public FlatNumericClosedShapeLightweightSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+    }
+
+    protected override T ReadDocument(DbDataReader reader)
+        => _serializer.FromJson<T>(reader, DataColumn);
+
+    protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
+        => await _serializer.FromJsonAsync<T>(reader, DataColumn, token).ConfigureAwait(false);
+}

--- a/src/Weasel.Storage/FlatOptimisticClosedShapeDirtyTrackingSelector.cs
+++ b/src/Weasel.Storage/FlatOptimisticClosedShapeDirtyTrackingSelector.cs
@@ -1,0 +1,25 @@
+#nullable enable
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Non-hierarchical, Optimistic DirtyTracking selector. #4659 Phase 2 leaf.
+/// </summary>
+public sealed class FlatOptimisticClosedShapeDirtyTrackingSelector<T, TId>: OptimisticClosedShapeDirtyTrackingSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    public FlatOptimisticClosedShapeDirtyTrackingSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+    }
+
+    protected override T ReadDocument(DbDataReader reader)
+        => _serializer.FromJson<T>(reader, DataColumn);
+
+    protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
+        => await _serializer.FromJsonAsync<T>(reader, DataColumn, token).ConfigureAwait(false);
+}

--- a/src/Weasel.Storage/FlatOptimisticClosedShapeIdentityMapSelector.cs
+++ b/src/Weasel.Storage/FlatOptimisticClosedShapeIdentityMapSelector.cs
@@ -1,0 +1,25 @@
+#nullable enable
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Non-hierarchical, Optimistic IdentityMap selector. #4659 Phase 2 leaf.
+/// </summary>
+public sealed class FlatOptimisticClosedShapeIdentityMapSelector<T, TId>: OptimisticClosedShapeIdentityMapSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    public FlatOptimisticClosedShapeIdentityMapSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+    }
+
+    protected override T ReadDocument(DbDataReader reader)
+        => _serializer.FromJson<T>(reader, DataColumn);
+
+    protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
+        => await _serializer.FromJsonAsync<T>(reader, DataColumn, token).ConfigureAwait(false);
+}

--- a/src/Weasel.Storage/FlatOptimisticClosedShapeLightweightSelector.cs
+++ b/src/Weasel.Storage/FlatOptimisticClosedShapeLightweightSelector.cs
@@ -1,0 +1,25 @@
+#nullable enable
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Non-hierarchical, Optimistic Lightweight selector. #4659 Phase 2 leaf.
+/// </summary>
+public sealed class FlatOptimisticClosedShapeLightweightSelector<T, TId>: OptimisticClosedShapeLightweightSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    public FlatOptimisticClosedShapeLightweightSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+    }
+
+    protected override T ReadDocument(DbDataReader reader)
+        => _serializer.FromJson<T>(reader, DataColumn);
+
+    protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
+        => await _serializer.FromJsonAsync<T>(reader, DataColumn, token).ConfigureAwait(false);
+}

--- a/src/Weasel.Storage/FlatUnversionedClosedShapeDirtyTrackingSelector.cs
+++ b/src/Weasel.Storage/FlatUnversionedClosedShapeDirtyTrackingSelector.cs
@@ -1,0 +1,25 @@
+#nullable enable
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Non-hierarchical, Off-mode DirtyTracking selector. #4659 Phase 2 leaf.
+/// </summary>
+public sealed class FlatUnversionedClosedShapeDirtyTrackingSelector<T, TId>: UnversionedClosedShapeDirtyTrackingSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    public FlatUnversionedClosedShapeDirtyTrackingSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+    }
+
+    protected override T ReadDocument(DbDataReader reader)
+        => _serializer.FromJson<T>(reader, DataColumn);
+
+    protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
+        => await _serializer.FromJsonAsync<T>(reader, DataColumn, token).ConfigureAwait(false);
+}

--- a/src/Weasel.Storage/FlatUnversionedClosedShapeIdentityMapSelector.cs
+++ b/src/Weasel.Storage/FlatUnversionedClosedShapeIdentityMapSelector.cs
@@ -1,0 +1,25 @@
+#nullable enable
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Non-hierarchical, Off-mode IdentityMap selector. #4659 Phase 2 leaf.
+/// </summary>
+public sealed class FlatUnversionedClosedShapeIdentityMapSelector<T, TId>: UnversionedClosedShapeIdentityMapSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    public FlatUnversionedClosedShapeIdentityMapSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+    }
+
+    protected override T ReadDocument(DbDataReader reader)
+        => _serializer.FromJson<T>(reader, DataColumn);
+
+    protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
+        => await _serializer.FromJsonAsync<T>(reader, DataColumn, token).ConfigureAwait(false);
+}

--- a/src/Weasel.Storage/FlatUnversionedClosedShapeLightweightSelector.cs
+++ b/src/Weasel.Storage/FlatUnversionedClosedShapeLightweightSelector.cs
@@ -1,0 +1,26 @@
+#nullable enable
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Non-hierarchical, Off-mode Lightweight selector. ReadDocument
+/// deserializes straight to <typeparamref name="T"/>. #4659 Phase 2 leaf.
+/// </summary>
+public sealed class FlatUnversionedClosedShapeLightweightSelector<T, TId>: UnversionedClosedShapeLightweightSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    public FlatUnversionedClosedShapeLightweightSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+    }
+
+    protected override T ReadDocument(DbDataReader reader)
+        => _serializer.FromJson<T>(reader, DataColumn);
+
+    protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
+        => await _serializer.FromJsonAsync<T>(reader, DataColumn, token).ConfigureAwait(false);
+}

--- a/src/Weasel.Storage/HierarchicalClosedShapeQueryOnlySelector.cs
+++ b/src/Weasel.Storage/HierarchicalClosedShapeQueryOnlySelector.cs
@@ -1,0 +1,47 @@
+#nullable enable
+using System;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Hierarchical QueryOnly selector. Reads the <c>mt_doc_type</c> alias
+/// from the descriptor's <see cref="DocumentStorageDescriptor{T,TId}.DocTypeReadIndex"/>
+/// and dispatches deserialization through the
+/// <see cref="DocumentStorageDescriptor{T,TId}.ResolveDocumentType"/> root —
+/// the alias-to-.NET-type lookup the polymorphic JSON path needs.
+/// #4659 Phase 2 leaf.
+/// </summary>
+public sealed class HierarchicalClosedShapeQueryOnlySelector<T, TId>: ClosedShapeQueryOnlySelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    private readonly Func<string, Type> _resolveType;
+    private readonly int _docTypeOrdinal;
+
+    public HierarchicalClosedShapeQueryOnlySelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+        // The factory only constructs this leaf when ResolveDocumentType is
+        // non-null; capture it once to avoid the per-row pattern-match.
+        _resolveType = descriptor.ResolveDocumentType
+            ?? throw new InvalidOperationException(
+                "HierarchicalClosedShapeQueryOnlySelector requires a non-null descriptor.ResolveDocumentType; " +
+                "the storage factory must dispatch to FlatClosedShapeQueryOnlySelector otherwise.");
+        _docTypeOrdinal = FirstMetadataColumn + descriptor.DocTypeReadIndex;
+    }
+
+    protected override T ReadDocument(DbDataReader reader)
+    {
+        var alias = reader.GetFieldValue<string>(_docTypeOrdinal);
+        return (T)_serializer.FromJson(_resolveType(alias), reader, DataColumn);
+    }
+
+    protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
+    {
+        var alias = await reader.GetFieldValueAsync<string>(_docTypeOrdinal, token).ConfigureAwait(false);
+        return (T)await _serializer.FromJsonAsync(_resolveType(alias), reader, DataColumn, token).ConfigureAwait(false);
+    }
+}

--- a/src/Weasel.Storage/HierarchicalNumericClosedShapeDirtyTrackingSelector.cs
+++ b/src/Weasel.Storage/HierarchicalNumericClosedShapeDirtyTrackingSelector.cs
@@ -1,0 +1,39 @@
+#nullable enable
+using System;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Hierarchical, Numeric DirtyTracking selector. #4659 Phase 2 leaf.
+/// </summary>
+public sealed class HierarchicalNumericClosedShapeDirtyTrackingSelector<T, TId>: NumericClosedShapeDirtyTrackingSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    private readonly Func<string, Type> _resolveType;
+    private readonly int _docTypeOrdinal;
+
+    public HierarchicalNumericClosedShapeDirtyTrackingSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+        _resolveType = descriptor.ResolveDocumentType
+            ?? throw new InvalidOperationException(
+                "HierarchicalNumericClosedShapeDirtyTrackingSelector requires a non-null descriptor.ResolveDocumentType.");
+        _docTypeOrdinal = FirstMetadataColumn + descriptor.DocTypeReadIndex;
+    }
+
+    protected override T ReadDocument(DbDataReader reader)
+    {
+        var alias = reader.GetFieldValue<string>(_docTypeOrdinal);
+        return (T)_serializer.FromJson(_resolveType(alias), reader, DataColumn);
+    }
+
+    protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
+    {
+        var alias = await reader.GetFieldValueAsync<string>(_docTypeOrdinal, token).ConfigureAwait(false);
+        return (T)await _serializer.FromJsonAsync(_resolveType(alias), reader, DataColumn, token).ConfigureAwait(false);
+    }
+}

--- a/src/Weasel.Storage/HierarchicalNumericClosedShapeIdentityMapSelector.cs
+++ b/src/Weasel.Storage/HierarchicalNumericClosedShapeIdentityMapSelector.cs
@@ -1,0 +1,39 @@
+#nullable enable
+using System;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Hierarchical, Numeric IdentityMap selector. #4659 Phase 2 leaf.
+/// </summary>
+public sealed class HierarchicalNumericClosedShapeIdentityMapSelector<T, TId>: NumericClosedShapeIdentityMapSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    private readonly Func<string, Type> _resolveType;
+    private readonly int _docTypeOrdinal;
+
+    public HierarchicalNumericClosedShapeIdentityMapSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+        _resolveType = descriptor.ResolveDocumentType
+            ?? throw new InvalidOperationException(
+                "HierarchicalNumericClosedShapeIdentityMapSelector requires a non-null descriptor.ResolveDocumentType.");
+        _docTypeOrdinal = FirstMetadataColumn + descriptor.DocTypeReadIndex;
+    }
+
+    protected override T ReadDocument(DbDataReader reader)
+    {
+        var alias = reader.GetFieldValue<string>(_docTypeOrdinal);
+        return (T)_serializer.FromJson(_resolveType(alias), reader, DataColumn);
+    }
+
+    protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
+    {
+        var alias = await reader.GetFieldValueAsync<string>(_docTypeOrdinal, token).ConfigureAwait(false);
+        return (T)await _serializer.FromJsonAsync(_resolveType(alias), reader, DataColumn, token).ConfigureAwait(false);
+    }
+}

--- a/src/Weasel.Storage/HierarchicalNumericClosedShapeLightweightSelector.cs
+++ b/src/Weasel.Storage/HierarchicalNumericClosedShapeLightweightSelector.cs
@@ -1,0 +1,39 @@
+#nullable enable
+using System;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Hierarchical, Numeric Lightweight selector. #4659 Phase 2 leaf.
+/// </summary>
+public sealed class HierarchicalNumericClosedShapeLightweightSelector<T, TId>: NumericClosedShapeLightweightSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    private readonly Func<string, Type> _resolveType;
+    private readonly int _docTypeOrdinal;
+
+    public HierarchicalNumericClosedShapeLightweightSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+        _resolveType = descriptor.ResolveDocumentType
+            ?? throw new InvalidOperationException(
+                "HierarchicalNumericClosedShapeLightweightSelector requires a non-null descriptor.ResolveDocumentType.");
+        _docTypeOrdinal = FirstMetadataColumn + descriptor.DocTypeReadIndex;
+    }
+
+    protected override T ReadDocument(DbDataReader reader)
+    {
+        var alias = reader.GetFieldValue<string>(_docTypeOrdinal);
+        return (T)_serializer.FromJson(_resolveType(alias), reader, DataColumn);
+    }
+
+    protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
+    {
+        var alias = await reader.GetFieldValueAsync<string>(_docTypeOrdinal, token).ConfigureAwait(false);
+        return (T)await _serializer.FromJsonAsync(_resolveType(alias), reader, DataColumn, token).ConfigureAwait(false);
+    }
+}

--- a/src/Weasel.Storage/HierarchicalOptimisticClosedShapeDirtyTrackingSelector.cs
+++ b/src/Weasel.Storage/HierarchicalOptimisticClosedShapeDirtyTrackingSelector.cs
@@ -1,0 +1,39 @@
+#nullable enable
+using System;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Hierarchical, Optimistic DirtyTracking selector. #4659 Phase 2 leaf.
+/// </summary>
+public sealed class HierarchicalOptimisticClosedShapeDirtyTrackingSelector<T, TId>: OptimisticClosedShapeDirtyTrackingSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    private readonly Func<string, Type> _resolveType;
+    private readonly int _docTypeOrdinal;
+
+    public HierarchicalOptimisticClosedShapeDirtyTrackingSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+        _resolveType = descriptor.ResolveDocumentType
+            ?? throw new InvalidOperationException(
+                "HierarchicalOptimisticClosedShapeDirtyTrackingSelector requires a non-null descriptor.ResolveDocumentType.");
+        _docTypeOrdinal = FirstMetadataColumn + descriptor.DocTypeReadIndex;
+    }
+
+    protected override T ReadDocument(DbDataReader reader)
+    {
+        var alias = reader.GetFieldValue<string>(_docTypeOrdinal);
+        return (T)_serializer.FromJson(_resolveType(alias), reader, DataColumn);
+    }
+
+    protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
+    {
+        var alias = await reader.GetFieldValueAsync<string>(_docTypeOrdinal, token).ConfigureAwait(false);
+        return (T)await _serializer.FromJsonAsync(_resolveType(alias), reader, DataColumn, token).ConfigureAwait(false);
+    }
+}

--- a/src/Weasel.Storage/HierarchicalOptimisticClosedShapeIdentityMapSelector.cs
+++ b/src/Weasel.Storage/HierarchicalOptimisticClosedShapeIdentityMapSelector.cs
@@ -1,0 +1,39 @@
+#nullable enable
+using System;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Hierarchical, Optimistic IdentityMap selector. #4659 Phase 2 leaf.
+/// </summary>
+public sealed class HierarchicalOptimisticClosedShapeIdentityMapSelector<T, TId>: OptimisticClosedShapeIdentityMapSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    private readonly Func<string, Type> _resolveType;
+    private readonly int _docTypeOrdinal;
+
+    public HierarchicalOptimisticClosedShapeIdentityMapSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+        _resolveType = descriptor.ResolveDocumentType
+            ?? throw new InvalidOperationException(
+                "HierarchicalOptimisticClosedShapeIdentityMapSelector requires a non-null descriptor.ResolveDocumentType.");
+        _docTypeOrdinal = FirstMetadataColumn + descriptor.DocTypeReadIndex;
+    }
+
+    protected override T ReadDocument(DbDataReader reader)
+    {
+        var alias = reader.GetFieldValue<string>(_docTypeOrdinal);
+        return (T)_serializer.FromJson(_resolveType(alias), reader, DataColumn);
+    }
+
+    protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
+    {
+        var alias = await reader.GetFieldValueAsync<string>(_docTypeOrdinal, token).ConfigureAwait(false);
+        return (T)await _serializer.FromJsonAsync(_resolveType(alias), reader, DataColumn, token).ConfigureAwait(false);
+    }
+}

--- a/src/Weasel.Storage/HierarchicalOptimisticClosedShapeLightweightSelector.cs
+++ b/src/Weasel.Storage/HierarchicalOptimisticClosedShapeLightweightSelector.cs
@@ -1,0 +1,39 @@
+#nullable enable
+using System;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Hierarchical, Optimistic Lightweight selector. #4659 Phase 2 leaf.
+/// </summary>
+public sealed class HierarchicalOptimisticClosedShapeLightweightSelector<T, TId>: OptimisticClosedShapeLightweightSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    private readonly Func<string, Type> _resolveType;
+    private readonly int _docTypeOrdinal;
+
+    public HierarchicalOptimisticClosedShapeLightweightSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+        _resolveType = descriptor.ResolveDocumentType
+            ?? throw new InvalidOperationException(
+                "HierarchicalOptimisticClosedShapeLightweightSelector requires a non-null descriptor.ResolveDocumentType.");
+        _docTypeOrdinal = FirstMetadataColumn + descriptor.DocTypeReadIndex;
+    }
+
+    protected override T ReadDocument(DbDataReader reader)
+    {
+        var alias = reader.GetFieldValue<string>(_docTypeOrdinal);
+        return (T)_serializer.FromJson(_resolveType(alias), reader, DataColumn);
+    }
+
+    protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
+    {
+        var alias = await reader.GetFieldValueAsync<string>(_docTypeOrdinal, token).ConfigureAwait(false);
+        return (T)await _serializer.FromJsonAsync(_resolveType(alias), reader, DataColumn, token).ConfigureAwait(false);
+    }
+}

--- a/src/Weasel.Storage/HierarchicalUnversionedClosedShapeDirtyTrackingSelector.cs
+++ b/src/Weasel.Storage/HierarchicalUnversionedClosedShapeDirtyTrackingSelector.cs
@@ -1,0 +1,39 @@
+#nullable enable
+using System;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Hierarchical, Off-mode DirtyTracking selector. #4659 Phase 2 leaf.
+/// </summary>
+public sealed class HierarchicalUnversionedClosedShapeDirtyTrackingSelector<T, TId>: UnversionedClosedShapeDirtyTrackingSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    private readonly Func<string, Type> _resolveType;
+    private readonly int _docTypeOrdinal;
+
+    public HierarchicalUnversionedClosedShapeDirtyTrackingSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+        _resolveType = descriptor.ResolveDocumentType
+            ?? throw new InvalidOperationException(
+                "HierarchicalUnversionedClosedShapeDirtyTrackingSelector requires a non-null descriptor.ResolveDocumentType.");
+        _docTypeOrdinal = FirstMetadataColumn + descriptor.DocTypeReadIndex;
+    }
+
+    protected override T ReadDocument(DbDataReader reader)
+    {
+        var alias = reader.GetFieldValue<string>(_docTypeOrdinal);
+        return (T)_serializer.FromJson(_resolveType(alias), reader, DataColumn);
+    }
+
+    protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
+    {
+        var alias = await reader.GetFieldValueAsync<string>(_docTypeOrdinal, token).ConfigureAwait(false);
+        return (T)await _serializer.FromJsonAsync(_resolveType(alias), reader, DataColumn, token).ConfigureAwait(false);
+    }
+}

--- a/src/Weasel.Storage/HierarchicalUnversionedClosedShapeIdentityMapSelector.cs
+++ b/src/Weasel.Storage/HierarchicalUnversionedClosedShapeIdentityMapSelector.cs
@@ -1,0 +1,39 @@
+#nullable enable
+using System;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Hierarchical, Off-mode IdentityMap selector. #4659 Phase 2 leaf.
+/// </summary>
+public sealed class HierarchicalUnversionedClosedShapeIdentityMapSelector<T, TId>: UnversionedClosedShapeIdentityMapSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    private readonly Func<string, Type> _resolveType;
+    private readonly int _docTypeOrdinal;
+
+    public HierarchicalUnversionedClosedShapeIdentityMapSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+        _resolveType = descriptor.ResolveDocumentType
+            ?? throw new InvalidOperationException(
+                "HierarchicalUnversionedClosedShapeIdentityMapSelector requires a non-null descriptor.ResolveDocumentType.");
+        _docTypeOrdinal = FirstMetadataColumn + descriptor.DocTypeReadIndex;
+    }
+
+    protected override T ReadDocument(DbDataReader reader)
+    {
+        var alias = reader.GetFieldValue<string>(_docTypeOrdinal);
+        return (T)_serializer.FromJson(_resolveType(alias), reader, DataColumn);
+    }
+
+    protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
+    {
+        var alias = await reader.GetFieldValueAsync<string>(_docTypeOrdinal, token).ConfigureAwait(false);
+        return (T)await _serializer.FromJsonAsync(_resolveType(alias), reader, DataColumn, token).ConfigureAwait(false);
+    }
+}

--- a/src/Weasel.Storage/HierarchicalUnversionedClosedShapeLightweightSelector.cs
+++ b/src/Weasel.Storage/HierarchicalUnversionedClosedShapeLightweightSelector.cs
@@ -1,0 +1,43 @@
+#nullable enable
+using System;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Hierarchical, Off-mode Lightweight selector. Reads <c>mt_doc_type</c>
+/// from the descriptor's <see cref="DocumentStorageDescriptor{T,TId}.DocTypeReadIndex"/>
+/// and dispatches deserialization through the
+/// <see cref="DocumentStorageDescriptor{T,TId}.ResolveDocumentType"/> root.
+/// #4659 Phase 2 leaf.
+/// </summary>
+public sealed class HierarchicalUnversionedClosedShapeLightweightSelector<T, TId>: UnversionedClosedShapeLightweightSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    private readonly Func<string, Type> _resolveType;
+    private readonly int _docTypeOrdinal;
+
+    public HierarchicalUnversionedClosedShapeLightweightSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+        _resolveType = descriptor.ResolveDocumentType
+            ?? throw new InvalidOperationException(
+                "HierarchicalUnversionedClosedShapeLightweightSelector requires a non-null descriptor.ResolveDocumentType.");
+        _docTypeOrdinal = FirstMetadataColumn + descriptor.DocTypeReadIndex;
+    }
+
+    protected override T ReadDocument(DbDataReader reader)
+    {
+        var alias = reader.GetFieldValue<string>(_docTypeOrdinal);
+        return (T)_serializer.FromJson(_resolveType(alias), reader, DataColumn);
+    }
+
+    protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
+    {
+        var alias = await reader.GetFieldValueAsync<string>(_docTypeOrdinal, token).ConfigureAwait(false);
+        return (T)await _serializer.FromJsonAsync(_resolveType(alias), reader, DataColumn, token).ConfigureAwait(false);
+    }
+}

--- a/src/Weasel.Storage/IDocumentSelector.cs
+++ b/src/Weasel.Storage/IDocumentSelector.cs
@@ -1,0 +1,20 @@
+namespace Weasel.Storage;
+
+/// <summary>
+/// Marker interface implemented by document selectors whose state is
+/// captured per-<see cref="IMartenSession"/> (identity map, version /
+/// revision trackers, dirty-check tracker registry). The compiled-query
+/// pipeline uses it via <c>IMaybeStatefulHandler.DependsOnDocumentSelector</c>
+/// to decide whether to clone the handler per session vs. share a
+/// single instance across sessions.
+/// </summary>
+/// <remarks>
+/// Pre-#4404 this lived alongside the Roslyn-emitted document selectors.
+/// With the closed-shape hierarchy it's implemented by
+/// <c>ClosedShapeLightweightSelector</c>, <c>ClosedShapeIdentityMapSelector</c>,
+/// and <c>ClosedShapeDirtyTrackingSelector</c>;
+/// <c>ClosedShapeQueryOnlySelector</c> is stateless and does not.
+/// </remarks>
+public interface IDocumentSelector
+{
+}

--- a/src/Weasel.Storage/NumericClosedShapeDirtyTrackingSelector.cs
+++ b/src/Weasel.Storage/NumericClosedShapeDirtyTrackingSelector.cs
@@ -1,0 +1,34 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Data.Common;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// <c>ConcurrencyMode.Numeric</c> DirtyTracking selector — concurrency-
+/// mode intermediate. CaptureVersion writes long into the session's
+/// per-type revision dict. Sealed Flat / Hierarchical subclasses
+/// provide ReadDocument. #4659 Phase 2.
+/// </summary>
+public abstract class NumericClosedShapeDirtyTrackingSelector<T, TId>: ClosedShapeDirtyTrackingSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    private readonly Dictionary<TId, long> _revisions;
+
+    protected NumericClosedShapeDirtyTrackingSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+        _revisions = session.Versions.RevisionsFor<T, TId>();
+    }
+
+    protected sealed override void CaptureVersion(DbDataReader reader, TId id)
+    {
+        var versionIndex = _descriptor.VersionReadIndex;
+        if (versionIndex < 0) return;
+        var versionOrdinal = FirstMetadataColumn + versionIndex;
+        if (reader.IsDBNull(versionOrdinal)) return;
+
+        _revisions[id] = reader.GetFieldValue<long>(versionOrdinal);
+    }
+}

--- a/src/Weasel.Storage/NumericClosedShapeIdentityMapSelector.cs
+++ b/src/Weasel.Storage/NumericClosedShapeIdentityMapSelector.cs
@@ -1,0 +1,34 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Data.Common;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// <c>ConcurrencyMode.Numeric</c> IdentityMap selector — concurrency-
+/// mode intermediate. CaptureVersion writes long into the session's
+/// per-type revision dict. Sealed Flat / Hierarchical subclasses
+/// provide ReadDocument. #4659 Phase 2.
+/// </summary>
+public abstract class NumericClosedShapeIdentityMapSelector<T, TId>: ClosedShapeIdentityMapSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    private readonly Dictionary<TId, long> _revisions;
+
+    protected NumericClosedShapeIdentityMapSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+        _revisions = session.Versions.RevisionsFor<T, TId>();
+    }
+
+    protected sealed override void CaptureVersion(DbDataReader reader, TId id)
+    {
+        var versionIndex = _descriptor.VersionReadIndex;
+        if (versionIndex < 0) return;
+        var versionOrdinal = FirstMetadataColumn + versionIndex;
+        if (reader.IsDBNull(versionOrdinal)) return;
+
+        _revisions[id] = reader.GetFieldValue<long>(versionOrdinal);
+    }
+}

--- a/src/Weasel.Storage/NumericClosedShapeLightweightSelector.cs
+++ b/src/Weasel.Storage/NumericClosedShapeLightweightSelector.cs
@@ -1,0 +1,35 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Data.Common;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// <c>ConcurrencyMode.Numeric</c> Lightweight selector — concurrency-
+/// mode intermediate. CaptureVersion writes the row's mt_version (long)
+/// into the session's per-type revision dict; sealed Flat / Hierarchical
+/// subclasses provide <c>ReadDocument</c> / <c>ReadDocumentAsync</c>
+/// (#4659 Phase 2).
+/// </summary>
+public abstract class NumericClosedShapeLightweightSelector<T, TId>: ClosedShapeLightweightSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    private readonly Dictionary<TId, long> _revisions;
+
+    protected NumericClosedShapeLightweightSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+        _revisions = session.Versions.RevisionsFor<T, TId>();
+    }
+
+    protected sealed override void CaptureVersion(DbDataReader reader, TId id)
+    {
+        var versionIndex = _descriptor.VersionReadIndex;
+        if (versionIndex < 0) return;
+        var versionOrdinal = FirstMetadataColumn + versionIndex;
+        if (reader.IsDBNull(versionOrdinal)) return;
+
+        _revisions[id] = reader.GetFieldValue<long>(versionOrdinal);
+    }
+}

--- a/src/Weasel.Storage/OptimisticClosedShapeDirtyTrackingSelector.cs
+++ b/src/Weasel.Storage/OptimisticClosedShapeDirtyTrackingSelector.cs
@@ -1,0 +1,35 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// <c>ConcurrencyMode.Optimistic</c> DirtyTracking selector —
+/// concurrency-mode intermediate. CaptureVersion writes Guid into the
+/// session's per-type version dict. Sealed Flat / Hierarchical
+/// subclasses provide ReadDocument. #4659 Phase 2.
+/// </summary>
+public abstract class OptimisticClosedShapeDirtyTrackingSelector<T, TId>: ClosedShapeDirtyTrackingSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    private readonly Dictionary<TId, Guid> _versions;
+
+    protected OptimisticClosedShapeDirtyTrackingSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+        _versions = session.Versions.ForType<T, TId>();
+    }
+
+    protected sealed override void CaptureVersion(DbDataReader reader, TId id)
+    {
+        var versionIndex = _descriptor.VersionReadIndex;
+        if (versionIndex < 0) return;
+        var versionOrdinal = FirstMetadataColumn + versionIndex;
+        if (reader.IsDBNull(versionOrdinal)) return;
+
+        _versions[id] = reader.GetFieldValue<Guid>(versionOrdinal);
+    }
+}

--- a/src/Weasel.Storage/OptimisticClosedShapeIdentityMapSelector.cs
+++ b/src/Weasel.Storage/OptimisticClosedShapeIdentityMapSelector.cs
@@ -1,0 +1,35 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// <c>ConcurrencyMode.Optimistic</c> IdentityMap selector — concurrency-
+/// mode intermediate. CaptureVersion writes Guid into the session's
+/// per-type version dict. Sealed Flat / Hierarchical subclasses provide
+/// ReadDocument. #4659 Phase 2.
+/// </summary>
+public abstract class OptimisticClosedShapeIdentityMapSelector<T, TId>: ClosedShapeIdentityMapSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    private readonly Dictionary<TId, Guid> _versions;
+
+    protected OptimisticClosedShapeIdentityMapSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+        _versions = session.Versions.ForType<T, TId>();
+    }
+
+    protected sealed override void CaptureVersion(DbDataReader reader, TId id)
+    {
+        var versionIndex = _descriptor.VersionReadIndex;
+        if (versionIndex < 0) return;
+        var versionOrdinal = FirstMetadataColumn + versionIndex;
+        if (reader.IsDBNull(versionOrdinal)) return;
+
+        _versions[id] = reader.GetFieldValue<Guid>(versionOrdinal);
+    }
+}

--- a/src/Weasel.Storage/OptimisticClosedShapeLightweightSelector.cs
+++ b/src/Weasel.Storage/OptimisticClosedShapeLightweightSelector.cs
@@ -1,0 +1,36 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// <c>ConcurrencyMode.Optimistic</c> Lightweight selector — concurrency-
+/// mode intermediate. CaptureVersion writes the row's mt_version (Guid)
+/// into the session's per-type version dict; sealed Flat / Hierarchical
+/// subclasses provide <c>ReadDocument</c> / <c>ReadDocumentAsync</c>
+/// (#4659 Phase 2).
+/// </summary>
+public abstract class OptimisticClosedShapeLightweightSelector<T, TId>: ClosedShapeLightweightSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    private readonly Dictionary<TId, Guid> _versions;
+
+    protected OptimisticClosedShapeLightweightSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+        _versions = session.Versions.ForType<T, TId>();
+    }
+
+    protected sealed override void CaptureVersion(DbDataReader reader, TId id)
+    {
+        var versionIndex = _descriptor.VersionReadIndex;
+        if (versionIndex < 0) return;
+        var versionOrdinal = FirstMetadataColumn + versionIndex;
+        if (reader.IsDBNull(versionOrdinal)) return;
+
+        _versions[id] = reader.GetFieldValue<Guid>(versionOrdinal);
+    }
+}

--- a/src/Weasel.Storage/UnversionedClosedShapeDirtyTrackingSelector.cs
+++ b/src/Weasel.Storage/UnversionedClosedShapeDirtyTrackingSelector.cs
@@ -1,0 +1,21 @@
+#nullable enable
+using System.Data.Common;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// <c>ConcurrencyMode.Off</c> DirtyTracking selector — concurrency-mode
+/// intermediate. CaptureVersion is a no-op. Sealed Flat / Hierarchical
+/// subclasses provide ReadDocument. #4659 Phase 2.
+/// </summary>
+public abstract class UnversionedClosedShapeDirtyTrackingSelector<T, TId>: ClosedShapeDirtyTrackingSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    protected UnversionedClosedShapeDirtyTrackingSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+    }
+
+    protected sealed override void CaptureVersion(DbDataReader reader, TId id) { /* no-op */ }
+}

--- a/src/Weasel.Storage/UnversionedClosedShapeIdentityMapSelector.cs
+++ b/src/Weasel.Storage/UnversionedClosedShapeIdentityMapSelector.cs
@@ -1,0 +1,21 @@
+#nullable enable
+using System.Data.Common;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// <c>ConcurrencyMode.Off</c> IdentityMap selector — concurrency-mode
+/// intermediate. CaptureVersion is a no-op. Sealed Flat / Hierarchical
+/// subclasses provide ReadDocument. #4659 Phase 2.
+/// </summary>
+public abstract class UnversionedClosedShapeIdentityMapSelector<T, TId>: ClosedShapeIdentityMapSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    protected UnversionedClosedShapeIdentityMapSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+    }
+
+    protected sealed override void CaptureVersion(DbDataReader reader, TId id) { /* no-op */ }
+}

--- a/src/Weasel.Storage/UnversionedClosedShapeLightweightSelector.cs
+++ b/src/Weasel.Storage/UnversionedClosedShapeLightweightSelector.cs
@@ -1,0 +1,25 @@
+#nullable enable
+using System.Data.Common;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// <c>ConcurrencyMode.Off</c> Lightweight selector — concurrency-mode
+/// intermediate. CaptureVersion is a no-op; sealed Flat / Hierarchical
+/// subclasses provide <c>ReadDocument</c> /
+/// <c>ReadDocumentAsync</c> (#4659 Phase 2).
+/// </summary>
+public abstract class UnversionedClosedShapeLightweightSelector<T, TId>: ClosedShapeLightweightSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    protected UnversionedClosedShapeLightweightSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+    }
+
+    protected sealed override void CaptureVersion(DbDataReader reader, TId id)
+    {
+        // Off-mode: nothing to capture.
+    }
+}


### PR DESCRIPTION
Fourth Weasel.Storage increment for the Marten **W2 storage-extraction epic** (JasperFx/marten#4821) — the complete closed-shape **read path**, lifted from Marten verbatim (bodies unchanged; namespace + visibility only):

- the 4 storage-style selector bases (`Lightweight` / `IdentityMap` / `DirtyTracking` / `QueryOnly`): row shape, identity-map insertion, version/revision capture into `IVersionTracker`, `ChangeTracker` registration
- the 9 concurrency intermediates (`Optimistic` / `Numeric` / `Unversioned` × tracking style)
- the 20 flat / hierarchical leaves (straight vs doc-type-alias-dispatched deserialization)
- the `IDocumentSelector` marker (per-session-state signal a store's compiled-query pipeline uses to decide handler cloning)

Everything types against `DocumentStorageDescriptor` / `IStorageSession` / `IStorageSerializer` / `ISelector<T>` — no store or provider references. Compiled untouched on the first build.

Bumps to **9.11.0**. Follows #333 (descriptor core).

Validated downstream with local packs: Marten consumes with DocumentDb 1033 + Linq 1312 green so far (full matrix before the Marten PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)