### PR TITLE
Extend db-apply's pool release and retry to SQL Server, MySQL and Oracle (#356)

### DIFF
--- a/docs/cli/db-apply.md
+++ b/docs/cli/db-apply.md
@@ -29,7 +29,23 @@ Databases are applied one at a time, in sequence, and each one's progress is rep
 
 Because `db-apply` is a one-shot command that owns its data sources, each database's connection pool is released as soon as that database is done, rather than being left to age out on its own idle lifetime. Peak connection usage therefore stays at roughly the one database being applied, instead of trailing an idle pool per recently-applied database -- which matters when applying across hundreds of databases on a server that is near `max_connections`.
 
-For the same reason, a database whose apply fails with a *transient connection refusal* -- PostgreSQL `53300 too_many_connections`, `53400`, or `57P03 cannot_connect_now` -- is retried twice with an exponential backoff (3 attempts in total), so ambient connection pressure doesn't fail an entire deployment step. Migration failures themselves are **not** retried and fail the command immediately.
+For the same reason, a database whose apply fails with a *transient connection refusal* is retried twice with an exponential backoff (3 attempts in total), so ambient connection pressure doesn't fail an entire deployment step. Migration failures themselves are **not** retried and fail the command immediately.
+
+What counts as a transient refusal is decided per provider:
+
+| Provider | Retried on |
+|----------|------------|
+| PostgreSQL | `53300` too_many_connections, `53400`, `57P03` cannot_connect_now |
+| SQL Server | `17809` too many user connections, and the Azure SQL resource/throttling set (`10928`/`10929`/`40197`/`40501`/`40613`/`49918`-`49920`) |
+| MySQL | `1040` too many connections, `1203`, `1226`, unable to connect to host |
+| Oracle | `ORA-00020` max processes exceeded, `ORA-12516`/`12518`/`12520` listener busy |
+| SQLite | N/A -- no server, so no connection ceiling to hit |
+
+The list is deliberately narrow, because a wrong retry is worse than a missed one: a missed code just means today's behavior (fail immediately), while a false positive silently re-runs a migration that genuinely failed. So errors that can't be told apart from a failed migration are excluded even when they look connection-ish -- SQL Server's `-2` ("timeout expired") is also raised for *command* timeouts, so a slow `CREATE INDEX` would otherwise be retried as though the server had refused it, and transport-level drops (`10053`/`10054`, `ORA-12537`/`12570`) are reported identically whether they happened while connecting or midway through a statement. Bad credentials, deadlocks and DDL mistakes are excluded for the same reason.
+
+::: tip
+Pool release is scoped differently by provider. PostgreSQL clears the specific `NpgsqlDataSource`, while the other providers' drivers key their pools by connection string within the process -- so releasing there also drops idle connections held elsewhere in the same process for that connection string. Connections in use are never killed (they're discarded when returned), and for a one-shot CLI like `db-apply` this makes no difference, but it's worth knowing if you call `ReleaseConnectionPoolAsync()` yourself from inside a running application.
+:::
 
 ## Idempotency
 

--- a/src/Weasel.Core.Tests/Migrations/apply_with_retries.cs
+++ b/src/Weasel.Core.Tests/Migrations/apply_with_retries.cs
@@ -79,6 +79,22 @@ public class apply_with_retries
     }
 
     [Fact]
+    public async Task a_failure_to_release_the_pool_does_not_defeat_the_retry()
+    {
+        // Release does real driver work now that every provider implements it, so it can fail. If that
+        // failure escaped, it would replace the transient exception being retried and turn a recoverable
+        // refusal into a hard failure.
+        var database = new FakeDatabase
+        {
+            FailuresBeforeSuccess = 1, FailureIsTransient = true, ReleaseThrows = true
+        };
+
+        (await apply(database)).ShouldBe(SchemaPatchDifference.Update);
+
+        database.Attempts.ShouldBe(2);
+    }
+
+    [Fact]
     public void the_backoff_doubles_per_attempt()
     {
         DatabaseExtensions.BackoffDelayMs(1, 1000).ShouldBeInRange(1000, 1100);
@@ -106,6 +122,7 @@ public class apply_with_retries
         public int PoolReleases { get; private set; }
         public int FailuresBeforeSuccess { get; set; }
         public bool FailureIsTransient { get; set; }
+        public bool ReleaseThrows { get; set; }
 
         public Task<SchemaPatchDifference> ApplyAllConfiguredChangesToDatabaseAsync(
             AutoCreate? @override = null,
@@ -126,6 +143,8 @@ public class apply_with_retries
         public ValueTask ReleaseConnectionPoolAsync(CancellationToken ct = default)
         {
             PoolReleases++;
+            if (ReleaseThrows) throw new InvalidOperationException("the pool could not be cleared");
+
             return ValueTask.CompletedTask;
         }
 

--- a/src/Weasel.Core/ExceptionChain.cs
+++ b/src/Weasel.Core/ExceptionChain.cs
@@ -1,0 +1,43 @@
+namespace Weasel.Core;
+
+/// <summary>
+///     Helpers for looking through exception wrapping.
+/// </summary>
+public static class ExceptionChain
+{
+    /// <summary>
+    ///     Enumerates the supplied exception and everything nested inside it -- inner exceptions, and every
+    ///     branch of any <see cref="AggregateException" />.
+    ///     <para>
+    ///     Exists for <see cref="Migrator.IsTransientConnectionFailure" /> implementations (weasel#356). The
+    ///     database drivers rarely surface a connection failure bare: the provider-specific exception
+    ///     carrying the error code is typically wrapped, and multi-host/failover data sources aggregate one
+    ///     failure per host. A predicate that only inspected the outermost exception would be inert for
+    ///     exactly the cases it exists to catch.
+    ///     </para>
+    /// </summary>
+    public static IEnumerable<Exception> Flatten(Exception exception)
+    {
+        if (exception is AggregateException aggregate)
+        {
+            foreach (var inner in aggregate.Flatten().InnerExceptions)
+            foreach (var e in Flatten(inner))
+            {
+                yield return e;
+            }
+
+            yield break;
+        }
+
+        for (var e = exception; e != null; e = e.InnerException)
+        {
+            yield return e;
+
+            if (e.InnerException is AggregateException nested)
+            {
+                foreach (var inner in Flatten(nested)) yield return inner;
+                yield break;
+            }
+        }
+    }
+}

--- a/src/Weasel.Core/Migrations/DatabaseBase.cs
+++ b/src/Weasel.Core/Migrations/DatabaseBase.cs
@@ -289,12 +289,19 @@ public abstract class DatabaseBase<TConnection>: IDatabase<TConnection> where TC
     }
 
     /// <summary>
-    ///     No-op by default. See <see cref="IDatabase.ReleaseConnectionPoolAsync" /> — providers that pool
-    ///     connections override this to close their idle connections.
+    ///     Releases this database's pooled connections by delegating to the provider-specific
+    ///     <see cref="Migrator" />, which is a no-op for providers with nothing to release. See
+    ///     <see cref="IDatabase.ReleaseConnectionPoolAsync" />.
+    ///     <para>
+    ///     The connection is created but deliberately never opened — the drivers key their pools off the
+    ///     connection string, so it serves only to identify which pool to clear. Opening one here would be
+    ///     the opposite of the point when the reason we are clearing is a server refusing connections.
+    ///     </para>
     /// </summary>
-    public virtual ValueTask ReleaseConnectionPoolAsync(CancellationToken ct = default)
+    public virtual async ValueTask ReleaseConnectionPoolAsync(CancellationToken ct = default)
     {
-        return ValueTask.CompletedTask;
+        await using var conn = CreateConnection();
+        await Migrator.ReleaseConnectionPoolAsync(conn, ct).ConfigureAwait(false);
     }
 
     public Task<SchemaMigration> CreateMigrationAsync(Type featureType, CancellationToken ct = default)

--- a/src/Weasel.Core/Migrations/IDatabase.cs
+++ b/src/Weasel.Core/Migrations/IDatabase.cs
@@ -203,7 +203,16 @@ public static class DatabaseExtensions
             {
                 // The refused attempt may still have left connections in this database's pool. Drop them
                 // before backing off so the retry is not competing against our own idle connections.
-                await database.ReleaseConnectionPoolAsync(ct).ConfigureAwait(false);
+                try
+                {
+                    await database.ReleaseConnectionPoolAsync(ct).ConfigureAwait(false);
+                }
+                catch (Exception) when (!ct.IsCancellationRequested)
+                {
+                    // Releasing is an optimization, and it does real driver work that can fail. Letting it
+                    // throw here would replace the transient failure we are retrying and skip the retry
+                    // altogether -- turning a recoverable refusal into a hard failure.
+                }
 
                 await Task.Delay(BackoffDelayMs(attempt, baseDelayMs), ct).ConfigureAwait(false);
             }

--- a/src/Weasel.Core/Migrator.cs
+++ b/src/Weasel.Core/Migrator.cs
@@ -296,6 +296,31 @@ public abstract class
     public virtual bool IsTransientConnectionFailure(Exception exception) => false;
 
     /// <summary>
+    ///     Release the pooled connections associated with the supplied connection, which is supplied closed
+    ///     purely to identify the pool. The default is a no-op; provider-specific migrators override it with
+    ///     their driver's pool-clearing call.
+    ///     <para>
+    ///     This hangs off <see cref="Migrator" /> rather than off a database class because it has to be
+    ///     reachable for every provider: only PostgreSQL and SQLite have their own <c>IDatabase</c> base
+    ///     class, while SQL Server, MySQL and Oracle databases are built on <see cref="DatabaseBase{T}" />
+    ///     directly by consumers. Every database has a provider-specific <see cref="Migrator" />, so putting
+    ///     it here means those consumers get pool release without implementing anything.
+    ///     </para>
+    ///     <para>
+    ///     <b>Scope differs by provider.</b> The classic ADO.NET drivers key their pools by connection
+    ///     string within the process, so clearing is process-wide for that connection string and will also
+    ///     evict idle connections held by anything else using it. Connections currently in use are not
+    ///     killed -- they are discarded when returned -- so this is safe, but it is a wider blast radius
+    ///     than <c>PostgresqlDatabase</c>'s data-source-scoped override. Bear that in mind when calling this
+    ///     from inside a running host rather than from one-shot tooling like <c>db-apply</c>.
+    ///     </para>
+    /// </summary>
+    /// <param name="connection">An unopened connection identifying the pool to clear</param>
+    /// <param name="ct">Cancellation Token</param>
+    public virtual ValueTask ReleaseConnectionPoolAsync(DbConnection connection, CancellationToken ct = default) =>
+        ValueTask.CompletedTask;
+
+    /// <summary>
     ///     Ensures that the database referenced by the supplied connection's connection string exists,
     ///     creating it if necessary. This is a lightweight operation that only creates the database --
     ///     it does not run any schema migrations or DDL.

--- a/src/Weasel.MySql.Tests/releasing_connection_pools.cs
+++ b/src/Weasel.MySql.Tests/releasing_connection_pools.cs
@@ -1,0 +1,88 @@
+using JasperFx;
+using JasperFx.Descriptors;
+using MySqlConnector;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Core.Migrations;
+using Xunit;
+
+namespace Weasel.MySql.Tests;
+
+/// <summary>
+///     weasel#356: proves the pool-release hook reaches MySQL. MySQL databases are built on
+///     <see cref="DatabaseBase{T}" /> directly, so release arrives via the provider-specific
+///     <see cref="Migrator" />.
+/// </summary>
+public class releasing_connection_pools
+{
+    [Fact]
+    public async Task the_migrator_releases_the_pool_through_the_database_base()
+    {
+        var database = new TestMySqlDatabase();
+
+        await using (var conn = database.CreateConnection())
+        {
+            await conn.OpenAsync();
+        }
+
+        await database.ReleaseConnectionPoolAsync();
+
+        // Releasing drops idle connections; the database must still work afterward.
+        await database.AssertConnectivityAsync();
+    }
+
+    [Fact]
+    public async Task releasing_the_pool_is_safe_when_nothing_has_been_pooled_yet()
+    {
+        var database = new TestMySqlDatabase();
+
+        await Should.NotThrowAsync(async () => await database.ReleaseConnectionPoolAsync());
+    }
+
+    public class TestMySqlDatabase: DatabaseBase<MySqlConnection>
+    {
+        public TestMySqlDatabase(): base(new DefaultMigrationLogger(), AutoCreate.All, new MySqlMigrator(),
+            "pool_release", ConnectionSource.ConnectionString)
+        {
+        }
+
+        public override IFeatureSchema[] BuildFeatureSchemas() => [];
+
+        public override DatabaseDescriptor Describe() => new()
+        {
+            Engine = MySqlProvider.EngineName, ServerName = "localhost", DatabaseName = "weasel_testing"
+        };
+    }
+}
+
+/// <summary>
+///     Unit coverage for the MySQL transient-connection-failure classification (weasel#356).
+/// </summary>
+public class MySqlTransientConnectionErrorTests
+{
+    [Theory]
+    [InlineData(MySqlErrorCode.ConnectionCountError)] // 1040 too many connections
+    [InlineData(MySqlErrorCode.TooManyUserConnections)] // 1203
+    [InlineData(MySqlErrorCode.UserLimitReached)] // 1226
+    [InlineData(MySqlErrorCode.UnableToConnectToHost)]
+    public void transient_connection_errors(MySqlErrorCode code)
+    {
+        MySqlMigrator.IsTransientConnectionError(code).ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData(MySqlErrorCode.AccessDenied)] // credentials never clear on retry
+    [InlineData(MySqlErrorCode.LockDeadlock)] // statement conflict, not a connection refusal
+    [InlineData(MySqlErrorCode.DuplicateKeyEntry)] // a real migration failure
+    [InlineData(MySqlErrorCode.ParseError)]
+    public void non_transient_errors(MySqlErrorCode code)
+    {
+        MySqlMigrator.IsTransientConnectionError(code).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void non_mysql_exceptions_are_not_transient()
+    {
+        new MySqlMigrator().IsTransientConnectionFailure(new InvalidOperationException("boom")).ShouldBeFalse();
+    }
+}

--- a/src/Weasel.MySql.Tests/releasing_connection_pools.cs
+++ b/src/Weasel.MySql.Tests/releasing_connection_pools.cs
@@ -41,10 +41,18 @@ public class releasing_connection_pools
 
     public class TestMySqlDatabase: DatabaseBase<MySqlConnection>
     {
+        // A distinct ApplicationName gives each instance its own pool key, so clearing it cannot evict
+        // connections from under the tests running in parallel in other collections.
         public TestMySqlDatabase(): base(new DefaultMigrationLogger(), AutoCreate.All, new MySqlMigrator(),
-            "pool_release", ConnectionSource.ConnectionString)
+            "pool_release", IsolatedConnectionString())
         {
         }
+
+        private static string IsolatedConnectionString() =>
+            new MySqlConnectionStringBuilder(ConnectionSource.ConnectionString)
+            {
+                ApplicationName = "weasel_356_" + Guid.NewGuid().ToString("N")[..8]
+            }.ConnectionString;
 
         public override IFeatureSchema[] BuildFeatureSchemas() => [];
 

--- a/src/Weasel.MySql/AssemblyInfo.cs
+++ b/src/Weasel.MySql/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Weasel.MySql.Tests")]

--- a/src/Weasel.MySql/MySqlMigrator.cs
+++ b/src/Weasel.MySql/MySqlMigrator.cs
@@ -19,6 +19,45 @@ public class MySqlMigrator: Migrator
         return connection is MySqlConnection;
     }
 
+    public override async ValueTask ReleaseConnectionPoolAsync(DbConnection connection, CancellationToken ct = default)
+    {
+        if (connection is MySqlConnection mysql)
+        {
+            await MySqlConnection.ClearPoolAsync(mysql, ct).ConfigureAwait(false);
+        }
+    }
+
+    public override bool IsTransientConnectionFailure(Exception exception)
+    {
+        foreach (var e in ExceptionChain.Flatten(exception))
+        {
+            if (e is MySqlException mysql && IsTransientConnectionError(mysql.ErrorCode)) return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    ///     True for the MySQL errors that mean the server would not hand out a connection right now
+    ///     (weasel#356):
+    ///     <list type="bullet">
+    ///         <item><c>ER_CON_COUNT_ERROR</c> (1040) too many connections</item>
+    ///         <item><c>ER_TOO_MANY_USER_CONNECTIONS</c> (1203) too many connections for this user</item>
+    ///         <item><c>ER_USER_LIMIT_REACHED</c> (1226) user resource limit reached</item>
+    ///         <item><c>UnableToConnectToHost</c> the server refused or was unreachable</item>
+    ///     </list>
+    ///     Deliberately excludes lock/deadlock errors, which are statement conflicts rather than connection
+    ///     refusals. Pure over the error code so it is unit-testable without constructing a
+    ///     <see cref="MySqlException" />.
+    /// </summary>
+    internal static bool IsTransientConnectionError(MySqlErrorCode code)
+    {
+        return code is MySqlErrorCode.ConnectionCountError
+            or MySqlErrorCode.TooManyUserConnections
+            or MySqlErrorCode.UserLimitReached
+            or MySqlErrorCode.UnableToConnectToHost;
+    }
+
     public override IDatabaseProvider Provider => MySqlProvider.Instance;
 
     public override void WriteScript(TextWriter writer, Action<Migrator, TextWriter> writeStep)

--- a/src/Weasel.Oracle.Tests/releasing_connection_pools.cs
+++ b/src/Weasel.Oracle.Tests/releasing_connection_pools.cs
@@ -42,9 +42,18 @@ public class releasing_connection_pools
     public class TestOracleDatabase: DatabaseBase<OracleConnection>
     {
         public TestOracleDatabase(): base(new DefaultMigrationLogger(), AutoCreate.All, new OracleMigrator(),
-            "pool_release", ConnectionSource.ConnectionString)
+            "pool_release", IsolatedConnectionString())
         {
         }
+
+        // ODP.NET has no ApplicationName, but pools are keyed by the connection string all the same, so any
+        // harmless distinct value gives this test its own pool -- and keeps its ClearPool from evicting
+        // connections out from under tests running in parallel in other collections.
+        private static string IsolatedConnectionString() =>
+            new OracleConnectionStringBuilder(ConnectionSource.ConnectionString)
+            {
+                ConnectionLifeTime = Random.Shared.Next(100_000, 200_000)
+            }.ConnectionString;
 
         public override IFeatureSchema[] BuildFeatureSchemas() => [];
 

--- a/src/Weasel.Oracle.Tests/releasing_connection_pools.cs
+++ b/src/Weasel.Oracle.Tests/releasing_connection_pools.cs
@@ -1,0 +1,90 @@
+using JasperFx;
+using JasperFx.Descriptors;
+using Oracle.ManagedDataAccess.Client;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Core.Migrations;
+using Xunit;
+
+namespace Weasel.Oracle.Tests;
+
+/// <summary>
+///     weasel#356: proves the pool-release hook reaches Oracle. Oracle databases are built on
+///     <see cref="DatabaseBase{T}" /> directly, so release arrives via the provider-specific
+///     <see cref="Migrator" />.
+/// </summary>
+public class releasing_connection_pools
+{
+    [Fact]
+    public async Task the_migrator_releases_the_pool_through_the_database_base()
+    {
+        var database = new TestOracleDatabase();
+
+        await using (var conn = database.CreateConnection())
+        {
+            await conn.OpenAsync();
+        }
+
+        await database.ReleaseConnectionPoolAsync();
+
+        // Releasing drops idle connections; the database must still work afterward.
+        await database.AssertConnectivityAsync();
+    }
+
+    [Fact]
+    public async Task releasing_the_pool_is_safe_when_nothing_has_been_pooled_yet()
+    {
+        var database = new TestOracleDatabase();
+
+        await Should.NotThrowAsync(async () => await database.ReleaseConnectionPoolAsync());
+    }
+
+    public class TestOracleDatabase: DatabaseBase<OracleConnection>
+    {
+        public TestOracleDatabase(): base(new DefaultMigrationLogger(), AutoCreate.All, new OracleMigrator(),
+            "pool_release", ConnectionSource.ConnectionString)
+        {
+        }
+
+        public override IFeatureSchema[] BuildFeatureSchemas() => [];
+
+        public override DatabaseDescriptor Describe() => new()
+        {
+            Engine = OracleProvider.EngineName, ServerName = "localhost", DatabaseName = "FREEPDB1"
+        };
+    }
+}
+
+/// <summary>
+///     Unit coverage for the Oracle transient-connection-failure classification (weasel#356).
+/// </summary>
+public class OracleTransientConnectionErrorTests
+{
+    [Theory]
+    [InlineData(20)] // ORA-00020 maximum number of processes exceeded
+    [InlineData(12516)] // listener could not find an available handler
+    [InlineData(12518)] // listener could not hand off the client connection
+    [InlineData(12520)]
+    public void transient_connection_errors(int number)
+    {
+        OracleMigrator.IsTransientConnectionError(number).ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData(12537)] // connection closed -- an established session dropped, not a refusal to connect
+    [InlineData(12570)] // unexpected packet read error -- ditto; retrying could replay committed DDL
+    [InlineData(1017)] // ORA-01017 invalid credentials -- never clears on retry
+    [InlineData(955)] // ORA-00955 name already used -- a real migration failure
+    [InlineData(60)] // ORA-00060 deadlock -- a statement conflict, not a connection refusal
+    [InlineData(942)] // ORA-00942 table or view does not exist
+    public void non_transient_errors(int number)
+    {
+        OracleMigrator.IsTransientConnectionError(number).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void non_oracle_exceptions_are_not_transient()
+    {
+        new OracleMigrator().IsTransientConnectionFailure(new InvalidOperationException("boom")).ShouldBeFalse();
+    }
+}

--- a/src/Weasel.Oracle/AssemblyInfo.cs
+++ b/src/Weasel.Oracle/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Weasel.Oracle.Tests")]

--- a/src/Weasel.Oracle/OracleMigrator.cs
+++ b/src/Weasel.Oracle/OracleMigrator.cs
@@ -19,6 +19,48 @@ public class OracleMigrator: Migrator
         return connection is OracleConnection;
     }
 
+    public override ValueTask ReleaseConnectionPoolAsync(DbConnection connection, CancellationToken ct = default)
+    {
+        if (connection is OracleConnection oracle)
+        {
+            OracleConnection.ClearPool(oracle);
+        }
+
+        return ValueTask.CompletedTask;
+    }
+
+    public override bool IsTransientConnectionFailure(Exception exception)
+    {
+        foreach (var e in ExceptionChain.Flatten(exception))
+        {
+            if (e is OracleException oracle && IsTransientConnectionError(oracle.Number)) return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    ///     True for the Oracle errors that mean the instance or its listener would not take a new connection
+    ///     right now (weasel#356):
+    ///     <list type="bullet">
+    ///         <item><c>ORA-00020</c> maximum number of processes exceeded</item>
+    ///         <item><c>ORA-12516</c> listener could not find an available handler</item>
+    ///         <item><c>ORA-12518</c> listener could not hand off the client connection</item>
+    ///         <item><c>ORA-12520</c> listener could not find an available handler for the server type</item>
+    ///     </list>
+    ///     Excludes <c>ORA-01017</c> (invalid credentials), which never clears on a retry, and deliberately
+    ///     excludes <c>ORA-12537</c> (connection closed) and <c>ORA-12570</c> (unexpected packet read
+    ///     error): those are raised when an <i>established</i> session is interrupted, which is
+    ///     indistinguishable from a migration dropped midway through. Re-running it would replay DDL that
+    ///     may already have committed and surface a bogus <c>ORA-00955 name is already used</c> in place of
+    ///     the real network error. Pure over the error number so it is unit-testable without constructing an
+    ///     <see cref="OracleException" />.
+    /// </summary>
+    internal static bool IsTransientConnectionError(int number)
+    {
+        return number is 20 or 12516 or 12518 or 12520;
+    }
+
     public override IDatabaseProvider Provider => OracleProvider.Instance;
 
     public override void WriteScript(TextWriter writer, Action<Migrator, TextWriter> writeStep)

--- a/src/Weasel.Postgresql.Tests/Migrations/releasing_connection_pools.cs
+++ b/src/Weasel.Postgresql.Tests/Migrations/releasing_connection_pools.cs
@@ -63,7 +63,7 @@ public class releasing_connection_pools: IAsyncLifetime
         // PostgresqlDatabase clears its NpgsqlDataSource directly, but a PostgreSQL database built on
         // DatabaseBase<NpgsqlConnection> with a connection string never inherits that override -- it has to
         // reach PostgresqlMigrator.ReleaseConnectionPoolAsync instead, like every other provider does.
-        var database = new TestConnectionStringDatabase();
+        var database = new TestConnectionStringDatabase(theApplicationName);
 
         await using (var conn = database.CreateConnection())
         {
@@ -76,10 +76,20 @@ public class releasing_connection_pools: IAsyncLifetime
 
     public class TestConnectionStringDatabase: DatabaseBase<NpgsqlConnection>
     {
-        public TestConnectionStringDatabase(): base(new DefaultMigrationLogger(), AutoCreate.All,
-            new PostgresqlMigrator(), "pool_release", ConnectionSource.ConnectionString)
+        // Npgsql keys its connection-string pools by the whole connection string, so a distinct
+        // ApplicationName gives this test its own pool. Without that, clearing it would evict connections
+        // out from under the tests running in parallel in other collections -- the process-wide blast
+        // radius that Migrator.ReleaseConnectionPoolAsync warns about, aimed at our own test suite.
+        public TestConnectionStringDatabase(string applicationName): base(new DefaultMigrationLogger(),
+            AutoCreate.All, new PostgresqlMigrator(), "pool_release", ConnectionStringFor(applicationName))
         {
         }
+
+        private static string ConnectionStringFor(string applicationName) =>
+            new NpgsqlConnectionStringBuilder(ConnectionSource.ConnectionString)
+            {
+                ApplicationName = applicationName
+            }.ConnectionString;
 
         public override IFeatureSchema[] BuildFeatureSchemas() => [];
 

--- a/src/Weasel.Postgresql.Tests/Migrations/releasing_connection_pools.cs
+++ b/src/Weasel.Postgresql.Tests/Migrations/releasing_connection_pools.cs
@@ -1,9 +1,13 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using JasperFx;
 using JasperFx.Core;
+using JasperFx.Descriptors;
 using Npgsql;
 using Shouldly;
+using Weasel.Core;
+using Weasel.Core.Migrations;
 using Xunit;
 
 namespace Weasel.Postgresql.Tests.Migrations;
@@ -51,6 +55,38 @@ public class releasing_connection_pools: IAsyncLifetime
         await theDatabase.ReleaseConnectionPoolAsync();
 
         await waitForServerConnectionsToReach(0);
+    }
+
+    [Fact]
+    public async Task a_connection_string_database_releases_through_the_migrator()
+    {
+        // PostgresqlDatabase clears its NpgsqlDataSource directly, but a PostgreSQL database built on
+        // DatabaseBase<NpgsqlConnection> with a connection string never inherits that override -- it has to
+        // reach PostgresqlMigrator.ReleaseConnectionPoolAsync instead, like every other provider does.
+        var database = new TestConnectionStringDatabase();
+
+        await using (var conn = database.CreateConnection())
+        {
+            await conn.OpenAsync();
+        }
+
+        await Should.NotThrowAsync(async () => await database.ReleaseConnectionPoolAsync());
+        await database.AssertConnectivityAsync();
+    }
+
+    public class TestConnectionStringDatabase: DatabaseBase<NpgsqlConnection>
+    {
+        public TestConnectionStringDatabase(): base(new DefaultMigrationLogger(), AutoCreate.All,
+            new PostgresqlMigrator(), "pool_release", ConnectionSource.ConnectionString)
+        {
+        }
+
+        public override IFeatureSchema[] BuildFeatureSchemas() => [];
+
+        public override DatabaseDescriptor Describe() => new()
+        {
+            Engine = PostgresqlProvider.EngineName, ServerName = "localhost", DatabaseName = "marten_testing"
+        };
     }
 
     [Fact]

--- a/src/Weasel.Postgresql/PostgresqlMigrator.cs
+++ b/src/Weasel.Postgresql/PostgresqlMigrator.cs
@@ -257,6 +257,25 @@ $$;
         };
     }
 
+    /// <summary>
+    ///     Clears the connection-string-keyed pool for the supplied connection.
+    ///     <para>
+    ///     <see cref="PostgresqlDatabase" /> overrides <c>ReleaseConnectionPoolAsync</c> to clear its
+    ///     <see cref="NpgsqlDataSource" /> directly, which is more precise, so this is only reached by
+    ///     PostgreSQL databases built on <see cref="DatabaseBase{T}" /> with a connection string instead.
+    ///     Without it those databases would be the one provider combination that silently released nothing.
+    ///     </para>
+    /// </summary>
+    public override ValueTask ReleaseConnectionPoolAsync(DbConnection connection, CancellationToken ct = default)
+    {
+        if (connection is NpgsqlConnection npgsql)
+        {
+            NpgsqlConnection.ClearPool(npgsql);
+        }
+
+        return ValueTask.CompletedTask;
+    }
+
     public override bool IsTransientConnectionFailure(Exception exception)
     {
         // Npgsql does not always surface the server's refusal bare. An NpgsqlMultiHostDataSource (which
@@ -264,37 +283,12 @@ $$;
         // failure to connect commonly arrives as an outer exception wrapping the PostgresException that
         // actually carries the SQLSTATE. Matching only the outermost exception would leave this predicate --
         // and therefore the whole retry -- inert for exactly the case it exists to handle.
-        foreach (var e in flatten(exception))
+        foreach (var e in ExceptionChain.Flatten(exception))
         {
             if (e is PostgresException pg && IsTransientConnectionFailure(pg.SqlState)) return true;
         }
 
         return false;
-    }
-
-    private static IEnumerable<Exception> flatten(Exception exception)
-    {
-        if (exception is AggregateException aggregate)
-        {
-            foreach (var inner in aggregate.Flatten().InnerExceptions)
-            foreach (var e in flatten(inner))
-            {
-                yield return e;
-            }
-
-            yield break;
-        }
-
-        for (var e = exception; e != null; e = e.InnerException)
-        {
-            yield return e;
-
-            if (e.InnerException is AggregateException nested)
-            {
-                foreach (var inner in flatten(nested)) yield return inner;
-                yield break;
-            }
-        }
     }
 
     /// <summary>

--- a/src/Weasel.SqlServer.Tests/releasing_connection_pools.cs
+++ b/src/Weasel.SqlServer.Tests/releasing_connection_pools.cs
@@ -1,0 +1,159 @@
+using JasperFx;
+using JasperFx.Descriptors;
+using Microsoft.Data.SqlClient;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Core.Migrations;
+using Xunit;
+
+namespace Weasel.SqlServer.Tests;
+
+/// <summary>
+///     weasel#356: proves the pool-release hook reaches SQL Server. SQL Server databases are built on
+///     <see cref="DatabaseBase{T}" /> directly (there is no SqlServerDatabase class), so release has to
+///     arrive via the provider-specific <see cref="Migrator" /> -- which is what these tests exercise.
+/// </summary>
+public class releasing_connection_pools
+{
+    [Fact]
+    public async Task the_migrator_releases_the_pool_through_the_database_base()
+    {
+        var database = new TestSqlServerDatabase();
+
+        await using (var conn = database.CreateConnection())
+        {
+            await conn.OpenAsync();
+        }
+
+        // Reaches SqlServerMigrator.ReleaseConnectionPoolAsync via DatabaseBase, without any
+        // SQL-Server-specific IDatabase implementation existing.
+        await database.ReleaseConnectionPoolAsync();
+
+        // Releasing the pool must not break the database -- it drops idle connections, nothing more.
+        await database.AssertConnectivityAsync();
+    }
+
+    [Fact]
+    public async Task releasing_the_pool_is_safe_when_nothing_has_been_pooled_yet()
+    {
+        var database = new TestSqlServerDatabase();
+
+        await Should.NotThrowAsync(async () => await database.ReleaseConnectionPoolAsync());
+    }
+
+    [Fact]
+    public async Task releasing_the_pool_closes_the_idle_connections_on_the_server()
+    {
+        // Tags this test's sessions so the count can't be confused by other activity on the server.
+        var applicationName = "weasel_356_" + Guid.NewGuid().ToString("N")[..8];
+        var connectionString =
+            new SqlConnectionStringBuilder(ConnectionSource.ConnectionString) { ApplicationName = applicationName }
+                .ConnectionString;
+
+        var database = new TestSqlServerDatabase(connectionString);
+
+        var connections = new List<SqlConnection>();
+        for (var i = 0; i < 3; i++)
+        {
+            var conn = database.CreateConnection();
+            await conn.OpenAsync();
+            connections.Add(conn);
+        }
+
+        // Return them to the pool only once all three are open, so the pool really holds three physical
+        // connections rather than re-using one.
+        foreach (var conn in connections) await conn.DisposeAsync();
+
+        // Idle in the pool, but still open on the server -- the tail that piles up across a long walk.
+        (await countServerSessions(applicationName)).ShouldBe(3);
+
+        await database.ReleaseConnectionPoolAsync();
+
+        await waitForServerSessionsToReach(applicationName, 0);
+    }
+
+    private static async Task<int> countServerSessions(string applicationName)
+    {
+        await using var conn = new SqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "select count(*) from sys.dm_exec_sessions where program_name = @name";
+        cmd.Parameters.AddWithValue("@name", applicationName);
+
+        return Convert.ToInt32(await cmd.ExecuteScalarAsync());
+    }
+
+    private static async Task waitForServerSessionsToReach(string applicationName, int expected)
+    {
+        // The DMV lags the actual teardown slightly, so poll rather than assert once.
+        var timeout = DateTimeOffset.UtcNow.AddSeconds(5);
+        while (DateTimeOffset.UtcNow < timeout)
+        {
+            if (await countServerSessions(applicationName) == expected) return;
+            await Task.Delay(100);
+        }
+
+        (await countServerSessions(applicationName)).ShouldBe(expected);
+    }
+
+    public class TestSqlServerDatabase: DatabaseBase<SqlConnection>
+    {
+        public TestSqlServerDatabase(): this(ConnectionSource.ConnectionString)
+        {
+        }
+
+        public TestSqlServerDatabase(string connectionString): base(new DefaultMigrationLogger(), AutoCreate.All,
+            new SqlServerMigrator(), "pool_release", connectionString)
+        {
+        }
+
+        public override IFeatureSchema[] BuildFeatureSchemas() => [];
+
+        public override DatabaseDescriptor Describe() => new()
+        {
+            Engine = SqlServerProvider.EngineName, ServerName = "localhost", DatabaseName = "master"
+        };
+    }
+}
+
+/// <summary>
+///     Unit coverage for the SQL Server transient-connection-failure classification (weasel#356). Pure over
+///     the error number, so the retry-worthy set is testable without provoking a real throttling event.
+/// </summary>
+public class SqlServerTransientConnectionErrorTests
+{
+    [Theory]
+    [InlineData(17809)] // too many user connections (on-premises)
+    [InlineData(40501)] // service is busy
+    [InlineData(40613)] // database currently unavailable
+    [InlineData(10928)] // resource limits reached
+    [InlineData(10929)]
+    [InlineData(49918)] // not enough resources
+    [InlineData(49920)]
+    [InlineData(40197)]
+    public void transient_connection_errors(int number)
+    {
+        SqlServerMigrator.IsTransientConnectionError(number).ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData(-2)] // timeout expired -- SqlClient raises this for COMMAND timeouts too, so retrying it
+                     // would silently re-run a migration that merely exceeded CommandTimeout
+    [InlineData(10054)] // transport-level drop -- indistinguishable from a half-applied migration
+    [InlineData(233)]
+    [InlineData(18456)] // login failed -- a credential problem, never clears on retry
+    [InlineData(1205)] // deadlock -- a statement conflict, not a connection refusal
+    [InlineData(2601)] // duplicate key -- a real migration failure
+    [InlineData(0)]
+    public void non_transient_errors(int number)
+    {
+        SqlServerMigrator.IsTransientConnectionError(number).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void non_sql_exceptions_are_not_transient()
+    {
+        new SqlServerMigrator().IsTransientConnectionFailure(new InvalidOperationException("boom")).ShouldBeFalse();
+    }
+}

--- a/src/Weasel.SqlServer/SqlServerMigrator.cs
+++ b/src/Weasel.SqlServer/SqlServerMigrator.cs
@@ -26,6 +26,66 @@ $$;
         return connection is SqlConnection;
     }
 
+    public override ValueTask ReleaseConnectionPoolAsync(DbConnection connection, CancellationToken ct = default)
+    {
+        if (connection is SqlConnection sql)
+        {
+            SqlConnection.ClearPool(sql);
+        }
+
+        return ValueTask.CompletedTask;
+    }
+
+    public override bool IsTransientConnectionFailure(Exception exception)
+    {
+        foreach (var e in ExceptionChain.Flatten(exception))
+        {
+            if (e is SqlException sql && sql.Errors.Cast<SqlError>().Any(x => IsTransientConnectionError(x.Number)))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    ///     True for the SQL Server error numbers that unambiguously mean "could not give you a connection
+    ///     right now, try again" rather than "your migration is wrong" (weasel#356) -- the on-premises
+    ///     connection-limit error plus the Azure SQL resource/throttling set:
+    ///     <list type="bullet">
+    ///         <item><c>17809</c> could not connect: too many user connections (on-premises)</item>
+    ///         <item><c>40197</c>, <c>40501</c> service is busy / error processing the request</item>
+    ///         <item><c>40613</c> database is currently unavailable</item>
+    ///         <item><c>10928</c>, <c>10929</c> resource limits reached</item>
+    ///         <item><c>49918</c>, <c>49919</c>, <c>49920</c> not enough resources to process the request</item>
+    ///     </list>
+    ///     The exclusions matter more than the inclusions here, because a false positive re-runs a
+    ///     migration that actually failed:
+    ///     <list type="bullet">
+    ///         <item>
+    ///             <c>-2</c> is <b>not</b> here despite being the classic "timeout expired": SqlClient
+    ///             raises it for <i>command</i> timeouts too, so retrying it would silently re-run a DDL
+    ///             statement that merely exceeded CommandTimeout (a slow CREATE INDEX on a large table)
+    ///             three times over -- exactly what this predicate promises not to do.
+    ///         </item>
+    ///         <item>
+    ///             <c>10053</c>/<c>10054</c>/<c>233</c>/<c>64</c>, likewise: a transport-level drop is
+    ///             reported the same way whether it happened while connecting or midway through a
+    ///             statement, so they cannot be distinguished from a half-applied migration.
+    ///         </item>
+    ///         <item><c>1205</c> deadlock is a statement conflict, handled at the statement level.</item>
+    ///         <item><c>18456</c> login failed is a credential problem that will never clear.</item>
+    ///     </list>
+    ///     Erring narrow is the safe direction: a missed code just means no retry, i.e. today's behavior.
+    ///     Pure over the error number so it is unit-testable without constructing a
+    ///     <see cref="SqlException" />.
+    /// </summary>
+    internal static bool IsTransientConnectionError(int number)
+    {
+        return number is 10928 or 10929 or 17809 or 40197 or 40501 or 40613 or 49918 or 49919 or 49920;
+    }
+
     public override IDatabaseProvider Provider => SqlServerProvider.Instance;
 
     public override void WriteScript(TextWriter writer, Action<Migrator, TextWriter> writeStep)


### PR DESCRIPTION
Follow-up to #357, which fixed #356 for PostgreSQL only.

### Why the hook had to move

I originally hung pool release on `PostgresqlDatabase`. That was the wrong place: **SQL Server, MySQL and Oracle have no `*Database` class in Weasel** — consumers (Marten, Wolverine) build on `DatabaseBase<TConnection>` directly. There was nowhere for them to inherit an override from, so `db-apply` kept the original bug on every engine but Postgres.

Pool release now hangs off **`Migrator`**, which every database already holds a provider-specific instance of. `DatabaseBase.ReleaseConnectionPoolAsync` delegates to it with an **unopened** connection — the drivers key their pools by connection string, so it only identifies which pool to clear, and opening one would be self-defeating when the reason we're clearing is a server refusing connections. Existing consumers get pool release with **no changes on their side**.

`PostgresqlDatabase` keeps its `DataSource.Clear()` override (data-source-scoped, strictly more precise). `PostgresqlMigrator` also implements the hook, so a Postgres database built on `DatabaseBase<NpgsqlConnection>` with a connection string isn't the one combination that silently releases nothing.

### Transient classification, deliberately narrow

The asymmetry drives this: a false negative is just today's behavior (fail immediately), but **a false positive silently re-runs a migration that genuinely failed**. So codes that can't be distinguished from a failed migration are excluded even when they look connection-ish:

| Provider | Retried on | Notably excluded |
|----------|-----------|------------------|
| SQL Server | `17809`, Azure set (`10928`/`10929`/`40197`/`40501`/`40613`/`49918`-`49920`) | **`-2`** — SqlClient raises it for *command* timeouts too, so a slow `CREATE INDEX` would be retried as a connection refusal; `10053`/`10054`/`233`/`64` transport drops |
| MySQL | `1040`, `1203`, `1226`, unable-to-connect-to-host | deadlocks, access denied |
| Oracle | `ORA-00020`, `ORA-12516`/`12518`/`12520` | `ORA-12537`/`12570` — raised when an *established* session drops; indistinguishable from a migration interrupted midway |
| SQLite | nothing — no server, no connection ceiling | n/a |

Also **guards the pool release inside the retry loop**: it does real driver work now that every provider implements it, so a throw there would replace the transient exception and skip the retry entirely (`ApplyCommand` already guarded its own call).

The exception-chain walk moved to a public `Weasel.Core.ExceptionChain`, since three providers now need it — as would any third-party provider implementing the hook.

### Tests

- **SQL Server** proves via `sys.dm_exec_sessions` that server-side connections actually close (3 → 0). Confirmed it fails when `ClearPool` is removed, same as I did for the Postgres one.
- MySQL/Oracle/Postgres cover release-through-`DatabaseBase` and that the database still works afterward, against real containers.
- Per-provider unit coverage of the classification, with the excluded codes asserted as *non*-transient so the `-2`/`12537` reasoning can't silently regress.
- New Core test that a failing pool release doesn't defeat the retry.

Full suite green locally across all six projects (1,792 tests).

**Honest gap**: the server-side "connections really close" proof exists for Postgres and SQL Server. MySQL and Oracle use the same ADO `ClearPool` mechanism SQL Server proves, and are covered for reach + non-breakage, but not for server-side effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)