### PR TITLE
feat(events): add archive/tombstone/progression seams to Weasel.Storage.Events

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>9.16.4</Version>
+        <Version>9.17.0</Version>
         <LangVersion>13.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/src/Weasel.Storage/Events/EventAuxiliaryOperations.cs
+++ b/src/Weasel.Storage/Events/EventAuxiliaryOperations.cs
@@ -1,0 +1,26 @@
+#nullable enable
+using System;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// Dialect-supplied factories for the event-store auxiliary write operations that sit alongside the
+/// append/stream lifecycle: archive/un-archive, tombstone (hard delete), and projection-progression
+/// upsert. These are append-mode-independent (the same regardless of Rich/Quick/QuickWithServerTimestamps)
+/// but their SQL is dialect-specific — SQL Server uses <c>SYSDATETIMEOFFSET()</c> and a <c>MERGE</c> for
+/// the progression upsert; Postgres uses <c>now()</c> and <c>ON CONFLICT</c>. A store's
+/// <see cref="IEventStoreSqlDialect"/> vends this record from
+/// <see cref="IEventStoreSqlDialect.BuildAuxiliaryOperations"/>; the built <see cref="EventStorage{TId}"/>
+/// exposes them through <see cref="EventStorage{TId}.ArchiveStream"/> / <see cref="EventStorage{TId}.TombstoneStream"/>
+/// / <see cref="EventStorage{TId}.UpdateProgress"/>.
+/// </summary>
+/// <remarks>
+/// Every factory is optional (nullable). A dialect that does not supply a given factory leaves the
+/// corresponding <see cref="EventStorage{TId}"/> method throwing <see cref="NotSupportedException"/>, so
+/// adding this seam does not force any existing dialect to implement it — stores that still keep these
+/// operations bespoke are unaffected.
+/// </remarks>
+public sealed record EventAuxiliaryOperations(
+    Func<object, string, bool, IStorageOperation>? ArchiveStream = null,
+    Func<object, string, IStorageOperation>? TombstoneStream = null,
+    Func<string, long, bool, IStorageOperation>? UpdateProgress = null);

--- a/src/Weasel.Storage/Events/EventStorage.cs
+++ b/src/Weasel.Storage/Events/EventStorage.cs
@@ -58,4 +58,43 @@ public abstract class EventStorage<TId>
     /// from its descriptor's tenancy style.
     /// </summary>
     public abstract IStorageOperation AssertStreamVersion(StreamAction stream);
+
+    /// <summary>
+    /// Dialect-supplied factories for the auxiliary event-store operations (archive / tombstone /
+    /// progression). Assigned by <see cref="EventStorageBuilder"/> from the dialect's
+    /// <see cref="IEventStoreSqlDialect.BuildAuxiliaryOperations"/>. Null (or a record with null members)
+    /// when the dialect does not provide them, in which case the corresponding methods below throw
+    /// <see cref="NotSupportedException"/>.
+    /// </summary>
+    public EventAuxiliaryOperations? AuxiliaryOperations { get; set; }
+
+    /// <summary>
+    /// Archive (or un-archive) a stream and all of its events — flips the <c>is_archived</c> flag on the
+    /// streams row and the event rows. Archive and un-archive differ only in <paramref name="archived"/>.
+    /// </summary>
+    public virtual IStorageOperation ArchiveStream(object streamId, string tenantId, bool archived)
+        => AuxiliaryOperations?.ArchiveStream is { } factory
+            ? factory(streamId, tenantId, archived)
+            : throw new NotSupportedException(
+                "This event storage dialect does not supply a stream-archive operation. Provide one via IEventStoreSqlDialect.BuildAuxiliaryOperations.");
+
+    /// <summary>
+    /// Hard-delete a stream — removes its event rows and the streams row outright (the tombstone path).
+    /// </summary>
+    public virtual IStorageOperation TombstoneStream(object streamId, string tenantId)
+        => AuxiliaryOperations?.TombstoneStream is { } factory
+            ? factory(streamId, tenantId)
+            : throw new NotSupportedException(
+                "This event storage dialect does not supply a stream-tombstone operation. Provide one via IEventStoreSqlDialect.BuildAuxiliaryOperations.");
+
+    /// <summary>
+    /// Write a projection/subscription progression mark for <paramref name="shardIdentity"/> up to
+    /// <paramref name="sequence"/>. When <paramref name="upsert"/> is true the row may not exist yet
+    /// (insert-or-update); otherwise it is an in-place update of an existing row.
+    /// </summary>
+    public virtual IStorageOperation UpdateProgress(string shardIdentity, long sequence, bool upsert)
+        => AuxiliaryOperations?.UpdateProgress is { } factory
+            ? factory(shardIdentity, sequence, upsert)
+            : throw new NotSupportedException(
+                "This event storage dialect does not supply a progression-update operation. Provide one via IEventStoreSqlDialect.BuildAuxiliaryOperations.");
 }

--- a/src/Weasel.Storage/Events/EventStorageBuilder.cs
+++ b/src/Weasel.Storage/Events/EventStorageBuilder.cs
@@ -23,7 +23,7 @@ public static class EventStorageBuilder
     {
         // The dialect owns descriptor construction end-to-end — SQL strings and
         // metadata-binder ordering are joint concerns it builds in lockstep.
-        return appendMode switch
+        EventStorage<TId> storage = appendMode switch
         {
             EventAppendMode.Rich =>
                 new RichEventStorage<TId>(dialect.BuildRichDescriptor(graph, serializer)),
@@ -38,5 +38,11 @@ public static class EventStorageBuilder
             _ => throw new ArgumentOutOfRangeException(nameof(appendMode),
                 $"Unsupported EventAppendMode for the closed-shape event-storage hierarchy: {appendMode}.")
         };
+
+        // Append-mode-independent auxiliary operations (archive / tombstone / progression). Null unless
+        // the dialect opts in; leaves the EventStorage methods throwing NotSupportedException otherwise.
+        storage.AuxiliaryOperations = dialect.BuildAuxiliaryOperations(graph);
+
+        return storage;
     }
 }

--- a/src/Weasel.Storage/Events/IEventStoreSqlDialect.cs
+++ b/src/Weasel.Storage/Events/IEventStoreSqlDialect.cs
@@ -28,4 +28,14 @@ public interface IEventStoreSqlDialect
 
     QuickWithServerTimestampsEventStorageDescriptor BuildQuickWithServerTimestampsDescriptor(
         EventRegistry graph, IStorageSerializer serializer);
+
+    /// <summary>
+    /// Build the dialect's factories for the auxiliary event-store operations (archive / tombstone /
+    /// progression) that sit alongside the append/stream lifecycle. Unlike the append descriptors these
+    /// are append-mode-independent, so a single record covers every mode. The default returns
+    /// <see langword="null"/> — a dialect that keeps these operations bespoke (as Marten does today) does
+    /// not have to implement it, and the corresponding <see cref="EventStorage{TId}"/> methods stay
+    /// throwing until a dialect opts in. See <see cref="EventAuxiliaryOperations"/>.
+    /// </summary>
+    EventAuxiliaryOperations? BuildAuxiliaryOperations(EventRegistry graph) => null;
 }


### PR DESCRIPTION
Extends the closed-shape event-storage hierarchy with dialect-supplied factories for the auxiliary event-store write operations that sit alongside the append/stream lifecycle: **archive/un-archive**, **tombstone** (hard delete), and **projection-progression** upsert.

## Why

`EventStorage<TId>` / `IEventStoreSqlDialect` already factor the append + stream-version lifecycle so a store provides only its dialect SQL. The archive/tombstone/progression operations are the last event-store write operations with no shared seam — every consuming store keeps them bespoke. This adds that seam so a store (Polecat first; see JasperFx/polecat#318) can route them through the shared runtime.

## Shape

These operations are **append-mode-independent** but their SQL is **dialect-specific** (SQL Server `SYSDATETIMEOFFSET()` + `MERGE` vs Postgres `now()` + `ON CONFLICT`), so they follow the same pattern as the existing `CreateQuickAppendEventsOperation` delegate:

- New `EventAuxiliaryOperations` record — three optional `IStorageOperation` factories.
- `EventStorage<TId>` gains an `AuxiliaryOperations` property plus virtual `ArchiveStream` / `TombstoneStream` / `UpdateProgress` methods that delegate to the factories, or throw `NotSupportedException` when a dialect doesn't supply them.
- `IEventStoreSqlDialect` gains a **default interface method** `BuildAuxiliaryOperations(EventRegistry) => null`.
- `EventStorageBuilder` assigns the dialect's auxiliary operations onto the built storage.

## Compatibility

**Purely additive and non-breaking.** The dialect method is a default interface member returning `null`, so existing dialects (Marten's `PostgresEventStoreDialect`) compile unchanged and keep their bespoke operations; the new `EventStorage<TId>` methods simply stay throwing until a dialect opts in. No behavior changes for any current consumer. Minor version bump **9.16.4 → 9.17.0**.

The seam is exercised end-to-end by the consuming store's event-store test suite (Polecat's, on the follow-up bump), consistent with how the rest of `EventStorage<TId>` is validated downstream rather than in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)