### PR TITLE
Make managed tenant partition bucketing actually share a partition (#391)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>9.19.1</Version>
+        <Version>9.20.0</Version>
         <LangVersion>13.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/src/Weasel.Postgresql.Tests/Tables/partitioning/managed_list_partitions.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/partitioning/managed_list_partitions.cs
@@ -414,6 +414,217 @@ public class managed_list_partitions : IntegrationContext
         (await partitionExists("teams", "orphan")).ShouldBeTrue();
     }
 
+    [Fact]
+    public async Task bucketed_values_registered_together_share_one_partition()
+    {
+        // weasel#391: several values deliberately sharing one suffix ("bucketing") must land in ONE
+        // physical partition carrying every member's value.
+        await dropManagedListsSchema();
+        var database = new ManagedListDatabase();
+        await database.Partitions.ResetValues(database, new Dictionary<string, string>(), CancellationToken.None);
+        await database.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        await database.Partitions.AddPartitionToAllTables(NullLogger.Instance, database,
+            new Dictionary<string, string> { { "smalla", "shared_bucket" }, { "smallb", "shared_bucket" } },
+            CancellationToken.None);
+
+        (await partitionValues("teams", "shared_bucket")).ShouldBe(["smalla", "smallb"]);
+        (await partitionValues("players", "shared_bucket")).ShouldBe(["smalla", "smallb"]);
+    }
+
+    [Fact]
+    public async Task bucketed_values_registered_separately_share_one_partition()
+    {
+        // weasel#391, the headline defect: bucket members are normally registered ONE AT A TIME as tenants
+        // onboard. AddPartitionToAllTables emitted a single-value ListPartition per value, so the second
+        // member's CREATE TABLE IF NOT EXISTS was a silent no-op against the partition the first member had
+        // already created. The bound kept only the first value and the second tenant's very first write died
+        // with 23514 "no partition of relation found for row".
+        await dropManagedListsSchema();
+        var database = new ManagedListDatabase();
+        await database.Partitions.ResetValues(database, new Dictionary<string, string>(), CancellationToken.None);
+        await database.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        await database.Partitions.AddPartitionToAllTables(database, "smalla", "shared_bucket", CancellationToken.None);
+        await database.Partitions.AddPartitionToAllTables(database, "smallb", "shared_bucket", CancellationToken.None);
+
+        try
+        {
+            (await partitionValues("teams", "shared_bucket")).ShouldBe(["smalla", "smallb"]);
+
+            // Both members write, and both rows land in the SAME physical partition — the entire point of
+            // bucketing. Pre-fix the second insert threw.
+            await insertTeam("Lions", "smalla");
+            await insertTeam("Tigers", "smallb");
+
+            (await partitionOfTeam("Lions")).ShouldBe("managed_lists.teams_shared_bucket");
+            (await partitionOfTeam("Tigers")).ShouldBe("managed_lists.teams_shared_bucket");
+        }
+        finally
+        {
+            // These rows would otherwise outlive the test and break a sibling's migration: the managed_lists
+            // schema is shared across this class, and a later ResetValues to a partition set that no longer
+            // covers 'smalla' makes the table rebuild fail with 23514.
+            await dropManagedListsSchema();
+        }
+    }
+
+    [Fact]
+    public async Task widening_a_bucket_preserves_the_rows_already_in_it()
+    {
+        // Widening is DETACH + re-ATTACH rather than CREATE IF NOT EXISTS, so it has to be non-destructive
+        // for the members already living in the partition.
+        await dropManagedListsSchema();
+        var database = new ManagedListDatabase();
+        await database.Partitions.ResetValues(database, new Dictionary<string, string>(), CancellationToken.None);
+        await database.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        try
+        {
+            await database.Partitions.AddPartitionToAllTables(database, "smalla", "shared_bucket",
+                CancellationToken.None);
+            await insertTeam("Lions", "smalla");
+
+            await database.Partitions.AddPartitionToAllTables(database, "smallb", "shared_bucket",
+                CancellationToken.None);
+
+            // The incumbent's row survives the DETACH/re-ATTACH untouched...
+            (await teamNames()).ShouldBe(["Lions"]);
+            (await partitionOfTeam("Lions")).ShouldBe("managed_lists.teams_shared_bucket");
+
+            // ...and the widen genuinely took effect, rather than being the old silent no-op.
+            await insertTeam("Tigers", "smallb");
+            (await partitionOfTeam("Tigers")).ShouldBe("managed_lists.teams_shared_bucket");
+            (await teamNames()).ShouldBe(["Lions", "Tigers"]);
+        }
+        finally
+        {
+            await dropManagedListsSchema();
+        }
+    }
+
+    [Fact]
+    public async Task dropping_one_bucket_member_preserves_the_other_members_data()
+    {
+        // weasel#391: DropPartitionFromAllTablesForValue resolved the value to its suffix and then dropped
+        // BY SUFFIX — deleting every registry row in the bucket and DROPping the shared partition table.
+        // Removing one small tenant therefore silently destroyed every co-tenant's rows.
+        await dropManagedListsSchema();
+        var database = new ManagedListDatabase();
+        await database.Partitions.ResetValues(database, new Dictionary<string, string>(), CancellationToken.None);
+        await database.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        try
+        {
+            await database.Partitions.AddPartitionToAllTables(database, "smalla", "shared_bucket",
+                CancellationToken.None);
+            await database.Partitions.AddPartitionToAllTables(database, "smallb", "shared_bucket",
+                CancellationToken.None);
+            await insertTeam("Lions", "smalla");
+            await insertTeam("Tigers", "smallb");
+
+            await database.Partitions.DropPartitionFromAllTablesForValue(database, NullLogger.Instance, "smalla",
+                CancellationToken.None);
+
+            // The survivor keeps its partition, its bound, and — the part that used to be lost — its rows.
+            (await partitionValues("teams", "shared_bucket")).ShouldBe(["smallb"]);
+            (await teamNames()).ShouldBe(["Tigers"]);
+
+            // and can still write afterwards
+            await insertTeam("Bears", "smallb");
+            (await teamNames()).ShouldBe(["Bears", "Tigers"]);
+
+            // The departed value is genuinely deregistered, not merely unrouted.
+            database.Partitions.ForceReload();
+            await database.Partitions.InitializeAsync(database, CancellationToken.None);
+            database.Partitions.Partitions.ShouldNotContainKey("smalla");
+            database.Partitions.Partitions.ShouldContainKey("smallb");
+        }
+        finally
+        {
+            await dropManagedListsSchema();
+        }
+    }
+
+    [Fact]
+    public async Task the_partition_is_released_only_with_the_last_bucket_member()
+    {
+        await dropManagedListsSchema();
+        var database = new ManagedListDatabase();
+        await database.Partitions.ResetValues(database, new Dictionary<string, string>(), CancellationToken.None);
+        await database.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        await database.Partitions.AddPartitionToAllTables(database, "smalla", "shared_bucket", CancellationToken.None);
+        await database.Partitions.AddPartitionToAllTables(database, "smallb", "shared_bucket", CancellationToken.None);
+
+        await database.Partitions.DropPartitionFromAllTablesForValue(database, NullLogger.Instance, "smalla",
+            CancellationToken.None);
+
+        // Still one member left, so the physical partition survives.
+        (await partitionExists("teams", "shared_bucket")).ShouldBeTrue();
+
+        await database.Partitions.DropPartitionFromAllTablesForValue(database, NullLogger.Instance, "smallb",
+            CancellationToken.None);
+
+        // Last member gone — now the partition is released on every managed table.
+        (await partitionExists("teams", "shared_bucket")).ShouldBeFalse();
+        (await partitionExists("players", "shared_bucket")).ShouldBeFalse();
+    }
+
+    private static async Task insertTeam(string name, string color)
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await conn.CreateCommand("insert into managed_lists.teams (name, color) values (:name, :color)")
+            .With("name", name)
+            .With("color", color)
+            .ExecuteNonQueryAsync();
+    }
+
+    private static async Task<string[]> teamNames()
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var reader = await conn.CreateCommand("select name from managed_lists.teams order by name")
+            .ExecuteReaderAsync();
+
+        var names = new List<string>();
+        while (await reader.ReadAsync())
+        {
+            names.Add(reader.GetString(0));
+        }
+
+        return names.ToArray();
+    }
+
+    private static async Task<string?> partitionOfTeam(string name)
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        return await conn.CreateCommand("select tableoid::regclass::text from managed_lists.teams where name = :name")
+            .With("name", name)
+            .ExecuteScalarAsync() as string;
+    }
+
+    /// <summary>
+    /// The values a partition's bound actually covers, sorted so the assertion does not depend on the order
+    /// PostgreSQL happens to echo them back in.
+    /// </summary>
+    private static async Task<string[]> partitionValues(string parent, string suffix)
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        var bound = await conn.CreateCommand(
+                "select pg_get_expr(c.relpartbound, c.oid) from pg_class c join pg_namespace n on n.oid = c.relnamespace where n.nspname = 'managed_lists' and c.relname = :name")
+            .With("name", $"{parent}_{suffix}")
+            .ExecuteScalarAsync() as string;
+
+        if (bound == null) return [];
+
+        var inner = bound.Substring(bound.IndexOf('(') + 1, bound.LastIndexOf(')') - bound.IndexOf('(') - 1);
+        return inner.Split(',').Select(x => x.Trim().Trim('\'')).OrderBy(x => x).ToArray();
+    }
+
     private static async Task dropManagedListsSchema()
     {
         await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);

--- a/src/Weasel.Postgresql/Tables/Partitioning/ManagedListPartitions.cs
+++ b/src/Weasel.Postgresql/Tables/Partitioning/ManagedListPartitions.cs
@@ -96,19 +96,91 @@ public class ManagedListPartitions : FeatureSchemaBase, IDatabaseInitializer<Npg
         // This is idempotent, so just do it here
         await InitializeAsync(conn, token).ConfigureAwait(false);
 
-        await conn.CloseAsync().ConfigureAwait(false);
-
-        try
+        if (!_partitions.TryGetValue(value, out var suffix))
         {
-            var suffix = _partitions[value];
-            await DropPartitionFromAllTables(database, logger, [suffix], token).ConfigureAwait(false);
-        }
-        catch (InvalidOperationException)
-        {
+            await conn.CloseAsync().ConfigureAwait(false);
             throw new ArgumentOutOfRangeException(nameof(value),
                 $"Could not find a partition with the value '{value}'");
         }
 
+        // weasel#391: this used to resolve the value to its suffix and then drop BY SUFFIX, which deletes
+        // every registry row in the bucket and DROPs the shared partition table. For a bucketed suffix that
+        // silently destroyed unrelated co-tenants' rows. When other values still share the partition, narrow
+        // the bucket instead; the partition is only released once its last member is gone.
+        var sanitizedSuffix = ListPartition.SanitizeSuffix(suffix);
+        var survivors = _partitions
+            .Where(pair => pair.Key != value && ListPartition.SanitizeSuffix(pair.Value) == sanitizedSuffix)
+            .Select(pair => pair.Key)
+            .ToArray();
+
+        if (survivors.Length == 0)
+        {
+            await conn.CloseAsync().ConfigureAwait(false);
+            await DropPartitionFromAllTables(database, logger, [suffix], token).ConfigureAwait(false);
+            return;
+        }
+
+        await removeValueFromSharedPartitionAsync(database, logger, conn, value, sanitizedSuffix, survivors,
+            token).ConfigureAwait(false);
+
+        await conn.CloseAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Remove one value from a shared ("bucketed") partition without disturbing the other values in it:
+    /// delete just this value's rows, then re-bind the partition to the remaining members.
+    /// </summary>
+    private async Task removeValueFromSharedPartitionAsync(PostgresqlDatabase database, ILogger logger,
+        NpgsqlConnection conn, string value, string sanitizedSuffix, string[] survivors, CancellationToken token)
+    {
+        await conn.CreateCommand($"delete from {_table.Identifier} where partition_value = :value")
+            .With("value", value)
+            .ExecuteNonQueryAsync(token).ConfigureAwait(false);
+
+        _partitions.Remove(value);
+
+        var remainingValues = survivors.Select(x => x.FormatSqlValue()).ToArray();
+
+        var tables = database
+            .AllObjects()
+            .OfType<Table>()
+            .Where(x => x.Partitioning is ListPartitioning list && list.PartitionManager == this)
+            .ToArray();
+
+        foreach (var table in tables)
+        {
+            var partitionName = PostgresqlObjectName.From(
+                new DbObjectName(table.Identifier.Schema, table.Identifier.Name + "_" + sanitizedSuffix));
+
+            var bound = await fetchPartitionBoundAsync(conn, table.Identifier.Schema,
+                table.Identifier.Name + "_" + sanitizedSuffix, token).ConfigureAwait(false);
+
+            // Same reasoning as the by-suffix drop: a configured parent may never have been physically
+            // migrated onto this database, in which case there is genuinely nothing to narrow.
+            if (bound == null)
+            {
+                logger.LogInformation(
+                    "Skipped narrowing partition {Partition} because it is not physically present on this database",
+                    partitionName);
+                continue;
+            }
+
+            var column = ((ListPartitioning)table.Partitioning!).Columns[0];
+
+            // ATTACH re-validates every remaining row against the narrower bound, so the departing value's
+            // rows have to go first. PostgreSQL partition removal is inherently data-removing — the
+            // whole-bucket path DROPs the table outright — so this is the same contract at value granularity.
+            await conn.CreateCommand($"delete from {partitionName} where {column} = :value")
+                .With("value", value)
+                .ExecuteNonQueryAsync(token).ConfigureAwait(false);
+
+            await rebindPartitionAsync(conn, table, partitionName, bound.IsAttached, remainingValues, token)
+                .ConfigureAwait(false);
+
+            logger.LogInformation(
+                "Removed value {Value} from shared partition {Partition}; {Count} value(s) remain",
+                value, partitionName, survivors.Length);
+        }
     }
 
     public async Task DropPartitionFromAllTables(PostgresqlDatabase database, ILogger logger, string[] suffixNames, CancellationToken token)
@@ -274,18 +346,18 @@ public class ManagedListPartitions : FeatureSchemaBase, IDatabaseInitializer<Npg
         // 23514 "no partition of relation ... found for row"). Creating exactly what was requested avoids
         // both, and needs no IgnorePartitionsInMigration toggling because it never runs the generic table
         // delta on the shared per-mapping Table instance (see JasperFx/marten#4706, #4713).
+        var buckets = resolveBuckets(newPartitions);
+
         foreach (var table in tables)
         {
             try
             {
-                var writer = new StringWriter();
-                foreach (var pair in newPartitions)
+                foreach (var bucket in buckets)
                 {
-                    var partition = new ListPartition(pair.Value, pair.Key.FormatSqlValue());
-                    ((IPartition)partition).WriteCreateStatement(writer, table);
+                    await createOrWidenPartitionAsync(conn, table, bucket.Key, bucket.Value, token)
+                        .ConfigureAwait(false);
                 }
 
-                await conn.CreateCommand(writer.ToString()).ExecuteNonQueryAsync(token).ConfigureAwait(false);
                 list.Add(new TablePartitionStatus(table.Identifier, PartitionMigrationStatus.Complete));
             }
             catch (Exception e)
@@ -297,6 +369,126 @@ public class ManagedListPartitions : FeatureSchemaBase, IDatabaseInitializer<Npg
 
         return list;
     }
+
+    /// <summary>
+    /// weasel#391: several values may deliberately share ONE suffix — tenant "bucketing", where many small
+    /// tenants live in a single physical partition to stay clear of per-table partition ceilings. The partition
+    /// table is named for the SANITIZED suffix, so that is the real bucket key, and its bound has to carry
+    /// EVERY value in the bucket. The previous code emitted one single-value <see cref="ListPartition"/> per
+    /// value, so the second member of a bucket was swallowed by CREATE TABLE IF NOT EXISTS and its writes
+    /// then failed with 23514 "no partition of relation found for row".
+    /// </summary>
+    private Dictionary<string, string[]> resolveBuckets(
+        IReadOnlyCollection<KeyValuePair<string, string>> newPartitions)
+    {
+        var buckets = new Dictionary<string, string[]>();
+
+        foreach (var group in newPartitions.GroupBy(pair => ListPartition.SanitizeSuffix(pair.Value)))
+        {
+            // The desired bound is the bucket's FULL membership, not merely the values supplied in THIS
+            // call. Bucket members are normally registered one tenant at a time, so widening an existing
+            // partition has to keep the members already in it. _partitions is authoritative here: callers
+            // record the new pairs into it before reaching this method.
+            buckets[group.Key] = _partitions
+                .Where(pair => ListPartition.SanitizeSuffix(pair.Value) == group.Key)
+                .Select(pair => pair.Key)
+                .Concat(group.Select(pair => pair.Key))
+                .Distinct()
+                .Select(value => value.FormatSqlValue())
+                .ToArray();
+        }
+
+        return buckets;
+    }
+
+    private static async Task createOrWidenPartitionAsync(NpgsqlConnection conn, Table table,
+        string sanitizedSuffix, string[] desiredValues, CancellationToken token)
+    {
+        var partitionName = PostgresqlObjectName.From(
+            new DbObjectName(table.Identifier.Schema, table.Identifier.Name + "_" + sanitizedSuffix));
+
+        var bound = await fetchPartitionBoundAsync(conn, table.Identifier.Schema,
+            table.Identifier.Name + "_" + sanitizedSuffix, token).ConfigureAwait(false);
+
+        if (bound == null)
+        {
+            // Brand new partition — one CREATE carrying the whole bucket.
+            var writer = new StringWriter();
+            var partition = new ListPartition(sanitizedSuffix, desiredValues);
+            ((IPartition)partition).WriteCreateStatement(writer, table);
+
+            await conn.CreateCommand(writer.ToString()).ExecuteNonQueryAsync(token).ConfigureAwait(false);
+            return;
+        }
+
+        // Purely additive: this path never narrows a bound (drop owns that), so the new bound is the union
+        // of what is already there and what was asked for.
+        var covered = bound.Values.Select(x => x.NormalizePartitionValue()).ToHashSet();
+        var missing = desiredValues.Where(x => !covered.Contains(x.NormalizePartitionValue())).ToArray();
+
+        if (missing.Length == 0 && bound.IsAttached)
+        {
+            return;
+        }
+
+        await rebindPartitionAsync(conn, table, partitionName, bound.IsAttached,
+            bound.Values.Concat(missing).ToArray(), token).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// The current partition bound of <paramref name="partitionTableName"/>, or null when no such table
+    /// exists. A table that exists but is not attached to a parent comes back with an empty, unattached
+    /// bound so the caller can ATTACH it without first issuing a DETACH that would fail.
+    /// </summary>
+    private static async Task<PartitionBound?> fetchPartitionBoundAsync(NpgsqlConnection conn,
+        string schemaName, string partitionTableName, CancellationToken token)
+    {
+        await using var reader = await conn
+            .CreateCommand(
+                "select pg_get_expr(c.relpartbound, c.oid) from pg_class c join pg_namespace n on n.oid = c.relnamespace where n.nspname = :schema and c.relname = :name")
+            .With("schema", schemaName)
+            .With("name", partitionTableName)
+            .ExecuteReaderAsync(token).ConfigureAwait(false);
+
+        if (!await reader.ReadAsync(token).ConfigureAwait(false))
+        {
+            return null;
+        }
+
+        if (await reader.IsDBNullAsync(0, token).ConfigureAwait(false))
+        {
+            return new PartitionBound([], false);
+        }
+
+        var expression = await reader.GetFieldValueAsync<string>(0, token).ConfigureAwait(false);
+        return new PartitionBound(expression.GetStringWithinParantheses().ToDelimitedArray(','), true);
+    }
+
+    /// <summary>
+    /// CREATE TABLE IF NOT EXISTS cannot alter the bound of an existing partition, so changing a bucket's
+    /// membership is DETACH followed by re-ATTACH. Both run inside ONE transaction: a failure between them
+    /// would leave the partition orphaned and every tenant in the bucket unroutable.
+    /// </summary>
+    private static async Task rebindPartitionAsync(NpgsqlConnection conn, Table table,
+        PostgresqlObjectName partitionName, bool isAttached, string[] values, CancellationToken token)
+    {
+        await using var tx = await conn.BeginTransactionAsync(token).ConfigureAwait(false);
+
+        if (isAttached)
+        {
+            await tx.CreateCommand(
+                    $"alter table {table.Identifier.QualifiedName} detach partition {partitionName};")
+                .ExecuteNonQueryAsync(token).ConfigureAwait(false);
+        }
+
+        await tx.CreateCommand(
+                $"alter table {table.Identifier.QualifiedName} attach partition {partitionName} for values in ({values.Join(", ")});")
+            .ExecuteNonQueryAsync(token).ConfigureAwait(false);
+
+        await tx.CommitAsync(token).ConfigureAwait(false);
+    }
+
+    private sealed record PartitionBound(string[] Values, bool IsAttached);
 
     public Task AddPartitionToAllTables(NpgsqlConnection conn, CancellationToken token, string value, string? suffix = null)
     {

--- a/src/Weasel.SqlServer.Tests/Tables/partitioning/managed_tenant_partitions_parity.cs
+++ b/src/Weasel.SqlServer.Tests/Tables/partitioning/managed_tenant_partitions_parity.cs
@@ -345,6 +345,155 @@ IF EXISTS (SELECT 1 FROM sys.partition_functions WHERE name = '{pfName}')
             .ShouldBe(new[] { "mtpp.porders", "mtpp.pevents" }, ignoreOrder: true);
     }
 
+    [Fact]
+    public async Task named_buckets_registered_separately_share_one_partition()
+    {
+        // weasel#391, the headline SQL Server defect: bucketing worked inside a single batch (the caller
+        // supplied the shared ordinal itself) but silently did NOT across calls — the natural
+        // tenant-onboarding shape and exactly what the docs showed. The registry persisted only
+        // tenant_id -> ordinal, so a brand-new tenant could not discover which ordinal its bucket already
+        // owned and each call allocated a fresh one. The tenants never shared, so the 15,000-partition
+        // ceiling bucketing exists to dodge was not actually mitigated.
+        await ResetSchemaAndPartitionObjects();
+
+        var database = new DatabaseWithTables("mtpp_integration", ConnectionSource.ConnectionString);
+        var manager = theManager();
+        manager.AllowOrdinalSharing = true;
+        var orders = theOrdersTable(manager);
+        database.AddTable(orders);
+
+        await CreateSchemaObjectInDatabase(orders);
+
+        var first = await manager.AddPartitionsToAllTables(NullLogger.Instance, database,
+            new Dictionary<string, string?> { ["smalla"] = "shared_bucket" }, CancellationToken.None);
+
+        var second = await manager.AddPartitionsToAllTables(NullLogger.Instance, database,
+            new Dictionary<string, string?> { ["smallb"] = "shared_bucket" }, CancellationToken.None);
+
+        first.Ordinals["smalla"].ShouldBe(second.Ordinals["smallb"]);
+        manager.Buckets.ShouldContainKeyAndValue("shared_bucket", first.Ordinals["smalla"]);
+
+        // One bucket, one boundary — beyond the sentinel. Pre-fix this was { 0, 1, 2 }.
+        (await ReadBoundariesAsync("pf_porders_tenant_ordinal")).ShouldBe(new[] { 0, 1 });
+    }
+
+    [Fact]
+    public async Task a_bucket_resolves_from_the_registry_for_a_brand_new_manager()
+    {
+        // The bucket key has to round-trip through the registry, not merely live in one process's memory:
+        // tenants are onboarded by whichever node happens to handle the request, often long after the
+        // bucket's first member was registered.
+        await ResetSchemaAndPartitionObjects();
+
+        var database = new DatabaseWithTables("mtpp_integration", ConnectionSource.ConnectionString);
+        var manager = theManager();
+        manager.AllowOrdinalSharing = true;
+        var orders = theOrdersTable(manager);
+        database.AddTable(orders);
+
+        await CreateSchemaObjectInDatabase(orders);
+
+        var first = await manager.AddPartitionsToAllTables(NullLogger.Instance, database,
+            new Dictionary<string, string?> { ["smalla"] = "shared_bucket" }, CancellationToken.None);
+
+        // A completely separate manager instance, as a different node would have.
+        var fresh = theManager();
+        fresh.AllowOrdinalSharing = true;
+        var freshDatabase = new DatabaseWithTables("mtpp_integration", ConnectionSource.ConnectionString);
+        freshDatabase.AddTable(theOrdersTable(fresh));
+
+        await fresh.InitializeAsync(freshDatabase, CancellationToken.None);
+        fresh.Buckets.ShouldContainKeyAndValue("shared_bucket", first.Ordinals["smalla"]);
+
+        var second = await fresh.AddPartitionsToAllTables(NullLogger.Instance, freshDatabase,
+            new Dictionary<string, string?> { ["smallb"] = "shared_bucket" }, CancellationToken.None);
+
+        second.Ordinals["smallb"].ShouldBe(first.Ordinals["smalla"]);
+    }
+
+    [Fact]
+    public async Task bucketless_tenants_still_get_their_own_partition()
+    {
+        await ResetSchemaAndPartitionObjects();
+
+        var database = new DatabaseWithTables("mtpp_integration", ConnectionSource.ConnectionString);
+        var manager = theManager();
+        manager.AllowOrdinalSharing = true;
+        var orders = theOrdersTable(manager);
+        database.AddTable(orders);
+
+        await CreateSchemaObjectInDatabase(orders);
+
+        var result = await manager.AddPartitionsToAllTables(NullLogger.Instance, database,
+            new Dictionary<string, string?>
+            {
+                ["big1"] = null,
+                ["big2"] = null,
+                ["smalla"] = "shared_bucket",
+                ["smallb"] = "shared_bucket"
+            }, CancellationToken.None);
+
+        result.Ordinals["big1"].ShouldNotBe(result.Ordinals["big2"]);
+        result.Ordinals["smalla"].ShouldBe(result.Ordinals["smallb"]);
+
+        // four tenants, three partitions
+        (await ReadBoundariesAsync("pf_porders_tenant_ordinal")).Length.ShouldBe(4);
+        manager.Ordinals.Values.Distinct().Count().ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task a_bucket_is_released_only_with_its_last_member()
+    {
+        await ResetSchemaAndPartitionObjects();
+
+        var database = new DatabaseWithTables("mtpp_integration", ConnectionSource.ConnectionString);
+        var manager = theManager();
+        manager.AllowOrdinalSharing = true;
+        var orders = theOrdersTable(manager);
+        database.AddTable(orders);
+
+        await CreateSchemaObjectInDatabase(orders);
+
+        await manager.AddPartitionsToAllTables(NullLogger.Instance, database,
+            new Dictionary<string, string?> { ["smalla"] = "shared_bucket", ["smallb"] = "shared_bucket" },
+            CancellationToken.None);
+
+        await manager.DropPartitionFromAllTables(NullLogger.Instance, database, new[] { "smalla" },
+            TenantDropBehavior.DeleteData, CancellationToken.None);
+
+        // still one member, so the bucket and its partition survive
+        manager.Buckets.ShouldContainKey("shared_bucket");
+        (await ReadBoundariesAsync("pf_porders_tenant_ordinal")).ShouldBe(new[] { 0, 1 });
+
+        await manager.DropPartitionFromAllTables(NullLogger.Instance, database, new[] { "smallb" },
+            TenantDropBehavior.DeleteData, CancellationToken.None);
+
+        // last member gone — the bucket is forgotten and the ordinal genuinely released. This is why the
+        // bucket key is a nullable column and not a pseudo-tenant row: a row would have pinned it forever.
+        manager.Buckets.ShouldNotContainKey("shared_bucket");
+        (await ReadBoundariesAsync("pf_porders_tenant_ordinal")).ShouldBe(new[] { 0 });
+    }
+
+    [Fact]
+    public async Task bucketing_more_than_one_tenant_requires_ordinal_sharing()
+    {
+        await ResetSchemaAndPartitionObjects();
+
+        var database = new DatabaseWithTables("mtpp_integration", ConnectionSource.ConnectionString);
+        var manager = theManager();
+        var orders = theOrdersTable(manager);
+        database.AddTable(orders);
+
+        await CreateSchemaObjectInDatabase(orders);
+
+        await manager.AddPartitionsToAllTables(NullLogger.Instance, database,
+            new Dictionary<string, string?> { ["smalla"] = "shared_bucket" }, CancellationToken.None);
+
+        await Should.ThrowAsync<InvalidOperationException>(() =>
+            manager.AddPartitionsToAllTables(NullLogger.Instance, database,
+                new Dictionary<string, string?> { ["smallb"] = "shared_bucket" }, CancellationToken.None));
+    }
+
     // ---------------------------------------------------------------------
     // Helpers
     // ---------------------------------------------------------------------

--- a/src/Weasel.SqlServer/Tables/Partitioning/ManagedTenantPartitions.cs
+++ b/src/Weasel.SqlServer/Tables/Partitioning/ManagedTenantPartitions.cs
@@ -68,6 +68,7 @@ public class ManagedTenantPartitions: FeatureSchemaBase, ISqlServerPartitioning,
     private readonly Table _registry;
     private readonly IndexDefinition _uniqueOrdinalIndex;
     private readonly Dictionary<string, int> _ordinals = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, int> _buckets = new(StringComparer.OrdinalIgnoreCase);
     private readonly SemaphoreSlim _semaphore = new(1, 1);
     private bool _hasInitialized;
 
@@ -104,6 +105,15 @@ public class ManagedTenantPartitions: FeatureSchemaBase, ISqlServerPartitioning,
         _registry = new Table(registryTableName);
         _registry.AddColumn("tenant_id", "varchar(200)").AsPrimaryKey().NotNull();
         _registry.AddColumn<int>("ordinal").NotNull();
+
+        // weasel#391: the bucket key a tenant was registered under, or NULL for a tenant that owns its
+        // partition outright. Without it the registry held only tenant_id -> ordinal, so a tenant joining
+        // an existing bucket in a LATER call had no way to discover which ordinal that bucket already
+        // owned — every sequential registration silently allocated a fresh ordinal and the tenants never
+        // actually shared a partition. Nullable and additive, so it migrates onto an existing registry.
+        // Deliberately a COLUMN rather than a pseudo-tenant row: a row would keep the ordinal referenced
+        // forever and defeat release-on-last-member (and therefore TenantDropBehavior.DeleteData).
+        _registry.AddColumn("bucket", "varchar(200)");
 
         // Unique index on ordinal lets us safely allocate from the in-memory
         // map without re-querying the table; concurrent ManagedTenantPartitions
@@ -169,6 +179,15 @@ public class ManagedTenantPartitions: FeatureSchemaBase, ISqlServerPartitioning,
     /// <inheritdoc />
     public IReadOnlyDictionary<string, int> Ordinals =>
         new ReadOnlyDictionary<string, int>(_ordinals);
+
+    /// <summary>
+    ///     Current bucket -&gt; ordinal map, i.e. which physical partition each named
+    ///     tenant bucket resolves to. Populated from the registry's <c>bucket</c>
+    ///     column, so a bucket registered in an earlier call (or by another process)
+    ///     is resolvable here. A bucket disappears once its last member is dropped.
+    /// </summary>
+    public IReadOnlyDictionary<string, int> Buckets =>
+        new ReadOnlyDictionary<string, int>(_buckets);
 
     /// <inheritdoc />
     protected override IEnumerable<ISchemaObject> schemaObjects()
@@ -356,16 +375,22 @@ public class ManagedTenantPartitions: FeatureSchemaBase, ISqlServerPartitioning,
             await _registry.MigrateAsync(conn, token).ConfigureAwait(false);
 
             _ordinals.Clear();
+            _buckets.Clear();
 
             await using var cmd = conn.CreateCommand();
             cmd.CommandText =
-                $"SELECT tenant_id, ordinal FROM {_registry.Identifier.QualifiedName}";
+                $"SELECT tenant_id, ordinal, bucket FROM {_registry.Identifier.QualifiedName}";
             await using var reader = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
             while (await reader.ReadAsync(token).ConfigureAwait(false))
             {
                 var tenantId = reader.GetString(0);
                 var ordinal = reader.GetInt32(1);
                 _ordinals[tenantId] = ordinal;
+
+                if (!await reader.IsDBNullAsync(2, token).ConfigureAwait(false))
+                {
+                    _buckets[reader.GetString(2)] = ordinal;
+                }
             }
 
             _hasInitialized = true;
@@ -539,6 +564,100 @@ public class ManagedTenantPartitions: FeatureSchemaBase, ISqlServerPartitioning,
     }
 
     /// <summary>
+    ///     Register tenants against named buckets — the durable form of tenant
+    ///     bucketing. A null or empty bucket means the tenant owns its partition
+    ///     outright; tenants sharing a bucket name share one ordinal, and therefore
+    ///     one physical partition, <b>whether they are registered together or in
+    ///     separate calls</b>. Requires <see cref="AllowOrdinalSharing" /> whenever a
+    ///     bucket ends up with more than one member.
+    /// </summary>
+    /// <remarks>
+    ///     Prefer this over the explicit-ordinal overload: the caller no longer has
+    ///     to know (or persist) which ordinal a bucket owns, because the bucket key
+    ///     itself round-trips through the registry (weasel#391).
+    /// </remarks>
+    public async Task<TenantPartitionAddResult> AddPartitionsToAllTables(
+        ILogger logger,
+        IDatabase<SqlConnection> database,
+        IReadOnlyDictionary<string, string?> tenantBuckets,
+        CancellationToken token)
+    {
+        await using var conn = database.CreateConnection();
+        await conn.OpenAsync(token).ConfigureAwait(false);
+
+        await InitializeAsync(conn, token).ConfigureAwait(false);
+
+        var assigned = new Dictionary<string, int>(StringComparer.Ordinal);
+
+        // Bucket-less tenants keep the historical one-partition-per-tenant behavior.
+        foreach (var pair in tenantBuckets.Where(x => string.IsNullOrEmpty(x.Value)))
+        {
+            if (string.IsNullOrEmpty(pair.Key))
+            {
+                continue;
+            }
+
+            assigned[pair.Key] = await upsertTenantAsync(conn, pair.Key, token).ConfigureAwait(false);
+        }
+
+        foreach (var bucket in tenantBuckets
+                     .Where(x => !string.IsNullOrEmpty(x.Value))
+                     .GroupBy(x => x.Value!, StringComparer.OrdinalIgnoreCase))
+        {
+            var members = bucket.Where(x => !string.IsNullOrEmpty(x.Key)).Select(x => x.Key).ToArray();
+            if (members.Length == 0)
+            {
+                continue;
+            }
+
+            var ordinal = resolveBucketOrdinal(bucket.Key, members);
+
+            foreach (var member in members)
+            {
+                assigned[member] = await upsertTenantAsync(conn, member, token, ordinal, bucket.Key)
+                    .ConfigureAwait(false);
+            }
+        }
+
+        var statuses = await splitTablesForNewOrdinalsAsync(logger, database, conn, token)
+            .ConfigureAwait(false);
+
+        await conn.CloseAsync().ConfigureAwait(false);
+
+        return new TenantPartitionAddResult(assigned, statuses.ToArray());
+    }
+
+    /// <summary>
+    ///     Which ordinal a bucket resolves to: the one already recorded for the bucket, else the one its
+    ///     already-registered members hold (covers a registry written before the bucket column existed),
+    ///     else a fresh ordinal.
+    /// </summary>
+    private int resolveBucketOrdinal(string bucket, string[] members)
+    {
+        if (_buckets.TryGetValue(bucket, out var known))
+        {
+            return known;
+        }
+
+        var existing = members.Where(m => _ordinals.ContainsKey(m))
+            .Select(m => _ordinals[m])
+            .Distinct()
+            .ToArray();
+
+        if (existing.Length > 1)
+        {
+            throw new InvalidOperationException(
+                $"Tenants {members.Join(", ")} for bucket '{bucket}' are already mapped to different " +
+                $"partitions ({existing.Select(x => x.ToString()).Join(", ")}). Existing rows keep their " +
+                "ordinal, so they cannot be merged into one partition after the fact.");
+        }
+
+        return existing.Length == 1
+            ? existing[0]
+            : (_ordinals.Count == 0 ? 1 : _ordinals.Values.Max() + 1);
+    }
+
+    /// <summary>
     ///     Register a single tenant with an explicitly assigned ordinal. See
     ///     <see cref="AddPartitionsToAllTables(ILogger,IDatabase{SqlConnection},IReadOnlyDictionary{string,int},CancellationToken)" />
     ///     for the bucketing semantics.
@@ -627,6 +746,10 @@ public class ManagedTenantPartitions: FeatureSchemaBase, ISqlServerPartitioning,
             }
 
             _ordinals.Clear();
+
+            // ResetValues rewrites the registry wholesale and carries no bucket names, so every previously
+            // known bucket is gone with it.
+            _buckets.Clear();
             foreach (var pair in values)
             {
                 _ordinals[pair.Key] = pair.Value;
@@ -732,6 +855,15 @@ public class ManagedTenantPartitions: FeatureSchemaBase, ISqlServerPartitioning,
             _ordinals.Remove(tenant);
         }
 
+        // A bucket only exists while it has members. Forgetting it once the last one is dropped keeps the
+        // ordinal genuinely releasable — the whole reason the bucket key is a nullable column rather than a
+        // pseudo-tenant row, which would have pinned the partition forever.
+        foreach (var stale in _buckets.Where(pair => !_ordinals.ContainsValue(pair.Value))
+                     .Select(pair => pair.Key).ToArray())
+        {
+            _buckets.Remove(stale);
+        }
+
         // With ordinal sharing, an ordinal is only released once its LAST tenant
         // is dropped; while other tenants still map to it the partition must
         // survive, and a purge by ordinal would take their rows with it.
@@ -831,7 +963,8 @@ public class ManagedTenantPartitions: FeatureSchemaBase, ISqlServerPartitioning,
         SqlConnection conn,
         string tenantId,
         CancellationToken token,
-        int? requestedOrdinal = null)
+        int? requestedOrdinal = null,
+        string? bucket = null)
     {
         if (_ordinals.TryGetValue(tenantId, out var existing))
         {
@@ -841,6 +974,11 @@ public class ManagedTenantPartitions: FeatureSchemaBase, ISqlServerPartitioning,
                     $"Tenant '{tenantId}' is already registered with ordinal {existing}; remapping to " +
                     $"{requestedOrdinal.Value} is not supported because existing rows keep the old ordinal. " +
                     "Drop the tenant first if it really has to move.");
+            }
+
+            if (bucket != null)
+            {
+                _buckets[bucket] = existing;
             }
 
             return existing;
@@ -870,12 +1008,13 @@ public class ManagedTenantPartitions: FeatureSchemaBase, ISqlServerPartitioning,
         // the InvalidOperationException propagates and the caller can retry.
         cmd.CommandText = $@"
 MERGE {_registry.Identifier.QualifiedName} WITH (HOLDLOCK) AS target
-USING (SELECT @tenant AS tenant_id, @ordinal AS ordinal) AS source
+USING (SELECT @tenant AS tenant_id, @ordinal AS ordinal, @bucket AS bucket) AS source
 ON target.tenant_id = source.tenant_id
-WHEN NOT MATCHED THEN INSERT (tenant_id, ordinal) VALUES (source.tenant_id, source.ordinal)
+WHEN NOT MATCHED THEN INSERT (tenant_id, ordinal, bucket) VALUES (source.tenant_id, source.ordinal, source.bucket)
 OUTPUT inserted.ordinal;";
         cmd.Parameters.AddWithValue("@tenant", tenantId);
         cmd.Parameters.AddWithValue("@ordinal", nextOrdinal);
+        cmd.Parameters.AddWithValue("@bucket", (object?)bucket ?? DBNull.Value);
 
         var insertedOrdinal = (int?)await cmd.ExecuteScalarAsync(token).ConfigureAwait(false);
 
@@ -897,6 +1036,14 @@ OUTPUT inserted.ordinal;";
         }
 
         _ordinals[tenantId] = insertedOrdinal.Value;
+
+        if (bucket != null)
+        {
+            // Record the bucket against whatever ordinal actually landed — which may be another process's
+            // if it won the MERGE race — so every later member of this bucket resolves to the same partition.
+            _buckets[bucket] = insertedOrdinal.Value;
+        }
+
         return insertedOrdinal.Value;
     }
 


### PR DESCRIPTION
Closes #391.

Both managed-partition strategies advertise multi-tenant **bucketing** — several small tenants sharing one
physical partition to stay clear of per-table partition ceilings — but neither could express it end to end.
Both halves reproduced against real PostgreSQL and SQL Server before fixing.

## PostgreSQL — `ManagedListPartitions`

`AddPartitionToAllTables` emitted one single-value `ListPartition` per value, so two values sharing a suffix
produced two `CREATE TABLE IF NOT EXISTS` statements against the same partition table name. The first created
it with only its own value; the second was silently swallowed. The partition never accepted the second value,
and that tenant's first write died with `23514 no partition of relation found for row`.

The additive path now groups by **sanitized** suffix — that is what names the physical table — and carries the
bucket's full membership, not just the values supplied in the current call. Since `CREATE TABLE IF NOT EXISTS`
cannot alter an existing bound, widening a partition that is already there is `DETACH` + re-`ATTACH` inside
**one transaction**; a failure between the two would orphan the partition and leave every tenant in the bucket
unroutable.

### Also fixed here: co-tenant data loss on drop

`DropPartitionFromAllTablesForValue` resolved a value to its suffix and then dropped **by suffix** — deleting
every registry row in the bucket and `DROP`ping the shared partition table. Removing one small tenant therefore
silently destroyed its co-tenants' rows. It now narrows the bucket instead: only the departing value's rows are
deleted, the partition is re-bound to the remaining members, and the partition is released only with the last
member. Filed as JasperFx/wolverine#3686.

## SQL Server — `ManagedTenantPartitions`

Bucketing worked inside a single batch, because the caller supplied the shared ordinal itself. Across calls —
the natural tenant-onboarding shape, and the one the Wolverine docs showed — it silently did not. The registry
persisted only `tenant_id -> ordinal`, so a brand-new tenant had no way to discover which ordinal its bucket
already owned; each call allocated a fresh one and the tenants never actually shared. The 15,000-partition
ceiling bucketing exists to dodge was not mitigated at all.

The registry gains a nullable `bucket` column, plus a bucket-aware `AddPartitionsToAllTables` overload taking
`tenant -> bucket`. Deliberately a **column** rather than the pseudo-tenant **row** considered in #391: a row
would keep the ordinal referenced forever, defeating release-on-last-member and therefore
`TenantDropBehavior.DeleteData`. A bucket is forgotten once its last member is dropped.

New public surface: the `IReadOnlyDictionary<string, string?>` overload of `AddPartitionsToAllTables`, and a
`Buckets` map. Nothing existing changed shape, and the new column is nullable and additive, so it migrates onto
an existing registry.

## Verification

Real PostgreSQL and real SQL Server, not mocks.

* 5 new PostgreSQL tests, **all 5 red on 9.19.1** and green here — covering in-batch bucketing, sequential
  bucketing, non-destructive widening, co-tenant survival on drop, and release-on-last-member.
* 5 new SQL Server tests. These exercise new API so they cannot compile against 9.19.1; the underlying defect
  was instead reproduced on 9.19.1 through the old API in the documented sequential shape, which allocated two
  distinct ordinals where one was expected.
* Full suites green: `Weasel.Postgresql` 780/783 and `Weasel.SqlServer` 323/331 (skips pre-existing).

Downstream: JasperFx/wolverine#3683 adopts this and adds bucketing compliance coverage on both engines.