### PR TITLE
Relocate closed-shape event-storage hierarchy + operations into Weasel.Storage (marten#4821 event E3)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>9.15.0</Version>
+        <Version>9.16.0</Version>
         <LangVersion>13.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/src/Weasel.Storage/Events/EventStorage.cs
+++ b/src/Weasel.Storage/Events/EventStorage.cs
@@ -1,0 +1,61 @@
+#nullable enable
+using JasperFx.Events;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Dialect-neutral closed-shape event-storage abstraction. Three concrete
+/// implementations ship — one per <see cref="EventAppendMode"/> flavor — and
+/// exactly one is wired into a store at construction time by
+/// <see cref="EventStorageBuilder"/>. Per-call dispatch is a virtual call
+/// through this base; no runtime branching on append mode. Relocated from
+/// Marten's <c>Marten.EventStorage.EventStorage&lt;TId&gt;</c> as the final
+/// slice of the marten#4821 event-storage move (event E3); the same hierarchy
+/// now serves Marten (Postgres) and Polecat (SQL Server) via their own
+/// <see cref="IEventStoreSqlDialect"/> implementations.
+/// </summary>
+/// <remarks>
+/// Write-only after Marten's E0 prework hoisted the stream-state query handler
+/// off this hierarchy. Each concrete subclass implements only the methods
+/// appropriate to its append mode; the "wrong-mode" methods throw
+/// <see cref="System.NotSupportedException"/> but are never reached because the
+/// builder's subclass pick and the session's dispatch are both gated by the
+/// same append-mode setting.
+/// </remarks>
+public abstract class EventStorage<TId>
+{
+    /// <summary>
+    /// Per-event append for the Full mode. One <see cref="IStorageOperation"/>
+    /// per event; the session enqueues N operations for an N-event stream.
+    /// </summary>
+    public abstract IStorageOperation AppendEvent(
+        IStorageSession session, StreamAction stream, IEvent @event);
+
+    /// <summary>
+    /// Per-event append for the QuickWithVersion mode — same per-event shape as
+    /// <see cref="AppendEvent"/>, but the event's version is pre-assigned by the
+    /// caller rather than computed from a stream-state lookup.
+    /// </summary>
+    public abstract IStorageOperation QuickAppendEventWithVersion(StreamAction stream, IEvent @event);
+
+    /// <summary>
+    /// Batched per-stream append. One <see cref="IStorageOperation"/> per stream;
+    /// the operation is dialect-supplied (Postgres binds array parameters to a
+    /// bulk function; another dialect may use a different SQL shape).
+    /// </summary>
+    public abstract IStorageOperation QuickAppendEvents(StreamAction stream);
+
+    /// <summary>Inserts the <c>mt_streams</c> row when a new stream is opened.</summary>
+    public abstract IStorageOperation InsertStream(StreamAction stream);
+
+    /// <summary>Increments the <c>mt_streams</c> version with an expected-version guard.</summary>
+    public abstract IStorageOperation UpdateStreamVersion(StreamAction stream);
+
+    /// <summary>
+    /// Asserts the expected <c>mt_streams</c> version without appending events
+    /// (the <c>AlwaysEnforceConsistency</c> zero-events path). The concrete
+    /// storage selects the single-tenant or conjoined operation variant once,
+    /// from its descriptor's tenancy style.
+    /// </summary>
+    public abstract IStorageOperation AssertStreamVersion(StreamAction stream);
+}

--- a/src/Weasel.Storage/Events/EventStorageBuilder.cs
+++ b/src/Weasel.Storage/Events/EventStorageBuilder.cs
@@ -1,0 +1,42 @@
+#nullable enable
+using System;
+using JasperFx.Events;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Factory for the per-mode <see cref="EventStorage{TId}"/> subclass that matches
+/// an event store's <see cref="EventAppendMode"/>. Picks ONE concrete subclass
+/// per store; no per-call append-mode branching after startup. Relocated from
+/// Marten (event E3) and made dialect-agnostic: it receives the
+/// <see cref="IEventStoreSqlDialect"/> and append mode rather than hardcoding a
+/// Postgres dialect, so Marten passes its <c>PostgresEventStoreDialect</c> and
+/// Polecat passes its SQL-Server dialect.
+/// </summary>
+public static class EventStorageBuilder
+{
+    public static EventStorage<TId> Build<TId>(
+        IEventStoreSqlDialect dialect,
+        EventAppendMode appendMode,
+        EventRegistry graph,
+        IStorageSerializer serializer)
+    {
+        // The dialect owns descriptor construction end-to-end — SQL strings and
+        // metadata-binder ordering are joint concerns it builds in lockstep.
+        return appendMode switch
+        {
+            EventAppendMode.Rich =>
+                new RichEventStorage<TId>(dialect.BuildRichDescriptor(graph, serializer)),
+
+            EventAppendMode.Quick =>
+                new QuickEventStorage<TId>(dialect.BuildQuickDescriptor(graph, serializer)),
+
+            EventAppendMode.QuickWithServerTimestamps =>
+                new QuickWithServerTimestampsEventStorage<TId>(
+                    dialect.BuildQuickWithServerTimestampsDescriptor(graph, serializer)),
+
+            _ => throw new ArgumentOutOfRangeException(nameof(appendMode),
+                $"Unsupported EventAppendMode for the closed-shape event-storage hierarchy: {appendMode}.")
+        };
+    }
+}

--- a/src/Weasel.Storage/Events/Operations/AppendEventOperationBase.cs
+++ b/src/Weasel.Storage/Events/Operations/AppendEventOperationBase.cs
@@ -1,0 +1,62 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using Weasel.Core;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Dialect-neutral base for the closed-shape per-event append operation — one
+/// <see cref="IStorageOperation"/> per event, no result set. Relocated from
+/// Marten's <c>Marten.Events.Operations.AppendEventOperationBase</c> as part of
+/// the marten#4821 event-storage move (event E3); Marten keeps its own
+/// like-named base behind for the legacy codegen write path ("Leave public for
+/// codegen!").
+/// </summary>
+/// <remarks>
+/// Implements the neutral <see cref="Weasel.Storage.IStorageOperation"/> — a
+/// store's own dialect-typed operation contract derives from it and bridges the
+/// dialect-typed <c>ConfigureCommand</c> down to this neutral slot with a
+/// default interface method, so a moved op that authors the neutral
+/// <see cref="ConfigureCommand"/> directly is a first-class citizen of the
+/// execution pipeline.
+/// </remarks>
+public abstract class AppendEventOperationBase: IStorageOperation, NoDataReturnedCall
+{
+    protected AppendEventOperationBase(StreamAction stream, IEvent e)
+    {
+        Stream = stream;
+        Event = e;
+
+        if (e.Version == 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(e), "Version cannot be 0");
+        }
+    }
+
+    public StreamAction Stream { get; }
+    public IEvent Event { get; }
+
+    public abstract void ConfigureCommand(ICommandBuilder builder, IStorageSession session);
+
+    public Type DocumentType => typeof(IEvent);
+
+    public Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)
+    {
+        return Task.CompletedTask;
+    }
+
+    public OperationRole Role()
+    {
+        return OperationRole.Events;
+    }
+
+    public override string ToString()
+    {
+        return $"Insert Event to Stream {Stream.Key ?? Stream.Id.ToString()}, Version {Event.Version}";
+    }
+}

--- a/src/Weasel.Storage/Events/Operations/AssertStreamVersionOperation.cs
+++ b/src/Weasel.Storage/Events/Operations/AssertStreamVersionOperation.cs
@@ -1,0 +1,78 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using Weasel.Core;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Dialect-neutral "assert expected stream version, append nothing" operation for
+/// the <c>AlwaysEnforceConsistency</c> zero-events path. Relocated from Marten's
+/// <c>Marten.EventStorage.AssertStreamVersionOperation&lt;TId&gt;</c> (event E3).
+/// Two concrete variants ship — <see cref="SingleTenantAssertStreamVersionOperation{TId}"/>
+/// and <see cref="ConjoinedAssertStreamVersionOperation{TId}"/> — and the owning
+/// <see cref="EventStorage{TId}"/> picks which to instantiate from the descriptor's
+/// tenancy style, so the tenancy branch is resolved once from configuration rather
+/// than on every <see cref="ConfigureCommand"/> call. The stream-identity variation
+/// (<see cref="Guid"/> vs <see cref="string"/>) is fixed by the closed generic
+/// <typeparamref name="TId"/>.
+/// </summary>
+public abstract class AssertStreamVersionOperation<TId>: IStorageOperation where TId : notnull
+{
+    /// <summary>
+    /// The <c>select version from {schema}.mt_streams where id = </c> prefix,
+    /// built once per store by the dialect and threaded through the descriptor.
+    /// Subclasses append the identity parameter (and, when conjoined, the
+    /// trailing <c>and tenant_id = $N</c>).
+    /// </summary>
+    protected readonly string SelectVersionByIdPrefix;
+
+    protected AssertStreamVersionOperation(string selectVersionByIdPrefix, StreamAction stream)
+    {
+        SelectVersionByIdPrefix = selectVersionByIdPrefix;
+        Stream = stream;
+    }
+
+    public StreamAction Stream { get; }
+
+    /// <summary>
+    /// The value bound as the <c>id</c> predicate — <see cref="StreamAction.Id"/>
+    /// for Guid-identified streams, <see cref="StreamAction.Key"/> for string.
+    /// The closed generic fixes the choice, so there is no per-call branch.
+    /// </summary>
+    protected object StreamIdentity => typeof(TId) == typeof(Guid) ? Stream.Id : Stream.Key!;
+
+    /// <summary>
+    /// <see cref="DbType"/> for the bound <c>id</c> parameter, fixed by the
+    /// closed generic <typeparamref name="TId"/>.
+    /// </summary>
+    protected static readonly DbType IdDbType = typeof(TId) == typeof(Guid) ? DbType.Guid : DbType.String;
+
+    public abstract void ConfigureCommand(ICommandBuilder builder, IStorageSession session);
+
+    public Type DocumentType => typeof(IEvent);
+
+    public async Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)
+    {
+        if (!await reader.ReadAsync(token).ConfigureAwait(false))
+        {
+            exceptions.Add(new EventStreamUnexpectedMaxEventIdException(StreamIdentity, Stream.AggregateType,
+                Stream.ExpectedVersionOnServer!.Value, 0));
+            return;
+        }
+
+        var actualVersion = await reader.GetFieldValueAsync<long>(0, token).ConfigureAwait(false);
+        if (actualVersion != Stream.ExpectedVersionOnServer!.Value)
+        {
+            exceptions.Add(new EventStreamUnexpectedMaxEventIdException(StreamIdentity, Stream.AggregateType,
+                Stream.ExpectedVersionOnServer.Value, actualVersion));
+        }
+    }
+
+    public OperationRole Role() => OperationRole.Events;
+}

--- a/src/Weasel.Storage/Events/Operations/ConjoinedAssertStreamVersionOperation.cs
+++ b/src/Weasel.Storage/Events/Operations/ConjoinedAssertStreamVersionOperation.cs
@@ -1,0 +1,40 @@
+#nullable enable
+using System.Data;
+using JasperFx.Events;
+using Weasel.Core;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Conjoined-tenant closed-shape assert-stream-version operation. Emits
+/// <c>select version from {schema}.mt_streams where id = $1 and tenant_id = $2</c>.
+/// Selected by <see cref="EventStorage{TId}.AssertStreamVersion"/> when the
+/// events table is conjoined-tenant. The trailing tenant predicate restores the
+/// <c>(tenant_id, id)</c> primary-key point seek and scopes the version check to
+/// the fetching tenant.
+/// </summary>
+internal sealed class ConjoinedAssertStreamVersionOperation<TId>: AssertStreamVersionOperation<TId>
+    where TId : notnull
+{
+    // Matches JasperFx.StorageConstants.TenantIdColumn — the metadata tenant
+    // column name is the same across the Postgres and SQL Server dialects.
+    private const string TenantIdColumnName = "tenant_id";
+
+    public ConjoinedAssertStreamVersionOperation(string selectVersionByIdPrefix, StreamAction stream)
+        : base(selectVersionByIdPrefix, stream)
+    {
+    }
+
+    public override void ConfigureCommand(ICommandBuilder builder, IStorageSession session)
+    {
+        builder.Append(SelectVersionByIdPrefix);
+        var idParam = builder.AppendParameter(StreamIdentity);
+        idParam.DbType = IdDbType;
+
+        builder.Append(" and ");
+        builder.Append(TenantIdColumnName);
+        builder.Append(" = ");
+        var tenantParam = builder.AppendParameter((object)Stream.TenantId);
+        tenantParam.DbType = DbType.String;
+    }
+}

--- a/src/Weasel.Storage/Events/Operations/InsertStreamOperationBase.cs
+++ b/src/Weasel.Storage/Events/Operations/InsertStreamOperationBase.cs
@@ -1,0 +1,84 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Core.Exceptions;
+using JasperFx.Events;
+using Weasel.Core;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Dialect-neutral base for the closed-shape <c>mt_streams</c> insert operation
+/// (one per new stream, no result set). Relocated from Marten's
+/// <c>Marten.Events.Operations.InsertStreamBase</c> as part of the marten#4821
+/// event-storage move (event E3).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The concrete command shape lives on a dialect-installed descriptor closure
+/// (<c>ConfigureInsertStreamCommand</c>); the subclasses are minimal shells that
+/// pull the closure off their descriptor and invoke it.
+/// </para>
+/// <para>
+/// Stream-id-collision friendliness is preserved without leaking any provider
+/// type into the neutral library: the base implements the neutral
+/// <see cref="IExceptionTransform"/> and delegates to an optional
+/// <c>TransformInsertStreamException</c> closure supplied by the descriptor. The
+/// Postgres dialect installs a closure that maps a unique-constraint violation on
+/// <c>mt_streams</c> to Marten's <c>ExistingStreamIdCollisionException</c>; a
+/// SQL Server dialect (Polecat) installs its own. When no closure is installed
+/// the raw provider exception flows through unchanged.
+/// </para>
+/// </remarks>
+public abstract class InsertStreamOperationBase: IStorageOperation, IExceptionTransform, NoDataReturnedCall
+{
+    private readonly Func<Exception, StreamAction, Exception?>? _transformInsertStreamException;
+
+    protected InsertStreamOperationBase(
+        StreamAction stream,
+        Func<Exception, StreamAction, Exception?>? transformInsertStreamException)
+    {
+        Stream = stream;
+        _transformInsertStreamException = transformInsertStreamException;
+    }
+
+    public StreamAction Stream { get; }
+
+    public abstract void ConfigureCommand(ICommandBuilder builder, IStorageSession session);
+
+    public Type DocumentType => typeof(IEvent);
+
+    public Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)
+    {
+        return Task.CompletedTask;
+    }
+
+    public OperationRole Role()
+    {
+        return OperationRole.Events;
+    }
+
+    public override string ToString()
+    {
+        return $"InsertStream: {Stream.Key ?? Stream.Id.ToString()}";
+    }
+
+    public bool TryTransform(Exception original, out Exception? transformed)
+    {
+        if (_transformInsertStreamException is { } transform)
+        {
+            var result = transform(original, Stream);
+            if (result is not null)
+            {
+                transformed = result;
+                return true;
+            }
+        }
+
+        transformed = null;
+        return false;
+    }
+}

--- a/src/Weasel.Storage/Events/Operations/QuickAppendEventWithVersionOperation.cs
+++ b/src/Weasel.Storage/Events/Operations/QuickAppendEventWithVersionOperation.cs
@@ -1,0 +1,98 @@
+#nullable enable
+using System;
+using JasperFx.Events;
+using Weasel.Core;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Closed-shape per-event INSERT operation for the Quick paths' "with version"
+/// branch — one INSERT per event with a pre-assigned <see cref="IEvent.Version"/>.
+/// Relocated from Marten's <c>Marten.EventStorage.Quick.QuickAppendEventWithVersionOperation</c>
+/// (event E3). The Quick appender uses this shape when a stream is starting (no
+/// prior version to fetch) or an existing stream has
+/// <see cref="StreamAction.ExpectedVersionOnServer"/> set; other cases use the
+/// dialect-supplied bulk append operation. Also reused by the Rich storage's
+/// side-effect replay path (raised events).
+/// </summary>
+/// <remarks>
+/// Same INSERT shape as <c>RichAppendEventOperation</c>, with one divergence:
+/// <c>seq_id</c> may be a server-side <c>nextval(...)</c> SQL literal baked into
+/// the supplied suffix instead of a bound parameter, in which case the supplied
+/// binder array excludes the sequence binder. The SQL prefix/suffix + binder set
+/// are passed in by the calling storage class so this single operation covers all
+/// three Quick/QWST/Rich-replay variants.
+/// </remarks>
+internal sealed class QuickAppendEventWithVersionOperation: AppendEventOperationBase
+{
+    private readonly string _appendEventSqlPrefix;
+    private readonly string _appendEventSqlSuffix;
+    private readonly IEventMetadataBinder[] _metadataBinders;
+    private readonly bool _isGuidStreamIdentity;
+    private readonly Func<IEvent, string> _serializeEventData;
+    private readonly Func<IEvent, byte[]?> _serializeEventBdata;
+    private readonly IStorageDialect _dialect;
+
+    public QuickAppendEventWithVersionOperation(
+        string appendEventSqlPrefix,
+        string appendEventSqlSuffix,
+        IEventMetadataBinder[] metadataBinders,
+        bool isGuidStreamIdentity,
+        Func<IEvent, string> serializeEventData,
+        Func<IEvent, byte[]?> serializeEventBdata,
+        IStorageDialect dialect,
+        StreamAction stream,
+        IEvent e)
+        : base(stream, e)
+    {
+        _appendEventSqlPrefix = appendEventSqlPrefix;
+        _appendEventSqlSuffix = appendEventSqlSuffix;
+        _metadataBinders = metadataBinders;
+        _isGuidStreamIdentity = isGuidStreamIdentity;
+        _serializeEventData = serializeEventData;
+        _serializeEventBdata = serializeEventBdata;
+        _dialect = dialect;
+    }
+
+    public override void ConfigureCommand(ICommandBuilder builder, IStorageSession session)
+    {
+        builder.Append(_appendEventSqlPrefix);
+
+        var dialect = _dialect;
+        IGroupedParameterBuilder pb = builder.CreateGroupedParameterBuilder(',');
+
+        // Core columns — same order + types as RichAppendEventOperation. Provider
+        // parameter types come from the dialect so the op carries no direct
+        // provider reference.
+        dialect.SetParameterType(pb.AppendParameter(_serializeEventData(Event)), StorageColumnType.Json);
+        dialect.SetParameterType(pb.AppendParameter(Event.EventTypeName), StorageColumnType.String);
+        dialect.SetParameterType(pb.AppendParameter(Event.DotNetTypeName), StorageColumnType.String);
+
+        // bdata bytea (nullable). NULL for JSON-serialized events; bytes for
+        // binary-serialized events. The neutral AppendParameter writes a null
+        // byte[] as DBNull.
+        var bdataBytes = _serializeEventBdata(Event);
+        dialect.SetParameterType(pb.AppendParameter(bdataBytes), StorageColumnType.Binary);
+
+        dialect.SetParameterType(pb.AppendParameter(Event.Id), StorageColumnType.Guid);
+
+        if (_isGuidStreamIdentity)
+            dialect.SetParameterType(pb.AppendParameter(Stream.Id), StorageColumnType.Guid);
+        else
+            dialect.SetParameterType(pb.AppendParameter(Stream.Key), StorageColumnType.String);
+
+        dialect.SetParameterType(pb.AppendParameter(Event.Version), StorageColumnType.Long);
+        dialect.SetParameterType(pb.AppendParameter(Event.Timestamp), StorageColumnType.Timestamp);
+        dialect.SetParameterType(pb.AppendParameter(Stream.TenantId), StorageColumnType.String);
+
+        // Optional metadata binders (causation / correlation / headers /
+        // user_name). The filtered list excludes SequenceColumnBinder when seq_id
+        // is server-set via the nextval() literal in the suffix.
+        for (var i = 0; i < _metadataBinders.Length; i++)
+        {
+            _metadataBinders[i].Bind(pb, Stream, Event, session);
+        }
+
+        builder.Append(_appendEventSqlSuffix);
+    }
+}

--- a/src/Weasel.Storage/Events/Operations/SingleTenantAssertStreamVersionOperation.cs
+++ b/src/Weasel.Storage/Events/Operations/SingleTenantAssertStreamVersionOperation.cs
@@ -1,0 +1,27 @@
+#nullable enable
+using JasperFx.Events;
+using Weasel.Core;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Single-tenant closed-shape assert-stream-version operation. Emits
+/// <c>select version from {schema}.mt_streams where id = $1</c>. Selected by
+/// <see cref="EventStorage{TId}.AssertStreamVersion"/> when the events table is
+/// not conjoined-tenant.
+/// </summary>
+internal sealed class SingleTenantAssertStreamVersionOperation<TId>: AssertStreamVersionOperation<TId>
+    where TId : notnull
+{
+    public SingleTenantAssertStreamVersionOperation(string selectVersionByIdPrefix, StreamAction stream)
+        : base(selectVersionByIdPrefix, stream)
+    {
+    }
+
+    public override void ConfigureCommand(ICommandBuilder builder, IStorageSession session)
+    {
+        builder.Append(SelectVersionByIdPrefix);
+        var idParam = builder.AppendParameter(StreamIdentity);
+        idParam.DbType = IdDbType;
+    }
+}

--- a/src/Weasel.Storage/Events/Operations/UpdateStreamVersionOperationBase.cs
+++ b/src/Weasel.Storage/Events/Operations/UpdateStreamVersionOperationBase.cs
@@ -1,0 +1,56 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using Weasel.Core;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Dialect-neutral base for the closed-shape <c>mt_streams</c>
+/// update-version operation (expected-version guard). Relocated from Marten's
+/// <c>Marten.Events.Operations.UpdateStreamVersion</c> as part of the
+/// marten#4821 event-storage move (event E3).
+/// </summary>
+/// <remarks>
+/// The command shape lives on a dialect-installed descriptor closure
+/// (<c>ConfigureUpdateStreamVersionCommand</c>). SQL shape:
+/// <c>update {schema}.mt_streams set version = $1 where id = $2 and version = $3 [and tenant_id = $4] returning version</c>.
+/// <see cref="PostprocessAsync"/> raises
+/// <see cref="EventStreamUnexpectedMaxEventIdException"/> when no row was
+/// updated (expected-version mismatch) — the concurrency exception lives in
+/// JasperFx.Events, so this Postprocess semantic ports neutrally.
+/// </remarks>
+public abstract class UpdateStreamVersionOperationBase: IStorageOperation
+{
+    protected UpdateStreamVersionOperationBase(StreamAction stream)
+    {
+        Stream = stream;
+    }
+
+    public StreamAction Stream { get; }
+
+    public abstract void ConfigureCommand(ICommandBuilder builder, IStorageSession session);
+
+    public Type DocumentType => typeof(IEvent);
+
+    public Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)
+    {
+        if (reader.RecordsAffected == 0)
+        {
+            exceptions.Add(new EventStreamUnexpectedMaxEventIdException(
+                Stream.Key ?? (object)Stream.Id, Stream.AggregateType,
+                Stream.ExpectedVersionOnServer!.Value, -1));
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public OperationRole Role()
+    {
+        return OperationRole.Events;
+    }
+}

--- a/src/Weasel.Storage/Events/Quick/QuickEventStorage.cs
+++ b/src/Weasel.Storage/Events/Quick/QuickEventStorage.cs
@@ -1,0 +1,65 @@
+#nullable enable
+using JasperFx.Events;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// <see cref="EventStorage{TId}"/> for <c>EventAppendMode.Quick</c> — batch
+/// append via a dialect-supplied bulk operation covering every event in the
+/// stream. Relocated from Marten (event E3).
+/// </summary>
+internal sealed class QuickEventStorage<TId>: EventStorage<TId>
+{
+    private readonly QuickEventStorageDescriptor _descriptor;
+
+    public QuickEventStorage(QuickEventStorageDescriptor descriptor)
+    {
+        _descriptor = descriptor;
+    }
+
+    public override IStorageOperation AppendEvent(IStorageSession session, StreamAction stream, IEvent @event)
+        // Full-mode per-event INSERT — seq_id is a bound parameter. The tombstone
+        // batch (and a few other code paths) call AppendEvent directly regardless
+        // of append mode, with sequences pre-assigned on @event.Sequence.
+        => new QuickAppendEventWithVersionOperation(
+            _descriptor.AppendEventSqlPrefix,
+            _descriptor.AppendEventFullSqlSuffix,
+            _descriptor.AppendEventFullMetadataBinders,
+            _descriptor.IsGuidStreamIdentity,
+            _descriptor.SerializeEventData,
+            _descriptor.SerializeEventBdata,
+            _descriptor.Dialect,
+            stream,
+            @event);
+
+    public override IStorageOperation QuickAppendEventWithVersion(StreamAction stream, IEvent @event)
+        => new QuickAppendEventWithVersionOperation(
+            _descriptor.AppendEventSqlPrefix,
+            _descriptor.AppendEventSqlSuffix,
+            _descriptor.MetadataBinders,
+            _descriptor.IsGuidStreamIdentity,
+            _descriptor.SerializeEventData,
+            _descriptor.SerializeEventBdata,
+            _descriptor.Dialect,
+            stream,
+            @event);
+
+    public override IStorageOperation QuickAppendEvents(StreamAction stream)
+        // Dialect-supplied — the batched append shape is inherently dialect-specific
+        // (Postgres binds array parameters to mt_quick_append_events; another dialect
+        // may use a multi-row INSERT + OUTPUT), so the operation's construction lives
+        // on the descriptor. The factory returns the neutral IStorageOperation, so no
+        // cast is needed here.
+        => _descriptor.CreateQuickAppendEventsOperation(_descriptor, stream);
+
+    public override IStorageOperation InsertStream(StreamAction stream)
+        => new QuickInsertStreamOperation(_descriptor, stream);
+
+    public override IStorageOperation UpdateStreamVersion(StreamAction stream)
+        => new QuickUpdateStreamVersionOperation(_descriptor, stream);
+
+    public override IStorageOperation AssertStreamVersion(StreamAction stream)
+        => _descriptor.IsTenancyConjoined
+            ? new ConjoinedAssertStreamVersionOperation<TId>(_descriptor.AssertStreamVersionSql, stream)
+            : new SingleTenantAssertStreamVersionOperation<TId>(_descriptor.AssertStreamVersionSql, stream);
+}

--- a/src/Weasel.Storage/Events/Quick/QuickInsertStreamOperation.cs
+++ b/src/Weasel.Storage/Events/Quick/QuickInsertStreamOperation.cs
@@ -1,0 +1,27 @@
+#nullable enable
+using JasperFx.Events;
+using Weasel.Core;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Closed-shape <see cref="InsertStreamOperationBase"/> for the Quick-mode paths.
+/// Identical shape to <see cref="RichInsertStreamOperation"/> — delegates to a
+/// descriptor-installed closure built by the dialect. Relocated from Marten
+/// (event E3).
+/// </summary>
+internal sealed class QuickInsertStreamOperation: InsertStreamOperationBase
+{
+    private readonly QuickEventStorageDescriptor _descriptor;
+
+    public QuickInsertStreamOperation(QuickEventStorageDescriptor descriptor, StreamAction stream)
+        : base(stream, descriptor.TransformInsertStreamException)
+    {
+        _descriptor = descriptor;
+    }
+
+    public override void ConfigureCommand(ICommandBuilder builder, IStorageSession session)
+    {
+        _descriptor.ConfigureInsertStreamCommand(builder, Stream);
+    }
+}

--- a/src/Weasel.Storage/Events/Quick/QuickUpdateStreamVersionOperation.cs
+++ b/src/Weasel.Storage/Events/Quick/QuickUpdateStreamVersionOperation.cs
@@ -1,0 +1,25 @@
+#nullable enable
+using JasperFx.Events;
+using Weasel.Core;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Closed-shape <see cref="UpdateStreamVersionOperationBase"/> for the Quick-mode
+/// paths. Symmetric with <see cref="RichUpdateStreamVersionOperation"/>. Relocated
+/// from Marten (event E3).
+/// </summary>
+internal sealed class QuickUpdateStreamVersionOperation: UpdateStreamVersionOperationBase
+{
+    private readonly QuickEventStorageDescriptor _descriptor;
+
+    public QuickUpdateStreamVersionOperation(QuickEventStorageDescriptor descriptor, StreamAction stream): base(stream)
+    {
+        _descriptor = descriptor;
+    }
+
+    public override void ConfigureCommand(ICommandBuilder builder, IStorageSession session)
+    {
+        _descriptor.ConfigureUpdateStreamVersionCommand(builder, Stream);
+    }
+}

--- a/src/Weasel.Storage/Events/QuickEventStorageDescriptor.cs
+++ b/src/Weasel.Storage/Events/QuickEventStorageDescriptor.cs
@@ -189,4 +189,13 @@ public sealed class QuickEventStorageDescriptor
         CreateQuickAppendEventsOperation { get; init; }
         = static (_, _) => throw new System.NotSupportedException(
             "QuickEventStorageDescriptor.CreateQuickAppendEventsOperation was not installed by the dialect.");
+
+    /// <summary>
+    /// Optional dialect-installed transform that maps a provider exception raised
+    /// by the <c>mt_streams</c> insert into a store-specific "stream id already
+    /// exists" exception — see
+    /// <see cref="RichEventStorageDescriptor.TransformInsertStreamException"/>.
+    /// Default: no transform.
+    /// </summary>
+    public System.Func<System.Exception, StreamAction, System.Exception?>? TransformInsertStreamException { get; init; }
 }

--- a/src/Weasel.Storage/Events/QuickWithServerTimestamps/QuickWithServerTimestampsEventStorage.cs
+++ b/src/Weasel.Storage/Events/QuickWithServerTimestamps/QuickWithServerTimestampsEventStorage.cs
@@ -1,0 +1,62 @@
+#nullable enable
+using JasperFx.Events;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// <see cref="EventStorage{TId}"/> for
+/// <c>EventAppendMode.QuickWithServerTimestamps</c>. Same shape as
+/// <see cref="QuickEventStorage{TId}"/> + the server-side <c>now()</c> timestamp
+/// array; the returned timestamps are written back onto each event in the bulk
+/// operation's <c>Postprocess</c>. Relocated from Marten (event E3).
+/// </summary>
+internal sealed class QuickWithServerTimestampsEventStorage<TId>: EventStorage<TId>
+{
+    private readonly QuickWithServerTimestampsEventStorageDescriptor _descriptor;
+
+    public QuickWithServerTimestampsEventStorage(QuickWithServerTimestampsEventStorageDescriptor descriptor)
+    {
+        _descriptor = descriptor;
+    }
+
+    public override IStorageOperation AppendEvent(IStorageSession session, StreamAction stream, IEvent @event)
+        // Full-mode per-event INSERT for the tombstone / direct-AppendEvent code
+        // paths that bypass the bulk function call.
+        => new QuickAppendEventWithVersionOperation(
+            _descriptor.AppendEventSqlPrefix,
+            _descriptor.AppendEventFullSqlSuffix,
+            _descriptor.AppendEventFullMetadataBinders,
+            _descriptor.IsGuidStreamIdentity,
+            _descriptor.SerializeEventData,
+            _descriptor.SerializeEventBdata,
+            _descriptor.Dialect,
+            stream,
+            @event);
+
+    public override IStorageOperation QuickAppendEventWithVersion(StreamAction stream, IEvent @event)
+        => new QuickAppendEventWithVersionOperation(
+            _descriptor.AppendEventSqlPrefix,
+            _descriptor.AppendEventSqlSuffix,
+            _descriptor.MetadataBinders,
+            _descriptor.IsGuidStreamIdentity,
+            _descriptor.SerializeEventData,
+            _descriptor.SerializeEventBdata,
+            _descriptor.Dialect,
+            stream,
+            @event);
+
+    public override IStorageOperation QuickAppendEvents(StreamAction stream)
+        // Dialect-supplied — see QuickEventStorage<TId>.QuickAppendEvents.
+        => _descriptor.CreateQuickAppendEventsOperation(_descriptor, stream);
+
+    public override IStorageOperation InsertStream(StreamAction stream)
+        => new QuickWithServerTimestampsInsertStreamOperation(_descriptor, stream);
+
+    public override IStorageOperation UpdateStreamVersion(StreamAction stream)
+        => new QuickWithServerTimestampsUpdateStreamVersionOperation(_descriptor, stream);
+
+    public override IStorageOperation AssertStreamVersion(StreamAction stream)
+        => _descriptor.IsTenancyConjoined
+            ? new ConjoinedAssertStreamVersionOperation<TId>(_descriptor.AssertStreamVersionSql, stream)
+            : new SingleTenantAssertStreamVersionOperation<TId>(_descriptor.AssertStreamVersionSql, stream);
+}

--- a/src/Weasel.Storage/Events/QuickWithServerTimestamps/QuickWithServerTimestampsInsertStreamOperation.cs
+++ b/src/Weasel.Storage/Events/QuickWithServerTimestamps/QuickWithServerTimestampsInsertStreamOperation.cs
@@ -1,0 +1,27 @@
+#nullable enable
+using JasperFx.Events;
+using Weasel.Core;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Closed-shape <see cref="InsertStreamOperationBase"/> for the
+/// QuickWithServerTimestamps path. Symmetric with the Rich + Quick equivalents —
+/// delegates to a descriptor-installed closure. Relocated from Marten (event E3).
+/// </summary>
+internal sealed class QuickWithServerTimestampsInsertStreamOperation: InsertStreamOperationBase
+{
+    private readonly QuickWithServerTimestampsEventStorageDescriptor _descriptor;
+
+    public QuickWithServerTimestampsInsertStreamOperation(
+        QuickWithServerTimestampsEventStorageDescriptor descriptor, StreamAction stream)
+        : base(stream, descriptor.TransformInsertStreamException)
+    {
+        _descriptor = descriptor;
+    }
+
+    public override void ConfigureCommand(ICommandBuilder builder, IStorageSession session)
+    {
+        _descriptor.ConfigureInsertStreamCommand(builder, Stream);
+    }
+}

--- a/src/Weasel.Storage/Events/QuickWithServerTimestamps/QuickWithServerTimestampsUpdateStreamVersionOperation.cs
+++ b/src/Weasel.Storage/Events/QuickWithServerTimestamps/QuickWithServerTimestampsUpdateStreamVersionOperation.cs
@@ -1,0 +1,26 @@
+#nullable enable
+using JasperFx.Events;
+using Weasel.Core;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Closed-shape <see cref="UpdateStreamVersionOperationBase"/> for the
+/// QuickWithServerTimestamps path. Symmetric with the Rich + Quick equivalents.
+/// Relocated from Marten (event E3).
+/// </summary>
+internal sealed class QuickWithServerTimestampsUpdateStreamVersionOperation: UpdateStreamVersionOperationBase
+{
+    private readonly QuickWithServerTimestampsEventStorageDescriptor _descriptor;
+
+    public QuickWithServerTimestampsUpdateStreamVersionOperation(
+        QuickWithServerTimestampsEventStorageDescriptor descriptor, StreamAction stream): base(stream)
+    {
+        _descriptor = descriptor;
+    }
+
+    public override void ConfigureCommand(ICommandBuilder builder, IStorageSession session)
+    {
+        _descriptor.ConfigureUpdateStreamVersionCommand(builder, Stream);
+    }
+}

--- a/src/Weasel.Storage/Events/QuickWithServerTimestampsEventStorageDescriptor.cs
+++ b/src/Weasel.Storage/Events/QuickWithServerTimestampsEventStorageDescriptor.cs
@@ -156,4 +156,13 @@ public sealed class QuickWithServerTimestampsEventStorageDescriptor
         CreateQuickAppendEventsOperation { get; init; }
         = static (_, _) => throw new System.NotSupportedException(
             "QuickWithServerTimestampsEventStorageDescriptor.CreateQuickAppendEventsOperation was not installed by the dialect.");
+
+    /// <summary>
+    /// Optional dialect-installed transform that maps a provider exception raised
+    /// by the <c>mt_streams</c> insert into a store-specific "stream id already
+    /// exists" exception — see
+    /// <see cref="RichEventStorageDescriptor.TransformInsertStreamException"/>.
+    /// Default: no transform.
+    /// </summary>
+    public System.Func<System.Exception, StreamAction, System.Exception?>? TransformInsertStreamException { get; init; }
 }

--- a/src/Weasel.Storage/Events/Rich/RichAppendEventOperation.cs
+++ b/src/Weasel.Storage/Events/Rich/RichAppendEventOperation.cs
@@ -1,0 +1,78 @@
+#nullable enable
+using JasperFx.Events;
+using Weasel.Core;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Closed-shape <see cref="AppendEventOperationBase"/> for the Rich (full-mode)
+/// per-event append path. Binds one parameter per column in the order the
+/// dialect's <see cref="RichEventStorageDescriptor.AppendEventSqlPrefix"/>
+/// declares, then loops the descriptor's metadata-binder array (one virtual
+/// <see cref="IEventMetadataBinder.Bind"/> call per active metadata column, in
+/// lockstep with the SQL prefix's column order). Relocated from Marten's
+/// <c>Marten.EventStorage.Rich.RichAppendEventOperation</c> (event E3).
+/// </summary>
+internal sealed class RichAppendEventOperation: AppendEventOperationBase
+{
+    private readonly RichEventStorageDescriptor _descriptor;
+
+    public RichAppendEventOperation(RichEventStorageDescriptor descriptor, StreamAction stream, IEvent e)
+        : base(stream, e)
+    {
+        _descriptor = descriptor;
+    }
+
+    public override void ConfigureCommand(ICommandBuilder builder, IStorageSession session)
+    {
+        builder.Append(_descriptor.AppendEventSqlPrefix);
+
+        var dialect = _descriptor.Dialect;
+        IGroupedParameterBuilder pb = builder.CreateGroupedParameterBuilder(',');
+
+        // Core columns, in the dialect's column order. Must match the dialect's
+        // BuildAppendEventFullColumnsAndPrefix:
+        //   data, type, mt_dotnet_type, bdata, id, stream_id, version, timestamp,
+        //   tenant_id, then metadata binders (e.g., seq_id) at the end.
+        // Provider parameter types come from the dialect's SetParameterType so the
+        // op carries no direct provider reference.
+        dialect.SetParameterType(pb.AppendParameter(_descriptor.SerializeEventData(Event)), StorageColumnType.Json);
+
+        dialect.SetParameterType(pb.AppendParameter(Event.EventTypeName), StorageColumnType.String);
+        dialect.SetParameterType(pb.AppendParameter(Event.DotNetTypeName), StorageColumnType.String);
+
+        // bdata bytea (nullable): NULL for JSON-serialized events, payload for
+        // binary-serialized events. The neutral AppendParameter writes a null
+        // byte[] as DBNull.
+        var bdataBytes = _descriptor.SerializeEventBdata(Event);
+        dialect.SetParameterType(pb.AppendParameter(bdataBytes), StorageColumnType.Binary);
+
+        dialect.SetParameterType(pb.AppendParameter(Event.Id), StorageColumnType.Guid);
+
+        // stream_id — Guid streams use Stream.Id, string streams use Stream.Key.
+        // The descriptor flag is set once at startup.
+        if (_descriptor.IsGuidStreamIdentity)
+        {
+            dialect.SetParameterType(pb.AppendParameter(Stream.Id), StorageColumnType.Guid);
+        }
+        else
+        {
+            dialect.SetParameterType(pb.AppendParameter(Stream.Key), StorageColumnType.String);
+        }
+
+        dialect.SetParameterType(pb.AppendParameter(Event.Version), StorageColumnType.Long);
+        dialect.SetParameterType(pb.AppendParameter(Event.Timestamp), StorageColumnType.Timestamp);
+        dialect.SetParameterType(pb.AppendParameter(Stream.TenantId), StorageColumnType.String);
+
+        // Metadata binders (seq_id + any optional metadata columns). Order matches
+        // the metadata slice of the SQL prefix's column list; the dialect's
+        // descriptor builder owns both sides.
+        var binders = _descriptor.MetadataBinders;
+        for (var i = 0; i < binders.Length; i++)
+        {
+            binders[i].Bind(pb, Stream, Event, session);
+        }
+
+        builder.Append(_descriptor.AppendEventSqlSuffix);
+    }
+}

--- a/src/Weasel.Storage/Events/Rich/RichEventStorage.cs
+++ b/src/Weasel.Storage/Events/Rich/RichEventStorage.cs
@@ -1,0 +1,58 @@
+#nullable enable
+using System;
+using JasperFx.Events;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// <see cref="EventStorage{TId}"/> for the Rich (per-event) append paths — covers
+/// both <c>EventAppendMode.Rich</c> and <c>EventAppendMode.QuickWithVersion</c>.
+/// Yields one <see cref="IStorageOperation"/> per event. Relocated from Marten
+/// (event E3).
+/// </summary>
+internal sealed class RichEventStorage<TId>: EventStorage<TId>
+{
+    private readonly RichEventStorageDescriptor _descriptor;
+
+    public RichEventStorage(RichEventStorageDescriptor descriptor)
+    {
+        _descriptor = descriptor;
+    }
+
+    public override IStorageOperation AppendEvent(IStorageSession session, StreamAction stream, IEvent @event)
+        => new RichAppendEventOperation(_descriptor, stream, @event);
+
+    // Invoked by JasperFx.Events EventSlice.BuildOperations during async
+    // projection side-effect replay (raised events) — the caller pre-assigns
+    // event.Version but not event.Sequence, so the per-event INSERT uses the
+    // server-side seq_id nextval() literal in the suffix. The INSERT shape is
+    // identical to the Quick "with version" op, so we reuse it: descriptor SQL
+    // strings differ, operation logic doesn't.
+    public override IStorageOperation QuickAppendEventWithVersion(StreamAction stream, IEvent @event)
+        => new QuickAppendEventWithVersionOperation(
+            _descriptor.AppendEventSqlPrefix,
+            _descriptor.AppendEventQuickWithVersionSqlSuffix,
+            _descriptor.MetadataBindersWithoutSequence,
+            _descriptor.IsGuidStreamIdentity,
+            _descriptor.SerializeEventData,
+            _descriptor.SerializeEventBdata,
+            _descriptor.Dialect,
+            stream,
+            @event);
+
+    public override IStorageOperation QuickAppendEvents(StreamAction stream)
+        => throw new NotSupportedException(
+            $"{nameof(RichEventStorage<TId>)} doesn't support batch quick-append. " +
+            $"Set the append mode to Quick or QuickWithServerTimestamps to use a batched storage class.");
+
+    public override IStorageOperation InsertStream(StreamAction stream)
+        => new RichInsertStreamOperation(_descriptor, stream);
+
+    public override IStorageOperation UpdateStreamVersion(StreamAction stream)
+        => new RichUpdateStreamVersionOperation(_descriptor, stream);
+
+    public override IStorageOperation AssertStreamVersion(StreamAction stream)
+        => _descriptor.IsTenancyConjoined
+            ? new ConjoinedAssertStreamVersionOperation<TId>(_descriptor.AssertStreamVersionSql, stream)
+            : new SingleTenantAssertStreamVersionOperation<TId>(_descriptor.AssertStreamVersionSql, stream);
+}

--- a/src/Weasel.Storage/Events/Rich/RichInsertStreamOperation.cs
+++ b/src/Weasel.Storage/Events/Rich/RichInsertStreamOperation.cs
@@ -1,0 +1,30 @@
+#nullable enable
+using JasperFx.Events;
+using Weasel.Core;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Closed-shape <see cref="InsertStreamOperationBase"/> for the Rich (full-mode)
+/// path. The complete command shape lives on
+/// <see cref="RichEventStorageDescriptor.ConfigureInsertStreamCommand"/> — a
+/// closure the dialect composes once at descriptor-build time based on
+/// stream-identity (Guid vs string) and tenancy style. This class is the minimal
+/// <see cref="IStorageOperation"/> shell: pull the closure off the descriptor,
+/// invoke it. Relocated from Marten (event E3).
+/// </summary>
+internal sealed class RichInsertStreamOperation: InsertStreamOperationBase
+{
+    private readonly RichEventStorageDescriptor _descriptor;
+
+    public RichInsertStreamOperation(RichEventStorageDescriptor descriptor, StreamAction stream)
+        : base(stream, descriptor.TransformInsertStreamException)
+    {
+        _descriptor = descriptor;
+    }
+
+    public override void ConfigureCommand(ICommandBuilder builder, IStorageSession session)
+    {
+        _descriptor.ConfigureInsertStreamCommand(builder, Stream);
+    }
+}

--- a/src/Weasel.Storage/Events/Rich/RichUpdateStreamVersionOperation.cs
+++ b/src/Weasel.Storage/Events/Rich/RichUpdateStreamVersionOperation.cs
@@ -1,0 +1,28 @@
+#nullable enable
+using JasperFx.Events;
+using Weasel.Core;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Closed-shape <see cref="UpdateStreamVersionOperationBase"/> for the Rich
+/// (full-mode) path. Like <see cref="RichInsertStreamOperation"/> the command
+/// shape lives on a descriptor-owned closure
+/// (<see cref="RichEventStorageDescriptor.ConfigureUpdateStreamVersionCommand"/>).
+/// The base's <c>PostprocessAsync</c> raises the expected-version-mismatch
+/// exception when no row was updated. Relocated from Marten (event E3).
+/// </summary>
+internal sealed class RichUpdateStreamVersionOperation: UpdateStreamVersionOperationBase
+{
+    private readonly RichEventStorageDescriptor _descriptor;
+
+    public RichUpdateStreamVersionOperation(RichEventStorageDescriptor descriptor, StreamAction stream): base(stream)
+    {
+        _descriptor = descriptor;
+    }
+
+    public override void ConfigureCommand(ICommandBuilder builder, IStorageSession session)
+    {
+        _descriptor.ConfigureUpdateStreamVersionCommand(builder, Stream);
+    }
+}

--- a/src/Weasel.Storage/Events/RichEventStorageDescriptor.cs
+++ b/src/Weasel.Storage/Events/RichEventStorageDescriptor.cs
@@ -147,4 +147,16 @@ public sealed class RichEventStorageDescriptor
     public System.Action<ICommandBuilder, StreamAction> ConfigureUpdateStreamVersionCommand { get; init; }
         = static (_, _) => throw new System.NotSupportedException(
             "RichEventStorageDescriptor.ConfigureUpdateStreamVersionCommand was not installed by the dialect.");
+
+    /// <summary>
+    /// Optional dialect-installed transform that maps a provider exception raised
+    /// by the <c>mt_streams</c> insert (e.g. a unique-constraint violation on the
+    /// streams table) into a store-specific "stream id already exists" exception,
+    /// given the offending <see cref="StreamAction"/>. Returns <c>null</c> to
+    /// leave the original exception unchanged. Keeps provider exception types out
+    /// of the neutral <see cref="InsertStreamOperationBase"/>: the Postgres
+    /// dialect installs the <c>ExistingStreamIdCollisionException</c> mapping, a
+    /// SQL Server dialect installs its own. Default: no transform.
+    /// </summary>
+    public System.Func<System.Exception, StreamAction, System.Exception?>? TransformInsertStreamException { get; init; }
 }


### PR DESCRIPTION
Final slice of the marten#4821 closed-shape **event**-storage move (the doc-side train was weasel#333–#337 → 9.10–9.13; the event-side train is E1 → 9.14.0, E2 → 9.15.0, and this **E3**). Unblocks Polecat (SQL Server, polecat#273) as the second consumer.

## What moves

The dialect-neutral `EventStorage<TId>` hierarchy, its per-mode operations, and `EventStorageBuilder` relocate from Marten's `src/Marten/EventStorage/` into the shared `Weasel.Storage` package — flat `namespace Weasel.Storage`, matching the E2 convention. **Purely additive** on the Weasel side; Marten deletes its copies and consumes 9.16.0.

**New neutral operation bases** (Marten keeps its own like-named bases behind for the legacy codegen write path — "Leave public for codegen!"):
- `AppendEventOperationBase`, `InsertStreamOperationBase`, `UpdateStreamVersionOperationBase` — implement the neutral `Weasel.Storage.IStorageOperation` (neutral `ConfigureCommand`), carry `StreamAction`/`IEvent` state + Postprocess semantics. The update/assert Postprocess raises `JasperFx.Events.EventStreamUnexpectedMaxEventIdException` (already neutral).
- `AssertStreamVersionOperation<TId>` + `SingleTenant`/`Conjoined` variants.

**Relocated storage + ops:** `EventStorage<TId>`, `Rich`/`Quick`/`QuickWithServerTimestamps` `EventStorage<TId>`, `RichAppendEventOperation`, `QuickAppendEventWithVersionOperation`, the Rich/Quick/QWST insert-stream + update-stream shells, `EventStorageBuilder`.

## Retypes on the move (all mandated by the handoff)

- `ConfigureCommand` takes `Weasel.Core.ICommandBuilder` + `Weasel.Storage.IStorageSession`.
- Storage methods return `Weasel.Storage.IStorageOperation` — the `QuickAppendEvents` cast back to Marten's `IStorageOperation` is gone (the descriptor factory already returns the neutral type).
- `EventStorageBuilder` is now **dialect-agnostic**: it receives `IEventStoreSqlDialect` + `EventAppendMode` + `EventRegistry` + `IStorageSerializer` instead of hardcoding `new PostgresEventStoreDialect()`. Marten's `ClosedShapeEventDocumentStorage` constructs its dialect and passes it in.

## One additive-beyond-relocation decision — the stream-collision exception seam

`InsertStreamBase` in Marten mapped a unique-violation on `mt_streams` to `ExistingStreamIdCollisionException` via a **Postgres-specific** `IExceptionTransform` — that can't move as-is. To preserve the friendly-exception behavior without leaking any provider type into the neutral library, the 3 event descriptors gain an optional `TransformInsertStreamException` closure, and `InsertStreamOperationBase` implements the neutral `JasperFx.Core.Exceptions.IExceptionTransform` delegating to it. This mirrors the doc-side `IOperationExceptionTransform` seam already shipped in `ClosedShapeInsertOperation`.

**Marten consumer must:** install the `ExistingStreamIdCollisionException` mapping via `TransformInsertStreamException` on each descriptor in `PostgresEventStoreDialect` (the PG-match logic — `PostgresException` / `MartenCommandException` / `StreamsTable.TableName` — stays Marten-side). A SQL Server dialect installs its own. Until installed, a stream-id collision surfaces as the raw provider exception (safe degradation, no crash).

## Validation

Builds clean on **net9.0 + net10.0**, full solution green. Consistent with E1/E2, `Weasel.Storage` is a standalone leaf with no in-repo consumer or test project — the behavioral gate is **Marten's `EventSourcingTests` + `TenantPartitionedEventsTests`** run against a `9.16.0` local pack per the coordination protocol (Weasel branch → local-pack → Marten validates → merge + publish). Recommend that local-pack validation before merging/publishing this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)