### PR TITLE
release: 9.16.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>9.16.1</Version>
+        <Version>9.16.2</Version>
         <LangVersion>13.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>


### PR DESCRIPTION
Bumps the family version `9.16.1 -> 9.16.2` for the next NuGet release.

Contents since 9.16.1:
- fix: tolerate missing partition-parent table in `DropPartitionFromAllTables` (#344)
- fix: guard `AdvisoryLock` against a disposed data source during shutdown, PG + SQL Server (#349)
- chore: upgrade `JasperFx` 2.13.1 -> 2.24.1 (#351)

🤖 Generated with [Claude Code](https://claude.com/claude-code)