### PR TITLE
Bound db-apply's connection usage over many databases (#356)

### DIFF
--- a/docs/cli/db-apply.md
+++ b/docs/cli/db-apply.md
@@ -23,6 +23,14 @@ The command reports one of:
 - **No changes needed** -- the database already matches the configuration.
 - **Successfully applied migrations** -- changes were detected and applied.
 
+## Many databases
+
+Databases are applied one at a time, in sequence, and each one's progress is reported as `(n/total)` so a long walk over a sharded or multi-tenanted store can be watched.
+
+Because `db-apply` is a one-shot command that owns its data sources, each database's connection pool is released as soon as that database is done, rather than being left to age out on its own idle lifetime. Peak connection usage therefore stays at roughly the one database being applied, instead of trailing an idle pool per recently-applied database -- which matters when applying across hundreds of databases on a server that is near `max_connections`.
+
+For the same reason, a database whose apply fails with a *transient connection refusal* -- PostgreSQL `53300 too_many_connections`, `53400`, or `57P03 cannot_connect_now` -- is retried twice with an exponential backoff (3 attempts in total), so ambient connection pressure doesn't fail an entire deployment step. Migration failures themselves are **not** retried and fail the command immediately.
+
 ## Idempotency
 
 `db-apply` is safe to run multiple times. If the database already matches the expected state, no changes are made.

--- a/src/Weasel.Core.Tests/Migrations/apply_with_retries.cs
+++ b/src/Weasel.Core.Tests/Migrations/apply_with_retries.cs
@@ -1,0 +1,206 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using JasperFx.Descriptors;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Core.Migrations;
+using Xunit;
+
+namespace Weasel.Core.Tests.Migrations;
+
+/// <summary>
+///     Coverage for <see cref="DatabaseExtensions.ApplyAllConfiguredChangesWithRetriesAsync" /> (weasel#356):
+///     a one-shot apply against a server at its connection ceiling should back off and retry rather than
+///     fail the whole job on the first refusal, and should not retry a genuine migration failure.
+/// </summary>
+public class apply_with_retries
+{
+    private static Task<SchemaPatchDifference> apply(FakeDatabase database) =>
+        database.ApplyAllConfiguredChangesWithRetriesAsync(baseDelayMs: 1);
+
+    [Fact]
+    public async Task no_retry_when_the_first_attempt_succeeds()
+    {
+        var database = new FakeDatabase();
+
+        (await apply(database)).ShouldBe(SchemaPatchDifference.Update);
+
+        database.Attempts.ShouldBe(1);
+        database.PoolReleases.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task retries_a_transient_connection_failure_until_it_succeeds()
+    {
+        var database = new FakeDatabase { FailuresBeforeSuccess = 2, FailureIsTransient = true };
+
+        (await apply(database)).ShouldBe(SchemaPatchDifference.Update);
+
+        database.Attempts.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task releases_the_pool_before_each_retry()
+    {
+        var database = new FakeDatabase { FailuresBeforeSuccess = 2, FailureIsTransient = true };
+
+        await apply(database);
+
+        // Once per failed attempt -- the refused attempt's connections should not be left in the pool
+        // competing with the retry.
+        database.PoolReleases.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task gives_up_after_the_maximum_number_of_attempts()
+    {
+        var database = new FakeDatabase { FailuresBeforeSuccess = 99, FailureIsTransient = true };
+
+        await Should.ThrowAsync<TimeoutException>(() =>
+            database.ApplyAllConfiguredChangesWithRetriesAsync(maxAttempts: 4, baseDelayMs: 1));
+
+        database.Attempts.ShouldBe(4);
+    }
+
+    [Fact]
+    public async Task does_not_retry_a_failure_that_is_not_a_transient_connection_failure()
+    {
+        var database = new FakeDatabase { FailuresBeforeSuccess = 1, FailureIsTransient = false };
+
+        await Should.ThrowAsync<TimeoutException>(() => apply(database));
+
+        // A DDL failure is not transient. Retrying it only delays a failure the operator needs to see.
+        database.Attempts.ShouldBe(1);
+        database.PoolReleases.ShouldBe(0);
+    }
+
+    [Fact]
+    public void the_backoff_doubles_per_attempt()
+    {
+        DatabaseExtensions.BackoffDelayMs(1, 1000).ShouldBeInRange(1000, 1100);
+        DatabaseExtensions.BackoffDelayMs(2, 1000).ShouldBeInRange(2000, 2100);
+        DatabaseExtensions.BackoffDelayMs(3, 1000).ShouldBeInRange(4000, 4100);
+    }
+
+    [Fact]
+    public void the_backoff_is_clamped_rather_than_overflowing()
+    {
+        // Naive `baseDelayMs * 2^(attempt-1)` in an int goes negative around attempt 32 and would throw
+        // out of Task.Delay, losing the connection failure being retried.
+        foreach (var attempt in new[] { 20, 32, 40, 1000, int.MaxValue })
+        {
+            DatabaseExtensions.BackoffDelayMs(attempt, 1000)
+                .ShouldBeInRange(0, DatabaseExtensions.MaxRetryDelayMs + 100);
+        }
+    }
+
+    #region Fakes
+
+    internal class FakeDatabase: IDatabase
+    {
+        public int Attempts { get; private set; }
+        public int PoolReleases { get; private set; }
+        public int FailuresBeforeSuccess { get; set; }
+        public bool FailureIsTransient { get; set; }
+
+        public Task<SchemaPatchDifference> ApplyAllConfiguredChangesToDatabaseAsync(
+            AutoCreate? @override = null,
+            ReconnectionOptions? reconnectionOptions = null,
+            CancellationToken ct = default
+        )
+        {
+            Attempts++;
+            if (Attempts <= FailuresBeforeSuccess)
+            {
+                // The exception type is irrelevant -- the Migrator decides what is transient.
+                throw new TimeoutException("refused");
+            }
+
+            return Task.FromResult(SchemaPatchDifference.Update);
+        }
+
+        public ValueTask ReleaseConnectionPoolAsync(CancellationToken ct = default)
+        {
+            PoolReleases++;
+            return ValueTask.CompletedTask;
+        }
+
+        public Migrator Migrator => new FakeMigrator(FailureIsTransient);
+
+        public DatabaseDescriptor Describe() => new();
+        public AutoCreate AutoCreate => AutoCreate.CreateOrUpdate;
+        public string Identifier => "fake";
+        public DatabaseId Id { get; } = new("server", "database");
+        public List<string> TenantIds { get; } = new();
+        public IFeatureSchema[] BuildFeatureSchemas() => throw new NotSupportedException();
+        public string[] AllSchemaNames() => throw new NotSupportedException();
+        public IEnumerable<ISchemaObject> AllObjects() => throw new NotSupportedException();
+
+        public Task<SchemaMigration> CreateMigrationAsync(IFeatureSchema group, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public string ToDatabaseScript() => throw new NotSupportedException();
+
+        public Task WriteCreationScriptToFileAsync(string filename, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task WriteScriptsByTypeAsync(string directory, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<SchemaMigration> CreateMigrationAsync(CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task AssertDatabaseMatchesConfigurationAsync(CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task AssertConnectivityAsync(CancellationToken ct = default) => throw new NotSupportedException();
+    }
+
+    internal class FakeMigrator: Migrator
+    {
+        private readonly bool _isTransient;
+
+        public FakeMigrator(bool isTransient): base("fake")
+        {
+            _isTransient = isTransient;
+        }
+
+        public override bool IsTransientConnectionFailure(Exception exception) => _isTransient;
+
+        public override IDatabaseWithTables CreateDatabase(DbConnection connection, string? identifier = null) =>
+            throw new NotSupportedException();
+
+        public override bool MatchesConnection(DbConnection connection) => throw new NotSupportedException();
+        public override IDatabaseProvider Provider => throw new NotSupportedException();
+        public override ITable CreateTable(DbObjectName identifier) => throw new NotSupportedException();
+
+        public override void WriteScript(TextWriter writer, Action<Migrator, TextWriter> writeStep) =>
+            throw new NotSupportedException();
+
+        public override void WriteSchemaCreationSql(IEnumerable<string> schemaNames, TextWriter writer) =>
+            throw new NotSupportedException();
+
+        public override void WriteSchemaDropSql(IEnumerable<string> schemaNames, TextWriter writer) =>
+            throw new NotSupportedException();
+
+        protected override Task executeDelta(
+            SchemaMigration migration,
+            DbConnection conn,
+            AutoCreate autoCreate,
+            IMigrationLogger logger,
+            CancellationToken ct = default
+        ) => throw new NotSupportedException();
+
+        public override string ToExecuteScriptLine(string scriptName) => throw new NotSupportedException();
+        public override void AssertValidIdentifier(string name) => throw new NotSupportedException();
+
+        public override string GenerateDeleteAllSql(IReadOnlyList<DbObjectName> tables, bool resetIdentity = true) =>
+            throw new NotSupportedException();
+    }
+
+    #endregion
+}

--- a/src/Weasel.Core/AssemblyInfo.cs
+++ b/src/Weasel.Core/AssemblyInfo.cs
@@ -4,3 +4,4 @@ using JasperFx.CommandLine;
 
 [assembly: JasperFxAssembly]
 [assembly: InternalsVisibleTo("Weasel.Postgresql")]
+[assembly: InternalsVisibleTo("Weasel.Core.Tests")]

--- a/src/Weasel.Core/CommandLine/ApplyCommand.cs
+++ b/src/Weasel.Core/CommandLine/ApplyCommand.cs
@@ -2,6 +2,7 @@ using JasperFx.CommandLine;
 using Spectre.Console;
 using Weasel.Core;
 using Weasel.Core.CommandLine;
+using Weasel.Core.Migrations;
 
 namespace Weasel.CommandLine;
 
@@ -26,23 +27,51 @@ public class ApplyCommand: JasperFxAsyncCommand<WeaselInput>
             return true;
         }
 
-        foreach (var database in databases)
+        var total = databases.Count;
+        for (var i = 0; i < total; i++)
         {
+            var database = databases[i];
             var descriptor = database.Describe();
 
-            // TODO -- it'd be cool to get a rundown of everything that changed.
-            var difference = await database.ApplyAllConfiguredChangesToDatabaseAsync().ConfigureAwait(false);
-            switch (difference)
-            {
-                case SchemaPatchDifference.None:
-                    AnsiConsole.MarkupLine($"[gray]No changes detected for DatabaseUri {descriptor.DatabaseUri()} with SubjectUri {descriptor.SubjectUri}.[/]");
-                    break;
+            // A 512-database walk with no output until it finishes (or fails) is its own small cruelty --
+            // an operator watching this needs to see it moving and be able to estimate completion.
+            var progress = $"({i + 1}/{total})";
 
-                case SchemaPatchDifference.Create:
-                case SchemaPatchDifference.Update:
+            try
+            {
+                // TODO -- it'd be cool to get a rundown of everything that changed.
+                var difference = await database.ApplyAllConfiguredChangesWithRetriesAsync().ConfigureAwait(false);
+                switch (difference)
+                {
+                    case SchemaPatchDifference.None:
+                        AnsiConsole.MarkupLine($"[gray]{progress} No changes detected for DatabaseUri {descriptor.DatabaseUri()} with SubjectUri {descriptor.SubjectUri}.[/]");
+                        break;
+
+                    case SchemaPatchDifference.Create:
+                    case SchemaPatchDifference.Update:
+                        AnsiConsole.MarkupLine(
+                            $"[bold green]{progress} Successfully applied migrations for DatabaseUri {descriptor.DatabaseUri()} with SubjectUri {descriptor.SubjectUri}.[/]");
+                        break;
+                }
+            }
+            finally
+            {
+                // Nothing else needs this database's connections once its apply is done, and this command
+                // owns its data sources -- there are no application sessions sharing them. Releasing here
+                // keeps peak connection usage at ~the one database being applied, instead of trailing an
+                // idle pool per database until the connection idle lifetime expires (weasel#356).
+                try
+                {
+                    await database.ReleaseConnectionPoolAsync().ConfigureAwait(false);
+                }
+                catch (Exception e)
+                {
+                    // Releasing the pool is housekeeping. If it throws while an apply is already failing,
+                    // letting it out of the finally would discard the migration exception the operator
+                    // actually needs to see.
                     AnsiConsole.MarkupLine(
-                        $"[bold green]Successfully applied migrations for DatabaseUri {descriptor.DatabaseUri()} with SubjectUri {descriptor.SubjectUri}.[/]");
-                    break;
+                        $"[yellow]{progress} Unable to release the connection pool for DatabaseUri {descriptor.DatabaseUri()}: {Markup.Escape(e.Message)}[/]");
+                }
             }
         }
 

--- a/src/Weasel.Core/Migrations/DatabaseBase.cs
+++ b/src/Weasel.Core/Migrations/DatabaseBase.cs
@@ -288,6 +288,15 @@ public abstract class DatabaseBase<TConnection>: IDatabase<TConnection> where TC
         return _connectionSource();
     }
 
+    /// <summary>
+    ///     No-op by default. See <see cref="IDatabase.ReleaseConnectionPoolAsync" /> — providers that pool
+    ///     connections override this to close their idle connections.
+    /// </summary>
+    public virtual ValueTask ReleaseConnectionPoolAsync(CancellationToken ct = default)
+    {
+        return ValueTask.CompletedTask;
+    }
+
     public Task<SchemaMigration> CreateMigrationAsync(Type featureType, CancellationToken ct = default)
     {
         var feature = FindFeature(featureType);

--- a/src/Weasel.Core/Migrations/IDatabase.cs
+++ b/src/Weasel.Core/Migrations/IDatabase.cs
@@ -114,6 +114,26 @@ public interface IDatabase
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
     Task AssertConnectivityAsync(CancellationToken ct = default);
+
+    /// <summary>
+    ///     Release any pooled connections held for this database without disposing the database itself.
+    ///     The default implementation is a no-op. Implementations that pool connections (see
+    ///     <c>PostgresqlDatabase</c>) should close their idle connections here.
+    ///     <para>
+    ///     This exists for one-shot tooling — <c>db-apply</c> in particular — that walks many databases
+    ///     sequentially (weasel#356). Each database owns its own pool, and nothing evicts a finished
+    ///     database's idle connections until the connection idle lifetime expires, so an apply that only
+    ///     ever needs one connection at a time drags a rolling tail of idle pools behind it and can push a
+    ///     busy server over <c>max_connections</c>. Calling this after a database is done bounds peak usage
+    ///     at the one pool actually in use.
+    ///     </para>
+    ///     <para>
+    ///     This must remain safe to call on a database that will be used again afterward: it releases idle
+    ///     connections, it does not tear the database's connectivity down.
+    ///     </para>
+    /// </summary>
+    /// <param name="ct">Cancellation Token</param>
+    ValueTask ReleaseConnectionPoolAsync(CancellationToken ct = default) => ValueTask.CompletedTask;
 }
 
 public static class DatabaseExtensions
@@ -147,6 +167,69 @@ public static class DatabaseExtensions
         }
 
         return database.CreateMigrationAsync(feature, ct);
+    }
+
+    /// <summary>
+    ///     Apply all detected changes to the database, retrying a bounded number of times with an
+    ///     exponential, jittered backoff when the attempt fails with a transient connection failure as
+    ///     judged by <see cref="Migrator.IsTransientConnectionFailure" /> — a server at its connection
+    ///     ceiling, most notably.
+    ///     <para>
+    ///     Intended for one-shot migration tooling against a live server (weasel#356): a connection
+    ///     refusal there is near-certainly transient ambient pressure, and failing the whole job on the
+    ///     first refusal blocks a deployment for something that would have succeeded a second later. The
+    ///     pool is released between attempts so a retry starts from a clean slate rather than re-using a
+    ///     pool full of connections the server just refused.
+    ///     </para>
+    /// </summary>
+    /// <param name="database"></param>
+    /// <param name="maxAttempts">The total number of attempts, including the first. Default is 3, i.e. two retries.</param>
+    /// <param name="baseDelayMs">Delay before the first retry. Doubles per subsequent retry, capped at <see cref="MaxRetryDelayMs" />. Default is 1000ms.</param>
+    /// <param name="ct">Cancellation Token</param>
+    public static async Task<SchemaPatchDifference> ApplyAllConfiguredChangesWithRetriesAsync(
+        this IDatabase database,
+        int maxAttempts = 3,
+        int baseDelayMs = 1000,
+        CancellationToken ct = default
+    )
+    {
+        for (var attempt = 1; ; attempt++)
+        {
+            try
+            {
+                return await database.ApplyAllConfiguredChangesToDatabaseAsync(ct: ct).ConfigureAwait(false);
+            }
+            catch (Exception e) when (attempt < maxAttempts && database.Migrator.IsTransientConnectionFailure(e))
+            {
+                // The refused attempt may still have left connections in this database's pool. Drop them
+                // before backing off so the retry is not competing against our own idle connections.
+                await database.ReleaseConnectionPoolAsync(ct).ConfigureAwait(false);
+
+                await Task.Delay(BackoffDelayMs(attempt, baseDelayMs), ct).ConfigureAwait(false);
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Ceiling on a single backoff delay. Doubling is only useful up to a point: a caller who asked for
+    ///     many attempts wants to keep trying while a connection storm clears, not to disappear for an hour
+    ///     on one sleep.
+    /// </summary>
+    internal const int MaxRetryDelayMs = 30_000;
+
+    /// <summary>
+    ///     Exponential backoff for the given (1-based) attempt, jittered so that several appliers refused at
+    ///     the same moment don't march back in lockstep. Computed in <see cref="long" /> and clamped: the
+    ///     naive <c>baseDelayMs * 2^(attempt-1)</c> overflows <see cref="int" /> around attempt 32 and goes
+    ///     negative, which would throw out of <c>Task.Delay</c> and lose the connection failure being retried.
+    ///     Pure so the clamping is unit-testable.
+    /// </summary>
+    internal static int BackoffDelayMs(int attempt, int baseDelayMs)
+    {
+        var doublings = Math.Min(attempt - 1, 30);
+        var delay = Math.Min((long)baseDelayMs << doublings, MaxRetryDelayMs);
+
+        return (int)delay + Random.Shared.Next(0, 100);
     }
 }
 

--- a/src/Weasel.Core/Migrator.cs
+++ b/src/Weasel.Core/Migrator.cs
@@ -284,6 +284,18 @@ public abstract class
     public virtual bool IsSystemColumn(string columnName) => false;
 
     /// <summary>
+    ///     Is this exception a transient failure to *connect* to the database — as opposed to a failure of
+    ///     the migration itself — such that retrying the same work after a backoff is likely to succeed?
+    ///     The default is <c>false</c>; provider-specific migrators override it with the error codes they
+    ///     know to be transient.
+    ///     <para>
+    ///     Only connection-level refusals belong here. A DDL error is not transient, and blanket-retrying
+    ///     one just delays a failure the operator needs to see.
+    ///     </para>
+    /// </summary>
+    public virtual bool IsTransientConnectionFailure(Exception exception) => false;
+
+    /// <summary>
     ///     Ensures that the database referenced by the supplied connection's connection string exists,
     ///     creating it if necessary. This is a lightweight operation that only creates the database --
     ///     it does not run any schema migrations or DDL.

--- a/src/Weasel.Postgresql.Tests/Migrations/releasing_connection_pools.cs
+++ b/src/Weasel.Postgresql.Tests/Migrations/releasing_connection_pools.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using JasperFx.Core;
+using Npgsql;
+using Shouldly;
+using Xunit;
+
+namespace Weasel.Postgresql.Tests.Migrations;
+
+/// <summary>
+///     weasel#356: a one-shot walk over many databases (db-apply against a sharded store) should not drag a
+///     tail of idle pools behind it. Proves that releasing a finished database's pool actually closes its
+///     physical connections on the server, rather than leaving them idle until the connection idle lifetime
+///     expires -- and that the database is still usable afterward.
+/// </summary>
+[Collection("pool_release")]
+public class releasing_connection_pools: IAsyncLifetime
+{
+    // Tags this test's backends so the assertions can't be confused by any other activity on the server.
+    private readonly string theApplicationName = "weasel_356_" + Guid.NewGuid().ToString("N")[..8];
+    private NpgsqlDataSource theDataSource = null!;
+    private TestDatabaseWithTables theDatabase = null!;
+
+    public Task InitializeAsync()
+    {
+        var builder = new NpgsqlDataSourceBuilder(ConnectionSource.ConnectionString);
+        builder.ConnectionStringBuilder.ApplicationName = theApplicationName;
+
+        theDataSource = builder.Build();
+        theDatabase = new TestDatabaseWithTables("pool_release", theDataSource);
+
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync()
+    {
+        theDataSource.Dispose();
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task releasing_the_pool_closes_the_idle_connections_on_the_server()
+    {
+        await openAndReturnConnections(3);
+
+        // Returned to the pool, but still open on the server -- this is the tail that piles up across a
+        // many-database walk.
+        (await countServerConnections()).ShouldBe(3);
+
+        await theDatabase.ReleaseConnectionPoolAsync();
+
+        await waitForServerConnectionsToReach(0);
+    }
+
+    [Fact]
+    public async Task the_database_is_still_usable_after_releasing_its_pool()
+    {
+        await openAndReturnConnections(1);
+        await theDatabase.ReleaseConnectionPoolAsync();
+
+        // Release closes idle connections; it does not tear the database's connectivity down.
+        await theDatabase.AssertConnectivityAsync();
+    }
+
+    private async Task openAndReturnConnections(int count)
+    {
+        var connections = Enumerable.Range(0, count).Select(_ => theDataSource.CreateConnection()).ToArray();
+        foreach (var conn in connections) await conn.OpenAsync();
+
+        // Dispose only after all of them are open, so the pool really does hold `count` physical connections
+        // rather than re-using a single one.
+        foreach (var conn in connections) await conn.DisposeAsync();
+    }
+
+    private async Task<int> countServerConnections()
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "select count(*) from pg_stat_activity where application_name = $1";
+        cmd.Parameters.AddWithValue(theApplicationName);
+
+        return Convert.ToInt32(await cmd.ExecuteScalarAsync());
+    }
+
+    private async Task waitForServerConnectionsToReach(int expected)
+    {
+        // pg_stat_activity lags the actual backend teardown slightly, so poll rather than assert once.
+        var timeout = DateTimeOffset.UtcNow.Add(5.Seconds());
+        while (DateTimeOffset.UtcNow < timeout)
+        {
+            if (await countServerConnections() == expected) return;
+            await Task.Delay(100);
+        }
+
+        (await countServerConnections()).ShouldBe(expected);
+    }
+}

--- a/src/Weasel.Postgresql.Tests/PostgresqlMigratorConnectionRetryTests.cs
+++ b/src/Weasel.Postgresql.Tests/PostgresqlMigratorConnectionRetryTests.cs
@@ -1,0 +1,101 @@
+using System;
+using Npgsql;
+using Shouldly;
+using Xunit;
+
+namespace Weasel.Postgresql.Tests;
+
+/// <summary>
+///     Unit coverage for the transient-connection-failure predicate that lets one-shot migration tooling
+///     retry a database that was refused a connection instead of failing the whole job (weasel#356).
+///     The classification is a pure function over the SQLSTATE and is fully testable here.
+/// </summary>
+public class PostgresqlMigratorConnectionRetryTests
+{
+    [Fact]
+    public void too_many_connections_is_transient()
+    {
+        PostgresqlMigrator.IsTransientConnectionFailure(PostgresErrorCodes.TooManyConnections).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void configuration_limit_exceeded_is_transient()
+    {
+        PostgresqlMigrator.IsTransientConnectionFailure(PostgresErrorCodes.ConfigurationLimitExceeded).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void cannot_connect_now_is_transient()
+    {
+        PostgresqlMigrator.IsTransientConnectionFailure(PostgresErrorCodes.CannotConnectNow).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void disk_full_is_not_transient()
+    {
+        // Also class 53 (insufficient_resources), but retrying will not clear it.
+        PostgresqlMigrator.IsTransientConnectionFailure(PostgresErrorCodes.DiskFull).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void out_of_memory_is_not_transient()
+    {
+        PostgresqlMigrator.IsTransientConnectionFailure(PostgresErrorCodes.OutOfMemory).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void syntax_error_is_not_transient()
+    {
+        PostgresqlMigrator.IsTransientConnectionFailure(PostgresErrorCodes.SyntaxError).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void unknown_sqlstate_is_not_transient()
+    {
+        PostgresqlMigrator.IsTransientConnectionFailure(null).ShouldBeFalse();
+        PostgresqlMigrator.IsTransientConnectionFailure("").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void non_postgres_exceptions_are_not_transient()
+    {
+        new PostgresqlMigrator().IsTransientConnectionFailure(new InvalidOperationException("boom")).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void a_bare_too_many_connections_is_transient()
+    {
+        new PostgresqlMigrator().IsTransientConnectionFailure(tooManyConnections()).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void a_wrapped_too_many_connections_is_transient()
+    {
+        // Npgsql commonly delivers a connect-time failure as an outer exception wrapping the
+        // PostgresException that carries the SQLSTATE.
+        var wrapped = new NpgsqlException("Failed to connect", tooManyConnections());
+
+        new PostgresqlMigrator().IsTransientConnectionFailure(wrapped).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void an_aggregated_too_many_connections_is_transient()
+    {
+        // The shape an NpgsqlMultiHostDataSource produces when every host refuses.
+        var aggregate = new AggregateException(tooManyConnections(), tooManyConnections());
+
+        new PostgresqlMigrator().IsTransientConnectionFailure(aggregate).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void a_wrapped_non_transient_postgres_error_is_not_transient()
+    {
+        var wrapped = new NpgsqlException("boom",
+            new PostgresException("syntax error", "ERROR", "ERROR", PostgresErrorCodes.SyntaxError));
+
+        new PostgresqlMigrator().IsTransientConnectionFailure(wrapped).ShouldBeFalse();
+    }
+
+    private static PostgresException tooManyConnections() =>
+        new("sorry, too many clients already", "FATAL", "FATAL", PostgresErrorCodes.TooManyConnections);
+}

--- a/src/Weasel.Postgresql/PostgresqlDatabase.cs
+++ b/src/Weasel.Postgresql/PostgresqlDatabase.cs
@@ -140,6 +140,18 @@ public abstract class PostgresqlDatabase: DatabaseBase<NpgsqlConnection>, IAsync
         return CreateConnection();
     }
 
+    /// <summary>
+    ///     Closes the idle connections in this database's <see cref="NpgsqlDataSource" /> pool. Unlike
+    ///     <see cref="DisposeAsync" /> this is safe regardless of <see cref="OwnsDataSource" />: connections
+    ///     currently in use are left alone and simply discarded when they are returned, and the data source
+    ///     stays usable afterward.
+    /// </summary>
+    public override ValueTask ReleaseConnectionPoolAsync(CancellationToken ct = default)
+    {
+        DataSource.Clear();
+        return ValueTask.CompletedTask;
+    }
+
     public ValueTask DisposeAsync()
     {
         // Only dispose the data source when this database owns its lifetime. When it was supplied by the caller

--- a/src/Weasel.Postgresql/PostgresqlMigrator.cs
+++ b/src/Weasel.Postgresql/PostgresqlMigrator.cs
@@ -257,6 +257,66 @@ $$;
         };
     }
 
+    public override bool IsTransientConnectionFailure(Exception exception)
+    {
+        // Npgsql does not always surface the server's refusal bare. An NpgsqlMultiHostDataSource (which
+        // PostgresqlDatabase.CreateConnection explicitly supports) aggregates its per-host failures, and a
+        // failure to connect commonly arrives as an outer exception wrapping the PostgresException that
+        // actually carries the SQLSTATE. Matching only the outermost exception would leave this predicate --
+        // and therefore the whole retry -- inert for exactly the case it exists to handle.
+        foreach (var e in flatten(exception))
+        {
+            if (e is PostgresException pg && IsTransientConnectionFailure(pg.SqlState)) return true;
+        }
+
+        return false;
+    }
+
+    private static IEnumerable<Exception> flatten(Exception exception)
+    {
+        if (exception is AggregateException aggregate)
+        {
+            foreach (var inner in aggregate.Flatten().InnerExceptions)
+            foreach (var e in flatten(inner))
+            {
+                yield return e;
+            }
+
+            yield break;
+        }
+
+        for (var e = exception; e != null; e = e.InnerException)
+        {
+            yield return e;
+
+            if (e.InnerException is AggregateException nested)
+            {
+                foreach (var inner in flatten(nested)) yield return inner;
+                yield break;
+            }
+        }
+    }
+
+    /// <summary>
+    ///     True for the PostgreSQL SQLSTATEs that signal a transient refusal to accept a new connection,
+    ///     where the same work retried after a backoff is likely to get through (weasel#356):
+    ///     <list type="bullet">
+    ///         <item><c>53300</c> too_many_connections — the server is at <c>max_connections</c></item>
+    ///         <item><c>53400</c> configuration_limit_exceeded</item>
+    ///         <item><c>57P03</c> cannot_connect_now — the server is still starting up</item>
+    ///     </list>
+    ///     Deliberately excludes the rest of class 53 (insufficient_resources): <c>53100</c> disk_full and
+    ///     <c>53200</c> out_of_memory are real conditions that retrying will not clear.
+    ///     Pure over the SQLSTATE so it is unit-testable without constructing a
+    ///     <see cref="PostgresException" />.
+    /// </summary>
+    internal static bool IsTransientConnectionFailure(string? sqlState)
+    {
+        return sqlState is PostgresErrorCodes.TooManyConnections
+            or PostgresErrorCodes.ConfigurationLimitExceeded
+            or PostgresErrorCodes.CannotConnectNow;
+    }
+
     public override string ToExecuteScriptLine(string scriptName)
     {
         return $"\\i {scriptName}";


### PR DESCRIPTION
Closes #356.

`db-apply` already walks its databases sequentially, but each database in a sharded/multi-tenanted store owns its own `NpgsqlDataSource` and nothing released a finished database's pool — so a walk spending 1–2s per database dragged a rolling tail of idle pools behind the single active one, and the first `53300` refusal failed the whole job (and with it the deploy step). Both asks from the issue, plus the optional third:

**1. Release each database's pool after applying it.** New `IDatabase.ReleaseConnectionPoolAsync(CancellationToken)`, a **defaulted interface method** with a no-op default (also a virtual no-op on `DatabaseBase<TConnection>`), so this is not a breaking change for implementors. `PostgresqlDatabase` overrides it with `DataSource.Clear()` — unlike `DisposeAsync` this is safe regardless of `OwnsDataSource` (in-use connections are left alone and discarded on return) and leaves the database usable afterward. `db-apply` calls it once each database is done, in a `finally`, so peak usage drops from `O(period/idle-lifetime)` pools to ~1.

**2. Bounded backoff-retry on connection refusal.** New `Migrator.IsTransientConnectionFailure(Exception)` (virtual, `false` by default) overridden in `PostgresqlMigrator` for the SQLSTATEs that mean *refused a connection, try again*: `53300` too_many_connections, `53400`, `57P03` cannot_connect_now. Deliberately **not** the rest of class 53 — `53100` disk_full and `53200` out_of_memory won't clear on a retry. It walks inner/aggregated exceptions, because Npgsql doesn't always surface a connect-time refusal bare (a multi-host data source aggregates per-host failures). `DatabaseExtensions.ApplyAllConfiguredChangesWithRetriesAsync` retries those with a clamped, jittered exponential backoff (3 attempts by default). **Migration failures themselves are never retried** — only connection-level refusals.

**3. Progress logging.** Each line is now prefixed `(n/total)`.

### Notes for review

- **Postgres-only for now.** The abstractions are provider-neutral but only `PostgresqlDatabase`/`PostgresqlMigrator` implement them; other providers inherit the no-op/`false` defaults and keep today's behavior. SQL Server has the equivalents (`SqlConnection.ClearPool`, transient error numbers) if you want that as a follow-up.
- The pool release in `db-apply`'s `finally` is guarded — housekeeping throwing there must not discard the migration exception the operator needs to see.

### Tests

- `releasing_connection_pools` (integration) proves via `pg_stat_activity` that release actually closes the server-side backends (3 → 0) and that the database still works afterward. Confirmed it fails if `Clear()` is removed.
- `apply_with_retries` covers the retry loop: retries transient failures, releases the pool between attempts, gives up at `maxAttempts`, doesn't retry non-transient failures, and clamps the backoff instead of overflowing.
- `PostgresqlMigratorConnectionRetryTests` covers the SQLSTATE classification, including wrapped/aggregated `PostgresException`s.

Full PostgreSQL suite green locally (761 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)