### PR TITLE
release: 9.16.3

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>9.16.2</Version>
+        <Version>9.16.3</Version>
         <LangVersion>13.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>


### PR DESCRIPTION
Version bump for the #354 fix.

`AdvisoryLock.TryAttainLockAsync` now treats a disposed `NpgsqlDataSource` as terminal: it latches `_disposed` and rethrows, so `ProjectionCoordinatorBase.executeAsync`'s terminate-on-`ObjectDisposedException` catch (jasperfx#500) can fire instead of the leadership loop re-polling a dead pool for the life of the process.

**Behavior note for consumers.** 9.16.2 swallowed the disposed-pool `ObjectDisposedException` and returned `false`; 9.16.3 rethrows it after latching. This restores the pre-9.16.2 escape. Both consumers of `IAdvisoryLock.TryAttainLockAsync` — Marten and Polecat — go through `ProjectionCoordinatorBase`, which has caught `ObjectDisposedException` since JasperFx 2.24.1, so neither sees an escaping exception. A caller that ignores the throw and keeps polling gets `false` from the latch without touching the pool.

See #354 and JasperFx/marten#4915 for the diagnosis and measurements. Companion Marten fix: JasperFx/marten#4923.

🤖 Generated with [Claude Code](https://claude.com/claude-code)