### PR TITLE
feat(sqlserver): ManagedTenantPartitions parity with ManagedListPartitions — drop semantics, bucketing, back-fill, status reporting

### DIFF
--- a/docs/sqlserver/partitioning.md
+++ b/docs/sqlserver/partitioning.md
@@ -117,4 +117,40 @@ table.PartitionByManagedTenants(manager);
 ```
 
 Managed strategies own their boundaries at runtime, so — unlike `RangePartitioning` — they are not
-diffed or migrated by `FindDeltaAsync`.
+diffed or migrated by `FindDeltaAsync`. When a table joins an *existing* managed set (tenants already
+registered), call `MigrateAllTablesAsync(logger, database, token)` to back-fill every managed table
+with the full set of registered tenant ordinals.
+
+### Dropping tenants: data semantics
+
+SQL Server's `MERGE RANGE` only removes the boundary point — the tenant's rows are merged into the
+neighboring partition, not deleted. `DropPartitionFromAllTables` therefore takes a `TenantDropBehavior`:
+
+- `TenantDropBehavior.RetainData` (default) — merge only; the caller owns any data purge.
+- `TenantDropBehavior.DeleteData` — delete the tenant's rows from every managed table first, then merge.
+  This is the hard-delete parity with the PostgreSQL managed drop (`DETACH PARTITION` + `DROP TABLE`).
+
+### Tenant bucketing (many tenants per partition)
+
+By default every tenant gets its own ordinal, guarded by a unique index on the registry table. For
+applications with many small tenants — or to stay clear of SQL Server's 15,000-partition-per-table
+ceiling — set `AllowOrdinalSharing = true` (which removes the unique index) and assign ordinals
+explicitly so several tenants share one partition:
+
+```cs
+manager.AllowOrdinalSharing = true;
+
+var result = await manager.AddPartitionsToAllTables(logger, database,
+    new Dictionary<string, int> { ["acme"] = 1, ["globex"] = 1, ["initech"] = 2 },
+    token);
+```
+
+A shared ordinal is only merged (and only purged under `DeleteData`) once its *last* tenant is
+dropped; while other tenants still map to it, the partition and all of its rows are left alone.
+
+### Batch registration and status reporting
+
+The batch `AddPartitionsToAllTables(...)` overloads return a `TenantPartitionAddResult` carrying both
+the assigned `tenant_id -> ordinal` map and a per-table `TablePartitionStatus[]` (parity with the
+PostgreSQL `ManagedListPartitions` batch add), so callers can surface partial failures — one table
+failing to split no longer prevents the remaining tables from being split.

--- a/src/Weasel.SqlServer.Tests/Tables/partitioning/managed_tenant_partitions_parity.cs
+++ b/src/Weasel.SqlServer.Tests/Tables/partitioning/managed_tenant_partitions_parity.cs
@@ -1,0 +1,372 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Weasel.Core;
+using Weasel.SqlServer.Tables;
+using Weasel.SqlServer.Tables.Partitioning;
+using Xunit;
+
+namespace Weasel.SqlServer.Tests.Tables.partitioning;
+
+/// <summary>
+///     ManagedTenantPartitions parity with the PostgreSQL ManagedListPartitions
+///     feature set (#362): data-removing drop semantics, tenant bucketing via
+///     explicit ordinals, new-table back-fill, and per-table status reporting.
+/// </summary>
+[Collection("integration")]
+public class managed_tenant_partitions_parity: IntegrationContext
+{
+    public managed_tenant_partitions_parity() : base("mtpp")
+    {
+    }
+
+    // ---------------------------------------------------------------------
+    // Unit — no database
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public void ordinal_sharing_removes_the_unique_registry_index()
+    {
+        var manager = new ManagedTenantPartitions(
+            "tenants", new DbObjectName("mtpp", "tenant_registry"));
+
+        var registry = (Table)((Weasel.Core.Migrations.IFeatureSchema)manager).Objects[0];
+        registry.Indexes.ShouldContain(x => x.Name == "uniq_tenant_registry_ordinal");
+        manager.AllowOrdinalSharing.ShouldBeFalse();
+
+        manager.AllowOrdinalSharing = true;
+        registry.Indexes.ShouldNotContain(x => x.Name == "uniq_tenant_registry_ordinal");
+
+        manager.AllowOrdinalSharing = false;
+        registry.Indexes.ShouldContain(x => x.Name == "uniq_tenant_registry_ordinal");
+    }
+
+    // ---------------------------------------------------------------------
+    // Integration
+    // ---------------------------------------------------------------------
+
+    private async Task ResetSchemaAndPartitionObjects()
+    {
+        await ResetSchema();
+
+        foreach (var pfName in new[] { "pf_porders_tenant_ordinal", "pf_pevents_tenant_ordinal" })
+        {
+            var psName = pfName.Replace("pf_", "ps_");
+            await theConnection.CreateCommand($@"
+IF EXISTS (SELECT 1 FROM sys.partition_schemes WHERE name = '{psName}')
+    DROP PARTITION SCHEME [{psName}];
+IF EXISTS (SELECT 1 FROM sys.partition_functions WHERE name = '{pfName}')
+    DROP PARTITION FUNCTION [{pfName}];")
+                .ExecuteNonQueryAsync();
+        }
+    }
+
+    private Table theOrdersTable(ManagedTenantPartitions manager)
+    {
+        var orders = new Table("mtpp.porders");
+        orders.AddColumn<int>("tenant_ordinal").AsPrimaryKey().NotNull();
+        orders.AddColumn<int>("id").AsPrimaryKey();
+        orders.PartitionByManagedTenants(manager);
+        return orders;
+    }
+
+    private Table theEventsTable(ManagedTenantPartitions manager)
+    {
+        var events = new Table("mtpp.pevents");
+        events.AddColumn<int>("tenant_ordinal").AsPrimaryKey().NotNull();
+        events.AddColumn<int>("id").AsPrimaryKey();
+        events.PartitionByManagedTenants(manager);
+        return events;
+    }
+
+    private ManagedTenantPartitions theManager() =>
+        new("tenants", new DbObjectName("mtpp", "tenant_registry"));
+
+    [Fact]
+    public async Task drop_with_delete_data_removes_the_tenant_rows_before_merging()
+    {
+        await ResetSchemaAndPartitionObjects();
+
+        var database = new DatabaseWithTables("mtpp_integration", ConnectionSource.ConnectionString);
+        var manager = theManager();
+        var orders = theOrdersTable(manager);
+        database.AddTable(orders);
+
+        await CreateSchemaObjectInDatabase(orders);
+
+        await manager.AddPartitionToAllTables(database, "acme", CancellationToken.None);
+        await manager.AddPartitionToAllTables(database, "globex", CancellationToken.None);
+
+        await theConnection.CreateCommand(
+                "INSERT INTO mtpp.porders (tenant_ordinal, id) VALUES (1, 1), (1, 2), (2, 3)")
+            .ExecuteNonQueryAsync();
+
+        await manager.DropPartitionFromAllTables(
+            NullLogger.Instance, database, new[] { "acme" }, TenantDropBehavior.DeleteData,
+            CancellationToken.None);
+
+        // acme's rows (ordinal 1) are gone, globex's (ordinal 2) survive
+        var remaining = (int)(await theConnection.CreateCommand(
+            "SELECT COUNT(*) FROM mtpp.porders").ExecuteScalarAsync())!;
+        remaining.ShouldBe(1);
+
+        var ordinalLeft = (int)(await theConnection.CreateCommand(
+            "SELECT tenant_ordinal FROM mtpp.porders").ExecuteScalarAsync())!;
+        ordinalLeft.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task drop_with_retain_data_keeps_the_tenant_rows()
+    {
+        await ResetSchemaAndPartitionObjects();
+
+        var database = new DatabaseWithTables("mtpp_integration", ConnectionSource.ConnectionString);
+        var manager = theManager();
+        var orders = theOrdersTable(manager);
+        database.AddTable(orders);
+
+        await CreateSchemaObjectInDatabase(orders);
+
+        await manager.AddPartitionToAllTables(database, "acme", CancellationToken.None);
+        await manager.AddPartitionToAllTables(database, "globex", CancellationToken.None);
+
+        await theConnection.CreateCommand(
+                "INSERT INTO mtpp.porders (tenant_ordinal, id) VALUES (1, 1), (1, 2), (2, 3)")
+            .ExecuteNonQueryAsync();
+
+        await manager.DropPartitionFromAllTables(
+            NullLogger.Instance, database, new[] { "acme" }, CancellationToken.None);
+
+        // historical behavior: merge only, rows are retained
+        var remaining = (int)(await theConnection.CreateCommand(
+            "SELECT COUNT(*) FROM mtpp.porders").ExecuteScalarAsync())!;
+        remaining.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task explicit_ordinals_bucket_multiple_tenants_into_one_partition()
+    {
+        await ResetSchemaAndPartitionObjects();
+
+        var database = new DatabaseWithTables("mtpp_integration", ConnectionSource.ConnectionString);
+        var manager = theManager();
+        manager.AllowOrdinalSharing = true;
+        var orders = theOrdersTable(manager);
+        database.AddTable(orders);
+
+        await CreateSchemaObjectInDatabase(orders);
+
+        var result = await manager.AddPartitionsToAllTables(
+            NullLogger.Instance, database,
+            new Dictionary<string, int> { ["acme"] = 1, ["globex"] = 1, ["initech"] = 2 },
+            CancellationToken.None);
+
+        result.Ordinals["acme"].ShouldBe(1);
+        result.Ordinals["globex"].ShouldBe(1);
+        result.Ordinals["initech"].ShouldBe(2);
+        result.Tables.ShouldContain(x =>
+            x.Identifier.QualifiedName == "mtpp.porders" && x.Status == PartitionMigrationStatus.Complete);
+
+        // three tenants, two partitions
+        var boundaries = await ReadBoundariesAsync("pf_porders_tenant_ordinal");
+        boundaries.ShouldBe(new[] { 0, 1, 2 });
+
+        manager.Ordinals.Count.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task explicit_ordinal_collision_throws_without_sharing_enabled()
+    {
+        await ResetSchemaAndPartitionObjects();
+
+        var database = new DatabaseWithTables("mtpp_integration", ConnectionSource.ConnectionString);
+        var manager = theManager();
+        var orders = theOrdersTable(manager);
+        database.AddTable(orders);
+
+        await CreateSchemaObjectInDatabase(orders);
+
+        await manager.AddPartitionToAllTables(
+            NullLogger.Instance, database, "acme", 1, CancellationToken.None);
+
+        await Should.ThrowAsync<InvalidOperationException>(() =>
+            manager.AddPartitionToAllTables(
+                NullLogger.Instance, database, "globex", 1, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task remapping_a_tenant_to_a_different_ordinal_throws()
+    {
+        await ResetSchemaAndPartitionObjects();
+
+        var database = new DatabaseWithTables("mtpp_integration", ConnectionSource.ConnectionString);
+        var manager = theManager();
+        var orders = theOrdersTable(manager);
+        database.AddTable(orders);
+
+        await CreateSchemaObjectInDatabase(orders);
+
+        await manager.AddPartitionToAllTables(
+            NullLogger.Instance, database, "acme", 3, CancellationToken.None);
+
+        // same ordinal is an idempotent no-op
+        var again = await manager.AddPartitionToAllTables(
+            NullLogger.Instance, database, "acme", 3, CancellationToken.None);
+        again.ShouldBe(3);
+
+        await Should.ThrowAsync<InvalidOperationException>(() =>
+            manager.AddPartitionToAllTables(
+                NullLogger.Instance, database, "acme", 5, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task dropping_one_tenant_of_a_shared_ordinal_keeps_the_partition_and_data()
+    {
+        await ResetSchemaAndPartitionObjects();
+
+        var database = new DatabaseWithTables("mtpp_integration", ConnectionSource.ConnectionString);
+        var manager = theManager();
+        manager.AllowOrdinalSharing = true;
+        var orders = theOrdersTable(manager);
+        database.AddTable(orders);
+
+        await CreateSchemaObjectInDatabase(orders);
+
+        await manager.AddPartitionsToAllTables(
+            NullLogger.Instance, database,
+            new Dictionary<string, int> { ["acme"] = 1, ["globex"] = 1 },
+            CancellationToken.None);
+
+        await theConnection.CreateCommand(
+                "INSERT INTO mtpp.porders (tenant_ordinal, id) VALUES (1, 1), (1, 2)")
+            .ExecuteNonQueryAsync();
+
+        // acme is dropped, but globex still owns ordinal 1 — no merge, no purge,
+        // even with DeleteData requested
+        await manager.DropPartitionFromAllTables(
+            NullLogger.Instance, database, new[] { "acme" }, TenantDropBehavior.DeleteData,
+            CancellationToken.None);
+
+        manager.Ordinals.ShouldNotContainKey("acme");
+        manager.Ordinals.ShouldContainKeyAndValue("globex", 1);
+
+        (await ReadBoundariesAsync("pf_porders_tenant_ordinal")).ShouldBe(new[] { 0, 1 });
+
+        var remaining = (int)(await theConnection.CreateCommand(
+            "SELECT COUNT(*) FROM mtpp.porders").ExecuteScalarAsync())!;
+        remaining.ShouldBe(2);
+
+        // dropping the LAST tenant of the ordinal releases the partition and the rows
+        await manager.DropPartitionFromAllTables(
+            NullLogger.Instance, database, new[] { "globex" }, TenantDropBehavior.DeleteData,
+            CancellationToken.None);
+
+        (await ReadBoundariesAsync("pf_porders_tenant_ordinal")).ShouldBe(new[] { 0 });
+        ((int)(await theConnection.CreateCommand(
+            "SELECT COUNT(*) FROM mtpp.porders").ExecuteScalarAsync())!).ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task new_table_added_to_an_existing_managed_set_is_backfilled()
+    {
+        await ResetSchemaAndPartitionObjects();
+
+        var database = new DatabaseWithTables("mtpp_integration", ConnectionSource.ConnectionString);
+        var manager = theManager();
+        var orders = theOrdersTable(manager);
+        database.AddTable(orders);
+
+        await CreateSchemaObjectInDatabase(orders);
+
+        await manager.AddPartitionToAllTables(database, "acme", CancellationToken.None);
+        await manager.AddPartitionToAllTables(database, "globex", CancellationToken.None);
+
+        // wire a NEW table to the existing managed set after tenants exist
+        var events = theEventsTable(manager);
+        database.AddTable(events);
+
+        var statuses = await manager.MigrateAllTablesAsync(
+            NullLogger.Instance, database, CancellationToken.None);
+
+        statuses.ShouldContain(x =>
+            x.Identifier.QualifiedName == "mtpp.pevents" && x.Status == PartitionMigrationStatus.Complete);
+
+        // the new table has every registered ordinal
+        (await ReadBoundariesAsync("pf_pevents_tenant_ordinal")).ShouldBe(new[] { 0, 1, 2 });
+    }
+
+    [Fact]
+    public async Task new_table_created_by_regular_migration_gets_all_existing_ordinals()
+    {
+        await ResetSchemaAndPartitionObjects();
+
+        var database = new DatabaseWithTables("mtpp_integration", ConnectionSource.ConnectionString);
+        var manager = theManager();
+        var orders = theOrdersTable(manager);
+        database.AddTable(orders);
+
+        await CreateSchemaObjectInDatabase(orders);
+
+        await manager.AddPartitionToAllTables(database, "acme", CancellationToken.None);
+        await manager.AddPartitionToAllTables(database, "globex", CancellationToken.None);
+
+        // a brand-new table created through the normal migration path picks up
+        // the full boundary set from the manager's in-memory map
+        var events = theEventsTable(manager);
+        database.AddTable(events);
+        await CreateSchemaObjectInDatabase(events);
+
+        (await ReadBoundariesAsync("pf_pevents_tenant_ordinal")).ShouldBe(new[] { 0, 1, 2 });
+    }
+
+    [Fact]
+    public async Task batch_add_reports_per_table_status()
+    {
+        await ResetSchemaAndPartitionObjects();
+
+        var database = new DatabaseWithTables("mtpp_integration", ConnectionSource.ConnectionString);
+        var manager = theManager();
+        var orders = theOrdersTable(manager);
+        var events = theEventsTable(manager);
+        database.AddTable(orders);
+        database.AddTable(events);
+
+        await CreateSchemaObjectInDatabase(orders);
+        await CreateSchemaObjectInDatabase(events);
+
+        var result = await manager.AddPartitionsToAllTables(
+            NullLogger.Instance, database, new[] { "acme", "globex" }, CancellationToken.None);
+
+        result.Ordinals.ShouldContainKeyAndValue("acme", 1);
+        result.Ordinals.ShouldContainKeyAndValue("globex", 2);
+
+        result.Tables.Length.ShouldBe(2);
+        result.Tables.ShouldAllBe(x => x.Status == PartitionMigrationStatus.Complete);
+        result.Tables.Select(x => x.Identifier.QualifiedName)
+            .ShouldBe(new[] { "mtpp.porders", "mtpp.pevents" }, ignoreOrder: true);
+    }
+
+    // ---------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------
+
+    private async Task<int[]> ReadBoundariesAsync(string partitionFunctionName)
+    {
+        await using var cmd = theConnection.CreateCommand();
+        cmd.CommandText = @"
+SELECT CAST(prv.value AS int)
+FROM sys.partition_functions pf
+JOIN sys.partition_range_values prv ON pf.function_id = prv.function_id
+WHERE pf.name = @pf
+ORDER BY prv.boundary_id;";
+        cmd.Parameters.AddWithValue("@pf", partitionFunctionName);
+
+        var list = new List<int>();
+        await using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            list.Add(reader.GetInt32(0));
+        }
+
+        return list.ToArray();
+    }
+}

--- a/src/Weasel.SqlServer/Tables/Partitioning/ManagedTenantPartitions.cs
+++ b/src/Weasel.SqlServer/Tables/Partitioning/ManagedTenantPartitions.cs
@@ -66,6 +66,7 @@ public class ManagedTenantPartitions: FeatureSchemaBase, ISqlServerPartitioning,
     ITenantPartitionManager, IDatabaseInitializer<SqlConnection>
 {
     private readonly Table _registry;
+    private readonly IndexDefinition _uniqueOrdinalIndex;
     private readonly Dictionary<string, int> _ordinals = new(StringComparer.Ordinal);
     private readonly SemaphoreSlim _semaphore = new(1, 1);
     private bool _hasInitialized;
@@ -108,10 +109,37 @@ public class ManagedTenantPartitions: FeatureSchemaBase, ISqlServerPartitioning,
         // map without re-querying the table; concurrent ManagedTenantPartitions
         // instances writing simultaneously will collide here rather than
         // silently producing two tenants in the same partition.
-        var uniqueOrdinal =
+        _uniqueOrdinalIndex =
             new IndexDefinition($"uniq_{registryTableName.Name}_ordinal") { IsUnique = true };
-        uniqueOrdinal.AgainstColumns("ordinal");
-        _registry.Indexes.Add(uniqueOrdinal);
+        _uniqueOrdinalIndex.AgainstColumns("ordinal");
+        _registry.Indexes.Add(_uniqueOrdinalIndex);
+    }
+
+    /// <summary>
+    ///     Opt-in tenant bucketing: allow multiple tenant ids to share one
+    ///     ordinal (and therefore one partition per table) through the
+    ///     explicit-ordinal <c>AddPartitionsToAllTables</c> overloads. Off by
+    ///     default — automatic allocation keeps one tenant per partition and a
+    ///     unique index on the registry's ordinal column guards against
+    ///     accidental sharing. Turning this on removes that unique index (an
+    ///     existing index is dropped by the next registry migration) and is the
+    ///     mitigation for SQL Server's 15,000-partition-per-table ceiling when
+    ///     hosting many small tenants.
+    /// </summary>
+    public bool AllowOrdinalSharing
+    {
+        get => !_registry.Indexes.Contains(_uniqueOrdinalIndex);
+        set
+        {
+            if (value)
+            {
+                _registry.Indexes.Remove(_uniqueOrdinalIndex);
+            }
+            else if (!_registry.Indexes.Contains(_uniqueOrdinalIndex))
+            {
+                _registry.Indexes.Add(_uniqueOrdinalIndex);
+            }
+        }
     }
 
     /// <inheritdoc />
@@ -418,9 +446,28 @@ public class ManagedTenantPartitions: FeatureSchemaBase, ISqlServerPartitioning,
     /// <summary>
     ///     Register multiple tenants at once, persist their ordinals, and SPLIT
     ///     RANGE every partitioned table. Returns the assigned ordinal for each
-    ///     tenant.
+    ///     tenant. Use <see cref="AddPartitionsToAllTables(ILogger,IDatabase{SqlConnection},IEnumerable{string},CancellationToken)" />
+    ///     when the per-table migration statuses are needed as well.
     /// </summary>
     public async Task<IReadOnlyDictionary<string, int>> AddPartitionToAllTables(
+        ILogger logger,
+        IDatabase<SqlConnection> database,
+        IEnumerable<string> tenantIds,
+        CancellationToken token)
+    {
+        var result = await AddPartitionsToAllTables(logger, database, tenantIds, token)
+            .ConfigureAwait(false);
+        return result.Ordinals;
+    }
+
+    /// <summary>
+    ///     Register multiple tenants at once, persist their ordinals, and SPLIT
+    ///     RANGE every partitioned table. Returns both the assigned ordinals and
+    ///     the per-table migration statuses (parity with the PostgreSQL
+    ///     <c>ManagedListPartitions</c> batch add) so callers can surface
+    ///     partial failures.
+    /// </summary>
+    public async Task<TenantPartitionAddResult> AddPartitionsToAllTables(
         ILogger logger,
         IDatabase<SqlConnection> database,
         IEnumerable<string> tenantIds,
@@ -443,11 +490,103 @@ public class ManagedTenantPartitions: FeatureSchemaBase, ISqlServerPartitioning,
                 await upsertTenantAsync(conn, tenantId, token).ConfigureAwait(false);
         }
 
-        await splitTablesForNewOrdinalsAsync(logger, database, conn, token).ConfigureAwait(false);
+        var statuses = await splitTablesForNewOrdinalsAsync(logger, database, conn, token)
+            .ConfigureAwait(false);
 
         await conn.CloseAsync().ConfigureAwait(false);
 
-        return assigned;
+        return new TenantPartitionAddResult(assigned, statuses.ToArray());
+    }
+
+    /// <summary>
+    ///     Register tenants with explicitly assigned ordinals — the tenant
+    ///     bucketing seam. With <see cref="AllowOrdinalSharing" /> enabled,
+    ///     multiple tenant ids may map to the same ordinal so small tenants
+    ///     share a partition (and the strategy stays clear of SQL Server's
+    ///     15,000-partition ceiling). Re-registering a tenant with its current
+    ///     ordinal is a no-op; re-registering with a different ordinal throws,
+    ///     because existing rows would keep the old ordinal.
+    /// </summary>
+    public async Task<TenantPartitionAddResult> AddPartitionsToAllTables(
+        ILogger logger,
+        IDatabase<SqlConnection> database,
+        IReadOnlyDictionary<string, int> tenantOrdinals,
+        CancellationToken token)
+    {
+        await using var conn = database.CreateConnection();
+        await conn.OpenAsync(token).ConfigureAwait(false);
+
+        await InitializeAsync(conn, token).ConfigureAwait(false);
+
+        var assigned = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (var pair in tenantOrdinals)
+        {
+            if (string.IsNullOrEmpty(pair.Key))
+            {
+                continue;
+            }
+
+            assigned[pair.Key] =
+                await upsertTenantAsync(conn, pair.Key, token, pair.Value).ConfigureAwait(false);
+        }
+
+        var statuses = await splitTablesForNewOrdinalsAsync(logger, database, conn, token)
+            .ConfigureAwait(false);
+
+        await conn.CloseAsync().ConfigureAwait(false);
+
+        return new TenantPartitionAddResult(assigned, statuses.ToArray());
+    }
+
+    /// <summary>
+    ///     Register a single tenant with an explicitly assigned ordinal. See
+    ///     <see cref="AddPartitionsToAllTables(ILogger,IDatabase{SqlConnection},IReadOnlyDictionary{string,int},CancellationToken)" />
+    ///     for the bucketing semantics.
+    /// </summary>
+    public async Task<int> AddPartitionToAllTables(
+        ILogger logger,
+        IDatabase<SqlConnection> database,
+        string tenantId,
+        int ordinal,
+        CancellationToken token)
+    {
+        if (string.IsNullOrEmpty(tenantId))
+        {
+            throw new ArgumentException("tenantId must not be null or empty", nameof(tenantId));
+        }
+
+        var result = await AddPartitionsToAllTables(logger, database,
+                new Dictionary<string, int> { [tenantId] = ordinal }, token)
+            .ConfigureAwait(false);
+        return result.Ordinals[tenantId];
+    }
+
+    /// <summary>
+    ///     Back-fill: make sure every table currently wired to this strategy has
+    ///     a partition boundary for every registered tenant ordinal. Use this
+    ///     after adding a table to an existing managed set — the regular
+    ///     <c>TableDelta</c> migration deliberately leaves managed partition
+    ///     functions alone, so a table whose partition function pre-dates newer
+    ///     tenants needs this explicit reconciliation. Tables (or partition
+    ///     functions) that don't exist yet are created via <c>MigrateAsync</c>
+    ///     with the full boundary set.
+    /// </summary>
+    public async Task<TablePartitionStatus[]> MigrateAllTablesAsync(
+        ILogger logger,
+        IDatabase<SqlConnection> database,
+        CancellationToken token)
+    {
+        await using var conn = database.CreateConnection();
+        await conn.OpenAsync(token).ConfigureAwait(false);
+
+        await InitializeAsync(conn, token).ConfigureAwait(false);
+
+        var statuses = await splitTablesForNewOrdinalsAsync(logger, database, conn, token)
+            .ConfigureAwait(false);
+
+        await conn.CloseAsync().ConfigureAwait(false);
+
+        return statuses.ToArray();
     }
 
     /// <summary>
@@ -501,19 +640,42 @@ public class ManagedTenantPartitions: FeatureSchemaBase, ISqlServerPartitioning,
 
     /// <summary>
     ///     Drop tenants from the registry and MERGE RANGE the corresponding
-    ///     boundaries off every partitioned table. The opposite of
+    ///     boundaries off every partitioned table, retaining the tenants' rows
+    ///     (<see cref="TenantDropBehavior.RetainData" />). The opposite of
     ///     <see cref="AddPartitionToAllTables(IDatabase{SqlConnection},string,CancellationToken)" />.
     /// </summary>
     /// <remarks>
     ///     SQL Server's <c>MERGE RANGE</c> only removes the boundary point — the
-    ///     data on either side is merged into the resulting partition. If you
-    ///     need to delete a tenant's rows first do that as a separate step
-    ///     before calling this method.
+    ///     data on either side is merged into the resulting partition. Pass
+    ///     <see cref="TenantDropBehavior.DeleteData" /> to the behavior overload
+    ///     to physically remove the tenants' rows first (PostgreSQL managed-drop
+    ///     parity), or delete them yourself before calling this method.
     /// </remarks>
+    public Task DropPartitionFromAllTables(
+        ILogger logger,
+        IDatabase<SqlConnection> database,
+        IEnumerable<string> tenantIds,
+        CancellationToken token)
+    {
+        return DropPartitionFromAllTables(logger, database, tenantIds, TenantDropBehavior.RetainData, token);
+    }
+
+    /// <summary>
+    ///     Drop tenants from the registry and MERGE RANGE the corresponding
+    ///     boundaries off every partitioned table. With
+    ///     <see cref="TenantDropBehavior.DeleteData" /> the tenants' rows are
+    ///     deleted from every managed table before the merge, so removing a
+    ///     tenant physically removes its data (parity with the PostgreSQL
+    ///     managed drop). An ordinal still referenced by other tenants (see
+    ///     <see cref="AllowOrdinalSharing" />) is never merged or purged — the
+    ///     remaining tenants keep the partition, and any finer-grained data
+    ///     removal belongs to the caller.
+    /// </summary>
     public async Task DropPartitionFromAllTables(
         ILogger logger,
         IDatabase<SqlConnection> database,
         IEnumerable<string> tenantIds,
+        TenantDropBehavior behavior,
         CancellationToken token)
     {
         var tenants = tenantIds.Where(x => !string.IsNullOrEmpty(x)).Distinct().ToArray();
@@ -527,12 +689,12 @@ public class ManagedTenantPartitions: FeatureSchemaBase, ISqlServerPartitioning,
 
         await InitializeAsync(conn, token).ConfigureAwait(false);
 
-        var ordinalsToMerge = new List<int>();
+        var droppedOrdinals = new HashSet<int>();
         foreach (var tenantId in tenants)
         {
             if (_ordinals.TryGetValue(tenantId, out var ordinal))
             {
-                ordinalsToMerge.Add(ordinal);
+                droppedOrdinals.Add(ordinal);
             }
             else
             {
@@ -542,7 +704,7 @@ public class ManagedTenantPartitions: FeatureSchemaBase, ISqlServerPartitioning,
             }
         }
 
-        if (ordinalsToMerge.Count == 0)
+        if (droppedOrdinals.Count == 0)
         {
             await conn.CloseAsync().ConfigureAwait(false);
             return;
@@ -570,6 +732,30 @@ public class ManagedTenantPartitions: FeatureSchemaBase, ISqlServerPartitioning,
             _ordinals.Remove(tenant);
         }
 
+        // With ordinal sharing, an ordinal is only released once its LAST tenant
+        // is dropped; while other tenants still map to it the partition must
+        // survive, and a purge by ordinal would take their rows with it.
+        var ordinalsToMerge = new List<int>();
+        foreach (var ordinal in droppedOrdinals.OrderBy(x => x))
+        {
+            if (_ordinals.ContainsValue(ordinal))
+            {
+                logger.LogWarning(
+                    "Ordinal {Ordinal} is still shared by other tenants — the partition is retained and " +
+                    "no rows are removed; per-tenant data removal within a shared partition belongs to the caller",
+                    ordinal);
+                continue;
+            }
+
+            ordinalsToMerge.Add(ordinal);
+        }
+
+        if (ordinalsToMerge.Count == 0)
+        {
+            await conn.CloseAsync().ConfigureAwait(false);
+            return;
+        }
+
         var tables = ResolveManagedTables(database);
 
         foreach (var table in tables)
@@ -577,6 +763,31 @@ public class ManagedTenantPartitions: FeatureSchemaBase, ISqlServerPartitioning,
             var pfName = PartitionFunctionName(table);
             foreach (var ordinal in ordinalsToMerge)
             {
+                if (behavior == TenantDropBehavior.DeleteData)
+                {
+                    await using var purge = conn.CreateCommand();
+                    purge.CommandText =
+                        $"DELETE FROM {table.Identifier.QualifiedName} WHERE [{Column}] = @ordinal;";
+                    purge.Parameters.AddWithValue("@ordinal", ordinal);
+                    try
+                    {
+                        var removed = await purge.ExecuteNonQueryAsync(token).ConfigureAwait(false);
+                        logger.LogInformation(
+                            "Deleted {Count} rows with ordinal {Ordinal} from table {Table}",
+                            removed, ordinal, table.Identifier);
+                    }
+                    catch (SqlException e)
+                    {
+                        // Leave the boundary in place rather than merging rows we
+                        // failed to delete into the neighboring partition.
+                        logger.LogError(e,
+                            "Could not delete rows with ordinal {Ordinal} from table {Table} — " +
+                            "skipping the boundary merge for this table",
+                            ordinal, table.Identifier);
+                        continue;
+                    }
+                }
+
                 await using var merge = conn.CreateCommand();
                 merge.CommandText =
                     $"ALTER PARTITION FUNCTION [{pfName}]() MERGE RANGE ({ordinal});";
@@ -619,14 +830,38 @@ public class ManagedTenantPartitions: FeatureSchemaBase, ISqlServerPartitioning,
     private async Task<int> upsertTenantAsync(
         SqlConnection conn,
         string tenantId,
-        CancellationToken token)
+        CancellationToken token,
+        int? requestedOrdinal = null)
     {
         if (_ordinals.TryGetValue(tenantId, out var existing))
         {
+            if (requestedOrdinal.HasValue && requestedOrdinal.Value != existing)
+            {
+                throw new InvalidOperationException(
+                    $"Tenant '{tenantId}' is already registered with ordinal {existing}; remapping to " +
+                    $"{requestedOrdinal.Value} is not supported because existing rows keep the old ordinal. " +
+                    "Drop the tenant first if it really has to move.");
+            }
+
             return existing;
         }
 
-        var nextOrdinal = (_ordinals.Count == 0) ? 1 : _ordinals.Values.Max() + 1;
+        if (requestedOrdinal is <= SentinelBoundary)
+        {
+            throw new ArgumentOutOfRangeException(nameof(requestedOrdinal),
+                $"Tenant ordinals must be positive — {SentinelBoundary} is the sentinel boundary");
+        }
+
+        if (requestedOrdinal.HasValue && !AllowOrdinalSharing &&
+            _ordinals.ContainsValue(requestedOrdinal.Value))
+        {
+            throw new InvalidOperationException(
+                $"Ordinal {requestedOrdinal.Value} is already assigned to another tenant. Set " +
+                $"{nameof(AllowOrdinalSharing)} = true to bucket multiple tenants into one partition.");
+        }
+
+        var nextOrdinal = requestedOrdinal ??
+                          ((_ordinals.Count == 0) ? 1 : _ordinals.Values.Max() + 1);
 
         await using var cmd = conn.CreateCommand();
         // MERGE rather than INSERT to handle a race where another process
@@ -665,56 +900,74 @@ OUTPUT inserted.ordinal;";
         return insertedOrdinal.Value;
     }
 
-    private async Task splitTablesForNewOrdinalsAsync(
+    private async Task<List<TablePartitionStatus>> splitTablesForNewOrdinalsAsync(
         ILogger logger,
         IDatabase<SqlConnection> database,
         SqlConnection conn,
         CancellationToken token)
     {
+        var statuses = new List<TablePartitionStatus>();
         var tables = ResolveManagedTables(database);
 
+        // Per-table failure isolation mirrors PG ManagedListPartitions: one
+        // table failing to split must not keep the remaining tables from
+        // getting the new tenant's partition, and callers get the per-table
+        // outcome to surface partial failures.
         foreach (var table in tables)
         {
-            var pfName = PartitionFunctionName(table);
-            var psName = PartitionSchemeName(table);
-
-            var existing = await fetchActualBoundariesAsync(conn, pfName, token).ConfigureAwait(false);
-            if (existing == null)
+            try
             {
-                // Function doesn't exist yet — let MigrateAsync create it.
-                logger.LogInformation(
-                    "Partition function {Function} for table {Table} not found — running MigrateAsync to create it",
-                    pfName, table.Identifier);
-                await table.MigrateAsync(conn, token).ConfigureAwait(false);
-                continue;
-            }
+                var pfName = PartitionFunctionName(table);
+                var psName = PartitionSchemeName(table);
 
-            foreach (var ordinal in OrderedBoundaries())
-            {
-                if (existing.Contains(ordinal.ToString()))
+                var existing = await fetchActualBoundariesAsync(conn, pfName, token).ConfigureAwait(false);
+                if (existing == null)
                 {
+                    // Function doesn't exist yet — let MigrateAsync create it.
+                    logger.LogInformation(
+                        "Partition function {Function} for table {Table} not found — running MigrateAsync to create it",
+                        pfName, table.Identifier);
+                    await table.MigrateAsync(conn, token).ConfigureAwait(false);
+                    statuses.Add(new TablePartitionStatus(table.Identifier, PartitionMigrationStatus.Complete));
                     continue;
                 }
 
-                await using (var nextUsed = conn.CreateCommand())
+                foreach (var ordinal in OrderedBoundaries())
                 {
-                    nextUsed.CommandText =
-                        $"ALTER PARTITION SCHEME [{psName}] NEXT USED [{Filegroup}];";
-                    await nextUsed.ExecuteNonQueryAsync(token).ConfigureAwait(false);
+                    if (existing.Contains(ordinal.ToString()))
+                    {
+                        continue;
+                    }
+
+                    await using (var nextUsed = conn.CreateCommand())
+                    {
+                        nextUsed.CommandText =
+                            $"ALTER PARTITION SCHEME [{psName}] NEXT USED [{Filegroup}];";
+                        await nextUsed.ExecuteNonQueryAsync(token).ConfigureAwait(false);
+                    }
+
+                    await using (var split = conn.CreateCommand())
+                    {
+                        split.CommandText =
+                            $"ALTER PARTITION FUNCTION [{pfName}]() SPLIT RANGE ({ordinal});";
+                        await split.ExecuteNonQueryAsync(token).ConfigureAwait(false);
+                    }
+
+                    logger.LogInformation(
+                        "Split partition function {Function} at boundary {Boundary} for table {Table}",
+                        pfName, ordinal, table.Identifier);
                 }
 
-                await using (var split = conn.CreateCommand())
-                {
-                    split.CommandText =
-                        $"ALTER PARTITION FUNCTION [{pfName}]() SPLIT RANGE ({ordinal});";
-                    await split.ExecuteNonQueryAsync(token).ConfigureAwait(false);
-                }
-
-                logger.LogInformation(
-                    "Split partition function {Function} at boundary {Boundary} for table {Table}",
-                    pfName, ordinal, table.Identifier);
+                statuses.Add(new TablePartitionStatus(table.Identifier, PartitionMigrationStatus.Complete));
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "Error trying to add table partitions to {Table}", table.Identifier);
+                statuses.Add(new TablePartitionStatus(table.Identifier, PartitionMigrationStatus.Failed));
             }
         }
+
+        return statuses;
     }
 
     private static async Task<HashSet<string>?> fetchActualBoundariesAsync(
@@ -768,3 +1021,49 @@ ORDER BY prv.boundary_id;";
         return count > 0;
     }
 }
+
+/// <summary>
+///     What happens to a tenant's rows when its partition is dropped via
+///     <see cref="ManagedTenantPartitions.DropPartitionFromAllTables(ILogger,IDatabase{SqlConnection},IEnumerable{string},TenantDropBehavior,CancellationToken)" />.
+/// </summary>
+public enum TenantDropBehavior
+{
+    /// <summary>
+    ///     Only the partition boundary is removed (<c>MERGE RANGE</c>) — SQL
+    ///     Server merges the tenant's rows into the neighboring partition. The
+    ///     caller owns any data purge. This is the historical behavior and the
+    ///     default.
+    /// </summary>
+    RetainData,
+
+    /// <summary>
+    ///     The tenant's rows are deleted from every managed table before the
+    ///     boundary is merged, mirroring the PostgreSQL managed drop
+    ///     (<c>DETACH PARTITION</c> + <c>DROP TABLE</c>) where the tenant's
+    ///     rows are physically removed. Needed for hard tenant deletion.
+    /// </summary>
+    DeleteData
+}
+
+/// <summary>
+///     Per-table outcome of a partition add / back-fill operation. Mirrors the
+///     PostgreSQL <c>ManagedListPartitions</c> status reporting so callers
+///     (Wolverine, Polecat, CritterWatch) can surface partial failures.
+/// </summary>
+public enum PartitionMigrationStatus
+{
+    Complete,
+    Failed,
+    RequiresTableRebuild
+}
+
+/// <summary>Per-table status of a partition add / back-fill operation.</summary>
+public record TablePartitionStatus(DbObjectName Identifier, PartitionMigrationStatus Status);
+
+/// <summary>
+///     Result of a batch tenant registration: the tenant_id -&gt; ordinal map
+///     that was assigned plus the per-table migration statuses.
+/// </summary>
+public record TenantPartitionAddResult(
+    IReadOnlyDictionary<string, int> Ordinals,
+    TablePartitionStatus[] Tables);


### PR DESCRIPTION
Closes #362. Part of the Wolverine conjoined EF Core multi-tenancy epic (JasperFx/wolverine#3465).

Closes the four gaps between SQL Server's `ManagedTenantPartitions` and the mature PostgreSQL `ManagedListPartitions` feature set, ahead of applying the strategy across many tables per application and driving it from CritterWatch tenant management.

## 1. Data-removing drop semantics

`DropPartitionFromAllTables` now takes a `TenantDropBehavior`:

- **`RetainData`** (default, historical behavior) — `MERGE RANGE` only; the XML docs now state plainly that the tenant's rows merge into the neighboring partition and the caller owns the purge.
- **`DeleteData`** — the tenant's rows are deleted from every managed table *before* the boundary merge, giving `RemoveTenant`/hard-delete parity with the PostgreSQL managed drop (`DETACH PARTITION` + `DROP TABLE`). If a purge fails for a table, the merge for that table is skipped rather than folding undeleted rows into the neighbor.

## 2. Tenant bucketing (many tenants → one partition)

- `AllowOrdinalSharing` (default `false`) removes the registry table's unique ordinal index and unlocks many-to-one mapping — the mitigation for SQL Server's 15,000-partition-per-table ceiling.
- New explicit-ordinal overloads: `AddPartitionsToAllTables(logger, db, IReadOnlyDictionary<string,int>, ct)` and `AddPartitionToAllTables(logger, db, tenantId, ordinal, ct)`.
- Guard rails: explicit ordinals must be positive (0 is the sentinel); a collision without sharing enabled throws; re-registering a tenant with its current ordinal is an idempotent no-op while remapping to a *different* ordinal throws (existing rows would keep the old ordinal).
- Drop honors sharing: an ordinal is only merged (and only purged under `DeleteData`) once its **last** tenant is dropped; while shared, the partition and its rows are left alone with a logged warning.

## 3. New-table back-fill

- New `MigrateAllTablesAsync(logger, database, ct)` reconciles every managed table against the registered ordinal set — the seam for a table joining an *existing* managed set, since `TableDelta` deliberately leaves managed partition functions alone.
- Test coverage confirms both paths: a brand-new table created through the regular migration path picks up the full boundary set, and a late-wired table gets split for all existing tenant ordinals.

## 4. Batch add / status reporting parity

- New `AddPartitionsToAllTables(...)` batch overloads return `TenantPartitionAddResult` — the assigned `tenant_id → ordinal` map **plus** per-table `TablePartitionStatus[]` (mirroring the PG batch add) so Wolverine/Polecat/CritterWatch can surface partial failures.
- The split loop is now per-table failure-isolated like the PG implementation: one failing table logs + reports `Failed` instead of aborting the remaining tables.
- Existing public signatures are unchanged (the old batch overload delegates to the new one and still returns the ordinal dictionary).

No change to disabled-tenant awareness — tenant lifecycle state deliberately stays in the consuming library's registry, per the issue.

## Testing

10 new tests in `managed_tenant_partitions_parity.cs` (unit + integration against SQL Server): delete-vs-retain drop, bucketing round-trip, collision/remap guards, shared-ordinal drop retention and last-tenant release, back-fill both ways, and per-table status reporting. Full Weasel.SqlServer.Tests suite green locally (312 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)