### PR TITLE
Weasel.Storage: the closed-shape write operations (marten#4821 INC-4)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>9.12.0</Version>
+        <Version>9.13.0</Version>
         <LangVersion>13.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/src/Weasel.Storage/ClosedShapeInsertOperation.cs
+++ b/src/Weasel.Storage/ClosedShapeInsertOperation.cs
@@ -1,0 +1,142 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Weasel.Core;
+
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Abstract base for the per-<see cref="ConcurrencyMode"/> closed-shape
+/// Insert operation. Holds the shared infrastructure (document, identity,
+/// tenant, descriptor, interface boilerplate) but pushes the parameter-
+/// binding and postprocess decisions onto sealed concurrency-specific
+/// subclasses so the hot path doesn't read <c>ConcurrencyMode</c> at
+/// runtime (#4659).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Subclasses:
+/// <list type="bullet">
+/// <item><see cref="UnversionedClosedShapeInsertOperation{TDoc, TId}"/> —
+///       <c>ConcurrencyMode.Off</c>; no version/revision binders to special-case.</item>
+/// <item><see cref="OptimisticClosedShapeInsertOperation{TDoc, TId}"/> —
+///       <c>ConcurrencyMode.Optimistic</c>; binds + tracks a Guid version
+///       per row.</item>
+/// <item><see cref="NumericClosedShapeInsertOperation{TDoc, TId}"/> —
+///       <c>ConcurrencyMode.Numeric</c>; binds a (2–4) revision-CASE block
+///       and tracks the returned revision.</item>
+/// </list>
+/// </para>
+/// </remarks>
+public abstract class ClosedShapeInsertOperation<TDoc, TId>: IDocumentStorageOperation, IRevisionedOperation, IIdentifiedOperation<TDoc, TId>, JasperFx.Core.Exceptions.IExceptionTransform
+    where TDoc : notnull
+    where TId : notnull
+{
+    protected readonly TDoc _document;
+    protected readonly TId _id;
+    protected readonly string _tenantId;
+    protected readonly DocumentStorageDescriptor<TDoc, TId> _descriptor;
+
+    protected ClosedShapeInsertOperation(
+        TDoc document,
+        TId id,
+        string tenantId,
+        DocumentStorageDescriptor<TDoc, TId> descriptor)
+    {
+        _document = document;
+        _id = id;
+        _tenantId = tenantId;
+        _descriptor = descriptor;
+    }
+
+    public TId Id => _id;
+
+    public long Revision { get; set; }
+
+    public bool IgnoreConcurrencyViolation { get; set; }
+
+    public Type DocumentType => typeof(TDoc);
+
+    public object Document => _document;
+
+    public IChangeTracker ToTracker(IStorageSession session)
+        => new ChangeTracker<TDoc>(session, _document);
+
+    public OperationRole Role() => OperationRole.Insert;
+
+    public abstract void ConfigureCommand(ICommandBuilder builder, IStorageSession session);
+
+    public abstract Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token);
+
+    /// <summary>
+    /// Bind the leading <c>[tenant_id, ] id, data</c> parameter triple and
+    /// project session-derived metadata onto the document before
+    /// serialization. Returns the next free parameter slot.
+    /// </summary>
+    /// <remarks>
+    /// Mirrors the codegen path's GenerateCodeToModifyDocument frames:
+    /// Correlation / Causation / Headers / LastModifiedBy etc. land on
+    /// the document so they flow into the JSON data column too.
+    /// </remarks>
+    protected int BindLeadingParameters(DbParameter[] parameters, IStorageSession session)
+    {
+        var slot = 0;
+        if (_descriptor.IsConjoined)
+        {
+            parameters[slot].Value = _tenantId;
+            _descriptor.Dialect.SetParameterType(parameters[slot], StorageColumnType.String);
+            slot++;
+        }
+
+        parameters[slot].Value = _descriptor.Identification.ToRawSqlValue(_id);
+        _descriptor.Dialect.SetIdParameterType(parameters[slot], _descriptor.Identification.RawSqlType);
+        slot++;
+
+        foreach (var binder in _descriptor.WriteBinders)
+        {
+            binder.ApplyToDocument(_document, session);
+        }
+
+        session.Serializer.WriteToParameter(parameters[slot], _document);
+        slot++;
+
+        return slot;
+    }
+
+    /// <summary>
+    /// Bind the optional <c>id [, tenant_id]</c> subquery slots that
+    /// <c>UseVersionFromMatchingStream</c> emits inside the revision
+    /// CASE expression. Returns the next free slot. Common to the
+    /// Numeric variants of Insert / Upsert / Overwrite.
+    /// </summary>
+    protected int BindUseVersionFromMatchingStreamSubquery(DbParameter[] parameters, int slot)
+    {
+        parameters[slot].Value = _descriptor.Identification.ToRawSqlValue(_id);
+        _descriptor.Dialect.SetIdParameterType(parameters[slot], _descriptor.Identification.RawSqlType);
+        slot++;
+
+        if (_descriptor.IsConjoined)
+        {
+            parameters[slot].Value = _tenantId;
+            _descriptor.Dialect.SetParameterType(parameters[slot], StorageColumnType.String);
+            slot++;
+        }
+
+        return slot;
+    }
+
+    public bool TryTransform(System.Exception original, out System.Exception? transformed)
+    {
+        if (_descriptor.ExceptionTransform is { } t)
+        {
+            return t.TryTransform(original, _descriptor.TableName, typeof(TDoc), _id!, out transformed);
+        }
+
+        transformed = null;
+        return false;
+    }
+}

--- a/src/Weasel.Storage/ClosedShapeOverwriteOperation.cs
+++ b/src/Weasel.Storage/ClosedShapeOverwriteOperation.cs
@@ -1,0 +1,135 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Weasel.Core;
+
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Abstract base for the per-<see cref="ConcurrencyMode"/> closed-shape
+/// Overwrite operation. Same shape as Upsert but the trailing
+/// concurrency guard is dropped — the caller has explicitly opted to
+/// bypass the optimistic / numeric check
+/// (<c>session.Store(doc, ignoreConcurrencyCheck: true)</c> or
+/// <see cref="Marten.Services.ConcurrencyChecks.Disabled"/>). Sealed
+/// subclasses provide the concrete <see cref="ConfigureCommand"/> +
+/// <see cref="PostprocessAsync"/> bodies so the hot path doesn't branch
+/// on <c>ConcurrencyMode</c> (#4659).
+/// </summary>
+public abstract class ClosedShapeOverwriteOperation<TDoc, TId>: IDocumentStorageOperation, IRevisionedOperation, IIdentifiedOperation<TDoc, TId>, JasperFx.Core.Exceptions.IExceptionTransform
+    where TDoc : notnull
+    where TId : notnull
+{
+    protected readonly TDoc _document;
+    protected readonly TId _id;
+    protected readonly string _tenantId;
+    protected readonly DocumentStorageDescriptor<TDoc, TId> _descriptor;
+
+    protected ClosedShapeOverwriteOperation(
+        TDoc document,
+        TId id,
+        string tenantId,
+        DocumentStorageDescriptor<TDoc, TId> descriptor)
+    {
+        _document = document;
+        _id = id;
+        _tenantId = tenantId;
+        _descriptor = descriptor;
+    }
+
+    public TId Id => _id;
+
+    public long Revision { get; set; }
+
+    public bool IgnoreConcurrencyViolation { get; set; }
+
+    public Type DocumentType => typeof(TDoc);
+
+    public object Document => _document;
+
+    public IChangeTracker ToTracker(IStorageSession session)
+        => new ChangeTracker<TDoc>(session, _document);
+
+    public OperationRole Role() => OperationRole.Update;
+
+    public abstract void ConfigureCommand(ICommandBuilder builder, IStorageSession session);
+
+    public abstract Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token);
+
+    /// <summary>
+    /// Bind <c>[tenant_id,] id, data</c> + the client-side write binders
+    /// up to (not including) the trailing ON CONFLICT SET concurrency
+    /// slots. Returns the next free parameter slot.
+    /// </summary>
+    protected int BindPreOnConflictParameters(DbParameter[] parameters, IStorageSession session)
+    {
+        var slot = 0;
+        if (_descriptor.IsConjoined)
+        {
+            parameters[slot].Value = _tenantId;
+            _descriptor.Dialect.SetParameterType(parameters[slot], StorageColumnType.String);
+            slot++;
+        }
+
+        parameters[slot].Value = _descriptor.Identification.ToRawSqlValue(_id);
+        _descriptor.Dialect.SetIdParameterType(parameters[slot], _descriptor.Identification.RawSqlType);
+        slot++;
+
+        foreach (var binder in _descriptor.WriteBinders)
+        {
+            binder.ApplyToDocument(_document, session);
+        }
+
+        session.Serializer.WriteToParameter(parameters[slot], _document);
+        slot++;
+
+        foreach (var binder in _descriptor.ClientSideWriteBinders)
+        {
+            slot = BindClientSideBinder(parameters, slot, binder, session);
+        }
+
+        return slot;
+    }
+
+    /// <summary>
+    /// Bind the optional <c>id [, tenant_id]</c> subquery slots that
+    /// <c>UseVersionFromMatchingStream</c> emits inside the revision CASE
+    /// expression.
+    /// </summary>
+    protected int BindUseVersionFromMatchingStreamSubquery(DbParameter[] parameters, int slot)
+    {
+        parameters[slot].Value = _descriptor.Identification.ToRawSqlValue(_id);
+        _descriptor.Dialect.SetIdParameterType(parameters[slot], _descriptor.Identification.RawSqlType);
+        slot++;
+
+        if (_descriptor.IsConjoined)
+        {
+            parameters[slot].Value = _tenantId;
+            _descriptor.Dialect.SetParameterType(parameters[slot], StorageColumnType.String);
+            slot++;
+        }
+
+        return slot;
+    }
+
+    /// <summary>
+    /// Concurrency-aware subclasses override to special-case the
+    /// VersionBinder / RevisionBinder.
+    /// </summary>
+    protected abstract int BindClientSideBinder(DbParameter[] parameters, int slot, IDocumentMetadataBinder<TDoc> binder, IStorageSession session);
+
+    public bool TryTransform(System.Exception original, out System.Exception? transformed)
+    {
+        if (_descriptor.ExceptionTransform is { } t)
+        {
+            return t.TryTransform(original, _descriptor.TableName, typeof(TDoc), _id!, out transformed);
+        }
+
+        transformed = null;
+        return false;
+    }
+}

--- a/src/Weasel.Storage/ClosedShapeUpdateOperation.cs
+++ b/src/Weasel.Storage/ClosedShapeUpdateOperation.cs
@@ -1,0 +1,134 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Weasel.Core;
+
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Abstract base for the per-<see cref="ConcurrencyMode"/> closed-shape
+/// Update operation. Sealed subclasses provide the concrete
+/// <see cref="ConfigureCommand"/> + <see cref="PostprocessAsync"/> bodies
+/// so the hot path doesn't branch on <c>ConcurrencyMode</c> (#4659).
+/// </summary>
+/// <remarks>
+/// Subclasses:
+/// <list type="bullet">
+/// <item><see cref="UnversionedClosedShapeUpdateOperation{TDoc, TId}"/> —
+///       missing row → <see cref="Marten.Exceptions.NonExistentDocumentException"/>.</item>
+/// <item><see cref="OptimisticClosedShapeUpdateOperation{TDoc, TId}"/> —
+///       missing row → <see cref="Marten.Exceptions.ConcurrencyException"/>
+///       (unless <see cref="IRevisionedOperation.IgnoreConcurrencyViolation"/>).</item>
+/// <item><see cref="NumericClosedShapeUpdateOperation{TDoc, TId}"/> —
+///       same as Optimistic but with a revision CASE/WHERE block.</item>
+/// </list>
+/// </remarks>
+public abstract class ClosedShapeUpdateOperation<TDoc, TId>: IDocumentStorageOperation, IRevisionedOperation, IIdentifiedOperation<TDoc, TId>, JasperFx.Core.Exceptions.IExceptionTransform
+    where TDoc : notnull
+    where TId : notnull
+{
+    protected readonly TDoc _document;
+    protected readonly TId _id;
+    protected readonly string _tenantId;
+    protected readonly DocumentStorageDescriptor<TDoc, TId> _descriptor;
+
+    protected ClosedShapeUpdateOperation(
+        TDoc document,
+        TId id,
+        string tenantId,
+        DocumentStorageDescriptor<TDoc, TId> descriptor)
+    {
+        _document = document;
+        _id = id;
+        _tenantId = tenantId;
+        _descriptor = descriptor;
+    }
+
+    public TId Id => _id;
+
+    public long Revision { get; set; }
+
+    public bool IgnoreConcurrencyViolation { get; set; }
+
+    public Type DocumentType => typeof(TDoc);
+
+    public object Document => _document;
+
+    public IChangeTracker ToTracker(IStorageSession session)
+        => new ChangeTracker<TDoc>(session, _document);
+
+    public OperationRole Role() => OperationRole.Update;
+
+    public abstract void ConfigureCommand(ICommandBuilder builder, IStorageSession session);
+
+    public abstract Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token);
+
+    /// <summary>
+    /// Bind data + client-side binders + id [+ tenant_id] [+ partition PK
+    /// binders], stopping at the trailing concurrency WHERE slot. Returns
+    /// the slot index for the concurrency-guard parameters that each
+    /// concurrency-specific leaf appends.
+    /// </summary>
+    /// <remarks>
+    /// Bug #4223: partitioned tables include the partition column(s) in
+    /// the PK, so the WHERE clause adds a <c>{col} = ?</c> slot per
+    /// partition column. Without this we'd update every row matching
+    /// <c>id = ?</c> across partitions.
+    /// </remarks>
+    protected int BindPreConcurrencyParameters(DbParameter[] parameters, IStorageSession session)
+    {
+        foreach (var binder in _descriptor.WriteBinders)
+        {
+            binder.ApplyToDocument(_document, session);
+        }
+
+        session.Serializer.WriteToParameter(parameters[0], _document);
+
+        var slot = 1;
+        foreach (var binder in _descriptor.ClientSideWriteBinders)
+        {
+            slot = BindClientSideBinder(parameters, slot, binder, session);
+        }
+
+        parameters[slot].Value = _descriptor.Identification.ToRawSqlValue(_id);
+        _descriptor.Dialect.SetIdParameterType(parameters[slot], _descriptor.Identification.RawSqlType);
+        slot++;
+
+        if (_descriptor.IsConjoined)
+        {
+            parameters[slot].Value = _tenantId;
+            _descriptor.Dialect.SetParameterType(parameters[slot], StorageColumnType.String);
+            slot++;
+        }
+
+        foreach (var pk in _descriptor.PartitionPkBinders)
+        {
+            pk.BindParameter(parameters[slot], _document, session);
+            slot++;
+        }
+
+        return slot;
+    }
+
+    /// <summary>
+    /// Bind a single client-side write binder; concurrency-aware
+    /// subclasses override this to special-case the VersionBinder /
+    /// RevisionBinder.
+    /// </summary>
+    protected abstract int BindClientSideBinder(DbParameter[] parameters, int slot, IDocumentMetadataBinder<TDoc> binder, IStorageSession session);
+
+    public bool TryTransform(System.Exception original, out System.Exception? transformed)
+    {
+        if (_descriptor.ExceptionTransform is { } t)
+        {
+            return t.TryTransform(original, _descriptor.TableName, typeof(TDoc), _id!, out transformed);
+        }
+
+        transformed = null;
+        return false;
+    }
+}

--- a/src/Weasel.Storage/ClosedShapeUpsertOperation.cs
+++ b/src/Weasel.Storage/ClosedShapeUpsertOperation.cs
@@ -1,0 +1,139 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Weasel.Core;
+
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Abstract base for the per-<see cref="ConcurrencyMode"/> closed-shape
+/// Upsert operation. Sealed subclasses provide the concrete
+/// <see cref="ConfigureCommand"/> + <see cref="PostprocessAsync"/> bodies
+/// so the hot path doesn't branch on <c>ConcurrencyMode</c> (#4659).
+/// </summary>
+/// <remarks>
+/// The Upsert <see cref="OperationRole"/> is supplied by the caller
+/// (Upsert or Insert) so the dirty-tracking change tracker can register
+/// the right kind of op against the session. Subclasses inherit the same
+/// role choice.
+/// </remarks>
+public abstract class ClosedShapeUpsertOperation<TDoc, TId>: IDocumentStorageOperation, IRevisionedOperation, IIdentifiedOperation<TDoc, TId>, JasperFx.Core.Exceptions.IExceptionTransform
+    where TDoc : notnull
+    where TId : notnull
+{
+    protected readonly TDoc _document;
+    protected readonly TId _id;
+    protected readonly string _tenantId;
+    protected readonly DocumentStorageDescriptor<TDoc, TId> _descriptor;
+    protected readonly OperationRole _role;
+
+    protected ClosedShapeUpsertOperation(
+        TDoc document,
+        TId id,
+        string tenantId,
+        DocumentStorageDescriptor<TDoc, TId> descriptor,
+        OperationRole role)
+    {
+        _document = document;
+        _id = id;
+        _tenantId = tenantId;
+        _descriptor = descriptor;
+        _role = role;
+    }
+
+    public TId Id => _id;
+
+    public long Revision { get; set; }
+
+    public bool IgnoreConcurrencyViolation { get; set; }
+
+    public Type DocumentType => typeof(TDoc);
+
+    public object Document => _document;
+
+    public IChangeTracker ToTracker(IStorageSession session)
+        => new ChangeTracker<TDoc>(session, _document);
+
+    public OperationRole Role() => _role;
+
+    public abstract void ConfigureCommand(ICommandBuilder builder, IStorageSession session);
+
+    public abstract Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token);
+
+    /// <summary>
+    /// Bind <c>[tenant_id,] id, data</c> + the client-side write binders
+    /// up to (not including) the trailing ON CONFLICT concurrency-extras
+    /// slots. Returns the next free parameter slot.
+    /// </summary>
+    protected int BindPreOnConflictParameters(DbParameter[] parameters, IStorageSession session)
+    {
+        var slot = 0;
+        if (_descriptor.IsConjoined)
+        {
+            parameters[slot].Value = _tenantId;
+            _descriptor.Dialect.SetParameterType(parameters[slot], StorageColumnType.String);
+            slot++;
+        }
+
+        parameters[slot].Value = _descriptor.Identification.ToRawSqlValue(_id);
+        _descriptor.Dialect.SetIdParameterType(parameters[slot], _descriptor.Identification.RawSqlType);
+        slot++;
+
+        foreach (var binder in _descriptor.WriteBinders)
+        {
+            binder.ApplyToDocument(_document, session);
+        }
+
+        session.Serializer.WriteToParameter(parameters[slot], _document);
+        slot++;
+
+        foreach (var binder in _descriptor.ClientSideWriteBinders)
+        {
+            slot = BindClientSideBinder(parameters, slot, binder, session);
+        }
+
+        return slot;
+    }
+
+    /// <summary>
+    /// Bind the optional <c>id [, tenant_id]</c> subquery slots that
+    /// <c>UseVersionFromMatchingStream</c> emits inside the revision CASE
+    /// expression. Common to Numeric Upsert / Overwrite.
+    /// </summary>
+    protected int BindUseVersionFromMatchingStreamSubquery(DbParameter[] parameters, int slot)
+    {
+        parameters[slot].Value = _descriptor.Identification.ToRawSqlValue(_id);
+        _descriptor.Dialect.SetIdParameterType(parameters[slot], _descriptor.Identification.RawSqlType);
+        slot++;
+
+        if (_descriptor.IsConjoined)
+        {
+            parameters[slot].Value = _tenantId;
+            _descriptor.Dialect.SetParameterType(parameters[slot], StorageColumnType.String);
+            slot++;
+        }
+
+        return slot;
+    }
+
+    /// <summary>
+    /// Concurrency-aware subclasses override to special-case the
+    /// VersionBinder / RevisionBinder.
+    /// </summary>
+    protected abstract int BindClientSideBinder(DbParameter[] parameters, int slot, IDocumentMetadataBinder<TDoc> binder, IStorageSession session);
+
+    public bool TryTransform(System.Exception original, out System.Exception? transformed)
+    {
+        if (_descriptor.ExceptionTransform is { } t)
+        {
+            return t.TryTransform(original, _descriptor.TableName, typeof(TDoc), _id!, out transformed);
+        }
+
+        transformed = null;
+        return false;
+    }
+}

--- a/src/Weasel.Storage/DocumentStorageDescriptor.cs
+++ b/src/Weasel.Storage/DocumentStorageDescriptor.cs
@@ -59,7 +59,9 @@ public sealed class DocumentStorageDescriptor<TDoc, TId>
         int docTypeReadIndex,
         string tableName,
         IDocumentMetadataBinder<TDoc>[]? partitionPkBinders = null,
-        bool useVersionFromMatchingStream = false)
+        bool useVersionFromMatchingStream = false,
+        IOperationExceptionTransform? exceptionTransform = null,
+        Func<Type, object, Exception>? createMissingDocumentException = null)
     {
         Identification = identification;
         Serializer = serializer;
@@ -82,7 +84,21 @@ public sealed class DocumentStorageDescriptor<TDoc, TId>
         DocTypeReadIndex = docTypeReadIndex;
         PartitionPkBinders = partitionPkBinders ?? Array.Empty<IDocumentMetadataBinder<TDoc>>();
         UseVersionFromMatchingStream = useVersionFromMatchingStream;
+        ExceptionTransform = exceptionTransform;
+        CreateMissingDocumentException = createMissingDocumentException;
     }
+
+    /// <summary>
+    ///     Optional store-supplied translation of provider exceptions raised by the write
+    ///     operations (unique-constraint violations, etc.). Null = no translation.
+    /// </summary>
+    public IOperationExceptionTransform? ExceptionTransform { get; }
+
+    /// <summary>
+    ///     Optional store-supplied factory for the exception raised when an Update targets a
+    ///     document that does not exist. Null = a plain InvalidOperationException.
+    /// </summary>
+    public Func<Type, object, Exception>? CreateMissingDocumentException { get; }
 
     /// <summary>
     /// When set, the closed-shape SQL pulls the revision from the matching row in the event

--- a/src/Weasel.Storage/IDocumentStorageOperation.cs
+++ b/src/Weasel.Storage/IDocumentStorageOperation.cs
@@ -1,0 +1,34 @@
+#nullable enable
+namespace Weasel.Storage;
+
+/// <summary>
+///     A storage operation that persists one document instance — surfaces the document for
+///     unit-of-work bookkeeping (dedupe on re-Store, change-set reporting) and can convert
+///     itself into the dirty-tracking <see cref="IChangeTracker"/> registered after a commit.
+/// </summary>
+public interface IDocumentStorageOperation: IStorageOperation
+{
+    object Document { get; }
+    IChangeTracker ToTracker(IStorageSession session);
+}
+
+/// <summary>
+///     Implemented by write operations under numeric-revision concurrency: the caller-supplied
+///     revision (0 = auto-increment) and the opt-out that turns a revision miss into a no-op
+///     instead of a concurrency exception.
+/// </summary>
+public interface IRevisionedOperation
+{
+    long Revision { get; set; }
+    bool IgnoreConcurrencyViolation { get; set; }
+}
+
+/// <summary>
+///     Implemented by storage operations that carry a typed document id, so the session's
+///     unit-of-work can dedupe pending operations when a caller issues Store-then-Delete on the
+///     same id.
+/// </summary>
+public interface IIdentifiedOperation<TDoc, TId> where TDoc : notnull where TId : notnull
+{
+    TId Id { get; }
+}

--- a/src/Weasel.Storage/IOperationExceptionTransform.cs
+++ b/src/Weasel.Storage/IOperationExceptionTransform.cs
@@ -1,0 +1,15 @@
+#nullable enable
+namespace Weasel.Storage;
+
+/// <summary>
+///     Optional per-store seam for translating provider exceptions raised by the closed-shape
+///     write operations into store-specific exceptions (e.g. a unique-constraint violation on
+///     the document table into a document-already-exists exception). Supplied to the
+///     <see cref="DocumentStorageDescriptor{TDoc,TId}"/> by the owning store's descriptor
+///     builder; the operations pass their table name, document type, and identity so the
+///     transform can scope its match.
+/// </summary>
+public interface IOperationExceptionTransform
+{
+    bool TryTransform(Exception original, string tableName, Type documentType, object id, out Exception? transformed);
+}

--- a/src/Weasel.Storage/NumericClosedShapeInsertOperation.cs
+++ b/src/Weasel.Storage/NumericClosedShapeInsertOperation.cs
@@ -1,0 +1,111 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using Weasel.Core;
+
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// <c>ConcurrencyMode.Numeric</c> closed-shape Insert. Binds the revision
+/// <c>CASE WHEN ? = 0 THEN … ELSE ? END</c> block (2–4 parameter slots
+/// depending on <see cref="DocumentStorageDescriptor{TDoc,TId}.UseVersionFromMatchingStream"/>
+/// + <see cref="DocumentStorageDescriptor{TDoc,TId}.IsConjoined"/>),
+/// reads the resolved revision out of the RETURNING row, and writes it
+/// back through <see cref="DocumentRevisionBinder{TDoc}.ApplyRevisionTo"/>
+/// + the session's per-type revision tracker. #4659 leaf.
+/// </summary>
+public sealed class NumericClosedShapeInsertOperation<TDoc, TId>: ClosedShapeInsertOperation<TDoc, TId>
+    where TDoc : notnull
+    where TId : notnull
+{
+    private readonly Dictionary<TId, long>? _revisions;
+
+    public NumericClosedShapeInsertOperation(
+        TDoc document,
+        TId id,
+        string tenantId,
+        DocumentStorageDescriptor<TDoc, TId> descriptor,
+        Dictionary<TId, long>? revisions)
+        : base(document, id, tenantId, descriptor)
+    {
+        _revisions = revisions;
+    }
+
+    public override void ConfigureCommand(ICommandBuilder builder, IStorageSession session)
+    {
+        var parameters = builder.AppendWithDbParameters(_descriptor.InsertSql, '?');
+        var slot = BindLeadingParameters(parameters, session);
+
+        foreach (var binder in _descriptor.ClientSideWriteBinders)
+        {
+            if (ReferenceEquals(binder, _descriptor.RevisionBinder))
+            {
+                slot = BindRevisionBlock(parameters, slot);
+            }
+            else
+            {
+                binder.BindParameter(parameters[slot], _document, session);
+                slot++;
+            }
+        }
+    }
+
+    public override async Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)
+    {
+        if (!await reader.ReadAsync(token).ConfigureAwait(false))
+        {
+            exceptions.Add(new DocumentAlreadyExistsException(null, typeof(TDoc), _id));
+            return;
+        }
+
+        var newRevision = await reader.GetFieldValueAsync<long>(0, token).ConfigureAwait(false);
+        // #4667 — null tracker (the InsertProjected path) skips the tracker
+        // write. RevisionBinder still applies so the document's revision
+        // field is fresh.
+        if (_revisions is not null)
+        {
+            _revisions[_id] = newRevision;
+        }
+        _descriptor.RevisionBinder!.ApplyRevisionTo(_document, newRevision);
+    }
+
+    /// <summary>
+    /// Numeric Insert binds the revision CASE expression in two/three/four
+    /// slots:
+    /// <list type="bullet">
+    /// <item>Default: <c>CASE WHEN ? = 0 THEN 1 ELSE ? END</c> (2 slots).</item>
+    /// <item><c>UseVersionFromMatchingStream</c> (non-conjoined):
+    ///   <c>CASE WHEN ? = 0 THEN COALESCE((select version from mt_streams where id = ?), 1) ELSE ? END</c>
+    ///   (3 slots — the <c>? = 0</c> check, the id subquery, the explicit revision).</item>
+    /// <item><c>UseVersionFromMatchingStream + IsConjoined</c>: extra <c>?</c> for
+    ///   <c>tenant_id</c> inside the subquery (4 slots).</item>
+    /// </list>
+    /// #4614: the parameter type tracks the column width (integer vs bigint)
+    /// so the CASE branch types align.
+    /// </summary>
+    private int BindRevisionBlock(DbParameter[] parameters, int slot)
+    {
+        var revisionColumnType = _descriptor.RevisionBinder!.RevisionColumnType;
+        var revisionValue = revisionColumnType == StorageColumnType.Int
+            ? (object)checked((int)Revision)
+            : Revision;
+
+        parameters[slot].Value = revisionValue;
+        _descriptor.Dialect.SetParameterType(parameters[slot], revisionColumnType);
+        slot++;
+
+        if (_descriptor.UseVersionFromMatchingStream)
+        {
+            slot = BindUseVersionFromMatchingStreamSubquery(parameters, slot);
+        }
+
+        parameters[slot].Value = revisionValue;
+        _descriptor.Dialect.SetParameterType(parameters[slot], revisionColumnType);
+        return slot + 1;
+    }
+}

--- a/src/Weasel.Storage/NumericClosedShapeOverwriteOperation.cs
+++ b/src/Weasel.Storage/NumericClosedShapeOverwriteOperation.cs
@@ -1,0 +1,92 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Weasel.Core;
+
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// <c>ConcurrencyMode.Numeric</c> closed-shape Overwrite. Same INSERT
+/// VALUES revision CASE block as the Numeric Upsert path, but the SET
+/// CASE is 2 slots (no WHERE guard). #4658 — the
+/// <see cref="DocumentStorage{TDoc,TId}.OverwriteProjected"/> path passes
+/// a null revisions tracker so the projection doesn't poison the
+/// session's revision dictionary. #4659 leaf.
+/// </summary>
+public sealed class NumericClosedShapeOverwriteOperation<TDoc, TId>: ClosedShapeOverwriteOperation<TDoc, TId>
+    where TDoc : notnull
+    where TId : notnull
+{
+    private readonly Dictionary<TId, long>? _revisions;
+
+    public NumericClosedShapeOverwriteOperation(
+        TDoc document,
+        TId id,
+        string tenantId,
+        DocumentStorageDescriptor<TDoc, TId> descriptor,
+        Dictionary<TId, long>? revisions)
+        : base(document, id, tenantId, descriptor)
+    {
+        _revisions = revisions;
+    }
+
+    public override void ConfigureCommand(ICommandBuilder builder, IStorageSession session)
+    {
+        var parameters = builder.AppendWithDbParameters(_descriptor.OverwriteSql, '?');
+        var slot = BindPreOnConflictParameters(parameters, session);
+
+        // DO UPDATE SET mt_version = CASE WHEN ? = 0 THEN current+1 ELSE ? END
+        // No WHERE guard — Overwrite always wins.
+        parameters[slot].Value = Revision;
+        _descriptor.Dialect.SetParameterType(parameters[slot], StorageColumnType.Long);
+        parameters[slot + 1].Value = Revision;
+        _descriptor.Dialect.SetParameterType(parameters[slot + 1], StorageColumnType.Long);
+    }
+
+    public override async Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)
+    {
+        if (await reader.ReadAsync(token).ConfigureAwait(false))
+        {
+            var newRevision = await reader.GetFieldValueAsync<long>(0, token).ConfigureAwait(false);
+            // #4658 — null tracker (OverwriteProjected) just skips the
+            // tracker write. RevisionBinder write still happens so the
+            // document's revision field is fresh.
+            if (_revisions is not null)
+            {
+                _revisions[_id] = newRevision;
+            }
+            _descriptor.RevisionBinder!.ApplyRevisionTo(_document, newRevision);
+        }
+    }
+
+    protected override int BindClientSideBinder(DbParameter[] parameters, int slot, IDocumentMetadataBinder<TDoc> binder, IStorageSession session)
+    {
+        if (ReferenceEquals(binder, _descriptor.RevisionBinder))
+        {
+            // INSERT VALUES CASE block — same shape as NumericClosedShapeUpsertOperation.
+            var revisionColumnType = _descriptor.RevisionBinder!.RevisionColumnType;
+            var revisionValue = revisionColumnType == StorageColumnType.Int
+                ? (object)checked((int)Revision)
+                : Revision;
+            parameters[slot].Value = revisionValue;
+            _descriptor.Dialect.SetParameterType(parameters[slot], revisionColumnType);
+            slot++;
+
+            if (_descriptor.UseVersionFromMatchingStream)
+            {
+                slot = BindUseVersionFromMatchingStreamSubquery(parameters, slot);
+            }
+
+            parameters[slot].Value = revisionValue;
+            _descriptor.Dialect.SetParameterType(parameters[slot], revisionColumnType);
+            return slot + 1;
+        }
+
+        binder.BindParameter(parameters[slot], _document, session);
+        return slot + 1;
+    }
+}

--- a/src/Weasel.Storage/NumericClosedShapeUpdateOperation.cs
+++ b/src/Weasel.Storage/NumericClosedShapeUpdateOperation.cs
@@ -1,0 +1,96 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using Weasel.Core;
+
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// <c>ConcurrencyMode.Numeric</c> closed-shape Update. Two revision
+/// slots in the SET CASE expression (<c>CASE WHEN ? = 0 THEN
+/// current+1 ELSE ? END</c>) plus two in the trailing WHERE clause
+/// (<c>? = 0 OR table.mt_version &lt; ?</c>). Missing RETURNING row →
+/// revision-guard failure → <see cref="ConcurrencyException"/>. #4659 leaf.
+/// </summary>
+public sealed class NumericClosedShapeUpdateOperation<TDoc, TId>: ClosedShapeUpdateOperation<TDoc, TId>
+    where TDoc : notnull
+    where TId : notnull
+{
+    private readonly Dictionary<TId, long>? _revisions;
+
+    public NumericClosedShapeUpdateOperation(
+        TDoc document,
+        TId id,
+        string tenantId,
+        DocumentStorageDescriptor<TDoc, TId> descriptor,
+        Dictionary<TId, long>? revisions)
+        : base(document, id, tenantId, descriptor)
+    {
+        _revisions = revisions;
+    }
+
+    public override void ConfigureCommand(ICommandBuilder builder, IStorageSession session)
+    {
+        var parameters = builder.AppendWithDbParameters(_descriptor.UpdateSql, '?');
+        var slot = BindPreConcurrencyParameters(parameters, session);
+
+        // Trailing WHERE (? = 0 or {table}.mt_version < ?) — bind the raw
+        // Revision to both slots. #4614: parameter type tracks column width.
+        var revisionColumnType = _descriptor.RevisionBinder!.RevisionColumnType;
+        var revisionValue = revisionColumnType == StorageColumnType.Int
+            ? (object)checked((int)Revision)
+            : Revision;
+        parameters[slot].Value = revisionValue;
+        _descriptor.Dialect.SetParameterType(parameters[slot], revisionColumnType);
+        parameters[slot + 1].Value = revisionValue;
+        _descriptor.Dialect.SetParameterType(parameters[slot + 1], revisionColumnType);
+    }
+
+    public override async Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)
+    {
+        if (!await reader.ReadAsync(token).ConfigureAwait(false))
+        {
+            if (!IgnoreConcurrencyViolation)
+            {
+                exceptions.Add(new ConcurrencyException(typeof(TDoc), _id));
+            }
+            return;
+        }
+
+        var newRevision = await reader.GetFieldValueAsync<long>(0, token).ConfigureAwait(false);
+        // #4667 — null tracker (the UpdateProjected path) skips the tracker
+        // write. RevisionBinder still applies so the document's revision
+        // field is fresh.
+        if (_revisions is not null)
+        {
+            _revisions[_id] = newRevision;
+        }
+        _descriptor.RevisionBinder!.ApplyRevisionTo(_document, newRevision);
+    }
+
+    protected override int BindClientSideBinder(DbParameter[] parameters, int slot, IDocumentMetadataBinder<TDoc> binder, IStorageSession session)
+    {
+        if (ReferenceEquals(binder, _descriptor.RevisionBinder))
+        {
+            // SET mt_version = CASE WHEN ? = 0 THEN current+1 ELSE ? END
+            // (2 slots — Update side never uses UseVersionFromMatchingStream)
+            var revisionColumnType = _descriptor.RevisionBinder!.RevisionColumnType;
+            var revisionValue = revisionColumnType == StorageColumnType.Int
+                ? (object)checked((int)Revision)
+                : Revision;
+            parameters[slot].Value = revisionValue;
+            _descriptor.Dialect.SetParameterType(parameters[slot], revisionColumnType);
+            parameters[slot + 1].Value = revisionValue;
+            _descriptor.Dialect.SetParameterType(parameters[slot + 1], revisionColumnType);
+            return slot + 2;
+        }
+
+        binder.BindParameter(parameters[slot], _document, session);
+        return slot + 1;
+    }
+}

--- a/src/Weasel.Storage/NumericClosedShapeUpsertOperation.cs
+++ b/src/Weasel.Storage/NumericClosedShapeUpsertOperation.cs
@@ -1,0 +1,104 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using Weasel.Core;
+
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// <c>ConcurrencyMode.Numeric</c> closed-shape Upsert. Two/three/four
+/// revision slots in the INSERT VALUES CASE block (depending on
+/// <see cref="DocumentStorageDescriptor{TDoc,TId}.UseVersionFromMatchingStream"/>
+/// + <see cref="DocumentStorageDescriptor{TDoc,TId}.IsConjoined"/>) plus
+/// four more in the ON CONFLICT DO UPDATE SET/WHERE block. Missing
+/// RETURNING row → revision-guard failure →
+/// <see cref="ConcurrencyException"/>. #4659 leaf.
+/// </summary>
+public sealed class NumericClosedShapeUpsertOperation<TDoc, TId>: ClosedShapeUpsertOperation<TDoc, TId>
+    where TDoc : notnull
+    where TId : notnull
+{
+    private readonly Dictionary<TId, long>? _revisions;
+
+    public NumericClosedShapeUpsertOperation(
+        TDoc document,
+        TId id,
+        string tenantId,
+        DocumentStorageDescriptor<TDoc, TId> descriptor,
+        OperationRole role,
+        Dictionary<TId, long>? revisions)
+        : base(document, id, tenantId, descriptor, role)
+    {
+        _revisions = revisions;
+    }
+
+    public override void ConfigureCommand(ICommandBuilder builder, IStorageSession session)
+    {
+        var parameters = builder.AppendWithDbParameters(_descriptor.UpsertSql, '?');
+        var slot = BindPreOnConflictParameters(parameters, session);
+
+        // ON CONFLICT trailing:
+        //   DO UPDATE SET mt_version = CASE WHEN ? = 0 THEN current+1 ELSE ? END
+        //   WHERE ? = 0 OR table.mt_version < ?
+        for (var i = 0; i < 4; i++)
+        {
+            parameters[slot + i].Value = Revision;
+            _descriptor.Dialect.SetParameterType(parameters[slot + i], StorageColumnType.Long);
+        }
+    }
+
+    public override async Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)
+    {
+        if (!await reader.ReadAsync(token).ConfigureAwait(false))
+        {
+            if (!IgnoreConcurrencyViolation)
+            {
+                exceptions.Add(new ConcurrencyException(typeof(TDoc), _id));
+            }
+            return;
+        }
+
+        var newRevision = await reader.GetFieldValueAsync<long>(0, token).ConfigureAwait(false);
+        // #4667 — null tracker (the UpsertProjected path) skips the tracker
+        // write. RevisionBinder still applies so the document's revision
+        // field is fresh.
+        if (_revisions is not null)
+        {
+            _revisions[_id] = newRevision;
+        }
+        _descriptor.RevisionBinder!.ApplyRevisionTo(_document, newRevision);
+    }
+
+    protected override int BindClientSideBinder(DbParameter[] parameters, int slot, IDocumentMetadataBinder<TDoc> binder, IStorageSession session)
+    {
+        if (ReferenceEquals(binder, _descriptor.RevisionBinder))
+        {
+            // INSERT VALUES CASE block — see NumericClosedShapeInsertOperation
+            // for the slot-count rationale.
+            var revisionColumnType = _descriptor.RevisionBinder!.RevisionColumnType;
+            var revisionValue = revisionColumnType == StorageColumnType.Int
+                ? (object)checked((int)Revision)
+                : Revision;
+            parameters[slot].Value = revisionValue;
+            _descriptor.Dialect.SetParameterType(parameters[slot], revisionColumnType);
+            slot++;
+
+            if (_descriptor.UseVersionFromMatchingStream)
+            {
+                slot = BindUseVersionFromMatchingStreamSubquery(parameters, slot);
+            }
+
+            parameters[slot].Value = revisionValue;
+            _descriptor.Dialect.SetParameterType(parameters[slot], revisionColumnType);
+            return slot + 1;
+        }
+
+        binder.BindParameter(parameters[slot], _document, session);
+        return slot + 1;
+    }
+}

--- a/src/Weasel.Storage/OptimisticClosedShapeInsertOperation.cs
+++ b/src/Weasel.Storage/OptimisticClosedShapeInsertOperation.cs
@@ -1,0 +1,77 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using JasperFx.Core;
+using Weasel.Core;
+
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// <c>ConcurrencyMode.Optimistic</c> closed-shape Insert. Generates a
+/// fresh Guid version at construction time, binds it in place of the
+/// VersionBinder's parameter slot, then writes it back through
+/// <see cref="DocumentVersionBinder{TDoc}.ApplyVersionTo"/> + the
+/// session's per-type version tracker on RETURNING success. #4659 leaf.
+/// </summary>
+public sealed class OptimisticClosedShapeInsertOperation<TDoc, TId>: ClosedShapeInsertOperation<TDoc, TId>
+    where TDoc : notnull
+    where TId : notnull
+{
+    private readonly Dictionary<TId, Guid>? _versions;
+    private readonly Guid _newVersion;
+
+    public OptimisticClosedShapeInsertOperation(
+        TDoc document,
+        TId id,
+        string tenantId,
+        DocumentStorageDescriptor<TDoc, TId> descriptor,
+        Dictionary<TId, Guid>? versions)
+        : base(document, id, tenantId, descriptor)
+    {
+        _versions = versions;
+        _newVersion = CombGuidIdGeneration.NewGuid();
+    }
+
+    public override void ConfigureCommand(ICommandBuilder builder, IStorageSession session)
+    {
+        var parameters = builder.AppendWithDbParameters(_descriptor.InsertSql, '?');
+        var slot = BindLeadingParameters(parameters, session);
+
+        foreach (var binder in _descriptor.ClientSideWriteBinders)
+        {
+            if (ReferenceEquals(binder, _descriptor.VersionBinder))
+            {
+                parameters[slot].Value = _newVersion;
+                _descriptor.Dialect.SetParameterType(parameters[slot], StorageColumnType.Guid);
+                _descriptor.VersionBinder!.ApplyVersionTo(_document, _newVersion);
+            }
+            else
+            {
+                binder.BindParameter(parameters[slot], _document, session);
+            }
+            slot++;
+        }
+    }
+
+    public override async Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)
+    {
+        if (!await reader.ReadAsync(token).ConfigureAwait(false))
+        {
+            exceptions.Add(new DocumentAlreadyExistsException(null, typeof(TDoc), _id));
+            return;
+        }
+
+        // #4667 — null tracker (the InsertProjected path) just skips the
+        // tracker write. The fresh version is still applied to the document
+        // via VersionBinder during command configuration.
+        if (_versions is not null)
+        {
+            _versions[_id] = _newVersion;
+        }
+    }
+}

--- a/src/Weasel.Storage/OptimisticClosedShapeOverwriteOperation.cs
+++ b/src/Weasel.Storage/OptimisticClosedShapeOverwriteOperation.cs
@@ -1,0 +1,77 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using JasperFx.Core;
+using Weasel.Core;
+
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// <c>ConcurrencyMode.Optimistic</c> closed-shape Overwrite. Generates a
+/// fresh Guid version, binds it for the SET VersionBinder slot, no
+/// trailing WHERE guard (Overwrite explicitly skips the version check).
+/// PostprocessAsync writes the new version to the session tracker on
+/// RETURNING success; a missing row only happens when the tracker dict
+/// was supplied null (the projection / fire-and-forget path) — silent
+/// no-op. #4659 leaf.
+/// </summary>
+public sealed class OptimisticClosedShapeOverwriteOperation<TDoc, TId>: ClosedShapeOverwriteOperation<TDoc, TId>
+    where TDoc : notnull
+    where TId : notnull
+{
+    private readonly Dictionary<TId, Guid>? _versions;
+    private readonly Guid _newVersion;
+
+    public OptimisticClosedShapeOverwriteOperation(
+        TDoc document,
+        TId id,
+        string tenantId,
+        DocumentStorageDescriptor<TDoc, TId> descriptor,
+        Dictionary<TId, Guid>? versions)
+        : base(document, id, tenantId, descriptor)
+    {
+        _versions = versions;
+        _newVersion = CombGuidIdGeneration.NewGuid();
+    }
+
+    public override void ConfigureCommand(ICommandBuilder builder, IStorageSession session)
+    {
+        var parameters = builder.AppendWithDbParameters(_descriptor.OverwriteSql, '?');
+        BindPreOnConflictParameters(parameters, session);
+        // Overwrite drops the trailing concurrency-guard slot vs Upsert.
+    }
+
+    public override async Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)
+    {
+        if (await reader.ReadAsync(token).ConfigureAwait(false))
+        {
+            // #4658 — null tracker (the OverwriteProjected path) just
+            // skips the tracker write. The fresh version is still
+            // applied to the document via VersionBinder during command
+            // configuration.
+            if (_versions is not null)
+            {
+                _versions[_id] = _newVersion;
+            }
+        }
+    }
+
+    protected override int BindClientSideBinder(DbParameter[] parameters, int slot, IDocumentMetadataBinder<TDoc> binder, IStorageSession session)
+    {
+        if (ReferenceEquals(binder, _descriptor.VersionBinder))
+        {
+            parameters[slot].Value = _newVersion;
+            _descriptor.Dialect.SetParameterType(parameters[slot], StorageColumnType.Guid);
+            _descriptor.VersionBinder!.ApplyVersionTo(_document, _newVersion);
+            return slot + 1;
+        }
+
+        binder.BindParameter(parameters[slot], _document, session);
+        return slot + 1;
+    }
+}

--- a/src/Weasel.Storage/OptimisticClosedShapeUpdateOperation.cs
+++ b/src/Weasel.Storage/OptimisticClosedShapeUpdateOperation.cs
@@ -1,0 +1,95 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using JasperFx.Core;
+using Weasel.Core;
+
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// <c>ConcurrencyMode.Optimistic</c> closed-shape Update. Generates a
+/// fresh Guid version at construction time, binds it for the SET
+/// VersionBinder slot, and binds the caller's expected Guid version
+/// (from the session tracker, or DBNull if unknown) at the trailing
+/// WHERE concurrency slot. Missing RETURNING row → version mismatch →
+/// <see cref="ConcurrencyException"/>. #4659 leaf.
+/// </summary>
+public sealed class OptimisticClosedShapeUpdateOperation<TDoc, TId>: ClosedShapeUpdateOperation<TDoc, TId>
+    where TDoc : notnull
+    where TId : notnull
+{
+    private readonly Dictionary<TId, Guid>? _versions;
+    private readonly Guid _newVersion;
+
+    public OptimisticClosedShapeUpdateOperation(
+        TDoc document,
+        TId id,
+        string tenantId,
+        DocumentStorageDescriptor<TDoc, TId> descriptor,
+        Dictionary<TId, Guid>? versions)
+        : base(document, id, tenantId, descriptor)
+    {
+        _versions = versions;
+        _newVersion = CombGuidIdGeneration.NewGuid();
+    }
+
+    public override void ConfigureCommand(ICommandBuilder builder, IStorageSession session)
+    {
+        var parameters = builder.AppendWithDbParameters(_descriptor.UpdateSql, '?');
+        var slot = BindPreConcurrencyParameters(parameters, session);
+
+        // Trailing WHERE mt_version = ? guard. #4667 — null tracker (the
+        // UpdateProjected path) treats expected version as DBNull, which the
+        // SQL WHERE never matches. Callers that go through UpdateProjected
+        // should also set IgnoreConcurrencyViolation = true to suppress the
+        // resulting "no row" exception.
+        if (_versions is not null && _versions.TryGetValue(_id, out var expected))
+        {
+            parameters[slot].Value = expected;
+        }
+        else
+        {
+            parameters[slot].Value = DBNull.Value;
+        }
+        _descriptor.Dialect.SetParameterType(parameters[slot], StorageColumnType.Guid);
+    }
+
+    public override async Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)
+    {
+        if (!await reader.ReadAsync(token).ConfigureAwait(false))
+        {
+            if (!IgnoreConcurrencyViolation)
+            {
+                exceptions.Add(new ConcurrencyException(typeof(TDoc), _id));
+            }
+            return;
+        }
+
+        // #4667 — null tracker (the UpdateProjected path) just skips the
+        // tracker write. The fresh version is still applied to the document
+        // via VersionBinder during command configuration.
+        if (_versions is not null)
+        {
+            _versions[_id] = _newVersion;
+        }
+    }
+
+    protected override int BindClientSideBinder(DbParameter[] parameters, int slot, IDocumentMetadataBinder<TDoc> binder, IStorageSession session)
+    {
+        if (ReferenceEquals(binder, _descriptor.VersionBinder))
+        {
+            parameters[slot].Value = _newVersion;
+            _descriptor.Dialect.SetParameterType(parameters[slot], StorageColumnType.Guid);
+            _descriptor.VersionBinder!.ApplyVersionTo(_document, _newVersion);
+            return slot + 1;
+        }
+
+        binder.BindParameter(parameters[slot], _document, session);
+        return slot + 1;
+    }
+}

--- a/src/Weasel.Storage/OptimisticClosedShapeUpsertOperation.cs
+++ b/src/Weasel.Storage/OptimisticClosedShapeUpsertOperation.cs
@@ -1,0 +1,96 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using JasperFx.Core;
+using Weasel.Core;
+
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// <c>ConcurrencyMode.Optimistic</c> closed-shape Upsert. Generates a
+/// fresh Guid version, binds it for the SET VersionBinder slot, and
+/// binds the caller's expected Guid version at the trailing
+/// <c>ON CONFLICT DO UPDATE … WHERE table.mt_version = ?</c> slot.
+/// Missing RETURNING row → version mismatch →
+/// <see cref="ConcurrencyException"/>. #4659 leaf.
+/// </summary>
+public sealed class OptimisticClosedShapeUpsertOperation<TDoc, TId>: ClosedShapeUpsertOperation<TDoc, TId>
+    where TDoc : notnull
+    where TId : notnull
+{
+    private readonly Dictionary<TId, Guid>? _versions;
+    private readonly Guid _newVersion;
+
+    public OptimisticClosedShapeUpsertOperation(
+        TDoc document,
+        TId id,
+        string tenantId,
+        DocumentStorageDescriptor<TDoc, TId> descriptor,
+        OperationRole role,
+        Dictionary<TId, Guid>? versions)
+        : base(document, id, tenantId, descriptor, role)
+    {
+        _versions = versions;
+        _newVersion = CombGuidIdGeneration.NewGuid();
+    }
+
+    public override void ConfigureCommand(ICommandBuilder builder, IStorageSession session)
+    {
+        var parameters = builder.AppendWithDbParameters(_descriptor.UpsertSql, '?');
+        var slot = BindPreOnConflictParameters(parameters, session);
+
+        // Trailing WHERE table.mt_version = ? guard. #4667 — null tracker
+        // (the UpsertProjected path) treats expected version as DBNull. On
+        // the ON CONFLICT branch the WHERE will never match, so existing
+        // rows in Optimistic mode are left untouched. The INSERT branch
+        // still fires for new rows.
+        if (_versions is not null && _versions.TryGetValue(_id, out var expected))
+        {
+            parameters[slot].Value = expected;
+        }
+        else
+        {
+            parameters[slot].Value = DBNull.Value;
+        }
+        _descriptor.Dialect.SetParameterType(parameters[slot], StorageColumnType.Guid);
+    }
+
+    public override async Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)
+    {
+        if (!await reader.ReadAsync(token).ConfigureAwait(false))
+        {
+            if (!IgnoreConcurrencyViolation)
+            {
+                exceptions.Add(new ConcurrencyException(typeof(TDoc), _id));
+            }
+            return;
+        }
+
+        // #4667 — null tracker (the UpsertProjected path) just skips the
+        // tracker write. The fresh version is still applied to the document
+        // via VersionBinder during command configuration.
+        if (_versions is not null)
+        {
+            _versions[_id] = _newVersion;
+        }
+    }
+
+    protected override int BindClientSideBinder(DbParameter[] parameters, int slot, IDocumentMetadataBinder<TDoc> binder, IStorageSession session)
+    {
+        if (ReferenceEquals(binder, _descriptor.VersionBinder))
+        {
+            parameters[slot].Value = _newVersion;
+            _descriptor.Dialect.SetParameterType(parameters[slot], StorageColumnType.Guid);
+            _descriptor.VersionBinder!.ApplyVersionTo(_document, _newVersion);
+            return slot + 1;
+        }
+
+        binder.BindParameter(parameters[slot], _document, session);
+        return slot + 1;
+    }
+}

--- a/src/Weasel.Storage/UnversionedClosedShapeInsertOperation.cs
+++ b/src/Weasel.Storage/UnversionedClosedShapeInsertOperation.cs
@@ -1,0 +1,54 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using Weasel.Core;
+
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// <c>ConcurrencyMode.Off</c> closed-shape Insert. Hand-written for the
+/// no-version-no-revision shape: bind <c>[tenant_id,] id, data</c> + the
+/// client-side metadata binders, then on RETURNING expect a row (otherwise
+/// raise <see cref="DocumentAlreadyExistsException"/>). No tracker writes,
+/// no version/revision binder special-casing. #4659 leaf.
+/// </summary>
+public sealed class UnversionedClosedShapeInsertOperation<TDoc, TId>: ClosedShapeInsertOperation<TDoc, TId>
+    where TDoc : notnull
+    where TId : notnull
+{
+    public UnversionedClosedShapeInsertOperation(
+        TDoc document,
+        TId id,
+        string tenantId,
+        DocumentStorageDescriptor<TDoc, TId> descriptor)
+        : base(document, id, tenantId, descriptor)
+    {
+    }
+
+    public override void ConfigureCommand(ICommandBuilder builder, IStorageSession session)
+    {
+        var parameters = builder.AppendWithDbParameters(_descriptor.InsertSql, '?');
+        var slot = BindLeadingParameters(parameters, session);
+
+        // Off mode: every client-side write binder binds its single slot.
+        // No version or revision binder is in this array under Off mode.
+        foreach (var binder in _descriptor.ClientSideWriteBinders)
+        {
+            binder.BindParameter(parameters[slot], _document, session);
+            slot++;
+        }
+    }
+
+    public override async Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)
+    {
+        if (!await reader.ReadAsync(token).ConfigureAwait(false))
+        {
+            exceptions.Add(new DocumentAlreadyExistsException(null, typeof(TDoc), _id));
+        }
+    }
+}

--- a/src/Weasel.Storage/UnversionedClosedShapeOverwriteOperation.cs
+++ b/src/Weasel.Storage/UnversionedClosedShapeOverwriteOperation.cs
@@ -1,0 +1,46 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Weasel.Core;
+
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// <c>ConcurrencyMode.Off</c> closed-shape Overwrite. Functionally
+/// identical to <see cref="UnversionedClosedShapeUpsertOperation{TDoc, TId}"/>
+/// — no concurrency guard either way under Off. PostprocessAsync is
+/// fire-and-forget. #4659 leaf.
+/// </summary>
+public sealed class UnversionedClosedShapeOverwriteOperation<TDoc, TId>: ClosedShapeOverwriteOperation<TDoc, TId>
+    where TDoc : notnull
+    where TId : notnull
+{
+    public UnversionedClosedShapeOverwriteOperation(
+        TDoc document,
+        TId id,
+        string tenantId,
+        DocumentStorageDescriptor<TDoc, TId> descriptor)
+        : base(document, id, tenantId, descriptor)
+    {
+    }
+
+    public override void ConfigureCommand(ICommandBuilder builder, IStorageSession session)
+    {
+        var parameters = builder.AppendWithDbParameters(_descriptor.OverwriteSql, '?');
+        BindPreOnConflictParameters(parameters, session);
+        // Off-mode OverwriteSql has no trailing concurrency-extras slot.
+    }
+
+    public override Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)
+        => Task.CompletedTask;
+
+    protected override int BindClientSideBinder(DbParameter[] parameters, int slot, IDocumentMetadataBinder<TDoc> binder, IStorageSession session)
+    {
+        binder.BindParameter(parameters[slot], _document, session);
+        return slot + 1;
+    }
+}

--- a/src/Weasel.Storage/UnversionedClosedShapeUpdateOperation.cs
+++ b/src/Weasel.Storage/UnversionedClosedShapeUpdateOperation.cs
@@ -1,0 +1,56 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Weasel.Core;
+
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// <c>ConcurrencyMode.Off</c> closed-shape Update. Plain
+/// <c>WHERE id = ? [AND tenant_id = ?] [AND partition_col = ?…]</c> —
+/// no concurrency guard. A missing row signals the document didn't
+/// exist; raises <see cref="NonExistentDocumentException"/>. #4659 leaf.
+/// </summary>
+public sealed class UnversionedClosedShapeUpdateOperation<TDoc, TId>: ClosedShapeUpdateOperation<TDoc, TId>
+    where TDoc : notnull
+    where TId : notnull
+{
+    public UnversionedClosedShapeUpdateOperation(
+        TDoc document,
+        TId id,
+        string tenantId,
+        DocumentStorageDescriptor<TDoc, TId> descriptor)
+        : base(document, id, tenantId, descriptor)
+    {
+    }
+
+    public override void ConfigureCommand(ICommandBuilder builder, IStorageSession session)
+    {
+        var parameters = builder.AppendWithDbParameters(_descriptor.UpdateSql, '?');
+        // Off mode has no trailing concurrency-guard slot — we just consume
+        // data + binders + id + tenant + partition PK.
+        BindPreConcurrencyParameters(parameters, session);
+    }
+
+    public override async Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)
+    {
+        if (!await reader.ReadAsync(token).ConfigureAwait(false))
+        {
+            if (!IgnoreConcurrencyViolation)
+            {
+                exceptions.Add(_descriptor.CreateMissingDocumentException?.Invoke(typeof(TDoc), _id!)
+                               ?? new InvalidOperationException($"Nonexistent document {typeof(TDoc).FullName}: {_id}"));
+            }
+        }
+    }
+
+    protected override int BindClientSideBinder(DbParameter[] parameters, int slot, IDocumentMetadataBinder<TDoc> binder, IStorageSession session)
+    {
+        binder.BindParameter(parameters[slot], _document, session);
+        return slot + 1;
+    }
+}

--- a/src/Weasel.Storage/UnversionedClosedShapeUpsertOperation.cs
+++ b/src/Weasel.Storage/UnversionedClosedShapeUpsertOperation.cs
@@ -1,0 +1,49 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Weasel.Core;
+
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// <c>ConcurrencyMode.Off</c> closed-shape Upsert. Plain
+/// <c>INSERT … ON CONFLICT (id) DO UPDATE SET … RETURNING id</c> — no
+/// version/revision guard. PostprocessAsync is fire-and-forget: the
+/// RETURNING row is there for symmetry with Insert/Update but the result
+/// isn't inspected (Off-mode Upsert always wins, no concurrency-failure
+/// outcome to detect). #4659 leaf.
+/// </summary>
+public sealed class UnversionedClosedShapeUpsertOperation<TDoc, TId>: ClosedShapeUpsertOperation<TDoc, TId>
+    where TDoc : notnull
+    where TId : notnull
+{
+    public UnversionedClosedShapeUpsertOperation(
+        TDoc document,
+        TId id,
+        string tenantId,
+        DocumentStorageDescriptor<TDoc, TId> descriptor,
+        OperationRole role)
+        : base(document, id, tenantId, descriptor, role)
+    {
+    }
+
+    public override void ConfigureCommand(ICommandBuilder builder, IStorageSession session)
+    {
+        var parameters = builder.AppendWithDbParameters(_descriptor.UpsertSql, '?');
+        BindPreOnConflictParameters(parameters, session);
+        // Off-mode UpsertSql has no trailing concurrency-extras slot.
+    }
+
+    public override Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)
+        => Task.CompletedTask;
+
+    protected override int BindClientSideBinder(DbParameter[] parameters, int slot, IDocumentMetadataBinder<TDoc> binder, IStorageSession session)
+    {
+        binder.BindParameter(parameters[slot], _document, session);
+        return slot + 1;
+    }
+}


### PR DESCRIPTION
Sixth (and final planned) Weasel.Storage increment for the Marten **W2 storage-extraction epic** (JasperFx/marten#4821) — the complete closed-shape **write path**:

- the 4 abstract operation bases (upsert / insert / update / overwrite): the parameter-slot arithmetic over the descriptor's SQL + binder arrays
- the 12 concurrency leaves (Unversioned / Optimistic / Numeric variants), incl. the revision CASE slot binding and the postprocess concurrency branches
- the operation support contracts: `IDocumentStorageOperation` (: `IStorageOperation` + `Document`/`ToTracker`), `IRevisionedOperation`, `IIdentifiedOperation<TDoc,TId>`

### De-couplings
- `ConfigureCommand` now implements the neutral `IStorageOperation.ConfigureCommand(Weasel.Core.ICommandBuilder, IStorageSession)` **directly** — the bodies only ever used `AppendWithDbParameters`, a Weasel.Core member.
- The store-static exception transform becomes a descriptor-carried **`IOperationExceptionTransform`** seam (Marten's Postgres transform stays in Marten and is supplied by its descriptor builder).
- The store's missing-document exception becomes a descriptor-carried factory (`CreateMissingDocumentException`).

Bumps to **9.13.0**. Follows #335 (binders).

Validated downstream with local packs: Marten consumes with all seven suites green (DocumentDb 1033 / EventSourcing 1421 / Daemon 198 / Linq 1312 / Patching 122 / Core 458 / ValueType 339) and Wolverine.Marten + Wolverine.Http.Marten compile unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)