### PR TITLE
Weasel.Storage: the closed-shape metadata binders (marten#4821 INC-3)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>9.11.0</Version>
+        <Version>9.12.0</Version>
         <LangVersion>13.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/src/Weasel.Storage/DocumentCausationIdBinder.cs
+++ b/src/Weasel.Storage/DocumentCausationIdBinder.cs
@@ -1,0 +1,57 @@
+#nullable enable
+using System;
+using System.Data.Common;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Core.Reflection;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// <see cref="IDocumentMetadataBinder{TDoc}"/> for the <c>causation_id</c>
+/// column. Value comes from <see cref="IStorageSession.CausationId"/> on
+/// every write; read path projects the stored value onto the document's
+/// <c>[CausationId]</c>-annotated member when one exists.
+/// </summary>
+public sealed class DocumentCausationIdBinder<TDoc>: IDocumentMetadataBinder<TDoc>
+    where TDoc : notnull
+{
+    private readonly Action<TDoc, string?>? _setter;
+
+    private readonly IStorageDialect _dialect;
+
+    public DocumentCausationIdBinder(string columnName, IStorageDialect dialect, MemberInfo? causationIdMember)
+    {
+        ColumnName = columnName;
+        _dialect = dialect;
+        if (causationIdMember is not null)
+        {
+            _setter = LambdaBuilder.Setter<TDoc, string?>(causationIdMember);
+        }
+    }
+
+    public string ColumnName { get; }
+
+    public string ValueSql => "?";
+
+    public void BindParameter(DbParameter parameter, TDoc document, IStorageSession session)
+    {
+        _dialect.SetParameterType(parameter, StorageColumnType.String);
+        parameter.Value = (object?)session.CausationId ?? DBNull.Value;
+    }
+
+    public void ApplyToDocument(TDoc document, IStorageSession session)
+        => _setter?.Invoke(document, session.CausationId);
+
+    public void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IStorageSession session)
+    {
+        if (_setter is null) return;
+        if (reader.IsDBNull(columnOrdinal)) return;
+
+        var value = reader.GetFieldValue<string>(columnOrdinal);
+        _setter(document, value);
+    }
+
+    public BulkColumnValue GetBulkValue(TDoc document) => BulkColumnValue.Null;
+}

--- a/src/Weasel.Storage/DocumentCorrelationIdBinder.cs
+++ b/src/Weasel.Storage/DocumentCorrelationIdBinder.cs
@@ -1,0 +1,63 @@
+#nullable enable
+using System;
+using System.Data.Common;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Core.Reflection;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// <see cref="IDocumentMetadataBinder{TDoc}"/> for the
+/// <c>correlation_id</c> column. The value comes from
+/// <see cref="IStorageSession.CorrelationId"/> on every write — not from
+/// the document — mirroring the codegen path's
+/// <c>setStringParameter(_, session.CorrelationId)</c> emit. On read the
+/// stored value is projected back onto the document's
+/// <c>[CorrelationId]</c>-annotated member when one exists.
+/// </summary>
+public sealed class DocumentCorrelationIdBinder<TDoc>: IDocumentMetadataBinder<TDoc>
+    where TDoc : notnull
+{
+    private readonly Action<TDoc, string?>? _setter;
+
+    private readonly IStorageDialect _dialect;
+
+    public DocumentCorrelationIdBinder(string columnName, IStorageDialect dialect, MemberInfo? correlationIdMember)
+    {
+        ColumnName = columnName;
+        _dialect = dialect;
+        if (correlationIdMember is not null)
+        {
+            _setter = LambdaBuilder.Setter<TDoc, string?>(correlationIdMember);
+        }
+    }
+
+    public string ColumnName { get; }
+
+    public string ValueSql => "?";
+
+    public void BindParameter(DbParameter parameter, TDoc document, IStorageSession session)
+    {
+        _dialect.SetParameterType(parameter, StorageColumnType.String);
+        parameter.Value = (object?)session.CorrelationId ?? DBNull.Value;
+    }
+
+    public void ApplyToDocument(TDoc document, IStorageSession session)
+        => _setter?.Invoke(document, session.CorrelationId);
+
+    public void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IStorageSession session)
+    {
+        if (_setter is null) return;
+        if (reader.IsDBNull(columnOrdinal)) return;
+
+        var value = reader.GetFieldValue<string>(columnOrdinal);
+        _setter(document, value);
+    }
+
+    public BulkColumnValue GetBulkValue(TDoc document)
+        // Bulk loader has no session — no source for a correlation id. Write null;
+        // mirrors the codegen path's bulk emit (the column was never session-aware on COPY).
+        => BulkColumnValue.Null;
+}

--- a/src/Weasel.Storage/DocumentCreatedAtBinder.cs
+++ b/src/Weasel.Storage/DocumentCreatedAtBinder.cs
@@ -1,0 +1,68 @@
+#nullable enable
+using System;
+using System.Data.Common;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Core.Reflection;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Read-only <see cref="IDocumentMetadataBinder{TDoc}"/> for the
+/// <c>mt_created_at</c> column. Issue #4575: in v8 the codegen storage path
+/// projected the column back onto a <c>[CreatedAt]</c>-annotated /
+/// <c>Metadata(m =&gt; m.CreatedAt.MapTo(...))</c> member; the v9 closed-shape
+/// rewrite (#4498) ported every other metadata column but missed this one,
+/// so the .NET member stayed at <c>default(DateTimeOffset)</c> after a
+/// reload.
+/// <para>
+/// Unlike <see cref="DocumentLastModifiedBinder{TDoc}"/>, this binder is
+/// added to <c>readBinders</c> only — never <c>writeBinders</c>. The
+/// underlying <see cref="Marten.Storage.Metadata.CreatedAtColumn"/> carries
+/// a <c>transaction_timestamp()</c> DEFAULT, so PostgreSQL fills the value
+/// on insert; participating in <c>writeBinders</c> would put the column
+/// into the UPDATE SET list too and clobber the original creation time on
+/// every subsequent save.
+/// </para>
+/// </summary>
+public sealed class DocumentCreatedAtBinder<TDoc>: IDocumentMetadataBinder<TDoc>
+    where TDoc : notnull
+{
+    private readonly Action<TDoc, DateTimeOffset>? _setter;
+
+    public DocumentCreatedAtBinder(string columnName, MemberInfo? createdAtMember)
+    {
+        ColumnName = columnName;
+        if (createdAtMember is not null)
+        {
+            _setter = LambdaBuilder.Setter<TDoc, DateTimeOffset>(createdAtMember);
+        }
+    }
+
+    public string ColumnName { get; }
+
+    // No write path — the column's transaction_timestamp() DEFAULT does
+    // the work on insert, and CreatedAt is immutable after that. ValueSql
+    // is non-"?" so IsServerSide is true; even if a future caller adds
+    // this binder to writeBinders, BindParameter throwing keeps the
+    // "never written client-side" invariant honest.
+    public string ValueSql => "transaction_timestamp()";
+
+    public void BindParameter(DbParameter parameter, TDoc document, IStorageSession session)
+        => throw new NotSupportedException(
+            "mt_created_at has a server-side DEFAULT and is never written through this binder.");
+
+    public void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IStorageSession session)
+    {
+        if (_setter is null) return;
+        if (reader.IsDBNull(columnOrdinal)) return;
+
+        var ts = reader.GetFieldValue<DateTimeOffset>(columnOrdinal);
+        _setter(document, ts);
+    }
+
+    public BulkColumnValue GetBulkValue(TDoc document)
+        => throw new NotSupportedException(
+            "mt_created_at is filled by the column DEFAULT during bulk load; this binder is read-only.");
+}

--- a/src/Weasel.Storage/DocumentDocTypeBinder.cs
+++ b/src/Weasel.Storage/DocumentDocTypeBinder.cs
@@ -1,0 +1,65 @@
+#nullable enable
+using System;
+using System.Collections.Concurrent;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// W3 spike (M11): <see cref="IDocumentMetadataBinder{TDoc}"/> for the
+/// <c>mt_doc_type</c> column on a hierarchical mapping. Writes the
+/// runtime type's hierarchy alias (looked up via an agnostic
+/// <c>Func&lt;Type, string&gt;</c> the builder captures from
+/// <c>DocumentMapping.AliasFor</c> — #4829, so this binder no longer
+/// references the Marten mapping type); the alias drives the SubClass
+/// storage's WHERE filter and selector dispatch on read.
+/// </summary>
+/// <remarks>
+/// Read participation is handled directly by the selectors when the
+/// descriptor has hierarchy mode on — <see cref="Apply"/> is a no-op
+/// because the alias controls deserialization-type dispatch, not a
+/// document member projection. If the document has a
+/// <c>[DocumentTypeMember]</c>-annotated string, the codegen path
+/// writes it there; deferred for the spike.
+/// </remarks>
+public sealed class DocumentDocTypeBinder<TDoc>: IDocumentMetadataBinder<TDoc>
+    where TDoc : notnull
+{
+    private readonly Func<Type, string> _resolveAlias;
+    private readonly ConcurrentDictionary<Type, string> _aliasCache = new();
+
+    private readonly IStorageDialect _dialect;
+
+    public DocumentDocTypeBinder(string columnName, IStorageDialect dialect, Func<Type, string> resolveAlias)
+    {
+        ColumnName = columnName;
+        _dialect = dialect;
+        _resolveAlias = resolveAlias;
+    }
+
+    public string ColumnName { get; }
+
+    public string ValueSql => "?";
+
+    public void BindParameter(DbParameter parameter, TDoc document, IStorageSession session)
+    {
+        var alias = _aliasCache.GetOrAdd(document.GetType(), t => _resolveAlias(t));
+        parameter.Value = alias;
+        _dialect.SetParameterType(parameter, StorageColumnType.String);
+    }
+
+    public void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IStorageSession session)
+    {
+        // No-op — the alias is read directly by the selector to dispatch
+        // deserialization to the right subclass type, not projected onto
+        // the document.
+    }
+
+    public BulkColumnValue GetBulkValue(TDoc document)
+    {
+        var alias = _aliasCache.GetOrAdd(document.GetType(), t => _resolveAlias(t));
+        return new BulkColumnValue(alias, StorageColumnType.String);
+    }
+}

--- a/src/Weasel.Storage/DocumentDotNetTypeBinder.cs
+++ b/src/Weasel.Storage/DocumentDotNetTypeBinder.cs
@@ -1,0 +1,53 @@
+#nullable enable
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// <see cref="IDocumentMetadataBinder{TDoc}"/> for the
+/// <c>mt_dotnet_type</c> column. Stores the full .NET type name of the
+/// concrete instance — uses <c>document.GetType().FullName</c> so
+/// hierarchical mappings record the subclass name, not the base type
+/// <typeparamref name="TDoc"/>.
+/// </summary>
+public sealed class DocumentDotNetTypeBinder<TDoc>: IDocumentMetadataBinder<TDoc>
+    where TDoc : notnull
+{
+    private readonly IStorageDialect _dialect;
+
+    public DocumentDotNetTypeBinder(string columnName, IStorageDialect dialect)
+    {
+        ColumnName = columnName;
+        _dialect = dialect;
+    }
+
+    // Fast path for non-hierarchical mappings: cached because
+    // document.GetType() == typeof(TDoc) for every row.
+    private static readonly string _baseTypeName = typeof(TDoc).FullName!;
+
+    public string ColumnName { get; }
+
+    public string ValueSql => "?";
+
+    public void BindParameter(DbParameter parameter, TDoc document, IStorageSession session)
+    {
+        parameter.Value = ResolveTypeName(document);
+        _dialect.SetParameterType(parameter, StorageColumnType.String);
+    }
+
+    public void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IStorageSession session)
+    {
+        // No-op — dotnet_type isn't projected back onto the document.
+    }
+
+    public BulkColumnValue GetBulkValue(TDoc document)
+        => new(ResolveTypeName(document), StorageColumnType.String);
+
+    private static string ResolveTypeName(TDoc document)
+    {
+        var actual = document.GetType();
+        return actual == typeof(TDoc) ? _baseTypeName : actual.FullName!;
+    }
+}

--- a/src/Weasel.Storage/DocumentHeadersBinder.cs
+++ b/src/Weasel.Storage/DocumentHeadersBinder.cs
@@ -1,0 +1,80 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Core.Reflection;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// <see cref="IDocumentMetadataBinder{TDoc}"/> for the <c>headers</c>
+/// (jsonb) column. Write path pulls the headers off the session — under
+/// a store session with a per-batch UTF-8 byte[] cache the serialization is
+/// reused across the batch so N storage ops serialize the dictionary
+/// once. Read path projects the deserialized dictionary onto the
+/// document's <c>[Headers]</c>-annotated member when one exists.
+/// </summary>
+public sealed class DocumentHeadersBinder<TDoc>: IDocumentMetadataBinder<TDoc>
+    where TDoc : notnull
+{
+    private readonly Action<TDoc, Dictionary<string, object>?>? _setter;
+
+    private readonly IStorageDialect _dialect;
+
+    public DocumentHeadersBinder(string columnName, IStorageDialect dialect, MemberInfo? headersMember)
+    {
+        ColumnName = columnName;
+        _dialect = dialect;
+        if (headersMember is not null)
+        {
+            _setter = LambdaBuilder.Setter<TDoc, Dictionary<string, object>?>(headersMember);
+        }
+    }
+
+    public string ColumnName { get; }
+
+    public string ValueSql => "?";
+
+    public void ApplyToDocument(TDoc document, IStorageSession session)
+        => _setter?.Invoke(document, session.Headers);
+
+    public void BindParameter(DbParameter parameter, TDoc document, IStorageSession session)
+    {
+        // Use the session's cached UTF-8 bytes when the owning store caches the serialized
+        // headers per batch (the cache returns null when there are no headers), otherwise fall
+        // back to direct serialization via the storage serializer.
+        var cachedBytes = session.TryGetCachedSerializedHeaders();
+        if (cachedBytes is not null)
+        {
+            _dialect.SetParameterType(parameter, StorageColumnType.Json);
+            parameter.Value = cachedBytes;
+            return;
+        }
+
+        if (session.Headers is null)
+        {
+            _dialect.SetParameterType(parameter, StorageColumnType.Json);
+            parameter.Value = DBNull.Value;
+        }
+        else
+        {
+            session.Serializer.WriteToParameter(parameter, session.Headers);
+        }
+    }
+
+    public void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IStorageSession session)
+    {
+        if (_setter is null) return;
+        if (reader.IsDBNull(columnOrdinal)) return;
+
+        var headers = session.Serializer.FromJson<Dictionary<string, object>>(reader, columnOrdinal);
+        _setter(document, headers);
+    }
+
+    public BulkColumnValue GetBulkValue(TDoc document)
+        // Headers aren't carried on the COPY path — write a typed JSONB null, as before.
+        => BulkColumnValue.TypedNull(StorageColumnType.Json);
+}

--- a/src/Weasel.Storage/DocumentLastModifiedBinder.cs
+++ b/src/Weasel.Storage/DocumentLastModifiedBinder.cs
@@ -1,0 +1,60 @@
+#nullable enable
+using System;
+using System.Data.Common;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Core.Reflection;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// W3 spike (M1): <see cref="IDocumentMetadataBinder{TDoc}"/> for the
+/// <c>mt_last_modified</c> column. Server-side value — declares
+/// <see cref="ValueSql"/> as <c>transaction_timestamp()</c> and skips
+/// <see cref="BindParameter"/>. The descriptor's SQL prefix bakes the
+/// literal into the VALUES list so no parameter slot is reserved.
+/// </summary>
+public sealed class DocumentLastModifiedBinder<TDoc>: IDocumentMetadataBinder<TDoc>
+    where TDoc : notnull
+{
+    private readonly Action<TDoc, DateTimeOffset>? _setter;
+
+    public DocumentLastModifiedBinder(string columnName, MemberInfo? lastModifiedMember)
+    {
+        ColumnName = columnName;
+        if (lastModifiedMember is not null)
+        {
+            _setter = LambdaBuilder.Setter<TDoc, DateTimeOffset>(lastModifiedMember);
+        }
+    }
+
+    public string ColumnName { get; }
+
+    public string ValueSql => "transaction_timestamp()";
+
+    public void BindParameter(DbParameter parameter, TDoc document, IStorageSession session)
+    {
+        // No-op — IsServerSide is true; the operation skips this binder
+        // in its write loop. The SQL literal in ValueSql does the work.
+    }
+
+    public void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IStorageSession session)
+    {
+        if (_setter is null) return;
+        if (reader.IsDBNull(columnOrdinal)) return;
+
+        var ts = reader.GetFieldValue<DateTimeOffset>(columnOrdinal);
+        _setter(document, ts);
+    }
+
+    public BulkColumnValue GetBulkValue(TDoc document)
+    {
+        // COPY can't run transaction_timestamp() — compute client-side.
+        // Slight skew vs. SQL writes that get the transaction's
+        // commit time; acceptable for the bulk path.
+        var now = DateTimeOffset.UtcNow;
+        _setter?.Invoke(document, now);
+        return new BulkColumnValue(now, StorageColumnType.Timestamp);
+    }
+}

--- a/src/Weasel.Storage/DocumentLastModifiedByBinder.cs
+++ b/src/Weasel.Storage/DocumentLastModifiedByBinder.cs
@@ -1,0 +1,61 @@
+#nullable enable
+using System;
+using System.Data.Common;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Core.Reflection;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// <see cref="IDocumentMetadataBinder{TDoc}"/> for the
+/// <c>last_modified_by</c> column. Value comes from
+/// <see cref="IStorageSession.LastModifiedBy"/> (alias of
+/// <c>CurrentUserName</c>) on every write; read path projects the stored
+/// value onto the document's <c>[LastModifiedBy]</c>-annotated member
+/// when one exists.
+/// </summary>
+public sealed class DocumentLastModifiedByBinder<TDoc>: IDocumentMetadataBinder<TDoc>
+    where TDoc : notnull
+{
+    private readonly Action<TDoc, string?>? _setter;
+
+    private readonly IStorageDialect _dialect;
+
+    public DocumentLastModifiedByBinder(string columnName, IStorageDialect dialect, MemberInfo? lastModifiedByMember)
+    {
+        ColumnName = columnName;
+        _dialect = dialect;
+        if (lastModifiedByMember is not null)
+        {
+            _setter = LambdaBuilder.Setter<TDoc, string?>(lastModifiedByMember);
+        }
+    }
+
+    public string ColumnName { get; }
+
+    public string ValueSql => "?";
+
+    public void BindParameter(DbParameter parameter, TDoc document, IStorageSession session)
+    {
+        _dialect.SetParameterType(parameter, StorageColumnType.String);
+        // IMetadataContext.LastModifiedBy is the alias of CurrentUserName;
+        // prefer CurrentUserName since the former is marked [Obsolete].
+        parameter.Value = (object?)session.CurrentUserName ?? DBNull.Value;
+    }
+
+    public void ApplyToDocument(TDoc document, IStorageSession session)
+        => _setter?.Invoke(document, session.CurrentUserName);
+
+    public void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IStorageSession session)
+    {
+        if (_setter is null) return;
+        if (reader.IsDBNull(columnOrdinal)) return;
+
+        var value = reader.GetFieldValue<string>(columnOrdinal);
+        _setter(document, value);
+    }
+
+    public BulkColumnValue GetBulkValue(TDoc document) => BulkColumnValue.Null;
+}

--- a/src/Weasel.Storage/DocumentRevisionBinder.cs
+++ b/src/Weasel.Storage/DocumentRevisionBinder.cs
@@ -1,0 +1,116 @@
+#nullable enable
+using System;
+using System.Data.Common;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Core.Reflection;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// W3 spike (M8): <see cref="IDocumentMetadataBinder{TDoc}"/> for the
+/// <c>mt_version</c> column when the mapping uses
+/// <see cref="ConcurrencyMode.Numeric"/>. The column is bigint rather
+/// than uuid; the binder projects the loaded revision onto the
+/// document's <c>[Version]</c>-annotated long member when one exists.
+/// </summary>
+/// <remarks>
+/// Operations bind this slot themselves with the appropriate value
+/// (caller-supplied <c>Revision</c> or auto-increment placeholder),
+/// so <see cref="BindParameter"/> is only used when the operation
+/// doesn't recognize the binder as the version slot — a defensive
+/// default that writes <c>0</c> and lets the SQL's <c>CASE</c>
+/// expression compute the effective value.
+/// </remarks>
+public sealed class DocumentRevisionBinder<TDoc>: IRevisionMetadataBinder<TDoc>
+    where TDoc : notnull
+{
+    private readonly Action<TDoc, long>? _setter;
+    private readonly StorageColumnType _columnType;
+
+    private readonly IStorageDialect _dialect;
+
+    public DocumentRevisionBinder(string columnName, IStorageDialect dialect, MemberInfo? revisionMember)
+        : this(columnName, dialect, revisionMember, StorageColumnType.Long)
+    {
+    }
+
+    public DocumentRevisionBinder(string columnName, IStorageDialect dialect, MemberInfo? revisionMember, StorageColumnType columnType)
+    {
+        ColumnName = columnName;
+        _dialect = dialect;
+        // #4614: the version column comes in two widths — bigint (default, used for
+        // ILongVersioned docs) or integer (used for IRevisioned docs, restored Marten 8
+        // behavior). The parameter's provider type has to match the column type so the database
+        // doesn't refuse the bind on the strict VALUES (CASE … END) path.
+        _columnType = columnType;
+
+        if (revisionMember is not null)
+        {
+            // #4526/#4528: regardless of column width, the document member is either int
+            // (IRevisioned) or long (ILongVersioned). Read-side conversion (long → int)
+            // handles the rare overflow path; the integer column can't overflow into an
+            // int member, but a bigint column with an int member can. Those docs should
+            // use ILongVersioned (documented caveat).
+            if (revisionMember.GetRawMemberType() == typeof(int))
+            {
+                var intSetter = LambdaBuilder.Setter<TDoc, int>(revisionMember);
+                _setter = (doc, revision) => intSetter(doc, (int)revision);
+            }
+            else
+            {
+                _setter = LambdaBuilder.Setter<TDoc, long>(revisionMember);
+            }
+        }
+    }
+
+    public StorageColumnType RevisionColumnType => _columnType;
+
+    public string ColumnName { get; }
+
+    public string ValueSql => "?";
+
+    public void BindParameter(DbParameter parameter, TDoc document, IStorageSession session)
+    {
+        if (_columnType == StorageColumnType.Int)
+        {
+            parameter.Value = 0;
+            _dialect.SetParameterType(parameter, StorageColumnType.Int);
+        }
+        else
+        {
+            parameter.Value = 0L;
+            _dialect.SetParameterType(parameter, StorageColumnType.Long);
+        }
+    }
+
+    public void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IStorageSession session)
+    {
+        if (_setter is null) return;
+        if (reader.IsDBNull(columnOrdinal)) return;
+
+        // Providers widen an int column to long via the field-value type handler, so
+        // reading as long works for both column widths.
+        var revision = reader.GetFieldValue<long>(columnOrdinal);
+        _setter(document, revision);
+    }
+
+    /// <summary>
+    /// W3 spike (M8): write a long revision directly onto the document's
+    /// <c>[Version]</c>-annotated member.
+    /// </summary>
+    public void ApplyRevisionTo(TDoc document, long revision)
+        => _setter?.Invoke(document, revision);
+
+    public BulkColumnValue GetBulkValue(TDoc document)
+    {
+        // Bulk path defaults to revision 1 — matches the codegen
+        // BulkLoader.GenerateBulkWriterCodeAsync's hard-coded "write
+        // (long)1" for RevisionArgument. The parameter type follows the column.
+        _setter?.Invoke(document, 1L);
+        return _columnType == StorageColumnType.Int
+            ? new BulkColumnValue(1, StorageColumnType.Int)
+            : new BulkColumnValue(1L, StorageColumnType.Long);
+    }
+}

--- a/src/Weasel.Storage/DocumentSoftDeletedAtBinder.cs
+++ b/src/Weasel.Storage/DocumentSoftDeletedAtBinder.cs
@@ -1,0 +1,60 @@
+#nullable enable
+using System;
+using System.Data.Common;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Core.Reflection;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// W3 spike (M9): <see cref="IDocumentMetadataBinder{TDoc}"/> for the
+/// <c>mt_deleted_at</c> column on a soft-delete mapping. Each write
+/// binds <see cref="DBNull"/> — only the soft-delete operation (issued
+/// via the inherited <c>DeleteFragment</c>) writes a concrete timestamp.
+/// Saving a previously soft-deleted document clears the timestamp,
+/// matching <c>UpsertFunction</c> codegen.
+/// </summary>
+public sealed class DocumentSoftDeletedAtBinder<TDoc>: IDocumentMetadataBinder<TDoc>
+    where TDoc : notnull
+{
+    private readonly Action<TDoc, DateTimeOffset?>? _setter;
+
+    private readonly IStorageDialect _dialect;
+
+    public DocumentSoftDeletedAtBinder(string columnName, IStorageDialect dialect, MemberInfo? member)
+    {
+        ColumnName = columnName;
+        _dialect = dialect;
+        if (member is not null)
+        {
+            _setter = LambdaBuilder.Setter<TDoc, DateTimeOffset?>(member);
+        }
+    }
+
+    public string ColumnName { get; }
+
+    public string ValueSql => "?";
+
+    public void BindParameter(DbParameter parameter, TDoc document, IStorageSession session)
+    {
+        parameter.Value = DBNull.Value;
+        _dialect.SetParameterType(parameter, StorageColumnType.Timestamp);
+    }
+
+    public void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IStorageSession session)
+    {
+        if (_setter is null) return;
+        if (reader.IsDBNull(columnOrdinal))
+        {
+            _setter(document, null);
+            return;
+        }
+
+        var value = reader.GetFieldValue<DateTimeOffset>(columnOrdinal);
+        _setter(document, value);
+    }
+
+    public BulkColumnValue GetBulkValue(TDoc document) => BulkColumnValue.Null;
+}

--- a/src/Weasel.Storage/DocumentSoftDeletedBinder.cs
+++ b/src/Weasel.Storage/DocumentSoftDeletedBinder.cs
@@ -1,0 +1,62 @@
+#nullable enable
+using System;
+using System.Data.Common;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Core.Reflection;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// W3 spike (M9): <see cref="IDocumentMetadataBinder{TDoc}"/> for the
+/// <c>mt_deleted</c> column on a soft-delete mapping. Each write resets
+/// the flag to <c>false</c> — saving a previously soft-deleted document
+/// undeletes it. Matches the codegen path's
+/// <c>UpsertFunction</c> behavior (the column appears in both the
+/// INSERT VALUES list and the ON CONFLICT DO UPDATE SET clause).
+/// </summary>
+/// <remarks>
+/// Read path: if the document declares an <c>[SoftDeleted]</c>-annotated
+/// member, the loaded boolean is projected onto it. Otherwise the
+/// column is in the table but absent from the SELECT projection.
+/// </remarks>
+public sealed class DocumentSoftDeletedBinder<TDoc>: IDocumentMetadataBinder<TDoc>
+    where TDoc : notnull
+{
+    private readonly Action<TDoc, bool>? _setter;
+
+    private readonly IStorageDialect _dialect;
+
+    public DocumentSoftDeletedBinder(string columnName, IStorageDialect dialect, MemberInfo? member)
+    {
+        ColumnName = columnName;
+        _dialect = dialect;
+        if (member is not null)
+        {
+            _setter = LambdaBuilder.Setter<TDoc, bool>(member);
+        }
+    }
+
+    public string ColumnName { get; }
+
+    public string ValueSql => "?";
+
+    public void BindParameter(DbParameter parameter, TDoc document, IStorageSession session)
+    {
+        parameter.Value = false;
+        _dialect.SetParameterType(parameter, StorageColumnType.Boolean);
+    }
+
+    public void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IStorageSession session)
+    {
+        if (_setter is null) return;
+        if (reader.IsDBNull(columnOrdinal)) return;
+
+        var value = reader.GetFieldValue<bool>(columnOrdinal);
+        _setter(document, value);
+    }
+
+    public BulkColumnValue GetBulkValue(TDoc document)
+        => new(false, StorageColumnType.Boolean);
+}

--- a/src/Weasel.Storage/DocumentTenantIdBinder.cs
+++ b/src/Weasel.Storage/DocumentTenantIdBinder.cs
@@ -1,0 +1,55 @@
+#nullable enable
+using System;
+using System.Data.Common;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Core.Reflection;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Read-only <see cref="IDocumentMetadataBinder{TDoc}"/> for the
+/// <c>tenant_id</c> column. The write side is handled directly in the
+/// storage operations (the tenant_id parameter is bound inline ahead of
+/// the binder loop, since it's a primary key column with a fixed
+/// position). This binder exists only so the read path can project the
+/// column onto the document's <c>[TenantId]</c>-annotated member when
+/// the mapping has one — added to <c>readBinders</c> only, never to
+/// <c>writeBinders</c>.
+/// </summary>
+public sealed class DocumentTenantIdBinder<TDoc>: IDocumentMetadataBinder<TDoc>
+    where TDoc : notnull
+{
+    private readonly Action<TDoc, string?>? _setter;
+
+    public DocumentTenantIdBinder(string columnName, MemberInfo? tenantIdMember)
+    {
+        ColumnName = columnName;
+        if (tenantIdMember is not null)
+        {
+            _setter = LambdaBuilder.Setter<TDoc, string?>(tenantIdMember);
+        }
+    }
+
+    public string ColumnName { get; }
+
+    public string ValueSql => "?";
+
+    public void BindParameter(DbParameter parameter, TDoc document, IStorageSession session)
+        => throw new NotSupportedException(
+            "tenant_id is bound directly by the storage operation; this binder is read-only.");
+
+    public void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IStorageSession session)
+    {
+        if (_setter is null) return;
+        if (reader.IsDBNull(columnOrdinal)) return;
+
+        var value = reader.GetFieldValue<string>(columnOrdinal);
+        _setter(document, value);
+    }
+
+    public BulkColumnValue GetBulkValue(TDoc document)
+        => throw new NotSupportedException(
+            "tenant_id is handled directly by the bulk loader; this binder is read-only.");
+}

--- a/src/Weasel.Storage/DocumentVersionBinder.cs
+++ b/src/Weasel.Storage/DocumentVersionBinder.cs
@@ -1,0 +1,81 @@
+#nullable enable
+using System;
+using System.Data.Common;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Core;
+using JasperFx.Core.Reflection;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// W3 spike (M1): <see cref="IDocumentMetadataBinder{TDoc}"/> for the
+/// <c>mt_version</c> column. Generates a new <see cref="Guid"/> per write
+/// via <c>CombGuidIdGeneration.NewGuid()</c>, projects it onto the
+/// document's <c>[Version]</c>-annotated member when one exists, binds
+/// it as a Uuid parameter. Read path projects the stored version back
+/// onto the same member if one exists.
+/// </summary>
+/// <remarks>
+/// The W3 spike doesn't implement optimistic concurrency yet — when that
+/// lands (M3), the new version is also stashed on the operation so
+/// <c>Postprocess</c> can compare against the row's prior version and
+/// raise <c>ConcurrencyException</c>. Today's spike just writes the new
+/// version unconditionally.
+/// </remarks>
+public sealed class DocumentVersionBinder<TDoc>: IVersionMetadataBinder<TDoc>
+    where TDoc : notnull
+{
+    private readonly Action<TDoc, Guid>? _setter;
+
+    private readonly IStorageDialect _dialect;
+
+    public DocumentVersionBinder(string columnName, IStorageDialect dialect, MemberInfo? versionMember)
+    {
+        ColumnName = columnName;
+        _dialect = dialect;
+        if (versionMember is not null)
+        {
+            _setter = LambdaBuilder.Setter<TDoc, Guid>(versionMember);
+        }
+    }
+
+    public string ColumnName { get; }
+
+    public string ValueSql => "?";
+
+    public void BindParameter(DbParameter parameter, TDoc document, IStorageSession session)
+    {
+        var newVersion = CombGuidIdGeneration.NewGuid();
+        _setter?.Invoke(document, newVersion);
+
+        parameter.Value = newVersion;
+        _dialect.SetParameterType(parameter, StorageColumnType.Guid);
+    }
+
+    public void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IStorageSession session)
+    {
+        if (_setter is null) return;
+        if (reader.IsDBNull(columnOrdinal)) return;
+
+        var version = reader.GetFieldValue<Guid>(columnOrdinal);
+        _setter(document, version);
+    }
+
+    /// <summary>
+    /// W3 spike (M7): write a Guid version directly onto the document's
+    /// <c>[Version]</c>-annotated member, bypassing the reader. Used from
+    /// the operation's Postprocess after it confirms the row's returned
+    /// version matches the just-written one.
+    /// </summary>
+    public void ApplyVersionTo(TDoc document, Guid version)
+        => _setter?.Invoke(document, version);
+
+    public BulkColumnValue GetBulkValue(TDoc document)
+    {
+        var newVersion = CombGuidIdGeneration.NewGuid();
+        _setter?.Invoke(document, newVersion);
+        return new BulkColumnValue(newVersion, StorageColumnType.Guid);
+    }
+}

--- a/src/Weasel.Storage/IStorageSession.cs
+++ b/src/Weasel.Storage/IStorageSession.cs
@@ -49,6 +49,14 @@ public interface IStorageSession: IMetadataContext
     Task<DbDataReader> ExecuteReaderAsync(DbCommand command, CancellationToken token = default);
 
     /// <summary>
+    ///     JSON-encoded bytes of the session's current header dictionary, when the owning store's
+    ///     session caches that serialization per batch — the headers metadata binder uses it to
+    ///     avoid re-serializing the same dictionary for every queued operation. Returns null when
+    ///     there are no headers (callers then bind a typed null). Default: no cache.
+    /// </summary>
+    byte[]? TryGetCachedSerializedHeaders() => null;
+
+    /// <summary>
     ///     Generates a unique temporary-table / CTE name scoped to this session. Used by LINQ
     ///     statement compilers for include queries and chained sub-selects — a session-scoped
     ///     concern any dialect performing include/CTE queries needs.


### PR DESCRIPTION
Fifth Weasel.Storage increment for the Marten **W2 storage-extraction epic** (JasperFx/marten#4821) — the 13 dialect-neutral document **metadata binders** (version, revision, created-at, last-modified(-by), correlation/causation ids, headers, tenant id, soft-delete flag + timestamp, doc-type alias, dotnet type), lifted from Marten with two mechanical de-couplings:

- provider parameter typing goes through ctor-injected **`IStorageDialect.SetParameterType(StorageColumnType)`** instead of casting to the provider's parameter type
- **column names are ctor-supplied** by the owning store's descriptor builder instead of referencing the store's schema constants

Plus a headers-cache seam on `IStorageSession` — `byte[]? TryGetCachedSerializedHeaders()` (default-null DIM) — so the headers binder reuses a store session's per-batch serialized-headers cache without downcasting to the store's session type.

The store-specific duplicated-field binder stays in the owning store (user-overridable provider column types by design).

Bumps to **9.12.0**. Follows #334 (selectors).

Validated downstream with local packs: Marten consumes with DocumentDb 1033 / EventSourcing 1421 / Daemon 198 / ValueType 339 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)