### PR TITLE
feat: move closed-shape event descriptor core into Weasel.Storage (marten#4821 event E2)

### DIFF
--- a/src/Weasel.Storage/Events/IEventMetadataBinder.cs
+++ b/src/Weasel.Storage/Events/IEventMetadataBinder.cs
@@ -1,0 +1,80 @@
+#nullable enable
+using System.Data.Common;
+using JasperFx.Events;
+using Weasel.Core;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Per-metadata-column seam in the closed-shape event-storage hierarchy.
+/// Sits alongside (not instead of) the inlined writes for the core columns
+/// (id, version, data, type, dotnet_type, stream id) — the metadata columns
+/// are where the per-<c>EventRegistry</c> variability lives.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Metadata columns are each on-or-off per event-store configuration, some
+/// carry server-side values that need writing back onto the event after
+/// Postprocess, and a dialect can swap their representation entirely
+/// (Postgres HSTORE tags ↔ SQL Server JSON / varbinary). Inlining those into
+/// a source-gen output would either blow up the closed-shape matrix
+/// combinatorially or push runtime if/then branches into the hot path.
+/// </para>
+/// <para>
+/// The binder array is built once per event-store configuration by the
+/// descriptor builder, ordered to match the SQL column list. Per-call cost
+/// is one virtual <see cref="Bind"/> per active metadata binder — typically
+/// 1–4 (tenant + zero or more of headers / causation / correlation /
+/// username / tags / sequence / timestamp).
+/// </para>
+/// </remarks>
+public interface IEventMetadataBinder
+{
+    /// <summary>
+    /// Stable column name. The descriptor builder threads this through to
+    /// the dialect when composing the INSERT column list so the parameter
+    /// order matches the column order.
+    /// </summary>
+    string ColumnName { get; }
+
+    /// <summary>
+    /// SQL fragment placed in the VALUES list at this binder's position.
+    /// <c>"?"</c> for a real parameter, <c>"now()"</c> for a server-side
+    /// constant (timestamp), <c>"nextval('mt_events_sequence_seq')"</c> for
+    /// a server-generated sequence (sequence column). Server-side values
+    /// bind nothing in <see cref="Bind"/> but may need to read back in
+    /// <see cref="OnRead"/> if the operation has a RETURNING clause.
+    /// </summary>
+    string ValueSql { get; }
+
+    /// <summary>
+    /// Per-event write hook. Called by the closed-shape operation's
+    /// <c>ConfigureCommand</c> after the inlined core-column writes, in the
+    /// same order as the descriptor's binder array. No-op for
+    /// server-side-constant binders (timestamp / sequence under the
+    /// quick-append paths).
+    /// </summary>
+    void Bind(IGroupedParameterBuilder pb, StreamAction stream, IEvent @event, IStorageSession session);
+
+    /// <summary>
+    /// Per-event read-back hook called from the operation's
+    /// <c>Postprocess</c> / <c>PostprocessAsync</c> after the database
+    /// returns rows. <paramref name="columnOrdinal"/> is the binder's
+    /// position in the result row (which is the same as its position in
+    /// the binder array for RETURNING-shaped operations).
+    /// </summary>
+    /// <remarks>
+    /// Default implementation is no-op. Binders that own server-set values
+    /// (sequence, timestamp) override this to write the returned value back
+    /// onto the <see cref="IEvent"/> instance — that's the "call back and
+    /// set values on the document itself after we get results" path that
+    /// motivates this seam in the first place. Operations whose SQL has no
+    /// RETURNING clause (today's full-mode append) never call this; the
+    /// binder array's <see cref="OnRead"/> hooks are only exercised by the
+    /// quick-append variants.
+    /// </remarks>
+    void OnRead(DbDataReader reader, int columnOrdinal, StreamAction stream, IEvent @event)
+    {
+        // Default no-op — only binders with server-set values override this.
+    }
+}

--- a/src/Weasel.Storage/Events/IEventStoreSqlDialect.cs
+++ b/src/Weasel.Storage/Events/IEventStoreSqlDialect.cs
@@ -1,0 +1,31 @@
+#nullable enable
+using JasperFx.Events;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Dialect seam for the closed-shape event-storage hierarchy. A store ships
+/// its own implementation (Marten the Postgres one; Polecat the SQL-Server
+/// one). The dialect builds per-mode descriptors end-to-end — SQL strings,
+/// metadata-column ordering, and binder selection are all joint concerns the
+/// dialect owns, so the SQL stays aligned with the parameter binds.
+/// </summary>
+/// <remarks>
+/// <para>
+/// One method per append mode returns the whole descriptor. The dialect's
+/// implementation knows which columns are in the SQL (config-aware) and
+/// which binders bind each metadata column, in lockstep. The event-store
+/// configuration arrives as the neutral <see cref="EventRegistry"/> (a
+/// store's own event graph derives from it and the dialect downcasts) and
+/// serialization through the neutral <see cref="IStorageSerializer"/>.
+/// </para>
+/// </remarks>
+public interface IEventStoreSqlDialect
+{
+    RichEventStorageDescriptor BuildRichDescriptor(EventRegistry graph, IStorageSerializer serializer);
+
+    QuickEventStorageDescriptor BuildQuickDescriptor(EventRegistry graph, IStorageSerializer serializer);
+
+    QuickWithServerTimestampsEventStorageDescriptor BuildQuickWithServerTimestampsDescriptor(
+        EventRegistry graph, IStorageSerializer serializer);
+}

--- a/src/Weasel.Storage/Events/Metadata/CausationIdColumnBinder.cs
+++ b/src/Weasel.Storage/Events/Metadata/CausationIdColumnBinder.cs
@@ -1,0 +1,31 @@
+#nullable enable
+using JasperFx.Events;
+using Weasel.Core;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// <see cref="IEventMetadataBinder"/> for the optional <c>causation_id</c>
+/// varchar column. Binds <see cref="IEvent.CausationId"/> as a string
+/// parameter. Included in the descriptor's binder array iff causation-id
+/// metadata is enabled. Write-only — the read-back goes through the events
+/// table's own column reader.
+/// </summary>
+public sealed class CausationIdColumnBinder: IEventMetadataBinder
+{
+    private readonly IStorageDialect _dialect;
+
+    public CausationIdColumnBinder(IStorageDialect dialect)
+    {
+        _dialect = dialect;
+    }
+
+    public string ColumnName => "causation_id";
+    public string ValueSql => "?";
+
+    public void Bind(IGroupedParameterBuilder pb, StreamAction stream, IEvent @event, IStorageSession session)
+    {
+        var parameter = pb.AppendParameter(@event.CausationId);
+        _dialect.SetParameterType(parameter, StorageColumnType.String);
+    }
+}

--- a/src/Weasel.Storage/Events/Metadata/CorrelationIdColumnBinder.cs
+++ b/src/Weasel.Storage/Events/Metadata/CorrelationIdColumnBinder.cs
@@ -1,0 +1,28 @@
+#nullable enable
+using JasperFx.Events;
+using Weasel.Core;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// <see cref="IEventMetadataBinder"/> for the optional <c>correlation_id</c>
+/// varchar column. Symmetric with <see cref="CausationIdColumnBinder"/>.
+/// </summary>
+public sealed class CorrelationIdColumnBinder: IEventMetadataBinder
+{
+    private readonly IStorageDialect _dialect;
+
+    public CorrelationIdColumnBinder(IStorageDialect dialect)
+    {
+        _dialect = dialect;
+    }
+
+    public string ColumnName => "correlation_id";
+    public string ValueSql => "?";
+
+    public void Bind(IGroupedParameterBuilder pb, StreamAction stream, IEvent @event, IStorageSession session)
+    {
+        var parameter = pb.AppendParameter(@event.CorrelationId);
+        _dialect.SetParameterType(parameter, StorageColumnType.String);
+    }
+}

--- a/src/Weasel.Storage/Events/Metadata/HeadersColumnBinder.cs
+++ b/src/Weasel.Storage/Events/Metadata/HeadersColumnBinder.cs
@@ -1,0 +1,46 @@
+#nullable enable
+using JasperFx.Events;
+using Weasel.Core;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// <see cref="IEventMetadataBinder"/> for the optional <c>headers</c> JSONB
+/// column. Write-only — no read-back. The descriptor builder includes this
+/// binder in the array iff the event-store configuration has headers enabled.
+/// </summary>
+/// <remarks>
+/// Demonstrates the "configurable presence" axis: the binder either is or
+/// isn't in the descriptor's array. If headers aren't enabled, the binder
+/// isn't in the array and the loop iteration count goes down by one — no
+/// per-call cost when the feature is off.
+/// </remarks>
+public sealed class HeadersColumnBinder: IEventMetadataBinder
+{
+    private readonly IStorageDialect _dialect;
+
+    public HeadersColumnBinder(IStorageDialect dialect)
+    {
+        _dialect = dialect;
+    }
+
+    public string ColumnName => "headers";
+
+    public string ValueSql => "?";
+
+    public void Bind(IGroupedParameterBuilder pb, StreamAction stream, IEvent @event, IStorageSession session)
+    {
+        // Bind a DBNull placeholder typed as the dialect's json column type,
+        // then let WriteToParameter fill in the actual JSON bytes (skipping
+        // the intermediate string allocation) or leave the parameter at DBNull
+        // when Headers is null. The neutral AppendParameter writes DBNull.Value
+        // as-is; the dialect maps StorageColumnType.Json to its provider json
+        // type (Postgres jsonb).
+        var parameter = pb.AppendParameter(System.DBNull.Value);
+        _dialect.SetParameterType(parameter, StorageColumnType.Json);
+        session.Serializer.WriteToParameter(parameter, @event.Headers);
+    }
+
+    // OnRead — default no-op (inherited from the interface default). Headers
+    // are write-only; nothing comes back from the server for this column.
+}

--- a/src/Weasel.Storage/Events/Metadata/SequenceColumnBinder.cs
+++ b/src/Weasel.Storage/Events/Metadata/SequenceColumnBinder.cs
@@ -1,0 +1,32 @@
+#nullable enable
+using JasperFx.Events;
+using Weasel.Core;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// <see cref="IEventMetadataBinder"/> for the <c>seq_id</c> column on the
+/// Rich (full-mode) append path. Binds <see cref="IEvent.Sequence"/> as a
+/// bigint parameter — the appender pre-fetches a queue of sequence numbers
+/// and assigns them to each event before <c>AppendEvent(...)</c> is called,
+/// so the value is already populated on <see cref="IEvent.Sequence"/> by the
+/// time this binder runs.
+/// </summary>
+public sealed class SequenceColumnBinder: IEventMetadataBinder
+{
+    private readonly IStorageDialect _dialect;
+
+    public SequenceColumnBinder(IStorageDialect dialect)
+    {
+        _dialect = dialect;
+    }
+
+    public string ColumnName => "seq_id";
+    public string ValueSql => "?";
+
+    public void Bind(IGroupedParameterBuilder pb, StreamAction stream, IEvent @event, IStorageSession session)
+    {
+        var parameter = pb.AppendParameter(@event.Sequence);
+        _dialect.SetParameterType(parameter, StorageColumnType.Long);
+    }
+}

--- a/src/Weasel.Storage/Events/Metadata/UserNameColumnBinder.cs
+++ b/src/Weasel.Storage/Events/Metadata/UserNameColumnBinder.cs
@@ -1,0 +1,34 @@
+#nullable enable
+using JasperFx.Events;
+using Weasel.Core;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// <see cref="IEventMetadataBinder"/> for the optional <c>user_name</c>
+/// varchar column. Binds <see cref="IEvent.UserName"/> as a string parameter.
+/// </summary>
+/// <remarks>
+/// The session-level "user name" lives on <see cref="IMetadataContext.LastModifiedBy"/>,
+/// but the event appender plumbs that into the per-event
+/// <see cref="IEvent.UserName"/> before queuing the operation, and we bind
+/// off the event so the SQL stays self-contained.
+/// </remarks>
+public sealed class UserNameColumnBinder: IEventMetadataBinder
+{
+    private readonly IStorageDialect _dialect;
+
+    public UserNameColumnBinder(IStorageDialect dialect)
+    {
+        _dialect = dialect;
+    }
+
+    public string ColumnName => "user_name";
+    public string ValueSql => "?";
+
+    public void Bind(IGroupedParameterBuilder pb, StreamAction stream, IEvent @event, IStorageSession session)
+    {
+        var parameter = pb.AppendParameter(@event.UserName);
+        _dialect.SetParameterType(parameter, StorageColumnType.String);
+    }
+}

--- a/src/Weasel.Storage/Events/QuickEventStorageDescriptor.cs
+++ b/src/Weasel.Storage/Events/QuickEventStorageDescriptor.cs
@@ -1,0 +1,192 @@
+#nullable enable
+using System;
+using JasperFx.Events;
+using Weasel.Core;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Per-event-store-configuration descriptor for the Quick (batch) append
+/// flow. Holds only the SQL strings the Quick operations need — no Rich
+/// per-row INSERT prefix, no <see cref="IEventMetadataBinder"/> array for
+/// the batched call.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Why no metadata binder array on the batched call: Quick-mode binds
+/// metadata as <i>per-batch arrays</i> — one array parameter per column,
+/// with the array's contents being one value per event in the stream. That
+/// shape is uniform enough across columns that inlining the bind code per
+/// active column is just as clean as a binder dispatch — and avoids the
+/// per-event-list allocation churn a per-binder approach would force.
+/// </para>
+/// <para>
+/// The per-event <c>QuickWithVersion</c> INSERT path (new streams and
+/// expected-version-on-server appends) DOES use a binder array, exposed via
+/// <see cref="MetadataBinders"/> / <see cref="AppendEventFullMetadataBinders"/>.
+/// </para>
+/// </remarks>
+public sealed class QuickEventStorageDescriptor
+{
+    public QuickEventStorageDescriptor(
+        string quickAppendEventsSql,
+        string insertStreamSql,
+        string updateStreamVersionSql,
+        Func<IEvent, string> serializeEventData,
+        Func<IEvent, byte[]?> serializeEventBdata)
+    {
+        QuickAppendEventsSql = quickAppendEventsSql;
+        InsertStreamSql = insertStreamSql;
+        UpdateStreamVersionSql = updateStreamVersionSql;
+        SerializeEventData = serializeEventData;
+        SerializeEventBdata = serializeEventBdata;
+    }
+
+    /// <summary>
+    /// Complete SQL for <c>select {schema}.mt_quick_append_events(</c> —
+    /// the operation appends parameters via <see cref="IGroupedParameterBuilder"/>
+    /// and the trailing <c>)</c> in <c>ConfigureCommand</c>. The function
+    /// signature varies by configuration; the descriptor flags below tell
+    /// the operation which columns participate.
+    /// </summary>
+    public string QuickAppendEventsSql { get; }
+
+    public string InsertStreamSql { get; }
+    public string UpdateStreamVersionSql { get; }
+    public Func<IEvent, string> SerializeEventData { get; }
+
+    /// <summary>
+    ///     Serializer for the <c>bdata</c> bytea column on the per-event
+    ///     QuickWithVersion INSERT shape. In Quick modes, binary event types
+    ///     are rejected at descriptor-build time, so the dialect installs a
+    ///     closure that always returns <c>null</c> — <c>bdata</c> binds as
+    ///     DBNull. The slot still exists because <c>mt_events.bdata</c> is
+    ///     part of the column list on every full-shape INSERT.
+    /// </summary>
+    public Func<IEvent, byte[]?> SerializeEventBdata { get; }
+
+    /// <summary>Guid stream identity (writeId) vs string identity (writeKey).</summary>
+    public bool IsGuidStreamIdentity { get; init; }
+
+    /// <summary>
+    /// The storage dialect used to set provider parameter types on the
+    /// per-event QuickWithVersion INSERT's bound parameters
+    /// (<see cref="IStorageDialect.SetParameterType"/>), keeping the
+    /// closed-shape ops free of any direct provider reference. Installed by
+    /// the event dialect at descriptor-build time.
+    /// </summary>
+    public IStorageDialect Dialect { get; init; } = default!;
+
+    /// <summary>Conjoined-tenant — affects per-stream ops (InsertStream / UpdateStreamVersion / StreamState).</summary>
+    public bool IsTenancyConjoined { get; init; }
+
+    /// <summary>
+    /// The <c>select version from {schema}.mt_streams where id = </c> prefix for the
+    /// AssertStreamVersion (AlwaysEnforceConsistency, zero-events) path. Built once by the dialect.
+    /// </summary>
+    public string AssertStreamVersionSql { get; init; } = string.Empty;
+
+    /// <summary>Whether the events table has the <c>causation_id</c> column.</summary>
+    public bool HasCausationId { get; init; }
+
+    /// <summary>Whether the events table has the <c>correlation_id</c> column.</summary>
+    public bool HasCorrelationId { get; init; }
+
+    /// <summary>Whether the events table has the <c>headers</c> jsonb column.</summary>
+    public bool HasHeaders { get; init; }
+
+    /// <summary>Whether the events table has the <c>user_name</c> column.</summary>
+    public bool HasUserName { get; init; }
+
+    /// <summary>
+    /// Whether DCB tag types are configured AND the storage mode wires them
+    /// as per-batch <c>varchar[]</c> parameters on <c>mt_quick_append_events</c>.
+    /// </summary>
+    public bool HasTagWrites { get; init; }
+
+    /// <summary>
+    /// <c>UseTenantPartitionedEvents</c> is on, which means the bulk function
+    /// carries the trailing <c>expected_version</c> parameter (default NULL)
+    /// for the optimistic-concurrency append shapes. The Quick operation
+    /// binds the parameter when this flag is on.
+    /// </summary>
+    public bool UseTenantPartitionedEvents { get; init; }
+
+    /// <summary>
+    /// <c>EnableBigIntEvents</c> picks <c>bigint</c> over <c>int</c> for sequence
+    /// + version columns, which propagates to the optimistic-concurrency
+    /// parameter type — has to match the function-signature width so the
+    /// database doesn't refuse the bind on the strict typed path.
+    /// </summary>
+    public bool UseBigIntEvents { get; init; }
+
+    /// <summary>
+    /// SQL prefix <c>insert into mt_events (cols) values (</c> for the
+    /// per-event QuickWithVersion path. The Quick appender uses this shape
+    /// (one INSERT per event) for new streams and for existing streams
+    /// with an expected-version-on-server guard.
+    /// </summary>
+    public string AppendEventSqlPrefix { get; init; } = string.Empty;
+
+    /// <summary>
+    /// SQL suffix for the per-event QuickWithVersion path. Includes the
+    /// trailing <c>, nextval('schema.mt_events_sequence'))</c> — server-set
+    /// sequence (no client param) and closing paren.
+    /// </summary>
+    public string AppendEventSqlSuffix { get; init; } = ")";
+
+    /// <summary>
+    /// Ordered optional-metadata-column binders for the per-event
+    /// QuickWithVersion path. Same shape as
+    /// <see cref="RichEventStorageDescriptor.MetadataBinders"/> but WITHOUT
+    /// the sequence binder — seq_id is server-set via the nextval-literal in
+    /// <see cref="AppendEventSqlSuffix"/>, not a bound parameter.
+    /// </summary>
+    public IEventMetadataBinder[] MetadataBinders { get; init; } = System.Array.Empty<IEventMetadataBinder>();
+
+    /// <summary>
+    /// SQL suffix for the Full-mode per-event INSERT used by
+    /// <c>QuickEventStorage.AppendEvent</c> (called by paths like the
+    /// tombstone batch regardless of append mode). Just <c>")"</c> — no
+    /// <c>nextval()</c> fragment; seq_id is a bound parameter.
+    /// </summary>
+    public string AppendEventFullSqlSuffix { get; init; } = ")";
+
+    /// <summary>
+    /// Metadata binders for the Full-mode per-event INSERT path. Mirror of
+    /// <see cref="RichEventStorageDescriptor.MetadataBinders"/> — includes
+    /// the sequence binder because seq_id is a bound parameter here (not
+    /// <c>nextval()</c>).
+    /// </summary>
+    public IEventMetadataBinder[] AppendEventFullMetadataBinders { get; init; } = System.Array.Empty<IEventMetadataBinder>();
+
+    /// <summary>
+    /// Configures the <c>mt_streams</c> insert command — identical shape to
+    /// the Rich descriptor's closure. Init-only; the dialect installs it.
+    /// </summary>
+    public System.Action<ICommandBuilder, StreamAction> ConfigureInsertStreamCommand { get; init; }
+        = static (_, _) => throw new System.NotSupportedException(
+            "QuickEventStorageDescriptor.ConfigureInsertStreamCommand was not installed by the dialect.");
+
+    /// <summary>
+    /// Configures the <c>mt_streams</c> update-version command — identical
+    /// shape to the Rich descriptor's closure.
+    /// </summary>
+    public System.Action<ICommandBuilder, StreamAction> ConfigureUpdateStreamVersionCommand { get; init; }
+        = static (_, _) => throw new System.NotSupportedException(
+            "QuickEventStorageDescriptor.ConfigureUpdateStreamVersionCommand was not installed by the dialect.");
+
+    /// <summary>
+    /// Creates the batched append operation for a stream. Dialect-installed —
+    /// the batch shape is inherently dialect-specific (Postgres binds
+    /// per-column array parameters to <c>mt_quick_append_events</c>; another
+    /// dialect may use a multi-row INSERT with an OUTPUT/RETURNING read-back),
+    /// so the operation type itself lives with the dialect rather than the
+    /// shared storage hierarchy. Takes the descriptor as an argument because
+    /// init-only slots can't close over the instance under construction.
+    /// </summary>
+    public System.Func<QuickEventStorageDescriptor, StreamAction, IStorageOperation>
+        CreateQuickAppendEventsOperation { get; init; }
+        = static (_, _) => throw new System.NotSupportedException(
+            "QuickEventStorageDescriptor.CreateQuickAppendEventsOperation was not installed by the dialect.");
+}

--- a/src/Weasel.Storage/Events/QuickWithServerTimestampsEventStorageDescriptor.cs
+++ b/src/Weasel.Storage/Events/QuickWithServerTimestampsEventStorageDescriptor.cs
@@ -1,0 +1,159 @@
+#nullable enable
+using System;
+using JasperFx.Events;
+using Weasel.Core;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Per-event-store-configuration descriptor for the Quick batch-append flow
+/// in <c>EventAppendMode.QuickWithServerTimestamps</c>. Same shape as
+/// <see cref="QuickEventStorageDescriptor"/>; the SQL differs (extra
+/// timestamp-array column in the function signature) and the operation
+/// writes one extra array parameter.
+/// </summary>
+/// <remarks>
+/// Kept as a separate type from <see cref="QuickEventStorageDescriptor"/>
+/// for symmetry with the three-storage-class split (Rich / Quick /
+/// QuickWithServerTimestamps each get their own descriptor with no shared
+/// base).
+/// </remarks>
+public sealed class QuickWithServerTimestampsEventStorageDescriptor
+{
+    public QuickWithServerTimestampsEventStorageDescriptor(
+        string quickAppendEventsWithServerTimestampsSql,
+        string insertStreamSql,
+        string updateStreamVersionSql,
+        Func<IEvent, string> serializeEventData,
+        Func<IEvent, byte[]?> serializeEventBdata)
+    {
+        QuickAppendEventsWithServerTimestampsSql = quickAppendEventsWithServerTimestampsSql;
+        InsertStreamSql = insertStreamSql;
+        UpdateStreamVersionSql = updateStreamVersionSql;
+        SerializeEventData = serializeEventData;
+        SerializeEventBdata = serializeEventBdata;
+    }
+
+    /// <summary>
+    /// Complete SQL for the <c>select mt_quick_append_events(...)</c> call
+    /// with the server-timestamp variant's extra timestamp-array parameter.
+    /// </summary>
+    public string QuickAppendEventsWithServerTimestampsSql { get; }
+
+    public string InsertStreamSql { get; }
+    public string UpdateStreamVersionSql { get; }
+    public Func<IEvent, string> SerializeEventData { get; }
+
+    /// <summary>
+    ///     Serializer for the <c>bdata</c> bytea column on the per-event
+    ///     QuickWithVersion INSERT shape. Binary event types are rejected at
+    ///     descriptor-build time in Quick modes, so this always returns
+    ///     <c>null</c> — see <see cref="QuickEventStorageDescriptor.SerializeEventBdata"/>.
+    /// </summary>
+    public Func<IEvent, byte[]?> SerializeEventBdata { get; }
+
+    /// <summary>Guid stream identity (writeId) vs string identity (writeKey).</summary>
+    public bool IsGuidStreamIdentity { get; init; }
+
+    /// <summary>
+    /// The storage dialect used to set provider parameter types on the
+    /// per-event QuickWithVersion INSERT's bound parameters
+    /// (<see cref="IStorageDialect.SetParameterType"/>), keeping the
+    /// closed-shape ops free of any direct provider reference. Installed by
+    /// the event dialect at descriptor-build time.
+    /// </summary>
+    public IStorageDialect Dialect { get; init; } = default!;
+
+    /// <summary>Conjoined-tenant — affects per-stream ops (InsertStream / UpdateStreamVersion / StreamState).</summary>
+    public bool IsTenancyConjoined { get; init; }
+
+    /// <summary>
+    /// The <c>select version from {schema}.mt_streams where id = </c> prefix for the
+    /// AssertStreamVersion (AlwaysEnforceConsistency, zero-events) path. Built once by the dialect.
+    /// </summary>
+    public string AssertStreamVersionSql { get; init; } = string.Empty;
+
+    /// <summary>Whether the events table has the <c>causation_id</c> column.</summary>
+    public bool HasCausationId { get; init; }
+
+    /// <summary>Whether the events table has the <c>correlation_id</c> column.</summary>
+    public bool HasCorrelationId { get; init; }
+
+    /// <summary>Whether the events table has the <c>headers</c> jsonb column.</summary>
+    public bool HasHeaders { get; init; }
+
+    /// <summary>Whether the events table has the <c>user_name</c> column.</summary>
+    public bool HasUserName { get; init; }
+
+    /// <summary>
+    /// Whether DCB tag types are configured AND the storage mode wires them
+    /// as per-batch <c>varchar[]</c> parameters on <c>mt_quick_append_events</c>.
+    /// </summary>
+    public bool HasTagWrites { get; init; }
+
+    /// <summary>
+    /// See <see cref="QuickEventStorageDescriptor.UseTenantPartitionedEvents"/>.
+    /// </summary>
+    public bool UseTenantPartitionedEvents { get; init; }
+
+    /// <summary>
+    /// See <see cref="QuickEventStorageDescriptor.UseBigIntEvents"/>.
+    /// </summary>
+    public bool UseBigIntEvents { get; init; }
+
+    /// <summary>
+    /// SQL prefix <c>insert into mt_events (cols) values (</c> for the
+    /// per-event QuickWithVersion path used by the Quick appender.
+    /// </summary>
+    public string AppendEventSqlPrefix { get; init; } = string.Empty;
+
+    /// <summary>
+    /// SQL suffix including the server-side <c>, nextval(...))</c> seq_id
+    /// fragment for the per-event QuickWithVersion path.
+    /// </summary>
+    public string AppendEventSqlSuffix { get; init; } = ")";
+
+    /// <summary>
+    /// Optional-metadata-column binders for the per-event QuickWithVersion
+    /// path. Excludes the sequence binder — seq_id is server-set.
+    /// </summary>
+    public IEventMetadataBinder[] MetadataBinders { get; init; } = System.Array.Empty<IEventMetadataBinder>();
+
+    /// <summary>
+    /// SQL suffix <c>")"</c> for the Full-mode per-event INSERT used by
+    /// <c>QuickWithServerTimestampsEventStorage.AppendEvent</c> (tombstone
+    /// path + similar).
+    /// </summary>
+    public string AppendEventFullSqlSuffix { get; init; } = ")";
+
+    /// <summary>
+    /// Metadata binders for the Full-mode per-event INSERT path. Mirror of
+    /// <see cref="RichEventStorageDescriptor.MetadataBinders"/> — seq_id is bound.
+    /// </summary>
+    public IEventMetadataBinder[] AppendEventFullMetadataBinders { get; init; } = System.Array.Empty<IEventMetadataBinder>();
+
+    /// <summary>
+    /// Configures the <c>mt_streams</c> insert command — identical shape to
+    /// the Rich descriptor's closure.
+    /// </summary>
+    public System.Action<ICommandBuilder, StreamAction> ConfigureInsertStreamCommand { get; init; }
+        = static (_, _) => throw new System.NotSupportedException(
+            "QuickWithServerTimestampsEventStorageDescriptor.ConfigureInsertStreamCommand was not installed by the dialect.");
+
+    /// <summary>
+    /// Configures the <c>mt_streams</c> update-version command — identical
+    /// shape to the Rich descriptor's closure.
+    /// </summary>
+    public System.Action<ICommandBuilder, StreamAction> ConfigureUpdateStreamVersionCommand { get; init; }
+        = static (_, _) => throw new System.NotSupportedException(
+            "QuickWithServerTimestampsEventStorageDescriptor.ConfigureUpdateStreamVersionCommand was not installed by the dialect.");
+
+    /// <summary>
+    /// Creates the batched append operation for a stream. Dialect-installed —
+    /// see <see cref="QuickEventStorageDescriptor.CreateQuickAppendEventsOperation"/>.
+    /// </summary>
+    public System.Func<QuickWithServerTimestampsEventStorageDescriptor, StreamAction, IStorageOperation>
+        CreateQuickAppendEventsOperation { get; init; }
+        = static (_, _) => throw new System.NotSupportedException(
+            "QuickWithServerTimestampsEventStorageDescriptor.CreateQuickAppendEventsOperation was not installed by the dialect.");
+}

--- a/src/Weasel.Storage/Events/RichEventStorageDescriptor.cs
+++ b/src/Weasel.Storage/Events/RichEventStorageDescriptor.cs
@@ -1,0 +1,150 @@
+#nullable enable
+using System;
+using JasperFx.Events;
+using Weasel.Core;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Per-event-store-configuration descriptor for the Rich (full-mode) append
+/// flow. Holds only the SQL strings + delegates the Rich operations need —
+/// nothing about the Quick paths leaks in.
+/// </summary>
+/// <remarks>
+/// Rich-mode SQL is split into a prefix + suffix because the append output
+/// writes parameters inline between them, one per core column plus one
+/// virtual <see cref="IEventMetadataBinder.Bind"/> call per active metadata
+/// binder. See <see cref="MetadataBinders"/> for the metadata hybrid.
+/// </remarks>
+public sealed class RichEventStorageDescriptor
+{
+    public RichEventStorageDescriptor(
+        string appendEventSqlPrefix,
+        string appendEventSqlSuffix,
+        string insertStreamSql,
+        string updateStreamVersionSql,
+        Func<IEvent, string> serializeEventData,
+        Func<IEvent, byte[]?> serializeEventBdata,
+        IEventMetadataBinder[] metadataBinders)
+    {
+        AppendEventSqlPrefix = appendEventSqlPrefix;
+        AppendEventSqlSuffix = appendEventSqlSuffix;
+        InsertStreamSql = insertStreamSql;
+        UpdateStreamVersionSql = updateStreamVersionSql;
+        SerializeEventData = serializeEventData;
+        SerializeEventBdata = serializeEventBdata;
+        MetadataBinders = metadataBinders;
+    }
+
+    public string AppendEventSqlPrefix { get; }
+    public string AppendEventSqlSuffix { get; }
+    public string InsertStreamSql { get; }
+    public string UpdateStreamVersionSql { get; }
+
+    /// <summary>
+    ///     Serializer for the <c>data</c> jsonb column. Returns the full JSON
+    ///     payload for JSON-serialized events and the literal <c>{}</c>
+    ///     placeholder for binary-serialized events (the real payload lives in
+    ///     <c>bdata</c> in that case — see <see cref="SerializeEventBdata"/>).
+    /// </summary>
+    public Func<IEvent, string> SerializeEventData { get; }
+
+    /// <summary>
+    ///     Serializer for the <c>bdata</c> bytea column. Returns the
+    ///     serialized bytes for binary-serialized events; returns <c>null</c>
+    ///     (bound as <see cref="System.DBNull.Value"/>) for JSON-serialized
+    ///     events.
+    /// </summary>
+    public Func<IEvent, byte[]?> SerializeEventBdata { get; }
+
+    /// <summary>
+    /// Ordered metadata-column binders. Rich-mode only — Quick-mode
+    /// descriptors don't expose this because Quick's metadata binding is
+    /// hand-written inline (per-batch array parameters; no per-event dispatch
+    /// worth abstracting).
+    /// </summary>
+    public IEventMetadataBinder[] MetadataBinders { get; }
+
+    /// <summary>
+    /// SQL suffix for the per-event <c>QuickWithVersion</c> path on this
+    /// Rich descriptor — same per-event INSERT shape as
+    /// <see cref="AppendEventSqlSuffix"/>, but with a server-side
+    /// <c>nextval('{schema}.mt_events_sequence')</c> literal in place of the
+    /// bound <c>seq_id</c> parameter. Used by the async-projection
+    /// side-effect replay path (raised events): the caller pre-assigns
+    /// <c>event.Version</c> but not <c>event.Sequence</c>, so the server
+    /// claims the sequence inline.
+    /// </summary>
+    public string AppendEventQuickWithVersionSqlSuffix { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Ordered metadata-column binders for the per-event
+    /// <c>QuickWithVersion</c> path on this Rich descriptor. Identical to
+    /// <see cref="MetadataBinders"/> except the sequence binder is omitted —
+    /// <c>seq_id</c> is server-set via the <c>nextval(...)</c> literal in
+    /// <see cref="AppendEventQuickWithVersionSqlSuffix"/>.
+    /// </summary>
+    public IEventMetadataBinder[] MetadataBindersWithoutSequence { get; init; }
+        = System.Array.Empty<IEventMetadataBinder>();
+
+    /// <summary>
+    /// Whether the events table is conjoined-tenant — every per-stream query
+    /// (StreamState lookup, UpdateStreamVersion, etc.) needs a trailing
+    /// <c>and tenant_id = $N</c> when this is true.
+    /// </summary>
+    /// <remarks>
+    /// Init-only so the dialect sets it once at descriptor construction. The
+    /// closed-shape path lifts the tenancy check to a per-descriptor boolean
+    /// so the storage methods don't carry an event-graph reference.
+    /// </remarks>
+    public bool IsTenancyConjoined { get; init; }
+
+    /// <summary>
+    /// The <c>select version from {schema}.mt_streams where id = </c> prefix for the
+    /// AssertStreamVersion (AlwaysEnforceConsistency, zero-events) path. Built once by the dialect.
+    /// </summary>
+    public string AssertStreamVersionSql { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Whether streams are identified by <see cref="System.Guid"/> (true) or
+    /// <see cref="string"/> (false). The Rich AppendEvent operation reads
+    /// <c>Stream.Id</c> vs <c>Stream.Key</c> based on this flag.
+    /// </summary>
+    public bool IsGuidStreamIdentity { get; init; }
+
+    /// <summary>
+    /// The storage dialect used to set provider parameter types on the
+    /// per-event append operation's bound parameters
+    /// (<see cref="IStorageDialect.SetParameterType"/>), keeping the
+    /// closed-shape ops free of any direct provider reference. Installed by
+    /// the event dialect at descriptor-build time.
+    /// </summary>
+    public IStorageDialect Dialect { get; init; } = default!;
+
+    /// <summary>
+    /// Configures the <c>mt_streams</c> insert command. The closure owns
+    /// the SQL shape (column list, parameter binds, tenancy/identity
+    /// variants) and the actual <see cref="IGroupedParameterBuilder"/>
+    /// dispatch.
+    /// </summary>
+    /// <remarks>
+    /// Init-only so the dialect installs it at descriptor-build time. Throws
+    /// if invoked before a closure is installed (means the dialect hasn't
+    /// wired this codepath yet — e.g., a strict-identity-enforcement variant
+    /// isn't supported yet).
+    /// </remarks>
+    public System.Action<ICommandBuilder, StreamAction> ConfigureInsertStreamCommand { get; init; }
+        = static (_, _) => throw new System.NotSupportedException(
+            "RichEventStorageDescriptor.ConfigureInsertStreamCommand was not installed by the dialect. " +
+            "This indicates a Rich-mode configuration variant (e.g., strict stream-identity enforcement) " +
+            "that the closed-shape hierarchy doesn't yet cover.");
+
+    /// <summary>
+    /// Configures the <c>mt_streams</c> update-version command. Symmetric
+    /// to <see cref="ConfigureInsertStreamCommand"/> — SQL shape and binds
+    /// owned by the dialect-installed closure.
+    /// </summary>
+    public System.Action<ICommandBuilder, StreamAction> ConfigureUpdateStreamVersionCommand { get; init; }
+        = static (_, _) => throw new System.NotSupportedException(
+            "RichEventStorageDescriptor.ConfigureUpdateStreamVersionCommand was not installed by the dialect.");
+}


### PR DESCRIPTION
## marten#4821 — event-storage move, slice E2

Dialect-neutral relocation of Marten's `src/Marten/EventStorage/` **descriptor core** into `Weasel.Storage` (`namespace Weasel.Storage`), the second slice of the closed-shape EVENT-storage move (E1 = grouped-parameter seam shipped in #339 / 9.14.0). Lets Polecat (SQL Server) and Marten share the closed-shape event write-path shapes.

**Purely additive on the Weasel side.** Marten will delete its copies and consume `9.15.0`; Polecat is the waiting second consumer (polecat#273).

### New files under `src/Weasel.Storage/Events/`
- **`IEventMetadataBinder`** (public) — `Bind` over `Weasel.Core.IGroupedParameterBuilder` + `Weasel.Storage.IStorageSession`; default no-op `OnRead`.
- **`IEventStoreSqlDialect`** (public; was `internal` in Marten) — retyped `EventGraph → JasperFx.Events.EventRegistry`, `ISerializer → Weasel.Storage.IStorageSerializer`.
- **`RichEventStorageDescriptor` / `QuickEventStorageDescriptor` / `QuickWithServerTimestampsEventStorageDescriptor`** — `ConfigureInsertStreamCommand` / `ConfigureUpdateStreamVersionCommand` closures retyped `Weasel.Postgresql.ICommandBuilder → Weasel.Core.ICommandBuilder`; `CreateQuickAppendEventsOperation` factory retyped `Marten.Internal.Operations.IStorageOperation → Weasel.Storage.IStorageOperation`; `Dialect` slot already neutral (`Weasel.Storage.IStorageDialect`).
- **`Metadata/`** — 5 binders (Sequence / Headers / CausationId / CorrelationId / UserName), made **public** (from Marten's `internal`) so a store's dialect can instantiate them cross-assembly.

### Notes for the Marten consumer
- All event types land in the flat `namespace Weasel.Storage` (matches the existing doc-side convention in this project).
- `StreamAction` / `IEvent` / `EventRegistry` all resolve to `JasperFx.Events` (single type — no `Marten.Events.StreamAction` exists).
- Binder visibility change (`internal → public`) is forced by the cross-assembly move (`PostgresEventStoreDialect` `new`s all five).

Builds clean (net9.0 + net10.0), full solution 0 errors, Weasel.Core.Tests green.