### PR TITLE
feat: dialect-neutral grouped-parameter seam + StorageColumnType.Binary (marten#4821 event E1)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>9.13.0</Version>
+        <Version>9.14.0</Version>
         <LangVersion>13.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/src/Weasel.Core/ICommandBuilder.cs
+++ b/src/Weasel.Core/ICommandBuilder.cs
@@ -35,6 +35,26 @@ public interface ICommandBuilder
     void AppendParameters(params object[] parameters);
 
     /// <summary>
+    ///     Append a single parameter with the supplied value to the underlying command's parameter
+    ///     collection *and* the command text, returning the newly created parameter upcast to the
+    ///     dialect-neutral <see cref="DbParameter" />. Lets a database-agnostic consumer bind a value and
+    ///     set <see cref="DbParameter.DbType" /> on it without referencing the provider parameter type.
+    ///     Each provider's own <c>ICommandBuilder</c> hides this with a provider-typed overload.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <returns></returns>
+    DbParameter AppendParameter(object value);
+
+    /// <summary>
+    ///     Create a dialect-neutral <see cref="IGroupedParameterBuilder" /> that appends a separated run
+    ///     of positional parameters against this command builder. Each provider's own
+    ///     <c>ICommandBuilder</c> hides this with an overload returning its provider-typed grouped builder.
+    /// </summary>
+    /// <param name="separator">Character emitted between parameters; when null, no separator is written.</param>
+    /// <returns></returns>
+    IGroupedParameterBuilder CreateGroupedParameterBuilder(char? separator = null);
+
+    /// <summary>
     ///     Append a SQL string with `?` placeholders for new parameters, and returns an
     ///     array of the newly created parameters upcast to the dialect-neutral <see cref="DbParameter" />.
     ///     Lets a database-agnostic consumer fill parameter slots without referencing the

--- a/src/Weasel.Core/IGroupedParameterBuilder.cs
+++ b/src/Weasel.Core/IGroupedParameterBuilder.cs
@@ -1,0 +1,52 @@
+using System.Data.Common;
+
+namespace Weasel.Core;
+
+/// <summary>
+///     Dialect-neutral surface for appending a separated group of positional parameters against an
+///     <see cref="ICommandBuilder" />. A database-agnostic consumer (e.g. a shared closed-shape storage
+///     runtime) can bind a run of parameters without referencing <c>Weasel.Postgresql</c> or
+///     <c>Weasel.SqlServer</c>. Each provider's own <c>IGroupedParameterBuilder</c> derives from this
+///     and adds the provider-typed <c>AppendParameter</c> overloads (returning the native parameter).
+/// </summary>
+public interface IGroupedParameterBuilder
+{
+    /// <summary>
+    ///     Append the next parameter in the group through the ADO.NET-neutral value path, emitting the
+    ///     group separator first for every parameter after the first. A <see langword="null" /> value is
+    ///     written as <see cref="DBNull" />. Returns the newly created parameter upcast to the
+    ///     dialect-neutral <see cref="DbParameter" /> so a caller can set <see cref="DbParameter.DbType" />
+    ///     on it if needed.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <returns></returns>
+    DbParameter AppendParameter(object? value);
+}
+
+/// <summary>
+///     Dialect-neutral <see cref="IGroupedParameterBuilder" /> that binds through the neutral
+///     <see cref="ICommandBuilder.AppendParameter(object)" />. Any provider command builder that only
+///     needs to satisfy the neutral contract (rather than expose provider-typed grouped overloads) can
+///     hand one of these back from <see cref="ICommandBuilder.CreateGroupedParameterBuilder(char?)" />.
+/// </summary>
+public sealed class GroupedParameterBuilder: IGroupedParameterBuilder
+{
+    private readonly ICommandBuilder _commandBuilder;
+    private readonly char? _separator;
+    private int _count;
+
+    public GroupedParameterBuilder(ICommandBuilder commandBuilder, char? separator)
+    {
+        _commandBuilder = commandBuilder;
+        _separator = separator;
+    }
+
+    public DbParameter AppendParameter(object? value)
+    {
+        if (_count > 0 && _separator.HasValue)
+            _commandBuilder.Append(_separator.Value);
+
+        _count++;
+        return _commandBuilder.AppendParameter(value ?? DBNull.Value);
+    }
+}

--- a/src/Weasel.Postgresql.Tests/NeutralGroupedParameterBuilderTests.cs
+++ b/src/Weasel.Postgresql.Tests/NeutralGroupedParameterBuilderTests.cs
@@ -1,0 +1,44 @@
+using Npgsql;
+using Shouldly;
+using Xunit;
+
+namespace Weasel.Postgresql.Tests;
+
+// DB-free unit tests for the dialect-neutral parameter seam added for the closed-shape
+// storage runtime (marten#4821 event side, E1). Exercises Weasel.Core.ICommandBuilder /
+// Weasel.Core.IGroupedParameterBuilder against the PostgreSQL command builder.
+public class NeutralGroupedParameterBuilderTests
+{
+    [Fact]
+    public void neutral_command_builder_appends_a_grouped_run_of_parameters()
+    {
+        var builder = new CommandBuilder();
+        Weasel.Core.ICommandBuilder neutral = builder;
+
+        neutral.Append("select ");
+        var group = neutral.CreateGroupedParameterBuilder(',');
+        group.AppendParameter(1);
+        group.AppendParameter("blue");
+        var nullParam = group.AppendParameter(null);
+
+        var command = builder.Compile();
+        command.CommandText.ShouldBe("select :p0,:p1,:p2");
+        command.Parameters.Count.ShouldBe(3);
+        nullParam.ShouldBeOfType<NpgsqlParameter>();
+        nullParam.Value.ShouldBe(DBNull.Value);
+    }
+
+    [Fact]
+    public void neutral_append_parameter_returns_the_dialect_neutral_parameter()
+    {
+        var builder = new CommandBuilder();
+        Weasel.Core.ICommandBuilder neutral = builder;
+
+        neutral.Append("select ");
+        var parameter = neutral.AppendParameter(42);
+
+        parameter.ShouldBeOfType<NpgsqlParameter>();
+        parameter.Value.ShouldBe(42);
+        builder.Compile().CommandText.ShouldBe("select :p0");
+    }
+}

--- a/src/Weasel.Postgresql/BatchBuilder.cs
+++ b/src/Weasel.Postgresql/BatchBuilder.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Data.Common;
 using System.Text;
 using Npgsql;
 using NpgsqlTypes;
@@ -118,6 +119,16 @@ public class BatchBuilder: ICommandBuilder
     public IGroupedParameterBuilder CreateGroupedParameterBuilder(char? seperator = null)
     {
         return new GroupedParameterBuilder(this, seperator);
+    }
+
+    DbParameter Weasel.Core.ICommandBuilder.AppendParameter(object value)
+    {
+        return AppendParameter(value);
+    }
+
+    Weasel.Core.IGroupedParameterBuilder Weasel.Core.ICommandBuilder.CreateGroupedParameterBuilder(char? seperator)
+    {
+        return CreateGroupedParameterBuilder(seperator);
     }
 
     /// <summary>

--- a/src/Weasel.Postgresql/CommandBuilder.cs
+++ b/src/Weasel.Postgresql/CommandBuilder.cs
@@ -76,6 +76,17 @@ public class CommandBuilder: CommandBuilderBase<NpgsqlCommand, NpgsqlParameter, 
         return new GroupedParameterBuilder(this, seperator);
     }
 
+    DbParameter Weasel.Core.ICommandBuilder.AppendParameter(object value)
+    {
+        base.AppendParameter(value);
+        return _command.Parameters[^1];
+    }
+
+    Weasel.Core.IGroupedParameterBuilder Weasel.Core.ICommandBuilder.CreateGroupedParameterBuilder(char? seperator)
+    {
+        return CreateGroupedParameterBuilder(seperator);
+    }
+
     public void StartNewCommand()
     {
         // do nothing!

--- a/src/Weasel.Postgresql/GroupedParameterBuilder.cs
+++ b/src/Weasel.Postgresql/GroupedParameterBuilder.cs
@@ -1,9 +1,15 @@
-﻿using Npgsql;
+﻿using System.Data.Common;
+using Npgsql;
 using NpgsqlTypes;
 
 namespace Weasel.Postgresql;
 
-public interface IGroupedParameterBuilder
+/// <summary>
+///     PostgreSQL grouped-parameter surface. Derives from the dialect-neutral
+///     <see cref="Weasel.Core.IGroupedParameterBuilder" /> and adds the Npgsql-typed overloads that
+///     return <see cref="NpgsqlParameter" />.
+/// </summary>
+public interface IGroupedParameterBuilder: Weasel.Core.IGroupedParameterBuilder
 {
     NpgsqlParameter AppendParameter<T>(T? value) where T : notnull;
     NpgsqlParameter AppendParameter<T>(T? value, NpgsqlDbType dbType) where T : notnull;
@@ -37,5 +43,14 @@ public sealed class GroupedParameterBuilder: IGroupedParameterBuilder
 
         _count++;
         return _commandBuilder.AppendParameter(value, dbType);
+    }
+
+    DbParameter Weasel.Core.IGroupedParameterBuilder.AppendParameter(object? value)
+    {
+        if (_count > 0 && _seperator.HasValue)
+            _commandBuilder.Append(_seperator.Value);
+
+        _count++;
+        return _commandBuilder.AppendParameter(value ?? DBNull.Value);
     }
 }

--- a/src/Weasel.Postgresql/ICommandBuilder.cs
+++ b/src/Weasel.Postgresql/ICommandBuilder.cs
@@ -13,10 +13,19 @@ public interface ICommandBuilder: Weasel.Core.ICommandBuilder
 {
     NpgsqlParameter AppendParameter<T>(T value);
     NpgsqlParameter AppendParameter<T>(T value, NpgsqlDbType dbType);
-    NpgsqlParameter AppendParameter(object value);
+
+    /// <summary>
+    ///     Npgsql-typed override of <see cref="Weasel.Core.ICommandBuilder.AppendParameter(object)" />.
+    /// </summary>
+    new NpgsqlParameter AppendParameter(object value);
     NpgsqlParameter AppendParameter(object? value, NpgsqlDbType? dbType);
 
-    IGroupedParameterBuilder CreateGroupedParameterBuilder(char? seperator = null);
+    /// <summary>
+    ///     Npgsql-typed override of
+    ///     <see cref="Weasel.Core.ICommandBuilder.CreateGroupedParameterBuilder(char?)" /> returning the
+    ///     provider grouped-parameter builder.
+    /// </summary>
+    new IGroupedParameterBuilder CreateGroupedParameterBuilder(char? seperator = null);
 
     /// <summary>
     ///     Append a SQL string with user defined placeholder characters for new parameters, and returns an

--- a/src/Weasel.SqlServer.Tests/NeutralGroupedParameterBuilderTests.cs
+++ b/src/Weasel.SqlServer.Tests/NeutralGroupedParameterBuilderTests.cs
@@ -1,0 +1,45 @@
+using Microsoft.Data.SqlClient;
+using Shouldly;
+using Xunit;
+
+namespace Weasel.SqlServer.Tests;
+
+// DB-free unit tests for the dialect-neutral parameter seam added for the closed-shape
+// storage runtime (marten#4821 event side, E1). The SQL Server CommandBuilder previously
+// exposed no grouped-parameter builder at all; the neutral seam gives it one via the shared
+// Weasel.Core.GroupedParameterBuilder.
+public class NeutralGroupedParameterBuilderTests
+{
+    [Fact]
+    public void neutral_command_builder_appends_a_grouped_run_of_parameters()
+    {
+        var builder = new CommandBuilder();
+        Weasel.Core.ICommandBuilder neutral = builder;
+
+        neutral.Append("select ");
+        var group = neutral.CreateGroupedParameterBuilder(',');
+        group.AppendParameter(1);
+        group.AppendParameter("blue");
+        var nullParam = group.AppendParameter(null);
+
+        var command = builder.Compile();
+        command.CommandText.ShouldBe("select @p0,@p1,@p2");
+        command.Parameters.Count.ShouldBe(3);
+        nullParam.ShouldBeOfType<SqlParameter>();
+        nullParam.Value.ShouldBe(DBNull.Value);
+    }
+
+    [Fact]
+    public void neutral_append_parameter_returns_the_dialect_neutral_parameter()
+    {
+        var builder = new CommandBuilder();
+        Weasel.Core.ICommandBuilder neutral = builder;
+
+        neutral.Append("select ");
+        var parameter = neutral.AppendParameter(42);
+
+        parameter.ShouldBeOfType<SqlParameter>();
+        parameter.Value.ShouldBe(42);
+        builder.Compile().CommandText.ShouldBe("select @p0");
+    }
+}

--- a/src/Weasel.SqlServer/BatchBuilder.cs
+++ b/src/Weasel.SqlServer/BatchBuilder.cs
@@ -144,6 +144,16 @@ public class BatchBuilder: ICommandBuilder
         return new GroupedParameterBuilder(this, seperator);
     }
 
+    System.Data.Common.DbParameter Weasel.Core.ICommandBuilder.AppendParameter(object value)
+    {
+        return AppendParameter(value);
+    }
+
+    Weasel.Core.IGroupedParameterBuilder Weasel.Core.ICommandBuilder.CreateGroupedParameterBuilder(char? seperator)
+    {
+        return CreateGroupedParameterBuilder(seperator);
+    }
+
     /// <summary>
     ///     Append a SQL string with user defined placeholder characters for new parameters, and returns an
     ///     array of the newly created parameters

--- a/src/Weasel.SqlServer/CommandBuilder.cs
+++ b/src/Weasel.SqlServer/CommandBuilder.cs
@@ -41,6 +41,24 @@ public class CommandBuilder: CommandBuilderBase<SqlCommand, SqlParameter, SqlDbT
         }
     }
 
+    /// <summary>
+    ///     Append a single parameter through the dialect-neutral value path, returning the newly created
+    ///     parameter upcast to <see cref="DbParameter" />. Implements
+    ///     <see cref="Weasel.Core.ICommandBuilder.AppendParameter(object)" />.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <returns></returns>
+    public DbParameter AppendParameter(object value)
+    {
+        base.AppendParameter(value);
+        return _command.Parameters[^1];
+    }
+
+    public Weasel.Core.IGroupedParameterBuilder CreateGroupedParameterBuilder(char? seperator = null)
+    {
+        return new Weasel.Core.GroupedParameterBuilder(this, seperator);
+    }
+
     public void StartNewCommand()
     {
         // do nothing!

--- a/src/Weasel.SqlServer/ICommandBuilder.cs
+++ b/src/Weasel.SqlServer/ICommandBuilder.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Data.Common;
 using Microsoft.Data.SqlClient;
 
 namespace Weasel.SqlServer;
@@ -13,10 +14,19 @@ public interface ICommandBuilder: Weasel.Core.ICommandBuilder
 {
     SqlParameter AppendParameter<T>(T value);
     SqlParameter AppendParameter<T>(T value, SqlDbType dbType);
-    SqlParameter AppendParameter(object value);
+
+    /// <summary>
+    ///     SqlClient-typed override of <see cref="Weasel.Core.ICommandBuilder.AppendParameter(object)" />.
+    /// </summary>
+    new SqlParameter AppendParameter(object value);
     SqlParameter AppendParameter(object? value, SqlDbType? dbType);
 
-    IGroupedParameterBuilder CreateGroupedParameterBuilder(char? seperator = null);
+    /// <summary>
+    ///     SqlClient-typed override of
+    ///     <see cref="Weasel.Core.ICommandBuilder.CreateGroupedParameterBuilder(char?)" /> returning the
+    ///     provider grouped-parameter builder.
+    /// </summary>
+    new IGroupedParameterBuilder CreateGroupedParameterBuilder(char? seperator = null);
 
     /// <summary>
     ///     Append a SQL string with user defined placeholder characters for new parameters, and returns an
@@ -36,7 +46,12 @@ public interface ICommandBuilder: Weasel.Core.ICommandBuilder
     SqlParameter[] AppendWithParameters(string text, char placeholder);
 }
 
-public interface IGroupedParameterBuilder
+/// <summary>
+///     SQL Server grouped-parameter surface. Derives from the dialect-neutral
+///     <see cref="Weasel.Core.IGroupedParameterBuilder" /> and adds the SqlClient-typed overloads that
+///     return <see cref="SqlParameter" />.
+/// </summary>
+public interface IGroupedParameterBuilder: Weasel.Core.IGroupedParameterBuilder
 {
     SqlParameter AppendParameter<T>(T? value) where T : notnull;
     SqlParameter AppendParameter<T>(T? value, SqlDbType dbType) where T : notnull;
@@ -70,5 +85,14 @@ public sealed class GroupedParameterBuilder: IGroupedParameterBuilder
 
         _count++;
         return _commandBuilder.AppendParameter(value, dbType);
+    }
+
+    DbParameter Weasel.Core.IGroupedParameterBuilder.AppendParameter(object? value)
+    {
+        if (_count > 0 && _seperator.HasValue)
+            _commandBuilder.Append(_seperator.Value);
+
+        _count++;
+        return _commandBuilder.AppendParameter(value ?? DBNull.Value);
     }
 }

--- a/src/Weasel.Storage/StorageColumnType.cs
+++ b/src/Weasel.Storage/StorageColumnType.cs
@@ -21,5 +21,12 @@ public enum StorageColumnType
     Int,
     Boolean,
     Timestamp,
-    Json
+    Json,
+
+    /// <summary>
+    ///     Raw binary payload column (Postgres <c>bytea</c> / SQL Server <c>varbinary</c>). Used by the
+    ///     closed-shape event runtime for the serialized event <c>bdata</c> column. A dialect maps this to
+    ///     its own provider parameter type in <see cref="IStorageDialect.SetParameterType" />.
+    /// </summary>
+    Binary
 }


### PR DESCRIPTION
## Summary

The **gate increment (E1)** for moving Marten's closed-shape **event** storage into `Weasel.Storage` (marten#4821, event side). Polecat (SQL Server) is the waiting second consumer.

This unifies the provider-specific `IGroupedParameterBuilder` / `AppendParameter` surfaces behind `Weasel.Core` so a database-agnostic storage runtime can bind parameters without referencing `Weasel.Postgresql` or `Weasel.SqlServer` — the same split pattern used for `ICommandBuilder` in weasel#327. **No file moves**; E2/E3 (the physical event-storage move) follow in later slices, one Weasel release each.

## Changes

- **`Weasel.Core.IGroupedParameterBuilder`** — new dialect-neutral surface with `DbParameter AppendParameter(object?)` (writes `DBNull` for null). Provider `IGroupedParameterBuilder`s now derive from it and keep their provider-typed overloads.
- **`Weasel.Core.GroupedParameterBuilder`** — shared neutral implementation that binds through the neutral command builder. Gives `SqlServer.CommandBuilder` a grouped-parameter builder for the first time.
- **`Weasel.Core.ICommandBuilder`** — adds neutral `DbParameter AppendParameter(object)` and `IGroupedParameterBuilder CreateGroupedParameterBuilder(char?)`. Provider interfaces hide these with their provider-typed versions (`new`).
- **Postgres / SqlServer** command + batch builders implement the neutral seam via explicit interface implementations delegating to the existing provider-typed members.
- **`StorageColumnType.Binary`** — new enum member (Postgres `bytea` / SQL Server `varbinary`) for the event `bdata` column; dialects map it in `IStorageDialect.SetParameterType` (mapping lives consumer-side).

## Versioning

Minor bump **9.13.0 → 9.14.0**. Marten consumes this to de-Npgsql the event binders/ops in place (INC-3 shape).

## Tests

Added DB-free unit tests (`NeutralGroupedParameterBuilderTests`) in the Postgres and SqlServer test projects covering the neutral grouped run and neutral `AppendParameter`. Full solution builds clean; new tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)