### PR TITLE
fix: skip disposing caller-owned NpgsqlDataSource (#345)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>9.16.0</Version>
+        <Version>9.16.1</Version>
         <LangVersion>13.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/src/Weasel.Postgresql.Tests/Connections/OwnsDataSourceTests.cs
+++ b/src/Weasel.Postgresql.Tests/Connections/OwnsDataSourceTests.cs
@@ -1,0 +1,123 @@
+using JasperFx;
+using Npgsql;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Core.Migrations;
+using Weasel.Postgresql.Connections;
+using Xunit;
+
+namespace Weasel.Postgresql.Tests.Connections;
+
+public class OwnsDataSourceTests
+{
+    private static NpgsqlDataSource BuildDataSource() =>
+        NpgsqlDataSource.Create(ConnectionSource.ConnectionString);
+
+    [Fact]
+    public void default_factory_owns_the_data_sources_it_builds()
+    {
+        using var factory = new DefaultNpgsqlDataSourceFactory();
+        var dataSource = factory.Create(ConnectionSource.ConnectionString);
+
+        factory.OwnsDataSource(dataSource).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void single_factory_does_not_own_the_wrapped_data_source()
+    {
+        using var wrapped = BuildDataSource();
+        var factory = new SingleNpgsqlDataSourceFactory(
+            connectionString => new NpgsqlDataSourceBuilder(connectionString), wrapped);
+
+        factory.OwnsDataSource(wrapped).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void single_factory_owns_child_data_sources_it_builds_itself()
+    {
+        using var wrapped = BuildDataSource();
+        var factory = new SingleNpgsqlDataSourceFactory(
+            connectionString => new NpgsqlDataSourceBuilder(connectionString), wrapped);
+
+        // A different connection string forces the factory to build its own child data source
+        var builder = new NpgsqlConnectionStringBuilder(ConnectionSource.ConnectionString)
+        {
+            ApplicationName = "weasel-owns-test"
+        };
+        var child = factory.Create(builder.ConnectionString);
+
+        child.ShouldNotBeSameAs(wrapped);
+        factory.OwnsDataSource(child).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task dispose_does_not_dispose_data_source_when_not_owned()
+    {
+        var dataSource = BuildDataSource();
+        var database = new TestDatabase(dataSource, ownsDataSource: false);
+
+        database.OwnsDataSource.ShouldBeFalse();
+
+        await database.DisposeAsync();
+
+        // The externally-owned data source must NOT have been disposed. Opening may still fail if no live
+        // database is present, but it must never fail with ObjectDisposedException.
+        try
+        {
+            await using var conn = await dataSource.OpenConnectionAsync();
+        }
+        catch (ObjectDisposedException)
+        {
+            throw new ShouldAssertException("The externally-owned data source was disposed but should not have been");
+        }
+        catch
+        {
+            // any other failure (e.g. no live database) is irrelevant to this test
+        }
+
+        await dataSource.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task dispose_disposes_data_source_when_owned()
+    {
+        var dataSource = BuildDataSource();
+        var database = new TestDatabase(dataSource, ownsDataSource: true);
+
+        database.OwnsDataSource.ShouldBeTrue();
+
+        await database.DisposeAsync();
+
+        // An owned data source is disposed, so it can no longer hand out connections
+        await Should.ThrowAsync<ObjectDisposedException>(async () => await dataSource.OpenConnectionAsync());
+    }
+
+    [Fact]
+    public async Task dispose_disposes_data_source_by_default()
+    {
+        var dataSource = BuildDataSource();
+        var database = new TestDatabase(dataSource);
+
+        database.OwnsDataSource.ShouldBeTrue();
+
+        await database.DisposeAsync();
+
+        await Should.ThrowAsync<ObjectDisposedException>(async () => await dataSource.OpenConnectionAsync());
+    }
+
+    private class TestDatabase: PostgresqlDatabase
+    {
+        public TestDatabase(NpgsqlDataSource dataSource)
+            : base(new DefaultMigrationLogger(), AutoCreate.All, new PostgresqlMigrator(), "owns-test", dataSource)
+        {
+        }
+
+        public TestDatabase(NpgsqlDataSource dataSource, bool ownsDataSource)
+            : base(new DefaultMigrationLogger(), AutoCreate.All, new PostgresqlMigrator(), "owns-test", dataSource,
+                ownsDataSource)
+        {
+        }
+
+        public override IFeatureSchema[] BuildFeatureSchemas() => [];
+    }
+}

--- a/src/Weasel.Postgresql/Connections/DefaultNpgsqlDataSourceFactory.cs
+++ b/src/Weasel.Postgresql/Connections/DefaultNpgsqlDataSourceFactory.cs
@@ -25,6 +25,11 @@ public class DefaultNpgsqlDataSourceFactory: INpgsqlDataSourceFactory, IAsyncDis
     public virtual NpgsqlDataSource Create(string connectionString) =>
         DataSources[connectionString];
 
+    /// <summary>
+    /// This factory builds and caches the data sources it hands out, so it owns their lifetime.
+    /// </summary>
+    public virtual bool OwnsDataSource(NpgsqlDataSource dataSource) => true;
+
     public virtual void Dispose()
     {
         var dataSources = DataSources.ToList();

--- a/src/Weasel.Postgresql/Connections/INpgsqlDataSourceFactory.cs
+++ b/src/Weasel.Postgresql/Connections/INpgsqlDataSourceFactory.cs
@@ -5,6 +5,15 @@ namespace Weasel.Postgresql.Connections;
 public interface INpgsqlDataSourceFactory
 {
     NpgsqlDataSource Create(string connectionString);
+
+    /// <summary>
+    /// Does this factory own the lifetime of the supplied <see cref="NpgsqlDataSource"/>? A factory that
+    /// builds a data source from a connection string owns it; one that merely wraps a caller-supplied data
+    /// source does not. When this returns <c>false</c>, consumers (e.g. <see cref="PostgresqlDatabase"/>) must
+    /// NOT dispose the data source because its lifetime is owned externally — disposing it would abort every
+    /// physical connection rented from it, including those still in use elsewhere.
+    /// </summary>
+    bool OwnsDataSource(NpgsqlDataSource dataSource) => true;
 }
 
 public static class NpgsqlDataSourceFactoryExtensions

--- a/src/Weasel.Postgresql/Connections/SingleNpgsqlDataSourceFactory.cs
+++ b/src/Weasel.Postgresql/Connections/SingleNpgsqlDataSourceFactory.cs
@@ -16,4 +16,11 @@ public class SingleNpgsqlDataSourceFactory(
         dataSource.ConnectionString.Equals(connectionString)
             ? dataSource
             : base.Create(connectionString);
+
+    /// <summary>
+    /// The wrapped data source was supplied from the outside (e.g. from DI), so this factory does NOT own it.
+    /// Any child data sources it builds itself from other connection strings are owned as usual.
+    /// </summary>
+    public override bool OwnsDataSource(NpgsqlDataSource candidate) =>
+        !ReferenceEquals(candidate, dataSource) && base.OwnsDataSource(candidate);
 }

--- a/src/Weasel.Postgresql/Migrations/SingleServerDatabaseCollection.cs
+++ b/src/Weasel.Postgresql/Migrations/SingleServerDatabaseCollection.cs
@@ -39,6 +39,13 @@ public abstract class SingleServerDatabaseCollection<T> where T : PostgresqlData
 
     protected abstract T buildDatabase(string databaseName, NpgsqlDataSource dataSource);
 
+    /// <summary>
+    /// Does the underlying data source factory own the lifetime of the given data source? Subclasses should
+    /// pass this through to the <see cref="PostgresqlDatabase"/> <c>ownsDataSource</c> constructor argument so
+    /// that a caller-supplied, externally-owned data source is not disposed out from under other consumers.
+    /// </summary>
+    protected bool OwnsDataSource(NpgsqlDataSource dataSource) => _dataSourceFactory.OwnsDataSource(dataSource);
+
     public virtual async ValueTask<T> FindOrCreateDatabase(string databaseName, CancellationToken ct = default)
     {
         if (_databases.TryFind(databaseName, out var database))

--- a/src/Weasel.Postgresql/PostgresqlDatabase.cs
+++ b/src/Weasel.Postgresql/PostgresqlDatabase.cs
@@ -18,9 +18,21 @@ public abstract class PostgresqlDatabase: DatabaseBase<NpgsqlConnection>, IAsync
         Migrator migrator,
         string identifier,
         NpgsqlDataSource dataSource
+    ): this(logger, autoCreate, migrator, identifier, dataSource, true)
+    {
+    }
+
+    protected PostgresqlDatabase(
+        IMigrationLogger logger,
+        AutoCreate autoCreate,
+        Migrator migrator,
+        string identifier,
+        NpgsqlDataSource dataSource,
+        bool ownsDataSource
     ): base(logger, autoCreate, migrator, identifier, () => dataSource.CreateConnection())
     {
         DataSource = dataSource ?? throw new ArgumentNullException(nameof(dataSource));
+        OwnsDataSource = ownsDataSource;
 
         // ReSharper disable once VirtualMemberCallInConstructor
         var descriptor = Describe();
@@ -70,6 +82,14 @@ public abstract class PostgresqlDatabase: DatabaseBase<NpgsqlConnection>, IAsync
     }
 
     public NpgsqlDataSource DataSource { get; }
+
+    /// <summary>
+    /// Does this database own the lifetime of its <see cref="DataSource"/>? When <c>false</c>, the data source
+    /// was supplied by the caller (or is shared across databases/stores) and <see cref="DisposeAsync"/> will NOT
+    /// dispose it — disposing an externally-owned <see cref="NpgsqlDataSource"/> aborts every physical connection
+    /// rented from it, including those still in use elsewhere. Defaults to <c>true</c> for backwards compatibility.
+    /// </summary>
+    public bool OwnsDataSource { get; }
 
     protected override ISchemaObject[] possiblyCheckForSchemas(ISchemaObject[] objects)
     {
@@ -122,7 +142,9 @@ public abstract class PostgresqlDatabase: DatabaseBase<NpgsqlConnection>, IAsync
 
     public ValueTask DisposeAsync()
     {
-        return DataSource.DisposeAsync();
+        // Only dispose the data source when this database owns its lifetime. When it was supplied by the caller
+        // or shared across databases/stores, disposing it here would abort connections still in use elsewhere.
+        return OwnsDataSource ? DataSource.DisposeAsync() : ValueTask.CompletedTask;
     }
 
     public async Task<Table[]> FetchExistingTablesAsync()


### PR DESCRIPTION
Fixes #345.

## Problem

`PostgresqlDatabase.DisposeAsync()` called `DataSource.DisposeAsync()` unconditionally. Disposing an `NpgsqlDataSource` aborts every physical connection rented from it, so when the data source is caller-supplied (Marten's `Connection(NpgsqlDataSource)` / `UseNpgsqlDataSource`) or shared across databases/stores, the async teardown pulls the socket out from under an in-flight operation (`ObjectDisposedException` / `IOException`). Marten guarded its own **sync** `Dispose()` (marten#4874) but could not cover this base **async** path without a Weasel-side ownership signal.

## Fix

Introduce an `OwnsDataSource` notion:

- **`INpgsqlDataSourceFactory.OwnsDataSource(NpgsqlDataSource)`** — new seam (default interface method returning `true`, so existing external implementers are unaffected). A factory that builds a data source from a connection string owns it.
- **`DefaultNpgsqlDataSourceFactory`** — owns the data sources it builds/caches (`true`).
- **`SingleNpgsqlDataSourceFactory`** — does **not** own the caller-supplied data source it wraps (`false`), but still owns any child data sources it builds itself from other connection strings.
- **`PostgresqlDatabase`** — new `OwnsDataSource` property + additive constructor overload taking `ownsDataSource` (existing constructor defaults it to `true`, preserving current behavior). `DisposeAsync()` skips disposal when not owned.
- **`SingleServerDatabaseCollection`** — additive protected `OwnsDataSource(dataSource)` helper so subclasses (e.g. Marten's) can thread the signal into `buildDatabase`.

This lets consumers stop hand-guarding disposal and closes the async path for marten#4874.

## Tests

Added `OwnsDataSourceTests` covering factory ownership semantics and that `DisposeAsync()` disposes an owned data source but leaves a not-owned one usable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)