### PR TITLE
Managed list partitions: additive targeted creation, not full-set reconcile

### DIFF
--- a/src/Weasel.Postgresql.Tests/Tables/partitioning/managed_list_partitions.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/partitioning/managed_list_partitions.cs
@@ -312,6 +312,46 @@ public class managed_list_partitions : IntegrationContext
         await database.ApplyAllConfiguredChangesToDatabaseAsync();
     }
 
+    [Fact]
+    public async Task adds_requested_partition_even_when_table_has_partitions_outside_the_managers_set()
+    {
+        // Regression for managed partitions living in sharded databases: the manager's in-memory partition
+        // set is the UNION of tenant values seen across ALL databases, so an individual database's table can
+        // hold partitions the manager's set does not include. Pre-fix, ListPartitioning.CreateDelta treated
+        // those extra partitions as PartitionDelta.Rebuild and additivelyMigrateTablesForNewPartitions
+        // skipped adding the genuinely-missing partition, so a new tenant's first write failed with 23514
+        // "no partition of relation ... found for row". The out-of-band add must create exactly the
+        // requested partition regardless of what else the table already holds.
+        await dropManagedListsSchema();
+        var database = new ManagedListDatabase();
+        await database.Partitions.ResetValues(database,
+            new Dictionary<string, string> { { "red", "red" } }, CancellationToken.None);
+        await database.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        // A partition that exists on THIS database's tables but is unknown to the manager, as if it were
+        // created for a tenant that lives on another shard database.
+        await using (var conn = new NpgsqlConnection(ConnectionSource.ConnectionString))
+        {
+            await conn.OpenAsync();
+            await conn.CreateCommand(
+                "create table managed_lists.teams_orphan partition of managed_lists.teams for values in ('orphan')")
+                .ExecuteNonQueryAsync();
+            await conn.CreateCommand(
+                "create table managed_lists.players_orphan partition of managed_lists.players for values in ('orphan')")
+                .ExecuteNonQueryAsync();
+        }
+
+        // Adding a brand-new value must still create ITS partition — not be skipped because of the orphan.
+        var fresh = new ManagedListDatabase();
+        await fresh.Partitions.AddPartitionToAllTables(fresh, "blue", "blue", CancellationToken.None);
+
+        (await partitionExists("teams", "blue")).ShouldBeTrue("the requested partition must be created");
+        (await partitionExists("players", "blue")).ShouldBeTrue("the requested partition must be created");
+        // Purely additive: the out-of-band add must not drop pre-existing or unmanaged partitions.
+        (await partitionExists("teams", "red")).ShouldBeTrue();
+        (await partitionExists("teams", "orphan")).ShouldBeTrue();
+    }
+
     private static async Task dropManagedListsSchema()
     {
         await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);

--- a/src/Weasel.Postgresql/Tables/Partitioning/ManagedListPartitions.cs
+++ b/src/Weasel.Postgresql/Tables/Partitioning/ManagedListPartitions.cs
@@ -182,7 +182,9 @@ public class ManagedListPartitions : FeatureSchemaBase, IDatabaseInitializer<Npg
 
         await AddPartitionToAllTables(conn, token, value, suffix).ConfigureAwait(false);
 
-        await additivelyMigrateTablesForNewPartitions(NullLogger.Instance, database, token, conn).ConfigureAwait(false);
+        var resolvedSuffix = suffix.IsEmpty() ? value.ToLowerInvariant() : suffix!;
+        await additivelyMigrateTablesForNewPartitions(NullLogger.Instance, database, token, conn,
+            new[] { new KeyValuePair<string, string>(value, resolvedSuffix) }).ConfigureAwait(false);
 
         await conn.CloseAsync().ConfigureAwait(false);
     }
@@ -213,74 +215,58 @@ public class ManagedListPartitions : FeatureSchemaBase, IDatabaseInitializer<Npg
 
         await tx.CommitAsync(token).ConfigureAwait(false);
 
-        var list = await additivelyMigrateTablesForNewPartitions(logger, database, token, conn).ConfigureAwait(false);
+        var list = await additivelyMigrateTablesForNewPartitions(logger, database, token, conn, values.ToArray()).ConfigureAwait(false);
 
         await conn.CloseAsync().ConfigureAwait(false);
 
         return list.ToArray();
     }
 
-    private async Task<List<TablePartitionStatus>> additivelyMigrateTablesForNewPartitions(ILogger logger, PostgresqlDatabase database,
-        CancellationToken token, NpgsqlConnection conn)
+    private async Task<List<TablePartitionStatus>> additivelyMigrateTablesForNewPartitions(ILogger logger,
+        PostgresqlDatabase database, CancellationToken token, NpgsqlConnection conn,
+        IReadOnlyCollection<KeyValuePair<string, string>> newPartitions)
     {
+        var list = new List<TablePartitionStatus>();
+        if (newPartitions.Count == 0) return list;
+
         var tables = database
             .AllObjects()
             .OfType<Table>()
             .Where(x => x.Partitioning is ListPartitioning list && list.PartitionManager == this)
             .ToArray();
 
-        var list = new List<TablePartitionStatus>();
-
+        // Targeted, purely-additive creation: create ONLY the partitions for the values registered in THIS
+        // call, each as CREATE TABLE IF NOT EXISTS (idempotent, via ListPartition.WriteCreateStatement).
+        //
+        // It deliberately does NOT reconcile every table against the manager's full partition set. That
+        // full-set reconcile is wrong once these managed-partition tables live in sharded databases: the
+        // manager's in-memory partition set is the UNION of tenant values seen across ALL databases, so
+        // reconciling each table against it (a) created partitions for tenants that live on OTHER shard
+        // databases (over-provisioning — every shard accumulated every tenant's partition), and (b) tripped
+        // ListPartitioning.CreateDelta's "the actual table has partitions the desired set does not" guard
+        // into PartitionDelta.Rebuild, which then skipped adding the genuinely-missing partition altogether
+        // (under-provisioning — a tenant's own partition was never created, so its first write failed with
+        // 23514 "no partition of relation ... found for row"). Creating exactly what was requested avoids
+        // both, and needs no IgnorePartitionsInMigration toggling because it never runs the generic table
+        // delta on the shared per-mapping Table instance (see JasperFx/marten#4706, #4713).
         foreach (var table in tables)
         {
-            // This is the explicit, out-of-band partition-management path (AddPartitionToAllTables).
-            // Managed-partition tables set IgnorePartitionsInMigration so the GENERIC schema diff leaves
-            // their partitions alone (JasperFx/marten#4706); here we are deliberately reconciling them,
-            // so clear the flag locally to let the delta compute the missing partitions to add.
-            //
-            // #4713: SAVE and RESTORE the flag. These Table objects are NOT throwaway clones — a Marten
-            // consumer reuses a per-mapping singleton Table across every shard database and across every
-            // schema apply. Leaving the flag at false permanently defeated the #4706 short-circuit on
-            // that shared instance, so a later ApplyAllConfiguredChangesToDatabaseAsync re-emitted
-            // CREATE TABLE ... partition of for already-existing per-tenant partitions (42P07) and could
-            // re-trigger the destructive rebuild. Restore it in a finally so this reconcile is the only
-            // thing that ever sees the flag cleared.
-            var priorIgnorePartitions = table.IgnorePartitionsInMigration;
-            table.IgnorePartitionsInMigration = false;
             try
             {
-                var existing = await table.FetchExistingAsync(conn, token).ConfigureAwait(false);
-                var delta = new TableDelta(table, existing);
-                if (delta.PartitionDelta == PartitionDelta.Additive)
+                var writer = new StringWriter();
+                foreach (var pair in newPartitions)
                 {
-                    try
-                    {
-                        await table.MigrateAsync(conn, token).ConfigureAwait(false);
-                        foreach (var partition in delta.MissingPartitions)
-                        {
-                            logger.LogInformation("Added partition {Partition} to table {TableName}", partition, table.Identifier);
-                        }
+                    var partition = new ListPartition(pair.Value, pair.Key.FormatSqlValue());
+                    ((IPartition)partition).WriteCreateStatement(writer, table);
+                }
 
-                        list.Add(new TablePartitionStatus(table.Identifier, PartitionMigrationStatus.Complete));
-                    }
-                    catch (Exception e)
-                    {
-                        logger.LogError(e, "Error trying to add table partitions to {Table}", table.Identifier);
-                        list.Add(new TablePartitionStatus(table.Identifier, PartitionMigrationStatus.Failed));
-                    }
-                }
-                else if (delta.PartitionDelta == PartitionDelta.None)
-                {
-                    list.Add(new TablePartitionStatus(table.Identifier, PartitionMigrationStatus.Complete));
-                }
-                else
-                {
-                    list.Add(new TablePartitionStatus(table.Identifier, PartitionMigrationStatus.RequiresTableRebuild));
-                }
+                await conn.CreateCommand(writer.ToString()).ExecuteNonQueryAsync(token).ConfigureAwait(false);
+                list.Add(new TablePartitionStatus(table.Identifier, PartitionMigrationStatus.Complete));
             }
-            finally
+            catch (Exception e)
             {
-                table.IgnorePartitionsInMigration = priorIgnorePartitions;
+                logger.LogError(e, "Error trying to add table partitions to {Table}", table.Identifier);
+                list.Add(new TablePartitionStatus(table.Identifier, PartitionMigrationStatus.Failed));
             }
         }
 


### PR DESCRIPTION
## Problem

`ManagedListPartitions.AddPartitionToAllTables` reconciled **every** managed-partition table against the manager's full in-memory partition set on each call (`additivelyMigrateTablesForNewPartitions` → `TableDelta` → `ListPartitioning.CreateDelta`).

Once these tables live in **sharded databases** — one `PartitionManager` instance shared across databases, its in-memory set being the union of tenant values seen across all of them — that reconcile is wrong in two ways:

1. **Over-provisioning**: every database accumulated a partition for every tenant value ever seen on *any* database, not just its own.
2. **Under-provisioning**: `ListPartitioning.CreateDelta` returns `PartitionDelta.Rebuild` when the actual table holds partitions the desired set does not (normal per-shard), so `additivelyMigrateTablesForNewPartitions` hit the `RequiresTableRebuild` branch and **skipped adding the genuinely-missing partition**. The new value's first insert then failed with `23514 no partition of relation ... found for row`.

## Change

`additivelyMigrateTablesForNewPartitions` now creates **only** the partitions for the values registered in the current call, each as `CREATE TABLE IF NOT EXISTS` (via `ListPartition.WriteCreateStatement`). It no longer runs the generic table delta against the manager's full set, so it neither over-creates nor gets tripped into a rebuild-skip — and it no longer needs to toggle `IgnorePartitionsInMigration` on the shared per-mapping `Table` instance (#4706/#4713).

Both `AddPartitionToAllTables` overloads (single value + dictionary) thread their values through.

## Tests

Added `adds_requested_partition_even_when_table_has_partitions_outside_the_managers_set`: a table with a partition unknown to the manager (simulating another shard's tenant) must still get a newly-requested partition created, and must not drop the others. All existing managed-list-partition tests stay green (13/13 in the class; 92/92 across `partitioning`).