### PR TITLE
fix: guard AdvisoryLock against disposed data source during shutdown (weasel#349)

### DIFF
--- a/src/Weasel.Postgresql.Tests/advisory_lock_usage.cs
+++ b/src/Weasel.Postgresql.Tests/advisory_lock_usage.cs
@@ -186,6 +186,44 @@ public class AdvisoryLockSpecs : IAsyncLifetime
 
 }
 
+public class advisory_lock_disposal_guard
+{
+    // weasel#349: during host shutdown on a HotCold cold/standby node, the projection coordinator's
+    // leadership poll can call TryAttainLockAsync while the owned NpgsqlDataSource is being disposed,
+    // which used to abort the process with ObjectDisposedException: 'Npgsql.PoolingDataSource'.
+
+    [Fact]
+    public async Task returns_false_when_the_data_source_is_disposed_out_from_under_it()
+    {
+        var dataSource = NpgsqlDataSource.Create(ConnectionSource.ConnectionString);
+        var theLock = new AdvisoryLock(dataSource, NullLogger.Instance, "localhost", new AdvisoryLockOptions());
+
+        // Simulate the shutdown ordering where the data source is torn down before/while the lock is used.
+        await dataSource.DisposeAsync();
+
+        // Pre-fix this threw ObjectDisposedException: 'Npgsql.PoolingDataSource'.
+        var attained = await theLock.TryAttainLockAsync(4242, CancellationToken.None);
+        attained.ShouldBeFalse();
+
+        await theLock.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task returns_false_once_the_lock_itself_has_begun_disposing()
+    {
+        var dataSource = NpgsqlDataSource.Create(ConnectionSource.ConnectionString);
+        var theLock = new AdvisoryLock(dataSource, NullLogger.Instance, "localhost", new AdvisoryLockOptions());
+
+        await theLock.DisposeAsync();
+
+        // Never start a new acquire after disposal has begun, even though the data source is still alive here.
+        var attained = await theLock.TryAttainLockAsync(4243, CancellationToken.None);
+        attained.ShouldBeFalse();
+
+        await dataSource.DisposeAsync();
+    }
+}
+
 public class SimplePostgresqlDatabase: PostgresqlDatabase
 {
     public SimplePostgresqlDatabase(NpgsqlDataSource dataSource) : base(new DefaultMigrationLogger(), JasperFx.AutoCreate.CreateOrUpdate, new PostgresqlMigrator(), "Simple", dataSource)

--- a/src/Weasel.Postgresql/AdvisoryLock.cs
+++ b/src/Weasel.Postgresql/AdvisoryLock.cs
@@ -30,6 +30,7 @@ public class AdvisoryLock : IAdvisoryLock
     private readonly ILogger _logger;
     private readonly Dictionary<int, PostgresDistributedLockHandle> _handles = new();
     private readonly LightweightCache<int, PostgresDistributedLock> _distributedLockProviders;
+    private volatile bool _disposed;
 
     public AdvisoryLock(NpgsqlDataSource dataSource, ILogger logger, string databaseName, AdvisoryLockOptions options)
     {
@@ -66,14 +67,33 @@ public class AdvisoryLock : IAdvisoryLock
 
     public async Task<bool> TryAttainLockAsync(int lockId, CancellationToken token)
     {
-        var locker = _distributedLockProviders[lockId];
-        var handle = await locker.TryAcquireAsync(cancellationToken: token).ConfigureAwait(false);
-        if (handle is not null)
+        // weasel#349: never start a new acquire once disposal has begun. On a HotCold cold/standby node the
+        // coordinator polls this on a cadence, and during host shutdown the owned NpgsqlDataSource races with
+        // disposal — an in-flight OpenAsync aborts with ObjectDisposedException: 'Npgsql.PoolingDataSource'.
+        if (_disposed) return false;
+
+        try
         {
-            _handles[lockId] = handle;
-            return true;
+            var locker = _distributedLockProviders[lockId];
+            var handle = await locker.TryAcquireAsync(cancellationToken: token).ConfigureAwait(false);
+            if (handle is not null)
+            {
+                _handles[lockId] = handle;
+                return true;
+            }
+            return false;
         }
-        return false;
+        catch (ObjectDisposedException)
+        {
+            // The data source / connection pool was disposed out from under an in-flight acquire during
+            // shutdown. Treat as "lock not attained" rather than letting a process-aborting exception escape.
+            return false;
+        }
+        catch (Exception e) when (_disposed && e is NpgsqlException or InvalidOperationException)
+        {
+            // Same shutdown race, surfaced as a disposed-pool NpgsqlException / InvalidOperationException.
+            return false;
+        }
     }
 
     public async Task ReleaseLockAsync(int lockId)
@@ -86,6 +106,9 @@ public class AdvisoryLock : IAdvisoryLock
 
     public async ValueTask DisposeAsync()
     {
+        // Set first, before disposing handles, so any concurrent TryAttainLockAsync short-circuits (weasel#349).
+        _disposed = true;
+
         foreach (var i in _handles.Keys)
         {
             if (_handles.Remove(i, out var handle))

--- a/src/Weasel.SqlServer.Tests/advisory_lock_usage.cs
+++ b/src/Weasel.SqlServer.Tests/advisory_lock_usage.cs
@@ -188,3 +188,36 @@ public class AdvisoryLockSpecs : IAsyncLifetime
     }
 
 }
+
+public class advisory_lock_disposal_guard
+{
+    // weasel#349: mirror of the Postgres guard for Polecat parity — opening the lock connection during host
+    // shutdown must never let a process-aborting disposed-connection exception escape TryAttainLockAsync.
+
+    [Fact]
+    public async Task returns_false_when_opening_the_connection_throws_a_disposed_exception()
+    {
+        // The connection factory is disposed out from under an in-flight acquire during shutdown.
+        var theLock = new AdvisoryLock(
+            () => throw new ObjectDisposedException("SqlConnection"), NullLogger.Instance, "Testing");
+
+        // Pre-fix this let the ObjectDisposedException escape and abort the process.
+        var attained = await theLock.TryAttainLockAsync(4242, CancellationToken.None);
+        attained.ShouldBeFalse();
+
+        await theLock.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task returns_false_once_the_lock_itself_has_begun_disposing()
+    {
+        var theLock = new AdvisoryLock(
+            () => new SqlConnection(ConnectionSource.ConnectionString), NullLogger.Instance, "Testing");
+
+        await theLock.DisposeAsync();
+
+        // Never start a new acquire (never open a connection) after disposal has begun.
+        var attained = await theLock.TryAttainLockAsync(4243, CancellationToken.None);
+        attained.ShouldBeFalse();
+    }
+}

--- a/src/Weasel.SqlServer/AdvisoryLock.cs
+++ b/src/Weasel.SqlServer/AdvisoryLock.cs
@@ -22,6 +22,7 @@ public class AdvisoryLock : IAdvisoryLock
     private readonly string _databaseName;
     private SqlConnection _conn;
     private readonly List<int> _locks = new();
+    private volatile bool _disposed;
 
     public AdvisoryLock(Func<SqlConnection> source, ILogger logger, string databaseName)
     {
@@ -37,40 +38,59 @@ public class AdvisoryLock : IAdvisoryLock
 
     public async Task<bool> TryAttainLockAsync(int lockId, CancellationToken token)
     {
-        if (_conn == null)
-        {
-            _conn = _source();
-            await _conn.OpenAsync(token).ConfigureAwait(false);
-        }
+        // weasel#349: never start a new acquire once disposal has begun. During host shutdown opening _conn
+        // races with disposal and can abort with a process-killing ObjectDisposedException — mirror the
+        // Postgres guard for Polecat parity.
+        if (_disposed) return false;
 
-        if (_conn.State == ConnectionState.Closed)
+        try
         {
-            try
+            if (_conn == null)
             {
-                await _conn.DisposeAsync().ConfigureAwait(false);
+                _conn = _source();
+                await _conn.OpenAsync(token).ConfigureAwait(false);
             }
-            catch (Exception e)
+
+            if (_conn.State == ConnectionState.Closed)
             {
-                _logger.LogError(e, "Error trying to clean up and restart an advisory lock connection");
+                try
+                {
+                    await _conn.DisposeAsync().ConfigureAwait(false);
+                }
+                catch (Exception e)
+                {
+                    _logger.LogError(e, "Error trying to clean up and restart an advisory lock connection");
+                }
+                finally
+                {
+                    _conn = null;
+                }
+
+                return false;
             }
-            finally
+
+
+
+            var attained = await _conn.TryGetGlobalLock(lockId.ToString(), cancellation: token).ConfigureAwait(false);
+            if (attained)
             {
-                _conn = null;
+                _locks.Add(lockId);
+                return true;
             }
 
             return false;
         }
-
-
-
-        var attained = await _conn.TryGetGlobalLock(lockId.ToString(), cancellation: token).ConfigureAwait(false);
-        if (attained)
+        catch (ObjectDisposedException)
         {
-            _locks.Add(lockId);
-            return true;
+            // The connection was disposed out from under an in-flight open/acquire during shutdown. Treat as
+            // "lock not attained" rather than letting a process-aborting exception escape.
+            return false;
         }
-
-        return false;
+        catch (Exception e) when (_disposed && e is SqlException or InvalidOperationException)
+        {
+            // Same shutdown race, surfaced as a disposed-connection SqlException / InvalidOperationException.
+            return false;
+        }
     }
 
     public async Task ReleaseLockAsync(int lockId)
@@ -99,6 +119,9 @@ public class AdvisoryLock : IAdvisoryLock
 
     public async ValueTask DisposeAsync()
     {
+        // Set first, before disposing the connection, so any concurrent TryAttainLockAsync short-circuits (weasel#349).
+        _disposed = true;
+
         if (_conn == null) return;
 
         try


### PR DESCRIPTION
Fixes #349. Priority 1 / **case B** of JasperFx/marten#4874.

## Problem

On a HotCold **cold/standby** node the projection coordinator's leadership poll re-opens a connection every `LeadershipPollingTime` to attempt the advisory lock, fails (the hot node holds it), and drops it — a steady stream of opens on the poll cadence. When that node is torn down, the owned `NpgsqlDataSource` is disposed out from under an in-flight `OpenAsync` that the coordinator's `StopAsync` did not drain:

```
SingleTenantProjectionDistributor.TryAttainLockAsync
 └ Weasel.Postgresql.AdvisoryLock.TryAttainLockAsync
    └ Medallion PostgresDistributedLock.TryAcquireAsync
       └ Npgsql OpenAsync  ⇒ ObjectDisposedException 'Npgsql.PoolingDataSource'
```

Weasel owns both the `AdvisoryLock` lifecycle and the `NpgsqlDataSource` handle Medallion opens against, so it is the correct layer to make this abort structurally impossible — independent of whether the coordinator's drain (JasperFx side, [jasperfx#499](https://github.com/JasperFx/jasperfx/issues/499)) is perfect.

## Change (`src/Weasel.Postgresql/AdvisoryLock.cs`)

1. Add a `volatile bool _disposed`; `TryAttainLockAsync` returns `false` immediately once disposal has begun (never start a new acquire during shutdown).
2. Wrap the acquire to catch `ObjectDisposedException` (and disposed-pool `NpgsqlException` / `InvalidOperationException` once disposing) and return `false` — treat it as "lock not attained during shutdown".
3. `DisposeAsync` sets the flag first, before disposing handles.

Same shape applied to `src/Weasel.SqlServer/AdvisoryLock.cs` for Polecat parity.

## Validation

Regression tests added on both providers, each **verified failing pre-fix**:
- PG: `advisory_lock_disposal_guard` — returns false when the data source is disposed out from under it (used to throw `ObjectDisposedException: 'Npgsql.PoolingDataSource'`), and once the lock itself has begun disposing.
- SQL Server: mirror — returns false when opening the connection throws a disposed exception, and once disposing has begun.

This guard alone should zero the `PoolingDataSource` abort count over the reporter's daemon-heavy subset, ahead of the JasperFx-side coordinator drain fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)