### PR TITLE
Sanitize suffix in managed partition drop path, symmetric with create (#338)

### DIFF
--- a/src/Weasel.Postgresql.Tests/Tables/partitioning/managed_list_partitions.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/partitioning/managed_list_partitions.cs
@@ -207,6 +207,38 @@ public class managed_list_partitions : IntegrationContext
     }
 
     [Fact]
+    public async Task remove_partition_with_hyphenated_suffix_is_symmetric_with_create()
+    {
+        // JasperFx/weasel#338: the CREATE path sanitizes the suffix (ListPartition.SanitizeSuffix
+        // lowercases and replaces every char outside [a-z0-9_] with '_') so a tenant id containing '-'
+        // (hyphenated ids, and GUID-shaped ids — the common real-world case) yields a valid UNQUOTED
+        // partition table name "<parent>_<sanitized>". The DROP path did NOT apply the same
+        // normalization: it built "<parent>_<raw-suffix>" straight from the raw id, so it either emitted
+        // invalid DDL (unquoted '-' => 42601 syntax error) or targeted a table name that create never
+        // produced. Drop must resolve the identical table name as create.
+        var database = new ManagedListDatabase();
+
+        // A GUID-shaped tenant id — contains '-', the common real-world case.
+        var tenantId = Guid.NewGuid().ToString();
+        var sanitized = tenantId.Replace('-', '_').ToLowerInvariant();
+
+        // ResetValues migrates the managed-partition metadata table and records the raw suffix.
+        await database.Partitions.ResetValues(database,
+            new Dictionary<string, string> { { tenantId, tenantId } }, CancellationToken.None);
+        await database.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        // Create sanitized the suffix, so the physical partition tables are "<parent>_<sanitized>".
+        (await partitionExists("teams", sanitized)).ShouldBeTrue($"teams_{sanitized} should have been created");
+        (await partitionExists("players", sanitized)).ShouldBeTrue($"players_{sanitized} should have been created");
+
+        // Pre-fix this threw 42601 (unquoted '-') or silently missed the real partition table.
+        await database.Partitions.DropPartitionFromAllTablesForValue(database, NullLogger.Instance, tenantId, CancellationToken.None);
+
+        (await partitionExists("teams", sanitized)).ShouldBeFalse($"teams_{sanitized} should have been dropped");
+        (await partitionExists("players", sanitized)).ShouldBeFalse($"players_{sanitized} should have been dropped");
+    }
+
+    [Fact]
     public async Task apply_additive_migration_2()
     {
         var database = new ManagedListDatabase();

--- a/src/Weasel.Postgresql/Tables/Partitioning/ManagedListPartitions.cs
+++ b/src/Weasel.Postgresql/Tables/Partitioning/ManagedListPartitions.cs
@@ -143,8 +143,15 @@ public class ManagedListPartitions : FeatureSchemaBase, IDatabaseInitializer<Npg
         {
             foreach (var suffixName in suffixNames)
             {
+                // weasel#338: the CREATE path (ListPartition) names the partition table with a SANITIZED
+                // suffix, so the DROP path must sanitize identically or it targets a different, invalid
+                // table name — an unquoted '-' from a hyphenated/GUID tenant id yields 42601, and even
+                // where quoting kicks in it resolves "<parent>_<raw>" instead of the "<parent>_<sanitized>"
+                // that create actually produced. The managed-partition metadata table above keys on the
+                // raw suffix (matching what was stored), only the physical DDL name is normalized.
+                var sanitizedSuffix = ListPartition.SanitizeSuffix(suffixName);
                 var partitionName = PostgresqlObjectName.From(
-                    new DbObjectName(table.Identifier.Schema, table.Identifier.Name + "_" + suffixName));
+                    new DbObjectName(table.Identifier.Schema, table.Identifier.Name + "_" + sanitizedSuffix));
 
                 try
                 {


### PR DESCRIPTION
Fixes #338.

## Problem

`ListPartition.WriteCreateStatement` names a partition table `{parent}_{SanitizeSuffix(suffix)}` — `SanitizeSuffix` lowercases and replaces every char outside `[a-z0-9_]` with `_`, precisely so an unquoted partition identifier with a `-` doesn't produce `42601 syntax error at or near "-"`.

The **drop** path (`ManagedListPartitions.DropPartitionFromAllTables` / `DropPartitionFromAllTablesForValue`) did **not** apply the same normalization — it built `{parent}_{raw-suffix}` straight from the raw suffix. For a tenant id containing `-` (hyphenated ids, and **GUID-shaped ids** — the common real-world case), that:

1. emitted invalid DDL — `PostgresqlObjectName`'s general-usage quoting only quotes for reserved keywords/uppercase, so a lowercase hyphenated suffix went out **unquoted** → `42601`; and
2. even where quoting kicked in, targeted `{parent}_{raw}` while create made `{parent}_{sanitized}` — a **different table name**, so DETACH/DROP missed the real partition (silent `if exists` no-op, or DETACH partition-not-found).

## Fix

Apply `ListPartition.SanitizeSuffix(suffixName)` before building the `PostgresqlObjectName` in the drop loop, so drop and create resolve the **identical** table name. The managed-partition metadata delete still keys on the raw suffix (matching what was stored in `partition_suffix`); only the physical DDL name is normalized. Quoting alone would be insufficient and would re-introduce the create/drop name mismatch.

## Test

Added `remove_partition_with_hyphenated_suffix_is_symmetric_with_create` to `managed_list_partitions`: seeds a GUID-shaped tenant id, applies (create sanitizes → `<parent>_<sanitized>` exists), then drops by value and asserts the sanitized partition tables are gone on both managed tables. Fails pre-fix (`42601` / wrong-table miss), passes post-fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)