### PR TITLE
Ignore constraint rows PostgreSQL clones from a parent (marten#5044)

### DIFF
--- a/src/Weasel.Postgresql.Tests/Tables/partitioning/foreign_keys_to_partitioned_tables.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/partitioning/foreign_keys_to_partitioned_tables.cs
@@ -1,0 +1,119 @@
+using JasperFx;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Postgresql.Tables;
+using Xunit;
+
+namespace Weasel.Postgresql.Tests.Tables.partitioning;
+
+/// <summary>
+/// A foreign key that REFERENCES a partitioned table gets cloned by PostgreSQL: one extra
+/// pg_constraint row per partition of the referenced table, carrying a PostgreSQL-chosen name and a
+/// non-zero conparentid. Those rows are not part of anyone's configuration and they cannot be
+/// dropped on their own -- "42P16: cannot drop inherited constraint". Reading them back as real
+/// foreign keys made every subsequent migration emit a DROP for them and fail.
+///
+/// Reported downstream as https://github.com/JasperFx/marten/issues/5044.
+/// </summary>
+[Collection("cloned_fks")]
+public class foreign_keys_to_partitioned_tables: IntegrationContext
+{
+    public foreign_keys_to_partitioned_tables(): base("cloned_fks")
+    {
+    }
+
+    public override async Task InitializeAsync()
+    {
+        await ResetSchema();
+    }
+
+    private Table buildStreams()
+    {
+        var streams = new Table(new PostgresqlObjectName(SchemaName, "streams"));
+        streams.AddColumn<Guid>("id").AsPrimaryKey();
+        streams.AddColumn<string>("tenant_id").AsPrimaryKey().NotNull()
+            .PartitionByListValues()
+            .AddPartition("one", "one");
+
+        return streams;
+    }
+
+    private Table buildLookup(Table streams)
+    {
+        var lookup = new Table(new PostgresqlObjectName(SchemaName, "lookup"));
+        lookup.AddColumn<string>("natural_key").AsPrimaryKey().NotNull();
+        lookup.AddColumn<Guid>("stream_id").NotNull();
+        lookup.AddColumn<string>("tenant_id").AsPrimaryKey().NotNull();
+
+        lookup.ForeignKeys.Add(new ForeignKey("fk_lookup_streams")
+        {
+            ColumnNames = ["stream_id", "tenant_id"],
+            LinkedNames = ["id", "tenant_id"],
+            LinkedTable = streams.Identifier,
+            OnDelete = CascadeAction.Cascade
+        });
+
+        return lookup;
+    }
+
+    [Fact]
+    public async Task cloned_foreign_key_rows_are_not_read_back_as_configuration()
+    {
+        if (theConnection.State != System.Data.ConnectionState.Open) await theConnection.OpenAsync();
+        await theConnection.EnsureSchemaExists(SchemaName);
+
+        var streams = buildStreams();
+        var lookup = buildLookup(streams);
+
+        var migrator = new PostgresqlMigrator();
+        var initial = await SchemaMigration.DetermineAsync(theConnection, CancellationToken.None, streams, lookup);
+        await migrator.ApplyAllAsync(theConnection, initial, AutoCreate.CreateOrUpdate);
+
+        // PostgreSQL has now cloned fk_lookup_streams once per partition of streams.
+        var existing = await lookup.FetchExistingAsync(theConnection);
+        existing.ShouldNotBeNull();
+        existing.ForeignKeys.Select(x => x.Name).ShouldBe(["fk_lookup_streams"]);
+
+        // ...so the schema reads as up to date rather than as drift...
+        var second = await SchemaMigration.DetermineAsync(theConnection, CancellationToken.None, streams, lookup);
+        second.Difference.ShouldBe(SchemaPatchDifference.None);
+
+        // ...and re-applying does not try to drop an inherited constraint.
+        await Should.NotThrowAsync(() =>
+            migrator.ApplyAllAsync(theConnection, second, AutoCreate.CreateOrUpdate));
+    }
+
+    [Fact]
+    public async Task adding_a_partition_to_the_referenced_table_does_not_become_drift()
+    {
+        if (theConnection.State != System.Data.ConnectionState.Open) await theConnection.OpenAsync();
+        await theConnection.EnsureSchemaExists(SchemaName);
+
+        var streams = buildStreams();
+        var lookup = buildLookup(streams);
+
+        var migrator = new PostgresqlMigrator();
+        var initial = await SchemaMigration.DetermineAsync(theConnection, CancellationToken.None, streams, lookup);
+        await migrator.ApplyAllAsync(theConnection, initial, AutoCreate.CreateOrUpdate);
+
+        // A second partition clones another set of foreign key rows onto lookup.
+        var streamsV2 = new Table(new PostgresqlObjectName(SchemaName, "streams"));
+        streamsV2.AddColumn<Guid>("id").AsPrimaryKey();
+        streamsV2.AddColumn<string>("tenant_id").AsPrimaryKey().NotNull()
+            .PartitionByListValues()
+            .AddPartition("one", "one")
+            .AddPartition("two", "two");
+
+        var lookupV2 = buildLookup(streamsV2);
+
+        var next = await SchemaMigration.DetermineAsync(theConnection, CancellationToken.None, streamsV2, lookupV2);
+        await migrator.ApplyAllAsync(theConnection, next, AutoCreate.CreateOrUpdate);
+
+        var existing = await lookupV2.FetchExistingAsync(theConnection);
+        existing.ShouldNotBeNull();
+        existing.ForeignKeys.Select(x => x.Name).ShouldBe(["fk_lookup_streams"]);
+
+        var third = await SchemaMigration.DetermineAsync(theConnection, CancellationToken.None, streamsV2, lookupV2);
+        third.Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+}

--- a/src/Weasel.Postgresql/Tables/Table.FetchExisting.cs
+++ b/src/Weasel.Postgresql/Tables/Table.FetchExisting.cs
@@ -85,6 +85,11 @@ FROM pg_constraint c
        JOIN pg_attribute col ON (col.attrelid = tbl.oid AND col.attnum = u.attnum)
 WHERE
 	c.contype in ('f', 'c') and
+	-- Skip constraint rows PostgreSQL clones from a parent: partition-inherited constraints, and
+	-- the extra per-partition rows created for a foreign key that references a PARTITIONED table.
+	-- They carry PostgreSQL-chosen names, they are not part of any table configuration, and they
+	-- cannot be dropped on their own -- 42P16, cannot drop inherited constraint.
+	c.conparentid = 0 and
 	sch.nspname = :{schemaParam} and
 	tbl.relname = :{nameParam}
 GROUP BY constraint_name, constraint_type, schema_name, table_name, definition;


### PR DESCRIPTION
Fixes the root cause of [JasperFx/marten#5044](https://github.com/JasperFx/marten/issues/5044).

## What was broken

A foreign key that **references** a partitioned table is not one `pg_constraint` row. PostgreSQL clones it — one extra row per partition of the referenced table — each with a PostgreSQL-chosen name and a non-zero `conparentid`. Partition-*inherited* constraints are cloned the same way.

The catalog read behind `Table.FetchExistingAsync` had no `conparentid` filter, so those clones came back as real foreign keys on the referencing table:

```
conname=fk_lookup_streams                       contype=f conparentid=0
conname=lookup_stream_id_tenant_id_fkey         contype=f conparentid=22418   <-- clone
```

They match nothing in anyone's configuration, so:

* every subsequent migration emitted `ALTER TABLE ... DROP CONSTRAINT` for each clone, and a clone cannot be dropped on its own —

  ```
  42P16: cannot drop inherited constraint "lookup_stream_id_tenant_id_fkey" of relation "lookup"
  ```

* `AssertDatabaseMatchesConfigurationAsync` reported permanent drift once a partition existed.

Downstream this meant a Marten application using `[NaturalKey]` with conjoined event tenancy and `UseTenantPartitionedEvents` booted fine, then failed to start on the *next* boot after the first tenant was provisioned.

## The fix

One predicate in the constraint query: `c.conparentid = 0`.

`TableDelta.PostProcess` already tried to correct for this via `Table.ReadOtherTables`, but only when `Actual.Partitioning != null` — i.e. only when the *referencing* table is itself partitioned. The common case, a plain table with an FK into a partitioned one, was never covered. Filtering at the source handles both and is where the distinction actually lives.

`conparentid` has existed since PostgreSQL 11.

## Tests

`foreign_keys_to_partitioned_tables` covers a non-partitioned `lookup` table with a composite FK into a list-partitioned `streams` table:

* the clones are not read back as configuration, the schema reads as `SchemaPatchDifference.None`, and re-applying does not throw;
* adding a second partition to the referenced table clones another set and still does not become drift.

Both are red on master with `42P16: cannot drop inherited constraint` — the exact downstream error. All 462 `Weasel.Postgresql.Tests.Tables` tests pass.

Verified end to end against Marten by packing this branch locally: the marten#5044 repro goes from failing to passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)