### PR TITLE
release: 9.16.4

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>9.16.3</Version>
+        <Version>9.16.4</Version>
         <LangVersion>13.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>


### PR DESCRIPTION
Version bump for the 9.16.4 patch release. Contains everything merged since 9.16.3:

- #357 — bound `db-apply`'s connection usage over many databases (PostgreSQL)
- #358 — extend the pool release and retry to SQL Server, MySQL and Oracle

Both address #356.

🤖 Generated with [Claude Code](https://claude.com/claude-code)