### PR TITLE
EF schema-mapping customization hook + index case-quoting fix for case-folded tables

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>9.18.0</Version>
+        <Version>9.18.1</Version>
         <LangVersion>13.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/src/Weasel.EntityFrameworkCore/DbContextExtensions.cs
+++ b/src/Weasel.EntityFrameworkCore/DbContextExtensions.cs
@@ -46,9 +46,38 @@ public record DbContextMigration(DbConnection Connection, Migrator Migrator, Sch
     }
 }
 
+/// <summary>
+///     Optional customization of the Weasel schema objects mapped from an EF Core
+///     model for migration purposes. Lets a caller (e.g. Wolverine's conjoined
+///     multi-tenancy) decorate mapped tables -- attach partitioning, adjust
+///     indexes -- and contribute additional schema objects such as partition
+///     control tables that must be migrated alongside the entity tables.
+/// </summary>
+public class EfSchemaMappingCustomization
+{
+    /// <summary>
+    ///     Called for every table mapped from an EF entity type, after the
+    ///     standard mapping. The same entity type/table pair is presented on
+    ///     every mapping pass (CreateDatabase and each CreateMigrationAsync)
+    /// </summary>
+    public Action<IEntityType, ITable>? CustomizeTable { get; set; }
+
+    /// <summary>
+    ///     Additional schema objects to migrate ahead of the mapped entity
+    ///     tables, e.g. partition control/registry tables
+    /// </summary>
+    public IReadOnlyList<ISchemaObject> AdditionalObjects { get; set; } = [];
+}
+
 public static class DbContextExtensions
 {
     public static IDatabaseWithTables CreateDatabase(this IServiceProvider services, DbContext context, string? identifier = null)
+    {
+        return services.CreateDatabase(context, null, identifier);
+    }
+
+    public static IDatabaseWithTables CreateDatabase(this IServiceProvider services, DbContext context,
+        EfSchemaMappingCustomization? customization, string? identifier = null)
     {
         identifier ??= context.GetType().FullNameInCode();
         var (originalConn, migrator) = services.FindMigratorForDbContext(context);
@@ -70,9 +99,18 @@ public static class DbContextExtensions
 
         try
         {
+            foreach (var additional in customization?.AdditionalObjects ?? [])
+            {
+                if (additional is ITable additionalTable)
+                {
+                    database.AddTable(additionalTable);
+                }
+            }
+
             foreach (var entityType in GetEntityTypesForMigration(context))
             {
                 var table = migrator.MapToTable(entityType);
+                customization?.CustomizeTable?.Invoke(entityType, table);
                 database.AddTable(table);
             }
 
@@ -84,15 +122,24 @@ public static class DbContextExtensions
         }
     }
 
+    public static Task<DbContextMigration> CreateMigrationAsync(
+        this IServiceProvider services,
+        DbContext context,
+        CancellationToken cancellation)
+    {
+        return services.CreateMigrationAsync(context, null, cancellation);
+    }
+
     public static async Task<DbContextMigration> CreateMigrationAsync(
         this IServiceProvider services,
         DbContext context,
+        EfSchemaMappingCustomization? customization,
         CancellationToken cancellation)
     {
         var (originalConn, migrator) = services.FindMigratorForDbContext(context);
         var conn = GetConnectionWithCredentials(context, originalConn);
 
-        var schemaObjects = GetSchemaObjectsForMigration(context, migrator!).ToArray();
+        var schemaObjects = GetSchemaObjectsForMigration(context, migrator!, customization).ToArray();
 
         await conn.OpenAsync(cancellation).ConfigureAwait(false);
 
@@ -116,6 +163,12 @@ public static class DbContextExtensions
     /// </summary>
     public static IReadOnlyList<ISchemaObject> GetSchemaObjectsForMigration(DbContext context, Migrator migrator)
     {
+        return GetSchemaObjectsForMigration(context, migrator, null);
+    }
+
+    public static IReadOnlyList<ISchemaObject> GetSchemaObjectsForMigration(DbContext context, Migrator migrator,
+        EfSchemaMappingCustomization? customization)
+    {
         var objects = new List<ISchemaObject>();
 
         foreach (var sequence in context.Model.GetSequences())
@@ -129,9 +182,22 @@ public static class DbContextExtensions
             objects.Add(mapped);
         }
 
-        objects.AddRange(GetEntityTypesForMigration(context)
-            .Select(x => migrator.MapToTable(x))
-            .OfType<ISchemaObject>());
+        // Contributed objects (partition control tables and the like) come before
+        // the entity tables so anything the tables depend on exists first
+        if (customization != null)
+        {
+            objects.AddRange(customization.AdditionalObjects);
+        }
+
+        foreach (var entityType in GetEntityTypesForMigration(context))
+        {
+            var table = migrator.MapToTable(entityType);
+            customization?.CustomizeTable?.Invoke(entityType, table);
+            if (table is ISchemaObject schemaObject)
+            {
+                objects.Add(schemaObject);
+            }
+        }
 
         return objects;
     }

--- a/src/Weasel.Postgresql/Tables/IndexDefinition.cs
+++ b/src/Weasel.Postgresql/Tables/IndexDefinition.cs
@@ -336,9 +336,16 @@ public class IndexDefinition: ITableIndex
             if (x.StartsWith('(') || x.Contains(' ') || x.Contains('-') || x.Contains('\''))
                 return x;
 
-            // QuoteName quotes reserved keywords (as before) and identifiers with
-            // uppercase characters, so case-preserved column names survive folding
-            return SchemaUtils.QuoteName(x);
+            // Case-quoting is only correct when the parent table itself preserved
+            // identifier case at creation (EF Core-mapped tables). On a case-folded
+            // table the physical column is lowercase, and quoting the declared
+            // casing would reference a column that does not exist (weasel#382)
+            if (parent is { PreserveIdentifierCase: true })
+            {
+                return SchemaUtils.QuoteName(x);
+            }
+
+            return SchemaUtils.IsReservedKeyword(x) ? $"\"{x}\"" : x;
         }).Join(", ");
         if (Mask.IsNotEmpty())
         {
@@ -712,7 +719,7 @@ public class IndexDefinition: ITableIndex
     /// <returns></returns>
     public bool Matches(IndexDefinition actual, Table parent)
     {
-        var expectedExpression = correctedExpression();
+        var expectedExpression = correctedExpression(parent);
 
         if (actual.Mask == expectedExpression)
         {
@@ -734,7 +741,7 @@ public class IndexDefinition: ITableIndex
     /// <exception cref="Exception"></exception>
     public void AssertMatches(IndexDefinition actual, Table parent)
     {
-        var expectedExpression = correctedExpression();
+        var expectedExpression = correctedExpression(parent);
 
 
         if (actual.Mask == expectedExpression)


### PR DESCRIPTION
Two changes needed by the Wolverine conjoined EF Core tenancy epic (wolverine#3465 / wolverine#3498):

1. **`EfSchemaMappingCustomization` hook** in the EF Core migration path: `CreateDatabase` / `CreateMigrationAsync` / `GetSchemaObjectsForMigration` accept an optional customization that (a) decorates every mapped table (Wolverine attaches `PartitionByList(tenant_id).UsePartitionManager(...)` / `PartitionByManagedTenants(...)` to `ITenanted` entity tables) and (b) contributes additional schema objects (the `wolverine_tenant_partitions` control/registry tables) into the same migration. Additive overloads only.

2. **Fix #382 (the real regression half): index column case-quoting on case-folded tables.** 9.18.0 started quoting any index column containing uppercase so EF-mapped (`PreserveIdentifierCase`) tables survive folding — but on a case-folded table the physical column is lowercase and the quoted declared casing references a column that does not exist (`42703`). This hit Wolverine's NServiceBus interop queue table (declared `Seq`, non-case-preserving table) with an unrecoverable broker-init retry loop. The quoting now consults the parent table: `QuoteName` only when `PreserveIdentifierCase` is true; pre-9.18 reserved-keyword-only quoting otherwise. Fixes 7 pre-existing failures in `Weasel.Postgresql.Tests` index suites; A/B verified zero regressions there and in the EF schema-comparison harness.

Wolverine's epic branch validates green against a local pack of this branch (`9.18.1-conjoined.2`); it needs a **9.18.1** release to consume before wolverine#3498 can go in.

Note from the same investigation: the SQL Server IDENTITY-for-conventional-int-keys half of #382 is working-as-intended parity (fixed Wolverine-side with a saga-key `ValueGeneratedNever` convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKamPNecC62LWBUh23yuPe