### PR TITLE
fix: latch AdvisoryLock disposed on a swallowed ObjectDisposedException (marten#4915)

### DIFF
--- a/src/Weasel.Postgresql.Tests/advisory_lock_usage.cs
+++ b/src/Weasel.Postgresql.Tests/advisory_lock_usage.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging.Abstractions;
+﻿using System.Runtime.ExceptionServices;
+using Microsoft.Extensions.Logging.Abstractions;
 using Npgsql;
 using Shouldly;
 using Weasel.Core;
@@ -204,6 +205,52 @@ public class advisory_lock_disposal_guard
         // Pre-fix this threw ObjectDisposedException: 'Npgsql.PoolingDataSource'.
         var attained = await theLock.TryAttainLockAsync(4242, CancellationToken.None);
         attained.ShouldBeFalse();
+
+        await theLock.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task latches_after_the_first_swallowed_abort_so_cadence_polling_stops_touching_the_dead_pool()
+    {
+        var dataSource = NpgsqlDataSource.Create(ConnectionSource.ConnectionString);
+        var theLock = new AdvisoryLock(dataSource, NullLogger.Instance, "localhost", new AdvisoryLockOptions());
+
+        await dataSource.DisposeAsync();
+
+        // First poll hits the disposed pool; the ObjectDisposedException is swallowed per weasel#349 ...
+        (await theLock.TryAttainLockAsync(4244, CancellationToken.None)).ShouldBeFalse();
+
+        // ... and must also LATCH. The HotCold projection coordinator calls TryAttainLockAsync on its
+        // LeadershipPollingTime cadence and reads false as "another node holds the lock", so without the
+        // latch every subsequent poll re-opens against a pool that can never come back — churning
+        // ObjectDisposedExceptions until process exit, and jasperfx#500's terminate-on-ODE never fires
+        // because the ODE it waits for is swallowed here (marten#4915). Count the aborts the same way
+        // marten's Bug_4874_coordinator_drain_ordering regression test does.
+        var aborts = 0;
+        EventHandler<FirstChanceExceptionEventArgs> handler = (_, e) =>
+        {
+            if (e.Exception is ObjectDisposedException ode &&
+                (ode.ObjectName?.Contains("PoolingDataSource") == true ||
+                 ode.Message.Contains("PoolingDataSource")))
+            {
+                Interlocked.Increment(ref aborts);
+            }
+        };
+
+        AppDomain.CurrentDomain.FirstChanceException += handler;
+        try
+        {
+            for (var i = 0; i < 5; i++)
+            {
+                (await theLock.TryAttainLockAsync(4244, CancellationToken.None)).ShouldBeFalse();
+            }
+        }
+        finally
+        {
+            AppDomain.CurrentDomain.FirstChanceException -= handler;
+        }
+
+        aborts.ShouldBe(0);
 
         await theLock.DisposeAsync();
     }

--- a/src/Weasel.Postgresql/AdvisoryLock.cs
+++ b/src/Weasel.Postgresql/AdvisoryLock.cs
@@ -87,6 +87,10 @@ public class AdvisoryLock : IAdvisoryLock
         {
             // The data source / connection pool was disposed out from under an in-flight acquire during
             // shutdown. Treat as "lock not attained" rather than letting a process-aborting exception escape.
+            // A disposed data source can never come back, so also latch: the HotCold projection coordinator
+            // polls this on a cadence and reads false as "another node holds the lock" — without the latch
+            // it re-opens against the dead pool on every poll until process exit (marten#4915).
+            _disposed = true;
             return false;
         }
         catch (Exception e) when (_disposed && e is NpgsqlException or InvalidOperationException)


### PR DESCRIPTION
Fixes the composition gap reported in JasperFx/marten#4915: the #349 guard catches the
disposed-pool `ObjectDisposedException` in `TryAttainLockAsync` and returns `false`, but `false`
reads as "another node holds the lock" to the HotCold projection coordinator, which polls this
method on its `LeadershipPollingTime` cadence. In the window where the *data source* is disposed
while the `AdvisoryLock` is still live, every subsequent poll re-opens against a pool that can
never come back — and jasperfx#500's terminate-on-ODE catch in
`ProjectionCoordinatorBase.executeAsync` never fires, because the ODE it was added for is
swallowed a layer below.

The change is one line: a disposed data source can never come back, so latch `_disposed` inside
the ODE catch. The next poll short-circuits without touching the pool — the same behavior as
after the lock's own `DisposeAsync`, which #349 already established as the safe state.

The regression test pins the uncovered state directly (no timing, no host): dispose the
`NpgsqlDataSource` out from under a live `AdvisoryLock`, poll `TryAttainLockAsync` repeatedly,
and count disposed-pool first-chance aborts the same way marten's
`Bug_4874_coordinator_drain_ordering` does. (That test can't catch this because a whole-host
teardown disposes the `AdvisoryLock` *before* the source, so the existing `_disposed`
short-circuit hides the gap.) Red before the fix — 35 first-chance aborts from 5 polls, 7 per
poll through the async frames — zero after.

Validation on the suite that surfaced marten#4915 (512 integration tests, Testcontainers
Postgres, ~24 host boot/dispose cycles per run). Stock Weasel 9.16.2 on Marten 9.13.0 fails
intermittently (2/2 runs in the original bisection; a third clean-session run passed) and
always churns: a first-chance handler bucketed **67,946** disposed-pool ODEs in the passing
stock run, **67,914 of them (99.95%) on the coordinator → `AdvisoryLock` poll path** — ~200/s
sustained for the whole 5.6-minute run. The identical config with only this patch: **512/512
and 512/512 green**, and the count collapses to **178 / 199 per run** — which is ~24 teardowns
× ~7 async-frame rethrows, i.e. exactly one aborted poll per teardown and then silence, the
latch working as intended.

Alternative considered: rethrowing (or rethrowing when `!_disposed`) so jasperfx#500's
coordinator termination becomes reachable and the loop actually ends. That would partially undo
#349's contain-the-escape intent for callers that don't have the #500 catch, so this PR takes
the smaller latch instead; happy to rework toward the rethrow if you'd rather the coordinator
loop terminate.
