### PR TITLE
feat: injectable server-timestamp SQL on CreatedAt/LastModified binders

### DIFF
--- a/src/Weasel.Storage/DocumentCreatedAtBinder.cs
+++ b/src/Weasel.Storage/DocumentCreatedAtBinder.cs
@@ -32,8 +32,20 @@ public sealed class DocumentCreatedAtBinder<TDoc>: IDocumentMetadataBinder<TDoc>
     private readonly Action<TDoc, DateTimeOffset>? _setter;
 
     public DocumentCreatedAtBinder(string columnName, MemberInfo? createdAtMember)
+        : this(columnName, createdAtMember, "transaction_timestamp()")
+    {
+    }
+
+    /// <summary>
+    ///     Overload for non-Postgres dialects: <paramref name="serverTimestampSql" /> is the
+    ///     engine's transaction/statement timestamp function (e.g. <c>SYSDATETIMEOFFSET()</c>
+    ///     on SQL Server). Read-only binder, so this only matters where a descriptor builder
+    ///     chooses to surface the value SQL (e.g. INSERT-only column lists).
+    /// </summary>
+    public DocumentCreatedAtBinder(string columnName, MemberInfo? createdAtMember, string serverTimestampSql)
     {
         ColumnName = columnName;
+        ValueSql = serverTimestampSql;
         if (createdAtMember is not null)
         {
             _setter = LambdaBuilder.Setter<TDoc, DateTimeOffset>(createdAtMember);
@@ -47,7 +59,7 @@ public sealed class DocumentCreatedAtBinder<TDoc>: IDocumentMetadataBinder<TDoc>
     // is non-"?" so IsServerSide is true; even if a future caller adds
     // this binder to writeBinders, BindParameter throwing keeps the
     // "never written client-side" invariant honest.
-    public string ValueSql => "transaction_timestamp()";
+    public string ValueSql { get; }
 
     public void BindParameter(DbParameter parameter, TDoc document, IStorageSession session)
         => throw new NotSupportedException(

--- a/src/Weasel.Storage/DocumentLastModifiedBinder.cs
+++ b/src/Weasel.Storage/DocumentLastModifiedBinder.cs
@@ -21,8 +21,19 @@ public sealed class DocumentLastModifiedBinder<TDoc>: IDocumentMetadataBinder<TD
     private readonly Action<TDoc, DateTimeOffset>? _setter;
 
     public DocumentLastModifiedBinder(string columnName, MemberInfo? lastModifiedMember)
+        : this(columnName, lastModifiedMember, "transaction_timestamp()")
+    {
+    }
+
+    /// <summary>
+    ///     Overload for non-Postgres dialects: <paramref name="serverTimestampSql" /> is the
+    ///     engine's transaction/statement timestamp function (e.g. <c>SYSDATETIMEOFFSET()</c>
+    ///     on SQL Server) baked into the SQL as the column's server-side value.
+    /// </summary>
+    public DocumentLastModifiedBinder(string columnName, MemberInfo? lastModifiedMember, string serverTimestampSql)
     {
         ColumnName = columnName;
+        ValueSql = serverTimestampSql;
         if (lastModifiedMember is not null)
         {
             _setter = LambdaBuilder.Setter<TDoc, DateTimeOffset>(lastModifiedMember);
@@ -31,7 +42,7 @@ public sealed class DocumentLastModifiedBinder<TDoc>: IDocumentMetadataBinder<TD
 
     public string ColumnName { get; }
 
-    public string ValueSql => "transaction_timestamp()";
+    public string ValueSql { get; }
 
     public void BindParameter(DbParameter parameter, TDoc document, IStorageSession session)
     {


### PR DESCRIPTION
The closed-shape metadata binders extracted in #335 (marten#4821 INC-3) are dialect-neutral except for two: `DocumentCreatedAtBinder` and `DocumentLastModifiedBinder` hard-code `ValueSql` as Postgres's `transaction_timestamp()`. Polecat's SQL Server descriptor builder needs `SYSDATETIMEOFFSET()` there.

Adds a ctor overload taking `serverTimestampSql`; the existing ctor delegates with `transaction_timestamp()`, so Marten is source- and behavior-compatible with no change.

Part of the Critter Stack closed-shape convergence (JasperFx/polecat#273).

🤖 Generated with [Claude Code](https://claude.com/claude-code)