### PR TITLE
fix: tolerate missing partition-parent table in DropPartitionFromAllTables (weasel#344)

### DIFF
--- a/src/Weasel.Postgresql.Tests/Tables/partitioning/managed_list_partitions.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/partitioning/managed_list_partitions.cs
@@ -239,6 +239,36 @@ public class managed_list_partitions : IntegrationContext
     }
 
     [Fact]
+    public async Task drop_partition_when_parent_table_is_not_physically_present()
+    {
+        // JasperFx/weasel#344: a configured partition-parent table may never have been physically migrated
+        // onto this database (e.g. a registered tenant whose doc/event tables don't exist on this shard yet).
+        // Dropping the partition must NOT throw 42P01 for the missing parent — there is genuinely nothing to
+        // drop, and the registry row still has to be removed.
+        await dropManagedListsSchema();
+
+        var database = new ManagedListDatabase();
+
+        // Register the partition value WITHOUT applying schema, so the teams/players parent tables are never
+        // physically created — only the managed-partition metadata table exists.
+        await database.Partitions.ResetValues(database,
+            new Dictionary<string, string> { { "red", "red" } }, CancellationToken.None);
+
+        (await tableExists("teams")).ShouldBeFalse("parent table must not be physically present for this repro");
+        (await tableExists("players")).ShouldBeFalse("parent table must not be physically present for this repro");
+
+        // Pre-fix this threw 42P01 (relation "managed_lists.teams" does not exist) from the fallback DETACH.
+        await Should.NotThrowAsync(() =>
+            database.Partitions.DropPartitionFromAllTables(database, NullLogger.Instance, ["red"], CancellationToken.None));
+
+        // The registry row must still have been removed. Force a reload so we read from the database rather
+        // than the in-memory cache.
+        database.Partitions.ForceReload();
+        await database.Partitions.InitializeAsync(database, CancellationToken.None);
+        database.Partitions.Partitions.ShouldNotContainKey("red");
+    }
+
+    [Fact]
     public async Task apply_additive_migration_2()
     {
         var database = new ManagedListDatabase();
@@ -389,6 +419,17 @@ public class managed_list_partitions : IntegrationContext
         await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
         await conn.OpenAsync();
         await conn.DropSchemaAsync("managed_lists");
+    }
+
+    private static async Task<bool> tableExists(string name)
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        var count = (long)(await conn.CreateCommand(
+                "select count(*) from pg_class c join pg_namespace n on n.oid = c.relnamespace where n.nspname = 'managed_lists' and c.relname = :name")
+            .With("name", name)
+            .ExecuteScalarAsync())!;
+        return count > 0;
     }
 
     private static async Task<bool> partitionExists(string parent, string suffix)

--- a/src/Weasel.Postgresql/Tables/Partitioning/ManagedListPartitions.cs
+++ b/src/Weasel.Postgresql/Tables/Partitioning/ManagedListPartitions.cs
@@ -141,6 +141,24 @@ public class ManagedListPartitions : FeatureSchemaBase, IDatabaseInitializer<Npg
 
         foreach (var table in tables)
         {
+            // weasel#344: a configured partition-parent table may never have been physically migrated onto
+            // this database (e.g. a registered tenant whose doc/event tables don't exist on this shard yet).
+            // In that case the DETACH below throws 42P01 (relation does not exist) and propagates, even
+            // though there is genuinely nothing to drop. Skip tables that aren't physically present — the
+            // child partition cannot exist without its parent, so the subsequent DROP would be a no-op too.
+            var parentExists = await conn
+                .CreateCommand("select to_regclass(:qualified) is not null")
+                .With("qualified", table.Identifier.QualifiedName)
+                .ExecuteScalarAsync(token).ConfigureAwait(false);
+
+            if (parentExists is not true)
+            {
+                logger.LogInformation(
+                    "Skipped dropping partitions for table {tableName} because it is not physically present on this database",
+                    table.Identifier);
+                continue;
+            }
+
             foreach (var suffixName in suffixNames)
             {
                 // weasel#338: the CREATE path (ListPartition) names the partition table with a SANITIZED


### PR DESCRIPTION
Fixes #344.

## Problem

`ManagedListPartitions.DropPartitionFromAllTables` (and `…ForValue`) enumerates the **configured** partition-parent tables and detaches each partition. When a configured parent was never physically migrated onto this database (a registered tenant whose doc/event tables don't exist on that shard yet), the `CONCURRENTLY` detach failed and the **fallback plain `DETACH` in the catch block was itself unguarded** — it threw `42P01: relation "…" does not exist` and propagated, even though the registry delete had already succeeded and the subsequent `drop table if exists` would have been a no-op.

## Fix

Guard each table with a `to_regclass` existence check and skip tables that aren't physically present — the child partition cannot exist without its parent, so the `DROP` would be a no-op anyway. This mirrors the `to_regclass` resilience Marten's former hand-rolled drop had, letting the consumer drop its `catch (PostgresException) when (SqlState == 42P01)` wrapper.

## Verification

Added regression test `drop_partition_when_parent_table_is_not_physically_present` that reproduces the exact scenario (register a partition value without applying schema, so the parent tables never exist, then drop). Confirmed it **fails against pre-fix code** (42P01) and **passes with the fix**. Full `managed_list_partitions` suite (15 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)