### PR TITLE
Oracle: first-class command builder + real statement splitting

### DIFF
--- a/src/Weasel.Core/CommandBuilderBase.cs
+++ b/src/Weasel.Core/CommandBuilderBase.cs
@@ -95,13 +95,60 @@ public class CommandBuilderBase<TCommand, TParameter, TParameterType>: ICommandB
     }
 
     /// <summary>
+    ///     Marks the end of a logical statement within the batch. On providers whose ADO.NET
+    ///     driver can execute several statements from a single command — which is every Weasel
+    ///     provider except Oracle — this is a no-op, because the statements are simply
+    ///     concatenated into one <see cref="DbCommand" />.
+    ///     <para>
+    ///     A provider whose driver cannot do that overrides this to close the current statement
+    ///     and start a new one, so that <see cref="CompileCommands" /> hands back one command per
+    ///     boundary. Callers that build a batch should call this between logical operations
+    ///     regardless of provider; on the multi-statement providers it costs nothing.
+    ///     </para>
+    /// </summary>
+    public virtual void StartNewCommand()
+    {
+        // Nothing by default -- multi-statement providers just keep appending
+    }
+
+    /// <summary>
+    ///     The number of executable commands accumulated so far. Providers that support
+    ///     multi-statement commands always report 1, no matter how many times
+    ///     <see cref="StartNewCommand" /> has been called.
+    /// </summary>
+    public virtual int CommandCount => 1;
+
+    /// <summary>
+    ///     Build out the batch as one or more executable ADO.NET commands, in order. Providers
+    ///     that support multi-statement commands return a single command holding every statement;
+    ///     providers that do not return one command per <see cref="StartNewCommand" /> boundary.
+    /// </summary>
+    /// <returns></returns>
+    public virtual IReadOnlyList<DbCommand> CompileCommands()
+    {
+        return [Compile()];
+    }
+
+    /// <summary>
+    ///     Take the SQL accumulated since the last call and reset the buffer. Intended for derived
+    ///     builders that implement real statement splitting in <see cref="StartNewCommand" />.
+    /// </summary>
+    /// <returns></returns>
+    protected string TakeSql()
+    {
+        var sql = _sql.ToString();
+        _sql.Clear();
+        return sql;
+    }
+
+    /// <summary>
     ///     Adds a parameter to the underlying command, but does NOT add the
     ///     parameter usage to the command text
     /// </summary>
     /// <param name="value"></param>
     /// <param name="dbType"></param>
     /// <returns></returns>
-    public TParameter AddParameter(object? value, TParameterType? dbType = null)
+    public virtual TParameter AddParameter(object? value, TParameterType? dbType = null)
     {
         var name = "p" + _command.Parameters.Count;
 
@@ -127,7 +174,7 @@ public class CommandBuilderBase<TCommand, TParameter, TParameterType>: ICommandB
     /// <param name="value"></param>
     /// <param name="dbType"></param>
     /// <returns></returns>
-    public TParameter AddNamedParameter(string name, object value, TParameterType? dbType = null)
+    public virtual TParameter AddNamedParameter(string name, object value, TParameterType? dbType = null)
     {
         var existing = _command.Parameters.OfType<TParameter>().FirstOrDefault(x => x.ParameterName == name);
         if (existing != null)

--- a/src/Weasel.Core/CommandBuilderBase.cs
+++ b/src/Weasel.Core/CommandBuilderBase.cs
@@ -58,6 +58,14 @@ public class CommandBuilderBase<TCommand, TParameter, TParameterType>: ICommandB
         : _command.Parameters[^1].ParameterName;
 
     /// <summary>
+    ///     The bind marker this dialect uses in command text — <c>@</c> for SQL Server, MySQL and
+    ///     SQLite, <c>:</c> for PostgreSQL and Oracle. Callers that hand-write a marker for a named
+    ///     parameter (rather than going through <see cref="AppendParameter(object, TParameterType?)" />,
+    ///     which writes it for them) should read it from here rather than hard-coding one.
+    /// </summary>
+    public char ParameterPrefix => _parameterPrefix;
+
+    /// <summary>
     ///     Add text to the batched command SQL string
     /// </summary>
     /// <param name="text"></param>

--- a/src/Weasel.Core/DbCommandBuilder.cs
+++ b/src/Weasel.Core/DbCommandBuilder.cs
@@ -18,6 +18,18 @@ public class DbCommandBuilder: CommandBuilderBase<DbCommand, DbParameter, DbType
     public DbCommandBuilder(DbConnection connection): base(DbDatabaseProvider.Instance, '@', connection.CreateCommand())
     {
     }
+
+    /// <summary>
+    ///     Build against a dialect whose bind marker is not <c>@</c> — Oracle's is <c>:</c>, for
+    ///     example. Lets a database-agnostic consumer keep using <see cref="DbCommandBuilder" />
+    ///     against such a provider instead of emitting SQL the driver will reject.
+    /// </summary>
+    /// <param name="command"></param>
+    /// <param name="parameterPrefix"></param>
+    protected DbCommandBuilder(DbCommand command, char parameterPrefix)
+        : base(DbDatabaseProvider.Instance, parameterPrefix, command)
+    {
+    }
 }
 
 public static class DbCommandBuilderExtensions

--- a/src/Weasel.Oracle.Tests/CommandBuilderTests.cs
+++ b/src/Weasel.Oracle.Tests/CommandBuilderTests.cs
@@ -1,0 +1,144 @@
+using System.Data.Common;
+using Oracle.ManagedDataAccess.Client;
+using Shouldly;
+using Xunit;
+
+namespace Weasel.Oracle.Tests;
+
+public class CommandBuilderTests
+{
+    [Fact]
+    public void uses_the_oracle_bind_marker()
+    {
+        var builder = new CommandBuilder();
+
+        builder.Append("select data from messages where ");
+        builder.AppendWithParameters("foo = ?").Length.ShouldBe(1);
+
+        builder.ToString().ShouldBe("select data from messages where foo = :p0");
+    }
+
+    [Fact]
+    public void binds_by_name()
+    {
+        var command = new OracleCommand();
+        _ = new CommandBuilder(command);
+
+        command.BindByName.ShouldBeTrue();
+    }
+
+    /// <summary>
+    ///     The Guid conversion used to be a `new` member, so every one of the base class's typed
+    ///     AppendParameter overloads routed straight past it through AddParameter and handed a raw
+    ///     Guid to OracleParameter.Value. Regression guard for that.
+    /// </summary>
+    [Fact]
+    public void typed_guid_overload_converts_to_raw()
+    {
+        var id = Guid.NewGuid();
+        var builder = new CommandBuilder();
+
+        builder.Append("select 1 from dual where id = ");
+        builder.AppendParameter(id);
+
+        var parameter = builder.Compile().Parameters[0];
+        parameter.OracleDbType.ShouldBe(OracleDbType.Raw);
+        parameter.Value.ShouldBe(id.ToByteArray());
+    }
+
+    [Fact]
+    public void boxed_guid_converts_to_raw()
+    {
+        var id = Guid.NewGuid();
+        var builder = new CommandBuilder();
+
+        builder.Append("select 1 from dual where id = ");
+        builder.AppendParameter((object)id);
+
+        var parameter = builder.Compile().Parameters[0];
+        parameter.OracleDbType.ShouldBe(OracleDbType.Raw);
+        parameter.Value.ShouldBe(id.ToByteArray());
+    }
+
+    [Fact]
+    public void named_boolean_parameter_converts_to_an_oracle_number()
+    {
+        var builder = new CommandBuilder();
+
+        builder.Append("update dead_letters set replayable = ");
+        builder.AddNamedParameter("replayable", true);
+
+        var parameter = builder.Compile().Parameters["replayable"];
+        parameter.OracleDbType.ShouldBe(OracleDbType.Int16);
+        parameter.Value.ShouldBe(1);
+    }
+
+    [Fact]
+    public void named_guid_parameter_converts_to_raw()
+    {
+        var id = Guid.NewGuid();
+        var builder = new CommandBuilder();
+
+        builder.AddNamedParameter("id", id);
+
+        var parameter = builder.Compile().Parameters["id"];
+        parameter.OracleDbType.ShouldBe(OracleDbType.Raw);
+        parameter.Value.ShouldBe(id.ToByteArray());
+    }
+
+    [Fact]
+    public void implements_the_dialect_neutral_command_builder()
+    {
+        Weasel.Core.ICommandBuilder builder = new CommandBuilder();
+
+        builder.Append("select data from messages where foo = ");
+        var parameter = builder.AppendParameter(5);
+
+        parameter.ShouldBeOfType<OracleParameter>();
+        builder.ToString().ShouldBe("select data from messages where foo = :p0");
+    }
+
+    [Fact]
+    public void append_with_db_parameters_returns_neutral_db_parameters()
+    {
+        Weasel.Core.ICommandBuilder builder = new CommandBuilder();
+
+        builder.Append("select data from messages where ");
+        DbParameter[] parameters = builder.AppendWithDbParameters("foo = ? and bar = ?");
+
+        parameters.Length.ShouldBe(2);
+        builder.ToString().ShouldBe("select data from messages where foo = :p0 and bar = :p1");
+    }
+
+    [Fact]
+    public void grouped_parameter_builder_appends_a_separated_run()
+    {
+        Weasel.Core.ICommandBuilder builder = new CommandBuilder();
+
+        builder.Append("select data from messages where id in (");
+        var grouped = builder.CreateGroupedParameterBuilder(',');
+        grouped.AppendParameter(1);
+        grouped.AppendParameter(2);
+        builder.Append(")");
+
+        builder.ToString().ShouldBe("select data from messages where id in (:p0,:p1)");
+    }
+
+    /// <summary>
+    ///     Oracle is the one provider that splits a batch. Everything else concatenates, so
+    ///     StartNewCommand has to stay free for them.
+    /// </summary>
+    [Fact]
+    public void start_new_command_is_a_no_op_on_the_plain_command_builder()
+    {
+        var builder = new CommandBuilder();
+
+        builder.Append("delete from incoming");
+        builder.StartNewCommand();
+        builder.Append(";delete from outgoing");
+
+        builder.CommandCount.ShouldBe(1);
+        builder.CompileCommands().Count.ShouldBe(1);
+        builder.CompileCommands()[0].CommandText.ShouldBe("delete from incoming;delete from outgoing");
+    }
+}

--- a/src/Weasel.Oracle.Tests/OracleDbCommandBuilderIntegrationTests.cs
+++ b/src/Weasel.Oracle.Tests/OracleDbCommandBuilderIntegrationTests.cs
@@ -1,0 +1,167 @@
+using Oracle.ManagedDataAccess.Client;
+using Shouldly;
+using Weasel.Core;
+using Xunit;
+
+namespace Weasel.Oracle.Tests;
+
+[Collection("integration")]
+public class OracleDbCommandBuilderIntegrationTests: IAsyncLifetime
+{
+    private readonly OracleConnection theConnection = new(ConnectionSource.ConnectionString);
+
+    public async Task InitializeAsync()
+    {
+        await theConnection.OpenAsync();
+
+        // In Oracle a schema *is* a user, so this has to go through Weasel rather than a plain
+        // "create schema"
+        await theConnection.ResetSchemaAsync("BATCHING");
+
+        await theConnection.CreateCommand(
+                "create table batching.messages (id raw(16) not null primary key, replayable number(1), expires timestamp with time zone)")
+            .ExecuteNonQueryAsync();
+
+        await theConnection.CreateCommand(
+                "create table batching.batch_notes (note varchar2(100))")
+            .ExecuteNonQueryAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await theConnection.CloseAsync();
+        await theConnection.DisposeAsync();
+    }
+
+    /// <summary>
+    ///     The whole point of the exercise: a batch built exactly the way a database-agnostic consumer
+    ///     builds one for PostgreSQL or SQL Server executes correctly against Oracle, with the `:` bind
+    ///     markers, the Guid-as-RAW and bool-as-NUMBER conversions, and one command per statement.
+    /// </summary>
+    [Fact]
+    public async Task execute_a_multi_statement_batch_in_one_transaction()
+    {
+        var kept = Guid.NewGuid();
+        var expired = Guid.NewGuid();
+
+        var builder = new OracleDbCommandBuilder();
+
+        builder.Append("insert into batching.messages (id, replayable, expires) values (");
+        builder.AppendParameter(kept);
+        builder.Append(", ");
+        // AddNamedParameter deliberately does not touch the command text, so the marker is written
+        // by hand -- this is exactly how Wolverine's replayable-message operation binds
+        builder.Append(":replayable");
+        builder.AddNamedParameter("replayable", true);
+        builder.Append(", ");
+        builder.AppendParameter(DateTimeOffset.UtcNow.AddDays(1));
+        builder.Append(")");
+
+        builder.StartNewCommand();
+
+        builder.Append("insert into batching.messages (id, replayable, expires) values (");
+        builder.AppendParameter(expired);
+        builder.Append(", ");
+        builder.Append(":replayable2");
+        builder.AddNamedParameter("replayable2", false);
+        builder.Append(", ");
+        builder.AppendParameter(DateTimeOffset.UtcNow.AddDays(-1));
+        builder.Append(")");
+
+        builder.StartNewCommand();
+
+        builder.Append("insert into batching.batch_notes (note) values (");
+        builder.AppendParameter("batched");
+        builder.Append(")");
+
+        var commands = builder.CompileCommands();
+        commands.Count.ShouldBe(3);
+
+        await using var tx = (OracleTransaction)await theConnection.BeginTransactionAsync();
+        foreach (var command in commands)
+        {
+            command.Connection = theConnection;
+            command.Transaction = tx;
+            await command.ExecuteNonQueryAsync();
+        }
+
+        await tx.CommitAsync();
+
+        (await countAsync("select count(*) from batching.messages")).ShouldBe(2);
+        (await countAsync("select count(*) from batching.batch_notes where note = 'batched'")).ShouldBe(1);
+
+        // The Guid round-trips through RAW(16), and the bool through NUMBER(1)
+        (await countAsync(
+                $"select count(*) from batching.messages where id = '{Convert.ToHexString(kept.ToByteArray())}' and replayable = 1"))
+            .ShouldBe(1);
+        (await countAsync(
+                $"select count(*) from batching.messages where id = '{Convert.ToHexString(expired.ToByteArray())}' and replayable = 0"))
+            .ShouldBe(1);
+    }
+
+    /// <summary>
+    ///     A batch that returns data: each statement gets its own reader, because ODP.NET cannot
+    ///     hand back several result sets from one command.
+    /// </summary>
+    [Fact]
+    public async Task read_results_from_each_command_in_the_batch()
+    {
+        var id = Guid.NewGuid();
+
+        await theConnection.CreateCommand(
+                "insert into batching.messages (id, replayable, expires) values (:id, 1, systimestamp)")
+            .With("id", id.ToByteArray())
+            .ExecuteNonQueryAsync();
+
+        await theConnection.CreateCommand("insert into batching.batch_notes (note) values ('read me')")
+            .ExecuteNonQueryAsync();
+
+        var builder = new OracleDbCommandBuilder();
+
+        builder.Append("select count(*) from batching.messages where id = ");
+        builder.AppendParameter(id);
+
+        builder.StartNewCommand();
+
+        builder.Append("select note from batching.batch_notes where note = ");
+        builder.AppendParameter("read me");
+
+        var commands = builder.CompileCommands();
+        commands.Count.ShouldBe(2);
+
+        foreach (var command in commands)
+        {
+            command.Connection = theConnection;
+        }
+
+        await using (var reader = await commands[0].ExecuteReaderAsync())
+        {
+            (await reader.ReadAsync()).ShouldBeTrue();
+            Convert.ToInt32(reader.GetValue(0)).ShouldBe(1);
+        }
+
+        await using (var reader = await commands[1].ExecuteReaderAsync())
+        {
+            (await reader.ReadAsync()).ShouldBeTrue();
+            reader.GetString(0).ShouldBe("read me");
+        }
+    }
+
+    /// <summary>
+    ///     ODP.NET does not implement the ADO.NET batching API at all, which is why Oracle needs the
+    ///     statement splitting in the first place. If this ever starts failing, ODP.NET has grown
+    ///     <see cref="System.Data.Common.DbBatch" /> support and the splitting could be revisited.
+    /// </summary>
+    [Fact]
+    public void odp_net_still_cannot_batch()
+    {
+        theConnection.CanCreateBatch.ShouldBeFalse();
+        Should.Throw<NotSupportedException>(() => theConnection.CreateBatch());
+    }
+
+    private async Task<int> countAsync(string sql)
+    {
+        await using var command = theConnection.CreateCommand(sql);
+        return Convert.ToInt32(await command.ExecuteScalarAsync());
+    }
+}

--- a/src/Weasel.Oracle.Tests/OracleDbCommandBuilderTests.cs
+++ b/src/Weasel.Oracle.Tests/OracleDbCommandBuilderTests.cs
@@ -69,6 +69,39 @@ public class OracleDbCommandBuilderTests
     }
 
     [Fact]
+    public void strips_the_trailing_semicolon_callers_write_for_other_providers()
+    {
+        var builder = new OracleDbCommandBuilder();
+
+        builder.Append("delete from incoming;");
+        builder.StartNewCommand();
+        builder.Append("delete from outgoing;");
+
+        builder.CompileCommands().Select(x => x.CommandText).ShouldBe([
+            "delete from incoming",
+            "delete from outgoing"
+        ]);
+    }
+
+    [Fact]
+    public void a_semicolon_only_statement_is_not_a_statement()
+    {
+        var builder = new OracleDbCommandBuilder();
+
+        builder.Append(";");
+        builder.StartNewCommand();
+        builder.Append("delete from incoming;");
+
+        builder.CompileCommands().Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void exposes_the_oracle_bind_marker()
+    {
+        new OracleDbCommandBuilder().ParameterPrefix.ShouldBe(':');
+    }
+
+    [Fact]
     public void empty_statements_do_not_produce_commands()
     {
         var builder = new OracleDbCommandBuilder();

--- a/src/Weasel.Oracle.Tests/OracleDbCommandBuilderTests.cs
+++ b/src/Weasel.Oracle.Tests/OracleDbCommandBuilderTests.cs
@@ -1,0 +1,215 @@
+using System.Data.Common;
+using Oracle.ManagedDataAccess.Client;
+using Shouldly;
+using Xunit;
+
+namespace Weasel.Oracle.Tests;
+
+public class OracleDbCommandBuilderTests
+{
+    [Fact]
+    public void uses_the_oracle_bind_marker_rather_than_the_generic_one()
+    {
+        var builder = new OracleDbCommandBuilder();
+
+        builder.Append("delete from messages where keep_until <= ");
+        builder.AppendParameter(DateTimeOffset.UtcNow);
+
+        builder.ToString().ShouldBe("delete from messages where keep_until <= :p0");
+    }
+
+    [Fact]
+    public void binds_by_name()
+    {
+        var command = new OracleCommand();
+        _ = new OracleDbCommandBuilder(command);
+
+        command.BindByName.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void a_single_statement_compiles_to_a_single_command()
+    {
+        var builder = new OracleDbCommandBuilder();
+
+        builder.Append("delete from incoming where id = ");
+        builder.AppendParameter(Guid.NewGuid());
+
+        var commands = builder.CompileCommands();
+
+        commands.Count.ShouldBe(1);
+        commands[0].CommandText.ShouldBe("delete from incoming where id = :p0");
+        commands[0].Parameters.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void no_statements_at_all_compiles_to_nothing()
+    {
+        new OracleDbCommandBuilder().CompileCommands().Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void splits_at_every_start_new_command_boundary()
+    {
+        var builder = new OracleDbCommandBuilder();
+
+        builder.Append("select destination from outgoing");
+        builder.StartNewCommand();
+        builder.Append("delete from incoming");
+        builder.StartNewCommand();
+        builder.Append("update nodes set active = 1");
+
+        var commands = builder.CompileCommands();
+
+        commands.Select(x => x.CommandText).ShouldBe([
+            "select destination from outgoing",
+            "delete from incoming",
+            "update nodes set active = 1"
+        ]);
+    }
+
+    [Fact]
+    public void empty_statements_do_not_produce_commands()
+    {
+        var builder = new OracleDbCommandBuilder();
+
+        builder.StartNewCommand();
+        builder.Append("delete from incoming");
+        builder.StartNewCommand();
+        builder.StartNewCommand();
+
+        var commands = builder.CompileCommands();
+
+        commands.Count.ShouldBe(1);
+        commands[0].CommandText.ShouldBe("delete from incoming");
+    }
+
+    [Fact]
+    public void each_split_command_only_carries_the_parameters_its_own_statement_bound()
+    {
+        var first = Guid.NewGuid();
+        var cutoff = DateTimeOffset.UtcNow;
+
+        var builder = new OracleDbCommandBuilder();
+
+        builder.Append("delete from incoming where id = ");
+        builder.AppendParameter(first);
+
+        builder.StartNewCommand();
+
+        builder.Append("delete from dead_letters where expires <= ");
+        builder.AppendParameter(cutoff);
+        builder.Append(" and node = ");
+        builder.AppendParameter(5);
+
+        var commands = builder.CompileCommands();
+
+        commands.Count.ShouldBe(2);
+
+        commands[0].CommandText.ShouldBe("delete from incoming where id = :p0");
+        commands[0].Parameters.Count.ShouldBe(1);
+        commands[0].Parameters[0].ParameterName.ShouldBe("p0");
+        commands[0].Parameters[0].Value.ShouldBe(first.ToByteArray());
+
+        commands[1].CommandText.ShouldBe("delete from dead_letters where expires <= :p1 and node = :p2");
+        commands[1].Parameters.Count.ShouldBe(2);
+        commands[1].Parameters[0].ParameterName.ShouldBe("p1");
+        commands[1].Parameters[0].Value.ShouldBe(cutoff);
+        commands[1].Parameters[1].ParameterName.ShouldBe("p2");
+        commands[1].Parameters[1].Value.ShouldBe(5);
+    }
+
+    [Fact]
+    public void split_commands_bind_by_name()
+    {
+        var builder = new OracleDbCommandBuilder();
+
+        builder.Append("delete from incoming");
+        builder.StartNewCommand();
+        builder.Append("delete from outgoing");
+
+        builder.CompileCommands().OfType<OracleCommand>()
+            .ShouldAllBe(x => x.BindByName);
+    }
+
+    [Fact]
+    public void command_count_reports_the_open_statement_too()
+    {
+        var builder = new OracleDbCommandBuilder();
+        builder.CommandCount.ShouldBe(0);
+
+        builder.Append("delete from incoming");
+        builder.CommandCount.ShouldBe(1);
+
+        builder.StartNewCommand();
+        builder.CommandCount.ShouldBe(1);
+
+        builder.Append("delete from outgoing");
+        builder.CommandCount.ShouldBe(2);
+    }
+
+    [Fact]
+    public void guids_are_bound_as_raw()
+    {
+        var id = Guid.NewGuid();
+        var builder = new OracleDbCommandBuilder();
+
+        builder.Append("select 1 from dual where id = ");
+        builder.AppendParameter(id);
+
+        var parameter = (OracleParameter)builder.CompileCommands()[0].Parameters[0];
+
+        parameter.OracleDbType.ShouldBe(OracleDbType.Raw);
+        parameter.Value.ShouldBe(id.ToByteArray());
+    }
+
+    [Fact]
+    public void booleans_are_bound_as_oracle_numbers()
+    {
+        var builder = new OracleDbCommandBuilder();
+
+        builder.Append("update dead_letters set replayable = ");
+        builder.AddNamedParameter("replayable", true);
+
+        var parameter = (OracleParameter)builder.CompileCommands()[0].Parameters["replayable"];
+
+        parameter.OracleDbType.ShouldBe(OracleDbType.Int16);
+        parameter.Value.ShouldBe(1);
+    }
+
+    [Fact]
+    public void date_time_offsets_keep_their_oracle_type()
+    {
+        var builder = new OracleDbCommandBuilder();
+
+        builder.Append("delete from incoming where expires <= ");
+        builder.AppendParameter(DateTimeOffset.UtcNow);
+
+        var parameter = (OracleParameter)builder.CompileCommands()[0].Parameters[0];
+
+        parameter.OracleDbType.ShouldBe(OracleDbType.TimeStampTZ);
+    }
+
+    [Fact]
+    public void null_values_are_bound_as_db_null()
+    {
+        var builder = new OracleDbCommandBuilder();
+
+        builder.Append("select 1 from dual where description = ");
+        builder.AppendParameter((object?)null);
+
+        builder.CompileCommands()[0].Parameters[0].Value.ShouldBe(DBNull.Value);
+    }
+
+    [Fact]
+    public void append_with_db_parameters_uses_the_oracle_marker()
+    {
+        var builder = new OracleDbCommandBuilder();
+
+        builder.Append("select data from messages where ");
+        DbParameter[] parameters = builder.AppendWithDbParameters("foo = ? and bar = ?");
+
+        parameters.Length.ShouldBe(2);
+        builder.ToString().ShouldBe("select data from messages where foo = :p0 and bar = :p1");
+    }
+}

--- a/src/Weasel.Oracle.Tests/OracleDbCommandBuilderTests.cs
+++ b/src/Weasel.Oracle.Tests/OracleDbCommandBuilderTests.cs
@@ -153,6 +153,46 @@ public class OracleDbCommandBuilderTests
     }
 
     [Fact]
+    public void a_named_parameter_shared_by_two_statements_is_bound_to_both()
+    {
+        var builder = new OracleDbCommandBuilder();
+
+        builder.Append("insert into incoming select * from dead_letters where replayable = :replayable;");
+        builder.AddNamedParameter("replayable", true);
+
+        builder.StartNewCommand();
+
+        builder.Append("delete from dead_letters where replayable = :replayable;");
+
+        var commands = builder.CompileCommands();
+
+        commands.Count.ShouldBe(2);
+        commands[0].Parameters["replayable"].Value.ShouldBe(1);
+        commands[1].Parameters["replayable"].Value.ShouldBe(1);
+    }
+
+    [Fact]
+    public void a_parameter_is_not_shared_just_because_its_name_is_a_prefix_of_another()
+    {
+        var builder = new OracleDbCommandBuilder();
+
+        builder.Append("delete from incoming where a = ");
+        builder.AppendParameter(1);
+        builder.Append(" and b = ");
+        builder.AppendParameter(2);
+
+        builder.StartNewCommand();
+
+        // References :p11 only -- must not drag in :p1
+        builder.Append("delete from outgoing where c = :p11");
+
+        var commands = builder.CompileCommands();
+
+        commands[0].Parameters.Count.ShouldBe(2);
+        commands[1].Parameters.Count.ShouldBe(0);
+    }
+
+    [Fact]
     public void split_commands_bind_by_name()
     {
         var builder = new OracleDbCommandBuilder();

--- a/src/Weasel.Oracle/CommandBuilder.cs
+++ b/src/Weasel.Oracle/CommandBuilder.cs
@@ -4,7 +4,7 @@ using Weasel.Core;
 
 namespace Weasel.Oracle;
 
-public class CommandBuilder: CommandBuilderBase<OracleCommand, OracleParameter, OracleDbType>
+public class CommandBuilder: CommandBuilderBase<OracleCommand, OracleParameter, OracleDbType>, ICommandBuilder
 {
     public CommandBuilder(): this(new OracleCommand())
     {
@@ -12,7 +12,16 @@ public class CommandBuilder: CommandBuilderBase<OracleCommand, OracleParameter, 
 
     public CommandBuilder(OracleCommand command): base(OracleProvider.Instance, ':', command)
     {
+        // ODP.NET binds by position unless told otherwise, which silently mis-binds any
+        // command whose parameters were added in a different order than they appear in the SQL.
+        command.BindByName = true;
     }
+
+    /// <summary>
+    /// It became so common, that it's turned out to be convenient to place
+    /// this here
+    /// </summary>
+    public string TenantId { get; set; } = string.Empty;
 
     /// <summary>
     /// Oracle-specific override: converts Guid to byte[] before setting parameter value,
@@ -25,15 +34,98 @@ public class CommandBuilder: CommandBuilderBase<OracleCommand, OracleParameter, 
 
     /// <summary>
     /// Oracle-specific override: converts Guid values to byte[] before setting parameter value.
+    /// <para>
+    /// This has to be an <c>override</c> rather than a <c>new</c> member — the base class routes
+    /// every one of its typed <c>AppendParameter</c> overloads through <c>AddParameter</c>, so a
+    /// hiding member would be bypassed on all of those paths and the raw <see cref="Guid" /> would
+    /// reach <see cref="OracleParameter.Value" /> and be rejected.
+    /// </para>
     /// </summary>
-    public new OracleParameter AddParameter(object? value, OracleDbType? dbType = null)
+    public override OracleParameter AddParameter(object? value, OracleDbType? dbType = null)
     {
-        if (value is Guid guidValue)
-        {
-            return base.AddParameter(guidValue.ToByteArray(), OracleDbType.Raw);
-        }
+        return base.AddParameter(normalize(value), dbType ?? inferType(value));
+    }
 
-        return base.AddParameter(value, dbType);
+    /// <summary>
+    /// Oracle-specific override, for the same reason as <see cref="AddParameter" />.
+    /// </summary>
+    public override OracleParameter AddNamedParameter(string name, object value, OracleDbType? dbType = null)
+    {
+        return base.AddNamedParameter(name, normalize(value)!, dbType ?? inferType(value));
+    }
+
+    /// <summary>
+    /// Oracle has no boolean type and stores Guids as RAW(16), so both have to be converted
+    /// before they reach <see cref="OracleParameter.Value" />.
+    /// </summary>
+    private static object? normalize(object? value)
+    {
+        return value switch
+        {
+            Guid guid => guid.ToByteArray(),
+            bool boolean => boolean ? 1 : 0,
+            _ => value
+        };
+    }
+
+    private static OracleDbType? inferType(object? value)
+    {
+        return value switch
+        {
+            Guid => OracleDbType.Raw,
+            bool => OracleDbType.Int16,
+            _ => null
+        };
+    }
+
+    OracleParameter ICommandBuilder.AppendParameter<T>(T value)
+    {
+        base.AppendParameter(value);
+        return _command.Parameters[^1];
+    }
+
+    public OracleParameter AppendParameter<T>(T value, OracleDbType dbType)
+    {
+        base.AppendParameter(value, dbType);
+        return _command.Parameters[^1];
+    }
+
+    OracleParameter ICommandBuilder.AppendParameter(object value)
+    {
+        base.AppendParameter(value);
+        return _command.Parameters[^1];
+    }
+
+    OracleParameter ICommandBuilder.AppendParameter(object? value, OracleDbType? dbType)
+    {
+        base.AppendParameter(value, dbType);
+        return _command.Parameters[^1];
+    }
+
+    DbParameter Weasel.Core.ICommandBuilder.AppendParameter(object value)
+    {
+        base.AppendParameter(value);
+        return _command.Parameters[^1];
+    }
+
+    void Weasel.Core.ICommandBuilder.AppendParameters(params object[] parameters)
+    {
+        if (parameters.Length == 0)
+            throw new ArgumentOutOfRangeException(nameof(parameters),
+                "Must be at least one parameter value, but got " + parameters.Length);
+
+        AppendParameter(parameters[0]);
+
+        for (var i = 1; i < parameters.Length; i++)
+        {
+            Append(", ");
+            AppendParameter(parameters[i]);
+        }
+    }
+
+    public Weasel.Core.IGroupedParameterBuilder CreateGroupedParameterBuilder(char? seperator = null)
+    {
+        return new Weasel.Core.GroupedParameterBuilder(this, seperator);
     }
 }
 

--- a/src/Weasel.Oracle/ICommandBuilder.cs
+++ b/src/Weasel.Oracle/ICommandBuilder.cs
@@ -1,0 +1,39 @@
+using Oracle.ManagedDataAccess.Client;
+
+namespace Weasel.Oracle;
+
+/// <summary>
+///     Oracle command-builder surface. Derives from the dialect-neutral
+///     <see cref="Weasel.Core.ICommandBuilder" /> (which contributes <see cref="Weasel.Core.ICommandBuilder.Append(string)" />,
+///     <see cref="Weasel.Core.ICommandBuilder.AppendWithDbParameters(string)" />, <c>AddParameters</c>, tenant id, etc.)
+///     and adds the ODP.NET-typed overloads that return <see cref="OracleParameter" />.
+/// </summary>
+public interface ICommandBuilder: Weasel.Core.ICommandBuilder
+{
+    OracleParameter AppendParameter<T>(T value);
+    OracleParameter AppendParameter<T>(T value, OracleDbType dbType);
+
+    /// <summary>
+    ///     ODP.NET-typed override of <see cref="Weasel.Core.ICommandBuilder.AppendParameter(object)" />.
+    /// </summary>
+    new OracleParameter AppendParameter(object value);
+
+    OracleParameter AppendParameter(object? value, OracleDbType? dbType);
+
+    /// <summary>
+    ///     Append a SQL string with `?` placeholders for new parameters, and returns an
+    ///     array of the newly created parameters
+    /// </summary>
+    /// <param name="text"></param>
+    /// <returns></returns>
+    OracleParameter[] AppendWithParameters(string text);
+
+    /// <summary>
+    ///     Append a SQL string with user defined placeholder characters for new parameters, and returns an
+    ///     array of the newly created parameters
+    /// </summary>
+    /// <param name="text"></param>
+    /// <param name="placeholder"></param>
+    /// <returns></returns>
+    OracleParameter[] AppendWithParameters(string text, char placeholder);
+}

--- a/src/Weasel.Oracle/OracleDbCommandBuilder.cs
+++ b/src/Weasel.Oracle/OracleDbCommandBuilder.cs
@@ -59,10 +59,10 @@ public class OracleDbCommandBuilder: DbCommandBuilder
     /// </summary>
     public override void StartNewCommand()
     {
-        var sql = TakeSql();
+        var sql = trim(TakeSql());
         var end = _oracleCommand.Parameters.Count;
 
-        if (sql.Trim().IsNotEmpty())
+        if (sql.IsNotEmpty())
         {
             _statements.Add(new Statement(sql, _boundary, end));
         }
@@ -71,7 +71,18 @@ public class OracleDbCommandBuilder: DbCommandBuilder
     }
 
     /// <inheritdoc />
-    public override int CommandCount => _statements.Count + (ToString().Trim().IsNotEmpty() ? 1 : 0);
+    public override int CommandCount => _statements.Count + (trim(ToString()).IsNotEmpty() ? 1 : 0);
+
+    /// <summary>
+    ///     Callers separate statements with a trailing semicolon, because that is what the providers
+    ///     that concatenate into one command need. Oracle executes one statement per command, where a
+    ///     trailing semicolon is a syntax error (ORA-00911), so strip it here rather than making every
+    ///     caller branch on the provider.
+    /// </summary>
+    private static string trim(string sql)
+    {
+        return sql.Trim().TrimEnd(';').Trim();
+    }
 
     /// <summary>
     ///     Compile into one <see cref="OracleCommand" /> per <see cref="StartNewCommand" /> boundary.

--- a/src/Weasel.Oracle/OracleDbCommandBuilder.cs
+++ b/src/Weasel.Oracle/OracleDbCommandBuilder.cs
@@ -1,0 +1,178 @@
+using System.Data;
+using System.Data.Common;
+using JasperFx.Core;
+using Oracle.ManagedDataAccess.Client;
+using Weasel.Core;
+// System.Data.Common has its own unrelated DbCommandBuilder (the SQL-generating one)
+using DbCommandBuilder = Weasel.Core.DbCommandBuilder;
+
+namespace Weasel.Oracle;
+
+/// <summary>
+///     A <see cref="DbCommandBuilder" /> that emits Oracle-shaped SQL, for database-agnostic consumers
+///     that build batches against the dialect-neutral <see cref="DbCommandBuilder" /> surface rather than
+///     against <see cref="CommandBuilder" />.
+///     <para>
+///     Two things make Oracle different from every other Weasel provider here. First, its bind marker is
+///     <c>:</c> rather than <c>@</c>. Second — and this is the one that can't be papered over — ODP.NET
+///     does not implement the ADO.NET batching API (<see cref="DbConnection.CanCreateBatch" /> is
+///     <see langword="false" /> and <see cref="DbConnection.CreateBatch" /> throws), and Oracle will not
+///     execute several semicolon-separated statements from a single <see cref="OracleCommand" />. So
+///     <see cref="StartNewCommand" /> here does real work: it closes the current statement and starts a
+///     new one, and <see cref="CompileCommands" /> hands back one <see cref="OracleCommand" /> per
+///     boundary, each carrying only the parameters that its own statement bound.
+///     </para>
+///     <para>
+///     Consumers do not need to know any of that. Build the batch exactly as you would for PostgreSQL or
+///     SQL Server, calling <see cref="StartNewCommand" /> between logical statements — on those providers
+///     it is a no-op and you still get a single multi-statement command back.
+///     </para>
+/// </summary>
+public class OracleDbCommandBuilder: DbCommandBuilder
+{
+    private readonly OracleCommand _oracleCommand;
+    private readonly List<Statement> _statements = [];
+
+    /// <summary>
+    ///     Index into the underlying command's parameter collection at which the statement
+    ///     currently being built started binding.
+    /// </summary>
+    private int _boundary;
+
+    public OracleDbCommandBuilder(): this(new OracleCommand())
+    {
+    }
+
+    public OracleDbCommandBuilder(OracleCommand command): base(command, ':')
+    {
+        _oracleCommand = command;
+
+        // ODP.NET binds by position unless told otherwise, which silently mis-binds any command
+        // whose parameters were not added in the same order they appear in the SQL. Splitting a
+        // batch into per-statement commands reorders them by construction, so this is mandatory.
+        _oracleCommand.BindByName = true;
+    }
+
+    /// <summary>
+    ///     Closes the statement currently being built and starts a new one. Unlike every other
+    ///     Weasel provider, this is not a no-op — see the type-level remarks.
+    /// </summary>
+    public override void StartNewCommand()
+    {
+        var sql = TakeSql();
+        var end = _oracleCommand.Parameters.Count;
+
+        if (sql.Trim().IsNotEmpty())
+        {
+            _statements.Add(new Statement(sql, _boundary, end));
+        }
+
+        _boundary = end;
+    }
+
+    /// <inheritdoc />
+    public override int CommandCount => _statements.Count + (ToString().Trim().IsNotEmpty() ? 1 : 0);
+
+    /// <summary>
+    ///     Compile into one <see cref="OracleCommand" /> per <see cref="StartNewCommand" /> boundary.
+    ///     Each command carries only the parameters bound by its own statement.
+    /// </summary>
+    public override IReadOnlyList<DbCommand> CompileCommands()
+    {
+        // Flush whatever statement is still open
+        StartNewCommand();
+
+        if (_statements.Count == 0)
+        {
+            return [];
+        }
+
+        if (_statements.Count == 1)
+        {
+            // Nothing to split -- hand back the command we've been building all along, parameters
+            // and all, so that callers keep the single-command diagnostics they'd get elsewhere.
+            _oracleCommand.CommandText = _statements[0].Sql;
+            return [_oracleCommand];
+        }
+
+        // An OracleParameter cannot belong to two collections at once, so detach them all first
+        // and then deal each one out to the command whose statement actually bound it.
+        var parameters = _oracleCommand.Parameters.Cast<OracleParameter>().ToArray();
+        _oracleCommand.Parameters.Clear();
+
+        var commands = new List<DbCommand>(_statements.Count);
+        foreach (var statement in _statements)
+        {
+            var command = new OracleCommand(statement.Sql) { BindByName = true };
+
+            for (var i = statement.Start; i < statement.End; i++)
+            {
+                command.Parameters.Add(parameters[i]);
+            }
+
+            commands.Add(command);
+        }
+
+        return commands;
+    }
+
+    /// <inheritdoc />
+    public override DbParameter AddParameter(object? value, DbType? dbType = null)
+    {
+        var parameter = base.AddParameter(normalize(value), null);
+        applyOracleType(parameter, value, dbType);
+
+        return parameter;
+    }
+
+    /// <inheritdoc />
+    public override DbParameter AddNamedParameter(string name, object value, DbType? dbType = null)
+    {
+        var parameter = base.AddNamedParameter(name, normalize(value)!, null);
+        applyOracleType(parameter, value, dbType);
+
+        return parameter;
+    }
+
+    /// <summary>
+    ///     Oracle has no boolean type and stores Guids as RAW(16), so neither can be handed to
+    ///     <see cref="OracleParameter.Value" /> as-is.
+    /// </summary>
+    private static object? normalize(object? value)
+    {
+        return value switch
+        {
+            Guid guid => guid.ToByteArray(),
+            bool boolean => boolean ? 1 : 0,
+            _ => value
+        };
+    }
+
+    /// <summary>
+    ///     Type the parameter from the *original* CLR value through <see cref="OracleProvider" />, rather
+    ///     than through the generic <see cref="DbType" /> mapping the neutral builder would otherwise
+    ///     apply. The generic mapping has no entry for <see cref="Guid" /> and resolves it to
+    ///     <see cref="DbType.Object" />, which ODP.NET rejects.
+    /// </summary>
+    private static void applyOracleType(DbParameter parameter, object? original, DbType? dbType)
+    {
+        if (parameter is not OracleParameter oracleParameter)
+        {
+            if (dbType.HasValue)
+            {
+                parameter.DbType = dbType.Value;
+            }
+
+            return;
+        }
+
+        if (original is null or DBNull)
+        {
+            return;
+        }
+
+        oracleParameter.OracleDbType = OracleProvider.Instance.ToParameterType(original.GetType());
+    }
+
+    private readonly record struct Statement(string Sql, int Start, int End);
+}

--- a/src/Weasel.Oracle/OracleDbCommandBuilder.cs
+++ b/src/Weasel.Oracle/OracleDbCommandBuilder.cs
@@ -116,9 +116,19 @@ public class OracleDbCommandBuilder: DbCommandBuilder
         {
             var command = new OracleCommand(statement.Sql) { BindByName = true };
 
-            for (var i = statement.Start; i < statement.End; i++)
+            for (var i = 0; i < parameters.Length; i++)
             {
-                command.Parameters.Add(parameters[i]);
+                // A parameter belongs to this statement if it was bound while the statement was open,
+                // or if the statement's SQL names it. The second case matters for a named parameter
+                // shared by more than one statement -- AddNamedParameter finds-or-adds, so it is only
+                // ever created once, but every statement that references it needs it bound.
+                var owned = i >= statement.Start && i < statement.End;
+                if (owned || references(statement.Sql, parameters[i].ParameterName))
+                {
+                    // An OracleParameter cannot be in two collections at once, so a shared one has
+                    // to be copied rather than moved
+                    command.Parameters.Add(owned ? parameters[i] : copyOf(parameters[i]));
+                }
             }
 
             commands.Add(command);
@@ -183,6 +193,48 @@ public class OracleDbCommandBuilder: DbCommandBuilder
         }
 
         oracleParameter.OracleDbType = OracleProvider.Instance.ToParameterType(original.GetType());
+    }
+
+    /// <summary>
+    ///     Does this statement's SQL bind <paramref name="name" />? Matches <c>:name</c> as a whole
+    ///     token, so that <c>:p1</c> does not count as a reference to <c>:p11</c>.
+    /// </summary>
+    private static bool references(string sql, string name)
+    {
+        var from = 0;
+        while (true)
+        {
+            var at = sql.IndexOf(':' + name, from, StringComparison.OrdinalIgnoreCase);
+            if (at < 0)
+            {
+                return false;
+            }
+
+            var after = at + name.Length + 1;
+            if (after >= sql.Length || !isIdentifierCharacter(sql[after]))
+            {
+                return true;
+            }
+
+            from = after;
+        }
+    }
+
+    private static bool isIdentifierCharacter(char c)
+    {
+        return char.IsLetterOrDigit(c) || c == '_' || c == '$' || c == '#';
+    }
+
+    private static OracleParameter copyOf(OracleParameter parameter)
+    {
+        return new OracleParameter
+        {
+            ParameterName = parameter.ParameterName,
+            OracleDbType = parameter.OracleDbType,
+            Value = parameter.Value,
+            Direction = parameter.Direction,
+            Size = parameter.Size
+        };
     }
 
     private readonly record struct Statement(string Sql, int Start, int End);

--- a/src/Weasel.Postgresql/CommandBuilder.cs
+++ b/src/Weasel.Postgresql/CommandBuilder.cs
@@ -87,9 +87,9 @@ public class CommandBuilder: CommandBuilderBase<NpgsqlCommand, NpgsqlParameter, 
         return CreateGroupedParameterBuilder(seperator);
     }
 
-    public void StartNewCommand()
+    public override void StartNewCommand()
     {
-        // do nothing!
+        // do nothing! Npgsql happily executes several statements from one command.
     }
 }
 

--- a/src/Weasel.SqlServer/CommandBuilder.cs
+++ b/src/Weasel.SqlServer/CommandBuilder.cs
@@ -59,9 +59,9 @@ public class CommandBuilder: CommandBuilderBase<SqlCommand, SqlParameter, SqlDbT
         return new Weasel.Core.GroupedParameterBuilder(this, seperator);
     }
 
-    public void StartNewCommand()
+    public override void StartNewCommand()
     {
-        // do nothing!
+        // do nothing! SqlClient happily executes several statements from one command.
     }
 }
 


### PR DESCRIPTION
## Background

Oracle is the one Weasel provider whose driver cannot execute several statements from a single command. Confirmed against ODP.NET 23.7.0:

```
CanCreateBatch = False
CreateBatch threw: NotSupportedException
```

Its bind marker is also `:` rather than `@`. So a database-agnostic consumer building a batch against the dialect-neutral `DbCommandBuilder` emits SQL Oracle rejects outright (`ORA-00933` / `ORA-00936`), and there was no way to hand back an Oracle-shaped builder instead — `Weasel.Oracle.CommandBuilder` is a *sibling* of `DbCommandBuilder`, not a subclass, so it can't be returned where one is expected.

This is what's currently blocking Wolverine's durability agent on Oracle (JasperFx/wolverine#3614).

## Weasel.Core

- `AddParameter` / `AddNamedParameter` are now `virtual`, so a provider can normalize values on *every* path that binds one.
- New `StartNewCommand()` / `CommandCount` / `CompileCommands()` on `CommandBuilderBase`, defaulting to exactly today's behaviour — one command holding every statement. A consumer can now mark statement boundaries unconditionally and let the provider decide whether they mean anything. Postgres and SQL Server keep concatenating and pay nothing for it.
- `DbCommandBuilder` gains a protected constructor taking the bind marker.

Nothing here changes existing behaviour for any current caller; `Weasel.Core.ICommandBuilder` is deliberately untouched so Marten is unaffected.

## Weasel.Oracle

- **New `OracleDbCommandBuilder`** — a `DbCommandBuilder` that emits `:` markers, sets `BindByName`, types parameters through `OracleProvider` rather than the generic `DbType` mapping (which resolves `Guid` to `DbType.Object`, which ODP.NET rejects), converts `Guid` → `RAW(16)` and `bool` → `NUMBER(1)`, and splits at every `StartNewCommand()` boundary into one `OracleCommand` per statement, each carrying only the parameters its own statement bound.
- **New `Weasel.Oracle.ICommandBuilder`**, with `CommandBuilder` implementing it — parity with the Postgres and SQL Server providers.
- **Bug fix**: `CommandBuilder`'s `Guid` → RAW conversion was a `new` member rather than an `override`. Since the base class routes all of its typed `AppendParameter` overloads through `AddParameter`, the hiding member was bypassed on every one of those paths and a raw `Guid` reached `OracleParameter.Value`. Now an `override`, and it covers `bool` too.
- **Bug fix**: `CommandBuilder` now sets `BindByName`, which ODP.NET otherwise leaves off — it binds positionally by default, silently mis-binding any command whose parameters weren't added in the same order they appear in the SQL.

## Validation

| Suite | Result |
|---|---|
| `Weasel.Oracle.Tests` (full, live Oracle) | 181/181 |
| `Weasel.Core.Tests` | 21/21 |
| `Weasel.Postgresql.Tests` builder + batcher (live PG) | 18/18 |
| `Weasel.SqlServer.Tests` builder + batcher (live SQL Server) | 14/14 |

Integration tests execute a real multi-statement batch against Oracle in a single transaction and assert the Guid/bool round trip, read results back per-command, and include a guard that will fail if ODP.NET ever grows `DbBatch` support and makes the splitting unnecessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)