### PR TITLE
chore: upgrade JasperFx 2.13.1 -> 2.24.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,7 @@
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.12.19" />
     <PackageVersion Include="DistributedLock.Postgres" Version="1.3.0" />
     <PackageVersion Include="DotNet.ReproducibleBuilds" Version="1.2.39" />
-    <PackageVersion Include="JasperFx" Version="2.13.1" />
+    <PackageVersion Include="JasperFx" Version="2.24.1" />
     <PackageVersion Include="JasperFx.Events" Version="2.0.0" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.9" />
     <!-- Override the transitive SQLitePCLRaw 2.1.11 (vulnerable native lib,


### PR DESCRIPTION
Bumps the `JasperFx` dependency from `2.13.1` to `2.24.1` (central version in `Directory.Packages.props`).

Full solution builds clean in Release against the new version across net8.0/net9.0/net10.0; `Weasel.Core.Tests` green locally. Relying on CI for the DB-backed provider suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)