### PR TITLE
Migrate all test projects to xUnit v3

### DIFF
--- a/.github/workflows/ci-build-mssql.yml
+++ b/.github/workflows/ci-build-mssql.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   config: Release
-  disable_test_parallelization: true
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   db_pwd: P@55w0rd
@@ -26,7 +25,6 @@ jobs:
                 - mcr.microsoft.com/mssql/server:2019-latest
                 - mcr.microsoft.com/mssql/server:2022-latest
             framework:
-                - net8.0
                 - net9.0
                 - net10.0
 
@@ -48,7 +46,6 @@ jobs:
       uses: actions/setup-dotnet@v5
       with:
         dotnet-version: |
-            8.0.x
             9.0.x
             10.0.x
 

--- a/.github/workflows/ci-build-mysql.yml
+++ b/.github/workflows/ci-build-mysql.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   config: Release
-  disable_test_parallelization: true
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   db_pwd: P@55w0rd
@@ -24,7 +23,6 @@ jobs:
             mysql-image:
                 - mysql:8.0
             framework:
-                - net8.0
                 - net9.0
                 - net10.0
 
@@ -53,7 +51,6 @@ jobs:
       uses: actions/setup-dotnet@v5
       with:
         dotnet-version: |
-            8.0.x
             9.0.x
             10.0.x
 

--- a/.github/workflows/ci-build-oracle.yml
+++ b/.github/workflows/ci-build-oracle.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   config: Release
-  disable_test_parallelization: true
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   db_pwd: P@55w0rd
@@ -22,7 +21,6 @@ jobs:
     strategy:
         matrix:
             framework:
-                - net8.0
                 - net9.0
                 - net10.0
 
@@ -44,7 +42,6 @@ jobs:
       uses: actions/setup-dotnet@v5
       with:
         dotnet-version: |
-            8.0.x
             9.0.x
             10.0.x
 

--- a/.github/workflows/ci-build-postgres.yml
+++ b/.github/workflows/ci-build-postgres.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   config: Release
-  disable_test_parallelization: true
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   db_name: weasel_testing
@@ -30,7 +29,6 @@ jobs:
                 - true
                 - false
             framework:
-                - net8.0
                 - net9.0
                 - net10.0
 
@@ -66,7 +64,6 @@ jobs:
       uses: actions/setup-dotnet@v5
       with:
           dotnet-version: |
-              8.0.x
               9.0.x
               10.0.x
 

--- a/.github/workflows/ci-build-sqlite.yml
+++ b/.github/workflows/ci-build-sqlite.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   config: Release
-  disable_test_parallelization: true
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
 
@@ -26,7 +25,6 @@ jobs:
           #- windows-latest
           #- macos-latest
         framework:
-          - net8.0
           - net9.0
           - net10.0
 
@@ -39,7 +37,6 @@ jobs:
       uses: actions/setup-dotnet@v5
       with:
           dotnet-version: |
-              8.0.x
               9.0.x
               10.0.x
 

--- a/.github/workflows/publish_nuget.yml
+++ b/.github/workflows/publish_nuget.yml
@@ -14,7 +14,6 @@ jobs:
       uses: actions/setup-dotnet@v5
       with:
           dotnet-version: |
-              8.0.x
               9.0.x
               10.0.x
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,9 @@ Weasel is a low-level database abstraction and schema migration library for .NET
 - **SQL Server:** Microsoft.Data.SqlClient
 - **Oracle:** Oracle.ManagedDataAccess.Core
 - **SQLite:** Microsoft.Data.Sqlite with JSON1 extension support
-- **Testing:** xUnit, Shouldly, NSubstitute
+- **Testing:** xUnit v3, Shouldly, NSubstitute. Test projects import
+  `Tests.Build.props` for the shared runner packages and `OutputType=Exe`
+  (required by v3), rather than declaring them individually.
 - **Build:** Nuke.Build
 
 ## Project Structure
@@ -77,7 +79,7 @@ dotnet test src/Weasel.SqlServer.Tests/Weasel.SqlServer.Tests.csproj
 dotnet test src/Weasel.Sqlite.Tests/Weasel.Sqlite.Tests.csproj
 
 # Target specific framework
-dotnet test --framework net8.0
+dotnet test --framework net9.0
 ```
 
 **Database Setup for Integration Tests:**

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,7 +18,7 @@
     <!-- EF Core versions are framework-conditional - see below -->
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.4" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="MySqlConnector" Version="2.4.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
     <PackageVersion Include="Npgsql" Version="9.0.4" />
@@ -30,8 +30,12 @@
     <PackageVersion Include="Oracle.ManagedDataAccess.Core" Version="23.7.0" />
     <!-- Pomelo EF Core is framework-conditional - see below -->
     <PackageVersion Include="Shouldly" Version="4.3.0" />
+    <!-- xunit 2.x stays until the last test project is moved over to xunit.v3;
+         xunit.runner.visualstudio 3.x discovers both, so the two can coexist
+         while the projects are converted one at a time. -->
     <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageVersion Include="xunit.v3" Version="3.2.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
   <!-- EF Core 9.x for net9.0 -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,10 +30,6 @@
     <PackageVersion Include="Oracle.ManagedDataAccess.Core" Version="23.7.0" />
     <!-- Pomelo EF Core is framework-conditional - see below -->
     <PackageVersion Include="Shouldly" Version="4.3.0" />
-    <!-- xunit 2.x stays until the last test project is moved over to xunit.v3;
-         xunit.runner.visualstudio 3.x discovers both, so the two can coexist
-         while the projects are converted one at a time. -->
-    <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>

--- a/Tests.Build.props
+++ b/Tests.Build.props
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Shared configuration for the xUnit v3 test projects. Imported explicitly by
+    each *.Tests.csproj, mirroring how the production projects import
+    Analysis.Build.props.
+-->
+<Project>
+    <PropertyGroup>
+        <!-- xUnit v3 test assemblies are self-executing - the runner supplies the
+             entry point - so a test project has to build as an executable. -->
+        <OutputType>Exe</OutputType>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <!-- ExcludeAssets="analyzers" keeps xunit.analyzers out of the build. This
+             suite predates them, and xUnit1051 alone (pass
+             TestContext.Current.CancellationToken to async calls) fires on
+             hundreds of async database calls. Adopting the analyzers is
+             deliberate follow-up work, not part of the v2 -> v3 conversion. -->
+        <PackageReference Include="xunit.v3" ExcludeAssets="analyzers" />
+        <PackageReference Include="xunit.runner.visualstudio">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="coverlet.collector">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+</Project>

--- a/Tests.Build.props
+++ b/Tests.Build.props
@@ -10,6 +10,14 @@
              entry point - so a test project has to build as an executable. -->
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
+
+        <!-- Every database-backed suite shares schemas between target frameworks, so
+             running the net9.0 and net10.0 suites concurrently makes them drop each
+             other's schemas mid-test. CI never hit this because each job names a
+             single target framework explicitly, but a bare `dotnet test` locally
+             does, and did so on the Postgres suite well before the xUnit v3
+             migration. -->
+        <TestTfmsInParallel>false</TestTfmsInParallel>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Weasel.slnx
+++ b/Weasel.slnx
@@ -6,13 +6,16 @@
   </Configurations>
   <Folder Name="/Build/">
     <File Path=".editorconfig" />
+    <File Path=".github/workflows/ci-build-efcore.yml" />
     <File Path=".github/workflows/ci-build-mssql.yml" />
     <File Path=".github/workflows/ci-build-mysql.yml" />
     <File Path=".github/workflows/ci-build-oracle.yml" />
     <File Path=".github/workflows/ci-build-postgres.yml" />
+    <File Path=".github/workflows/ci-build-sqlite.yml" />
     <File Path=".github/workflows/publish_nuget.yml" />
     <File Path="Analysis.Build.props" />
     <File Path="Directory.Build.props" />
+    <File Path="Tests.Build.props" />
     <File Path="docker-compose.yml" />
     <File Path="README.md" />
   </Folder>

--- a/src/DocSamples/DocSamples.csproj
+++ b/src/DocSamples/DocSamples.csproj
@@ -3,16 +3,17 @@
     <PropertyGroup>
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
+        <!-- The Web SDK defaults to Exe, but there is no entry point here - only
+             sample methods, one of which calls WebApplication.CreateBuilder.
+             Microsoft.NET.Test.Sdk used to paper over that by generating a Main;
+             it is gone now, so say Library outright. -->
+        <OutputType>Library</OutputType>
     </PropertyGroup>
 
+    <!-- Not a test project: DocSamples holds compilable mdsnippets sources and
+         contains no xunit code, so it carries no test framework packages. -->
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="Shouldly" />
-        <PackageReference Include="xunit" />
-        <PackageReference Include="xunit.runner.visualstudio">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Weasel.CommandLine.Tests/Weasel.CommandLine.Tests.csproj
+++ b/src/Weasel.CommandLine.Tests/Weasel.CommandLine.Tests.csproj
@@ -14,19 +14,10 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="NSubstitute" />
         <PackageReference Include="Shouldly" />
-        <PackageReference Include="xunit" />
-        <PackageReference Include="xunit.runner.visualstudio">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-      <ProjectReference Include="..\Weasel.Postgresql\Weasel.Postgresql.csproj" />
+        <ProjectReference Include="..\Weasel.Postgresql\Weasel.Postgresql.csproj" />
     </ItemGroup>
 
+    <Import Project="../../Tests.Build.props" />
 </Project>

--- a/src/Weasel.Core.Tests/Weasel.Core.Tests.csproj
+++ b/src/Weasel.Core.Tests/Weasel.Core.Tests.csproj
@@ -3,26 +3,16 @@
     <PropertyGroup>
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <Nullable>enable</Nullable>
-        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="NSubstitute" />
         <PackageReference Include="Shouldly" />
-        <PackageReference Include="xunit" />
-        <PackageReference Include="xunit.runner.visualstudio">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\Weasel.Core\Weasel.Core.csproj" />
     </ItemGroup>
 
+    <Import Project="../../Tests.Build.props" />
 </Project>

--- a/src/Weasel.EntityFrameworkCore.Tests/MigrationOperations/incremental_migration_end_to_end.cs
+++ b/src/Weasel.EntityFrameworkCore.Tests/MigrationOperations/incremental_migration_end_to_end.cs
@@ -21,7 +21,7 @@ namespace Weasel.EntityFrameworkCore.Tests.MigrationOperations;
 [Collection("pg-schema-comparison")]
 public class incremental_migration_end_to_end : IAsyncLifetime
 {
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         WeaselSampleDbContext.ConnectionString = PostgresqlDbContext.ConnectionString;
 
@@ -32,7 +32,7 @@ public class incremental_migration_end_to_end : IAsyncLifetime
         await cmd.ExecuteNonQueryAsync();
     }
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     private static ISchemaObject[] modifiedObjects()
     {

--- a/src/Weasel.EntityFrameworkCore.Tests/MigrationOperations/migration_file_emitter.cs
+++ b/src/Weasel.EntityFrameworkCore.Tests/MigrationOperations/migration_file_emitter.cs
@@ -143,7 +143,7 @@ public class migration_file_emitter
 [Collection("pg-schema-comparison")]
 public class generated_migration_end_to_end : IAsyncLifetime
 {
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         WeaselSampleDbContext.ConnectionString = PostgresqlDbContext.ConnectionString;
 
@@ -154,7 +154,7 @@ public class generated_migration_end_to_end : IAsyncLifetime
         await cmd.ExecuteNonQueryAsync();
     }
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     [Fact]
     public async Task applies_via_ef_round_trips_against_weasel_and_migrates_down()

--- a/src/Weasel.EntityFrameworkCore.Tests/MySql/end_to_end.cs
+++ b/src/Weasel.EntityFrameworkCore.Tests/MySql/end_to_end.cs
@@ -13,7 +13,7 @@ public class end_to_end : IAsyncLifetime
 {
     private IHost _host = null!;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         var serverVersion = new MySqlServerVersion(new Version(8, 0));
 
@@ -30,7 +30,7 @@ public class end_to_end : IAsyncLifetime
         await _host.StartAsync();
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await _host.StopAsync();
         _host.Dispose();

--- a/src/Weasel.EntityFrameworkCore.Tests/Oracle/end_to_end.cs
+++ b/src/Weasel.EntityFrameworkCore.Tests/Oracle/end_to_end.cs
@@ -13,7 +13,7 @@ public class end_to_end : IAsyncLifetime
 {
     private IHost _host = null!;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         _host = Host.CreateDefaultBuilder()
             .ConfigureServices(services =>
@@ -28,7 +28,7 @@ public class end_to_end : IAsyncLifetime
         await _host.StartAsync();
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await _host.StopAsync();
         _host.Dispose();

--- a/src/Weasel.EntityFrameworkCore.Tests/Postgresql/batch_query_tests.cs
+++ b/src/Weasel.EntityFrameworkCore.Tests/Postgresql/batch_query_tests.cs
@@ -14,7 +14,7 @@ public class batch_query_tests : IAsyncLifetime
 {
     private IHost _host = null!;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         _host = Host.CreateDefaultBuilder()
             .ConfigureServices(services =>
@@ -55,7 +55,7 @@ public class batch_query_tests : IAsyncLifetime
         await context.SaveChangesAsync();
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await _host.StopAsync();
         _host.Dispose();

--- a/src/Weasel.EntityFrameworkCore.Tests/Postgresql/database_cleaner_tests.cs
+++ b/src/Weasel.EntityFrameworkCore.Tests/Postgresql/database_cleaner_tests.cs
@@ -15,7 +15,7 @@ public class database_cleaner_tests : IAsyncLifetime
 {
     private IHost _host = null!;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         _host = Host.CreateDefaultBuilder()
             .ConfigureServices(services =>
@@ -40,7 +40,7 @@ public class database_cleaner_tests : IAsyncLifetime
         await creator!.CreateTablesAsync();
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await _host.StopAsync();
         _host.Dispose();

--- a/src/Weasel.EntityFrameworkCore.Tests/Postgresql/end_to_end.cs
+++ b/src/Weasel.EntityFrameworkCore.Tests/Postgresql/end_to_end.cs
@@ -13,7 +13,7 @@ public class end_to_end : IAsyncLifetime
 {
     private IHost _host = null!;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         _host = Host.CreateDefaultBuilder()
             .ConfigureServices(services =>
@@ -28,7 +28,7 @@ public class end_to_end : IAsyncLifetime
         await _host.StartAsync();
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await _host.StopAsync();
         _host.Dispose();
@@ -167,7 +167,7 @@ public class fk_dependency_ordering : IAsyncLifetime
 {
     private IHost _host = null!;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         _host = Host.CreateDefaultBuilder()
             .ConfigureServices(services =>
@@ -182,7 +182,7 @@ public class fk_dependency_ordering : IAsyncLifetime
         await _host.StartAsync();
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await _host.StopAsync();
         _host.Dispose();

--- a/src/Weasel.EntityFrameworkCore.Tests/Postgresql/json_column_end_to_end.cs
+++ b/src/Weasel.EntityFrameworkCore.Tests/Postgresql/json_column_end_to_end.cs
@@ -17,7 +17,7 @@ public class json_column_end_to_end : IAsyncLifetime
 {
     private IHost _host = null!;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         _host = Host.CreateDefaultBuilder()
             .ConfigureServices(services =>
@@ -32,7 +32,7 @@ public class json_column_end_to_end : IAsyncLifetime
         await _host.StartAsync();
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await _host.StopAsync();
         _host.Dispose();

--- a/src/Weasel.EntityFrameworkCore.Tests/Postgresql/lambda_initial_data_tests.cs
+++ b/src/Weasel.EntityFrameworkCore.Tests/Postgresql/lambda_initial_data_tests.cs
@@ -25,7 +25,7 @@ public class lambda_initial_data_tests : IAsyncLifetime
 {
     private IHost _host = null!;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         _host = Host.CreateDefaultBuilder()
             .ConfigureServices(services =>
@@ -58,7 +58,7 @@ public class lambda_initial_data_tests : IAsyncLifetime
         await creator!.CreateTablesAsync();
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await _host.StopAsync();
         _host.Dispose();

--- a/src/Weasel.EntityFrameworkCore.Tests/Postgresql/tph_base_class_fk_end_to_end.cs
+++ b/src/Weasel.EntityFrameworkCore.Tests/Postgresql/tph_base_class_fk_end_to_end.cs
@@ -18,7 +18,7 @@ public class tph_base_class_fk_end_to_end : IAsyncLifetime
 {
     private IHost _host = null!;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         _host = Host.CreateDefaultBuilder()
             .ConfigureServices(services =>
@@ -33,7 +33,7 @@ public class tph_base_class_fk_end_to_end : IAsyncLifetime
         await _host.StartAsync();
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await _host.StopAsync();
         _host.Dispose();

--- a/src/Weasel.EntityFrameworkCore.Tests/Postgresql/tph_end_to_end.cs
+++ b/src/Weasel.EntityFrameworkCore.Tests/Postgresql/tph_end_to_end.cs
@@ -13,7 +13,7 @@ public class tph_end_to_end : IAsyncLifetime
 {
     private IHost _host = null!;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         _host = Host.CreateDefaultBuilder()
             .ConfigureServices(services =>
@@ -28,7 +28,7 @@ public class tph_end_to_end : IAsyncLifetime
         await _host.StartAsync();
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await _host.StopAsync();
         _host.Dispose();

--- a/src/Weasel.EntityFrameworkCore.Tests/SqlServer/batch_query_tests.cs
+++ b/src/Weasel.EntityFrameworkCore.Tests/SqlServer/batch_query_tests.cs
@@ -14,7 +14,7 @@ public class sql_server_batch_query_tests : IAsyncLifetime
 {
     private IHost _host = null!;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         // Ensure the database exists first (race-tolerant for parallel classes)
         await SqlServerDatabaseBootstrap.EnsureDatabaseExistsAsync(SqlServerFkDbContext.ConnectionString);
@@ -62,7 +62,7 @@ public class sql_server_batch_query_tests : IAsyncLifetime
         await context.SaveChangesAsync();
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await _host.StopAsync();
         _host.Dispose();

--- a/src/Weasel.EntityFrameworkCore.Tests/SqlServer/end_to_end.cs
+++ b/src/Weasel.EntityFrameworkCore.Tests/SqlServer/end_to_end.cs
@@ -14,7 +14,7 @@ public class end_to_end : IAsyncLifetime
 {
     private IHost _host = null!;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         _host = Host.CreateDefaultBuilder()
             .ConfigureServices(services =>
@@ -29,7 +29,7 @@ public class end_to_end : IAsyncLifetime
         await _host.StartAsync();
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await _host.StopAsync();
         _host.Dispose();

--- a/src/Weasel.EntityFrameworkCore.Tests/Weasel.EntityFrameworkCore.Tests.csproj
+++ b/src/Weasel.EntityFrameworkCore.Tests/Weasel.EntityFrameworkCore.Tests.csproj
@@ -3,7 +3,6 @@
     <PropertyGroup>
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <Nullable>enable</Nullable>
-        <IsPackable>false</IsPackable>
         <!-- The end-to-end tests share database schemas between target frameworks;
              running the net9.0 and net10.0 suites concurrently makes them drop
              each other's schemas mid-test -->
@@ -12,7 +11,6 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Hosting" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="NSubstitute" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
@@ -20,15 +18,6 @@
         <PackageReference Include="Oracle.EntityFrameworkCore" Condition="'$(TargetFramework)' != 'net10.0'" />
         <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Condition="'$(TargetFramework)' != 'net10.0'" />
         <PackageReference Include="Shouldly" />
-        <PackageReference Include="xunit" />
-        <PackageReference Include="xunit.runner.visualstudio">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
     </ItemGroup>
 
     <!-- Exclude Oracle and MySql test files on net10.0 where those providers aren't available -->
@@ -45,4 +34,5 @@
         <ProjectReference Include="..\Weasel.MySql\Weasel.MySql.csproj" Condition="'$(TargetFramework)' != 'net10.0'" />
     </ItemGroup>
 
+    <Import Project="../../Tests.Build.props" />
 </Project>

--- a/src/Weasel.EntityFrameworkCore.Tests/Weasel.EntityFrameworkCore.Tests.csproj
+++ b/src/Weasel.EntityFrameworkCore.Tests/Weasel.EntityFrameworkCore.Tests.csproj
@@ -3,10 +3,8 @@
     <PropertyGroup>
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <Nullable>enable</Nullable>
-        <!-- The end-to-end tests share database schemas between target frameworks;
-             running the net9.0 and net10.0 suites concurrently makes them drop
-             each other's schemas mid-test -->
-        <TestTfmsInParallel>false</TestTfmsInParallel>
+        <!-- TestTfmsInParallel=false, which this suite needed first, is now the
+             default for every test project via Tests.Build.props -->
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Weasel.MySql.Tests/IntegrationContext.cs
+++ b/src/Weasel.MySql.Tests/IntegrationContext.cs
@@ -9,12 +9,12 @@ public abstract class IntegrationContext: IAsyncLifetime
 {
     protected MySqlConnection theConnection = default!;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         theConnection = await ConnectionSource.CreateOpenConnectionAsync();
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await theConnection.CloseAsync();
         await theConnection.DisposeAsync();
@@ -65,7 +65,7 @@ public class IntegrationCollection: ICollectionFixture<IntegrationFixture>
 
 public class IntegrationFixture: IAsyncLifetime
 {
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         // Ensure database exists
         var builder = new MySqlConnectionStringBuilder(ConnectionSource.ConnectionString);
@@ -80,8 +80,8 @@ public class IntegrationFixture: IAsyncLifetime
         await cmd.ExecuteNonQueryAsync();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        return Task.CompletedTask;
+        return ValueTask.CompletedTask;
     }
 }

--- a/src/Weasel.MySql.Tests/Weasel.MySql.Tests.csproj
+++ b/src/Weasel.MySql.Tests/Weasel.MySql.Tests.csproj
@@ -2,26 +2,16 @@
 
     <PropertyGroup>
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
-      <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="NSubstitute" />
         <PackageReference Include="Shouldly" />
-        <PackageReference Include="xunit" />
-        <PackageReference Include="xunit.runner.visualstudio">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\Weasel.MySql\Weasel.MySql.csproj" />
     </ItemGroup>
 
+    <Import Project="../../Tests.Build.props" />
 </Project>

--- a/src/Weasel.Oracle.Tests/IntegrationContext.cs
+++ b/src/Weasel.Oracle.Tests/IntegrationContext.cs
@@ -5,7 +5,7 @@ using Xunit;
 namespace Weasel.Oracle.Tests;
 
 [Collection("integration")]
-public abstract class IntegrationContext: IDisposable, IAsyncLifetime
+public abstract class IntegrationContext: IAsyncLifetime
 {
     private readonly string _schemaName;
     protected readonly OracleConnection theConnection = new OracleConnection(ConnectionSource.ConnectionString);
@@ -13,11 +13,6 @@ public abstract class IntegrationContext: IDisposable, IAsyncLifetime
     protected IntegrationContext(string schemaName)
     {
         _schemaName = schemaName.ToUpperInvariant();
-    }
-
-    public void Dispose()
-    {
-        theConnection?.Dispose();
     }
 
     protected async Task ResetSchema()
@@ -83,8 +78,12 @@ public abstract class IntegrationContext: IDisposable, IAsyncLifetime
         return ValueTask.CompletedTask;
     }
 
-    public virtual ValueTask DisposeAsync()
+    // Connection teardown lives here, not in an IDisposable.Dispose. xUnit v3's
+    // IAsyncLifetime inherits IAsyncDisposable, and when a test class implements both
+    // IAsyncDisposable and IDisposable, v3 calls DisposeAsync only - so a Dispose()
+    // holding the cleanup would silently never run and leak a connection per test.
+    public virtual async ValueTask DisposeAsync()
     {
-        return ValueTask.CompletedTask;
+        await theConnection.DisposeAsync();
     }
 }

--- a/src/Weasel.Oracle.Tests/IntegrationContext.cs
+++ b/src/Weasel.Oracle.Tests/IntegrationContext.cs
@@ -78,13 +78,13 @@ public abstract class IntegrationContext: IDisposable, IAsyncLifetime
         }
     }
 
-    public virtual Task InitializeAsync()
+    public virtual ValueTask InitializeAsync()
     {
-        return Task.CompletedTask;
+        return ValueTask.CompletedTask;
     }
 
-    public virtual Task DisposeAsync()
+    public virtual ValueTask DisposeAsync()
     {
-        return Task.CompletedTask;
+        return ValueTask.CompletedTask;
     }
 }

--- a/src/Weasel.Oracle.Tests/OracleDbCommandBuilderIntegrationTests.cs
+++ b/src/Weasel.Oracle.Tests/OracleDbCommandBuilderIntegrationTests.cs
@@ -10,7 +10,7 @@ public class OracleDbCommandBuilderIntegrationTests: IAsyncLifetime
 {
     private readonly OracleConnection theConnection = new(ConnectionSource.ConnectionString);
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         await theConnection.OpenAsync();
 
@@ -27,7 +27,7 @@ public class OracleDbCommandBuilderIntegrationTests: IAsyncLifetime
             .ExecuteNonQueryAsync();
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await theConnection.CloseAsync();
         await theConnection.DisposeAsync();

--- a/src/Weasel.Oracle.Tests/Tables/detecting_table_deltas.cs
+++ b/src/Weasel.Oracle.Tests/Tables/detecting_table_deltas.cs
@@ -21,7 +21,7 @@ public class detecting_table_deltas: IntegrationContext
         theTable.AddColumn("data", "CLOB");
     }
 
-    public override async Task InitializeAsync()
+    public override async ValueTask InitializeAsync()
     {
         await ResetSchema();
     }

--- a/src/Weasel.Oracle.Tests/Weasel.Oracle.Tests.csproj
+++ b/src/Weasel.Oracle.Tests/Weasel.Oracle.Tests.csproj
@@ -2,26 +2,16 @@
 
     <PropertyGroup>
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
-        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="NSubstitute" />
         <PackageReference Include="Shouldly" />
-        <PackageReference Include="xunit" />
-        <PackageReference Include="xunit.runner.visualstudio">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\Weasel.Oracle\Weasel.Oracle.csproj" />
     </ItemGroup>
 
+    <Import Project="../../Tests.Build.props" />
 </Project>

--- a/src/Weasel.Postgresql.Tests/Functions/UpsertFunctionTests.cs
+++ b/src/Weasel.Postgresql.Tests/Functions/UpsertFunctionTests.cs
@@ -23,7 +23,7 @@ public class UpsertFunctionTests: IntegrationContext
             "next_value", "hi_value");
     }
 
-    public override async Task InitializeAsync()
+    public override async ValueTask InitializeAsync()
     {
         await ResetSchema();
         await CreateSchemaObjectInDatabase(theHiloTable);

--- a/src/Weasel.Postgresql.Tests/IntegrationContext.cs
+++ b/src/Weasel.Postgresql.Tests/IntegrationContext.cs
@@ -83,13 +83,13 @@ public abstract class IntegrationContext: IDisposable, IAsyncLifetime
             .ExecuteNonQueryAsync();
     }
 
-    public virtual Task InitializeAsync()
+    public virtual ValueTask InitializeAsync()
     {
-        return Task.CompletedTask;
+        return ValueTask.CompletedTask;
     }
 
-    public virtual Task DisposeAsync()
+    public virtual ValueTask DisposeAsync()
     {
-        return Task.CompletedTask;
+        return ValueTask.CompletedTask;
     }
 }

--- a/src/Weasel.Postgresql.Tests/IntegrationContext.cs
+++ b/src/Weasel.Postgresql.Tests/IntegrationContext.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace Weasel.Postgresql.Tests;
 
-public abstract class IntegrationContext: IDisposable, IAsyncLifetime
+public abstract class IntegrationContext: IAsyncLifetime
 {
     protected readonly NpgsqlDataSource theDataSource = NpgsqlDataSource.Create(ConnectionSource.ConnectionString);
     private NpgsqlConnection? connection;
@@ -28,12 +28,6 @@ public abstract class IntegrationContext: IDisposable, IAsyncLifetime
     }
 
     public string SchemaName { get; }
-
-    public void Dispose()
-    {
-        connection?.Dispose();
-        theDataSource.Dispose();
-    }
 
     protected async Task ResetSchema()
     {
@@ -88,8 +82,17 @@ public abstract class IntegrationContext: IDisposable, IAsyncLifetime
         return ValueTask.CompletedTask;
     }
 
-    public virtual ValueTask DisposeAsync()
+    // Connection teardown lives here, not in an IDisposable.Dispose. xUnit v3's
+    // IAsyncLifetime inherits IAsyncDisposable, and when a test class implements both
+    // IAsyncDisposable and IDisposable, v3 calls DisposeAsync only - so a Dispose()
+    // holding the cleanup would silently never run and leak a connection per test.
+    public virtual async ValueTask DisposeAsync()
     {
-        return ValueTask.CompletedTask;
+        if (connection != null)
+        {
+            await connection.DisposeAsync();
+        }
+
+        await theDataSource.DisposeAsync();
     }
 }

--- a/src/Weasel.Postgresql.Tests/Migrations/migration_scenario_tests.cs
+++ b/src/Weasel.Postgresql.Tests/Migrations/migration_scenario_tests.cs
@@ -24,9 +24,9 @@ public class SchemaMigrationTests : IntegrationContext, IAsyncLifetime
         theDatabase = new TestDatabaseWithTables(AutoCreate.None, "Migrations", theDataSource);
     }
 
-    public override Task InitializeAsync()
+    public override ValueTask InitializeAsync()
     {
-        return ResetSchema();
+        return new(ResetSchema());
     }
 
     [Fact]

--- a/src/Weasel.Postgresql.Tests/Migrations/releasing_connection_pools.cs
+++ b/src/Weasel.Postgresql.Tests/Migrations/releasing_connection_pools.cs
@@ -26,7 +26,7 @@ public class releasing_connection_pools: IAsyncLifetime
     private NpgsqlDataSource theDataSource = null!;
     private TestDatabaseWithTables theDatabase = null!;
 
-    public Task InitializeAsync()
+    public ValueTask InitializeAsync()
     {
         var builder = new NpgsqlDataSourceBuilder(ConnectionSource.ConnectionString);
         builder.ConnectionStringBuilder.ApplicationName = theApplicationName;
@@ -34,13 +34,13 @@ public class releasing_connection_pools: IAsyncLifetime
         theDataSource = builder.Build();
         theDatabase = new TestDatabaseWithTables("pool_release", theDataSource);
 
-        return Task.CompletedTask;
+        return ValueTask.CompletedTask;
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
         theDataSource.Dispose();
-        return Task.CompletedTask;
+        return ValueTask.CompletedTask;
     }
 
     [Fact]

--- a/src/Weasel.Postgresql.Tests/Migrations/schema_fingerprint_tests.cs
+++ b/src/Weasel.Postgresql.Tests/Migrations/schema_fingerprint_tests.cs
@@ -24,7 +24,7 @@ public class schema_fingerprint_tests: IntegrationContext, IAsyncLifetime
         theDatabase = new TestDatabaseWithTables(AutoCreate.CreateOrUpdate, "Fingerprint", theDataSource);
     }
 
-    public override async Task InitializeAsync()
+    public override async ValueTask InitializeAsync()
     {
         await ResetSchema();
 

--- a/src/Weasel.Postgresql.Tests/PgVersionTargetedFact.cs
+++ b/src/Weasel.Postgresql.Tests/PgVersionTargetedFact.cs
@@ -1,94 +1,102 @@
 using Npgsql;
 using Shouldly;
 using Xunit;
-using Xunit.Abstractions;
-using Xunit.Sdk;
 
 namespace Weasel.Postgresql.Tests;
+
+/// <summary>
+/// The PostgreSQL server version the suite is running against. Resolved once, since it
+/// cannot change during a test run.
+/// </summary>
+public static class PgVersion
+{
+    public static readonly Version Current;
+
+    static PgVersion()
+    {
+        var versionFromEnv = Environment.GetEnvironmentVariable("postgresql_version");
+        if (!string.IsNullOrEmpty(versionFromEnv))
+        {
+            Current = Version.Parse(versionFromEnv);
+            return;
+        }
+
+        using var c = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        c.Open();
+        Current = c.PostgreSqlVersion;
+        c.Close();
+    }
+
+    /// <summary>
+    /// The reason a test constrained to this version range should be skipped on the
+    /// current server, or null when the server is inside the range.
+    /// </summary>
+    public static string? SkipReason(string? minimumVersion, string? maximumVersion)
+    {
+        if (minimumVersion != null && Version.TryParse(minimumVersion, out var minVersion) && Current < minVersion)
+        {
+            return $"Minimum required PG version {minimumVersion} is higher than {Current}";
+        }
+
+        if (maximumVersion != null && Version.TryParse(maximumVersion, out var maxVersion) && Current > maxVersion)
+        {
+            return $"Maximum allowed PG version {maximumVersion} is higher than {Current}";
+        }
+
+        return null;
+    }
+}
 
 /// <summary>
 /// Allows targeting test at specified minimum and/or maximum version of PG
 /// </summary>
 [AttributeUsage(AttributeTargets.Method)]
-[XunitTestCaseDiscoverer("Weasel.Postgresql.Tests.PgVersionTargetedFactDiscoverer", "Weasel.Postgresql.Tests")]
 public sealed class PgVersionTargetedFact: FactAttribute
 {
-    public string MinimumVersion { get; set; }
-    public string MaximumVersion { get; set; }
-}
+    private string? _minimumVersion;
+    private string? _maximumVersion;
 
-public sealed class PgVersionTargetedFactDiscoverer: FactDiscoverer
-{
-    internal static readonly Version Version;
-
-    static PgVersionTargetedFactDiscoverer()
+    public string? MinimumVersion
     {
-        var versionFromEnv = Environment.GetEnvironmentVariable("postgresql_version");
-        if (!string.IsNullOrEmpty(versionFromEnv))
+        get => _minimumVersion;
+        set
         {
-            Version = Version.Parse(versionFromEnv);
-            return;
+            _minimumVersion = value;
+            ApplyVersionGate();
         }
-
-        // PG version does not change during test run so we can do static ctor
-        using var c = new NpgsqlConnection(ConnectionSource.ConnectionString);
-        c.Open();
-        Version = c.PostgreSqlVersion;
-        c.Close();
     }
 
-    public PgVersionTargetedFactDiscoverer(IMessageSink diagnosticMessageSink): base(diagnosticMessageSink)
+    public string? MaximumVersion
     {
+        get => _maximumVersion;
+        set
+        {
+            _maximumVersion = value;
+            ApplyVersionGate();
+        }
     }
 
-    public override IEnumerable<IXunitTestCase> Discover(ITestFrameworkDiscoveryOptions discoveryOptions,
-        ITestMethod testMethod,
-        IAttributeInfo factAttribute)
+    // Replaces the v2 custom discoverer that handed back a pre-skipped XunitTestCase.
+    // v3 removed that extensibility point but seals FactAttribute.Skip rather than
+    // making it virtual, so the gate is applied as each named argument is assigned -
+    // which happens after construction, hence re-running on both setters. v3
+    // instantiates the attribute and reads Skip off the instance, so this is seen.
+    // Only ever sets Skip, never clears it, so an explicit Skip = "..." survives.
+    private void ApplyVersionGate()
     {
-        var minimumVersion = factAttribute.GetNamedArgument<string>(nameof(PgVersionTargetedFact.MinimumVersion));
-        var maximumVersion = factAttribute.GetNamedArgument<string>(nameof(PgVersionTargetedFact.MaximumVersion));
-
-        if (minimumVersion != null && Version.TryParse(minimumVersion, out var minVersion) && Version < minVersion)
+        var reason = PgVersion.SkipReason(_minimumVersion, _maximumVersion);
+        if (reason != null)
         {
-            yield return new TestCaseSkippedDueToVersion(
-                $"Minimum required PG version {minimumVersion} is higher than {Version}", DiagnosticMessageSink,
-                discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(),
-                testMethod);
-        }
-
-        if (maximumVersion != null && Version.TryParse(maximumVersion, out var maxVersion) && Version > maxVersion)
-        {
-            yield return new TestCaseSkippedDueToVersion(
-                $"Maximum allowed PG version {maximumVersion} is higher than {Version}", DiagnosticMessageSink,
-                discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(),
-                testMethod);
-        }
-
-        yield return base.CreateTestCase(discoveryOptions, testMethod, factAttribute);
-    }
-
-    internal sealed class TestCaseSkippedDueToVersion: XunitTestCase
-    {
-        [Obsolete("Called by the de-serializer", true)]
-        public TestCaseSkippedDueToVersion()
-        {
-        }
-
-        public TestCaseSkippedDueToVersion(string skipReason, IMessageSink diagnosticMessageSink,
-            TestMethodDisplay defaultMethodDisplay, TestMethodDisplayOptions defaultMethodDisplayOptions,
-            ITestMethod testMethod, object[] testMethodArguments = null): base(diagnosticMessageSink,
-            defaultMethodDisplay, defaultMethodDisplayOptions, testMethod, testMethodArguments)
-        {
-            SkipReason = skipReason;
+            Skip = reason;
         }
     }
 }
 
-public class PgVersionTargetedFactDiscovererTests
+public class PgVersionTests
 {
     [Fact]
-    public void PgVersionTargetedFactDiscoverer_CanConnectToDatabase()
+    public void PgVersion_CanConnectToDatabase()
     {
-        PgVersionTargetedFactDiscoverer.Version.ShouldNotBe(default);
+        PgVersion.Current.ShouldNotBe(default);
     }
 }

--- a/src/Weasel.Postgresql.Tests/PgVersionTargetedTheory.cs
+++ b/src/Weasel.Postgresql.Tests/PgVersionTargetedTheory.cs
@@ -1,8 +1,5 @@
-using Npgsql;
 using Shouldly;
 using Xunit;
-using Xunit.Abstractions;
-using Xunit.Sdk;
 
 namespace Weasel.Postgresql.Tests;
 
@@ -10,86 +7,49 @@ namespace Weasel.Postgresql.Tests;
 /// Allows targeting test at specified minimum and/or maximum version of PG
 /// </summary>
 [AttributeUsage(AttributeTargets.Method)]
-[XunitTestCaseDiscoverer("Weasel.Postgresql.Tests.PgVersionTargetedTheoryDiscoverer", "Weasel.Postgresql.Tests")]
 public sealed class PgVersionTargetedTheory: TheoryAttribute
 {
-    public string MinimumVersion { get; set; }
-    public string MaximumVersion { get; set; }
-}
+    private string? _minimumVersion;
+    private string? _maximumVersion;
 
-public sealed class PgVersionTargetedTheoryDiscoverer: TheoryDiscoverer
-{
-    internal static readonly Version Version;
-
-    static PgVersionTargetedTheoryDiscoverer()
+    public string? MinimumVersion
     {
-        // PG version does not change during test run so we can do static ctor
-        using var c = new NpgsqlConnection(ConnectionSource.ConnectionString);
-        c.Open();
-        Version = c.PostgreSqlVersion;
-        c.Close();
+        get => _minimumVersion;
+        set
+        {
+            _minimumVersion = value;
+            ApplyVersionGate();
+        }
     }
 
-    public PgVersionTargetedTheoryDiscoverer(IMessageSink diagnosticMessageSink): base(diagnosticMessageSink)
+    public string? MaximumVersion
     {
+        get => _maximumVersion;
+        set
+        {
+            _maximumVersion = value;
+            ApplyVersionGate();
+        }
     }
 
-    public override IEnumerable<IXunitTestCase> Discover(ITestFrameworkDiscoveryOptions discoveryOptions,
-        ITestMethod testMethod,
-        IAttributeInfo theoryAttribute)
+    // See the note on PgVersionTargetedFact.ApplyVersionGate.
+    private void ApplyVersionGate()
     {
-        var minimumVersion = theoryAttribute.GetNamedArgument<string>(nameof(PgVersionTargetedTheory.MinimumVersion));
-        var maximumVersion = theoryAttribute.GetNamedArgument<string>(nameof(PgVersionTargetedTheory.MaximumVersion));
-
-        if (minimumVersion != null && Version.TryParse(minimumVersion, out var minVersion) && Version < minVersion)
+        var reason = PgVersion.SkipReason(_minimumVersion, _maximumVersion);
+        if (reason != null)
         {
-            return new[]
-            {
-                new TestCaseSkippedDueToVersion(
-                    $"Minimum required PG version {minimumVersion} is higher than {Version}", DiagnosticMessageSink,
-                    discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(),
-                    testMethod)
-            };
-        }
-
-        if (maximumVersion != null && Version.TryParse(maximumVersion, out var maxVersion) && Version > maxVersion)
-        {
-            return new[]
-            {
-                new TestCaseSkippedDueToVersion(
-                    $"Maximum allowed PG version {maximumVersion} is higher than {Version}", DiagnosticMessageSink,
-                    discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(),
-                    testMethod)
-            };
-        }
-
-        return CreateTestCasesForTheory(discoveryOptions, testMethod, theoryAttribute);
-    }
-
-    internal sealed class TestCaseSkippedDueToVersion: XunitTestCase
-    {
-        [Obsolete("Called by the de-serializer", true)]
-        public TestCaseSkippedDueToVersion()
-        {
-        }
-
-        public TestCaseSkippedDueToVersion(string skipReason, IMessageSink diagnosticMessageSink,
-            TestMethodDisplay defaultMethodDisplay, TestMethodDisplayOptions defaultMethodDisplayOptions,
-            ITestMethod testMethod, object[] testMethodArguments = null): base(diagnosticMessageSink,
-            defaultMethodDisplay, defaultMethodDisplayOptions, testMethod, testMethodArguments)
-        {
-            SkipReason = skipReason;
+            Skip = reason;
         }
     }
 }
 
-public class PgVersionTargetedTheoryDiscovererTests
+public class PgVersionTargetedTheoryTests
 {
     [Theory]
     [InlineData("test1")]
     [InlineData("test2")]
-    public void PgVersionTargetedTheoryDiscoverer_CanConnectToDatabase(string ignore)
+    public void PgVersionTargetedTheory_CanConnectToDatabase(string ignore)
     {
-        PgVersionTargetedTheoryDiscoverer.Version.ShouldNotBe(default);
+        PgVersion.Current.ShouldNotBe(default);
     }
 }

--- a/src/Weasel.Postgresql.Tests/Tables/Indexes/IndexDeltasDetectionContext.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/Indexes/IndexDeltasDetectionContext.cs
@@ -9,8 +9,8 @@ public abstract class IndexDeltasDetectionContext: IntegrationContext
     protected Table theTable;
     protected Table theOtherTable;
 
-    public override Task InitializeAsync() =>
-        ResetSchema();
+    public override ValueTask InitializeAsync() =>
+        new(ResetSchema());
 
     protected IndexDeltasDetectionContext(string schemaName, string tableName = "people"): base(schemaName)
     {

--- a/src/Weasel.Postgresql.Tests/Tables/TableTests.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/TableTests.cs
@@ -4,7 +4,6 @@ using Shouldly;
 using Weasel.Core;
 using Weasel.Postgresql.Tables;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Weasel.Postgresql.Tests.Tables;
 

--- a/src/Weasel.Postgresql.Tests/Tables/column_drift_detection.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/column_drift_detection.cs
@@ -17,7 +17,7 @@ public class column_drift_detection: IntegrationContext
     {
     }
 
-    public override Task InitializeAsync() => ResetSchema();
+    public override ValueTask InitializeAsync() => new(ResetSchema());
 
     private async Task AssertNoDeltasAfterPatching(Table table)
     {

--- a/src/Weasel.Postgresql.Tests/Tables/computed_columns.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/computed_columns.cs
@@ -17,7 +17,7 @@ public class computed_columns: IntegrationContext
     {
     }
 
-    public override Task InitializeAsync() => ResetSchema();
+    public override ValueTask InitializeAsync() => new(ResetSchema());
 
     private async Task AssertNoDeltasAfterPatching(Table table)
     {

--- a/src/Weasel.Postgresql.Tests/Tables/mixed_case_table_with_index.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/mixed_case_table_with_index.cs
@@ -32,7 +32,7 @@ public class mixed_case_table_with_index : IntegrationContext
         });
     }
 
-    public override Task InitializeAsync() => ResetSchema();
+    public override ValueTask InitializeAsync() => new(ResetSchema());
 
     [Fact]
     public async Task should_detect_no_delta_after_creating_table_with_unique_index()

--- a/src/Weasel.Postgresql.Tests/Tables/partitioning/foreign_keys_to_partitioned_tables.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/partitioning/foreign_keys_to_partitioned_tables.cs
@@ -22,7 +22,7 @@ public class foreign_keys_to_partitioned_tables: IntegrationContext
     {
     }
 
-    public override async Task InitializeAsync()
+    public override async ValueTask InitializeAsync()
     {
         await ResetSchema();
     }

--- a/src/Weasel.Postgresql.Tests/Tables/partitioning/managed_list_partitions.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/partitioning/managed_list_partitions.cs
@@ -18,6 +18,14 @@ public class managed_list_partitions : IntegrationContext
 
     }
 
+    // Every test here works against the same "managed_lists" schema, and
+    // migrate_tables_smoke_test_with_variable_value_and_tenant_id is purely additive -
+    // its ResetValues call is commented out deliberately - so it asserts on whatever
+    // partitions the previously executed test happened to leave behind. That held only
+    // because of the order xUnit v2 ran these in. Resetting the schema per test makes
+    // all of them independent of execution order.
+    public override ValueTask InitializeAsync() => new(ResetSchema());
+
     [Fact]
     public async Task can_load_values_smoke_test()
     {

--- a/src/Weasel.Postgresql.Tests/Tables/pk_migration_with_referencing_fks.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/pk_migration_with_referencing_fks.cs
@@ -18,7 +18,7 @@ public class pk_migration_with_referencing_fks : IntegrationContext
     {
     }
 
-    public override async Task InitializeAsync()
+    public override async ValueTask InitializeAsync()
     {
         await ResetSchema();
     }

--- a/src/Weasel.Postgresql.Tests/TestSetup.cs
+++ b/src/Weasel.Postgresql.Tests/TestSetup.cs
@@ -1,15 +1,20 @@
-using Xunit;
-using Xunit.Abstractions;
-using Xunit.Sdk;
-
-[assembly: TestFramework("Weasel.Postgresql.Tests.TestSetup", "Weasel.Postgresql.Tests")]
+using System.Runtime.CompilerServices;
 
 namespace Weasel.Postgresql.Tests;
 
-public class TestSetup: XunitTestFramework
+/// <summary>
+/// The Postgres CI matrix runs the whole suite twice, once with case-sensitive
+/// qualified names and once without, selected by an environment variable.
+/// </summary>
+/// <remarks>
+/// This was a custom xUnit v2 TestFramework. v3 reshaped that extensibility point,
+/// and a module initializer is a better fit anyway: it needs no test-framework hook,
+/// and it runs before discovery rather than alongside it.
+/// </remarks>
+internal static class TestSetup
 {
-    public TestSetup(IMessageSink messageSink)
-        : base(messageSink)
+    [ModuleInitializer]
+    internal static void Initialize()
     {
         if (bool.TryParse(
                 Environment.GetEnvironmentVariable("USE_CASE_SENSITIVE_QUALIFIED_NAMES"),

--- a/src/Weasel.Postgresql.Tests/Views/ViewTests.cs
+++ b/src/Weasel.Postgresql.Tests/Views/ViewTests.cs
@@ -3,7 +3,6 @@ using Shouldly;
 using Weasel.Core;
 using Weasel.Postgresql.Views;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Weasel.Postgresql.Tests.Views;
 

--- a/src/Weasel.Postgresql.Tests/Weasel.Postgresql.Tests.csproj
+++ b/src/Weasel.Postgresql.Tests/Weasel.Postgresql.Tests.csproj
@@ -2,28 +2,18 @@
 
     <PropertyGroup>
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
-        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="Npgsql" VersionOverride="10.0.0" />
         <PackageReference Include="Npgsql.NetTopologySuite" VersionOverride="10.0.0" />
         <PackageReference Include="NSubstitute" />
         <PackageReference Include="Shouldly" />
-        <PackageReference Include="xunit" />
-        <PackageReference Include="xunit.runner.visualstudio">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\Weasel.Postgresql\Weasel.Postgresql.csproj" />
     </ItemGroup>
 
+    <Import Project="../../Tests.Build.props" />
 </Project>

--- a/src/Weasel.Postgresql.Tests/advisory_lock_usage.cs
+++ b/src/Weasel.Postgresql.Tests/advisory_lock_usage.cs
@@ -145,14 +145,14 @@ public class AdvisoryLockSpecs : IAsyncLifetime
     private NpgsqlDataSource _database = null!;
     private AdvisoryLock theLock = null!;
 
-    public Task InitializeAsync()
+    public ValueTask InitializeAsync()
     {
         _database = NpgsqlDataSource.Create(ConnectionSource.ConnectionString);
         theLock = new AdvisoryLock(_database, NullLogger.Instance, "localhost", new AdvisoryLockOptions());
-        return Task.CompletedTask;
+        return ValueTask.CompletedTask;
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await theLock.DisposeAsync();
         await _database.DisposeAsync();

--- a/src/Weasel.SqlServer.Tests/IntegrationContext.cs
+++ b/src/Weasel.SqlServer.Tests/IntegrationContext.cs
@@ -5,7 +5,7 @@ using Xunit;
 namespace Weasel.SqlServer.Tests;
 
 [Collection("integration")]
-public abstract class IntegrationContext: IDisposable, IAsyncLifetime
+public abstract class IntegrationContext: IAsyncLifetime
 {
     private readonly string _schemaName;
     protected readonly SqlConnection theConnection = new SqlConnection(ConnectionSource.ConnectionString);
@@ -13,11 +13,6 @@ public abstract class IntegrationContext: IDisposable, IAsyncLifetime
     protected IntegrationContext(string schemaName)
     {
         _schemaName = schemaName;
-    }
-
-    public void Dispose()
-    {
-        theConnection?.Dispose();
     }
 
     protected async Task ResetSchema()
@@ -59,8 +54,12 @@ public abstract class IntegrationContext: IDisposable, IAsyncLifetime
         return ValueTask.CompletedTask;
     }
 
-    public virtual ValueTask DisposeAsync()
+    // Connection teardown lives here, not in an IDisposable.Dispose. xUnit v3's
+    // IAsyncLifetime inherits IAsyncDisposable, and when a test class implements both
+    // IAsyncDisposable and IDisposable, v3 calls DisposeAsync only - so a Dispose()
+    // holding the cleanup would silently never run and leak a connection per test.
+    public virtual async ValueTask DisposeAsync()
     {
-        return ValueTask.CompletedTask;
+        await theConnection.DisposeAsync();
     }
 }

--- a/src/Weasel.SqlServer.Tests/IntegrationContext.cs
+++ b/src/Weasel.SqlServer.Tests/IntegrationContext.cs
@@ -54,13 +54,13 @@ public abstract class IntegrationContext: IDisposable, IAsyncLifetime
             .ExecuteNonQueryAsync();
     }
 
-    public virtual Task InitializeAsync()
+    public virtual ValueTask InitializeAsync()
     {
-        return Task.CompletedTask;
+        return ValueTask.CompletedTask;
     }
 
-    public virtual Task DisposeAsync()
+    public virtual ValueTask DisposeAsync()
     {
-        return Task.CompletedTask;
+        return ValueTask.CompletedTask;
     }
 }

--- a/src/Weasel.SqlServer.Tests/Procedures/StoredProcedureTests.cs
+++ b/src/Weasel.SqlServer.Tests/Procedures/StoredProcedureTests.cs
@@ -67,7 +67,7 @@ AS
 ");
     }
 
-    public override async Task InitializeAsync()
+    public override async ValueTask InitializeAsync()
     {
         await ResetSchema();
 

--- a/src/Weasel.SqlServer.Tests/Tables/TableTests.cs
+++ b/src/Weasel.SqlServer.Tests/Tables/TableTests.cs
@@ -4,7 +4,6 @@ using Shouldly;
 using Weasel.Core;
 using Weasel.SqlServer.Tables;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Weasel.SqlServer.Tests.Tables;
 

--- a/src/Weasel.SqlServer.Tests/Tables/column_drift_detection.cs
+++ b/src/Weasel.SqlServer.Tests/Tables/column_drift_detection.cs
@@ -17,7 +17,7 @@ public class column_drift_detection: IntegrationContext
     {
     }
 
-    public override Task InitializeAsync() => ResetSchema();
+    public override ValueTask InitializeAsync() => new(ResetSchema());
 
     private async Task AssertNoDeltasAfterPatching(Table table)
     {

--- a/src/Weasel.SqlServer.Tests/Tables/computed_columns.cs
+++ b/src/Weasel.SqlServer.Tests/Tables/computed_columns.cs
@@ -17,7 +17,7 @@ public class computed_columns: IntegrationContext
     {
     }
 
-    public override Task InitializeAsync() => ResetSchema();
+    public override ValueTask InitializeAsync() => new(ResetSchema());
 
     private async Task AssertNoDeltasAfterPatching(Table table)
     {

--- a/src/Weasel.SqlServer.Tests/Tables/detecting_table_deltas.cs
+++ b/src/Weasel.SqlServer.Tests/Tables/detecting_table_deltas.cs
@@ -22,7 +22,7 @@ public class detecting_table_deltas: IntegrationContext
         theTable.AddColumn("data", "text");
     }
 
-    public override async Task InitializeAsync()
+    public override async ValueTask InitializeAsync()
     {
         await ResetSchema();
     }

--- a/src/Weasel.SqlServer.Tests/Weasel.SqlServer.Tests.csproj
+++ b/src/Weasel.SqlServer.Tests/Weasel.SqlServer.Tests.csproj
@@ -2,22 +2,11 @@
 
     <PropertyGroup>
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
-      <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="NSubstitute" />
         <PackageReference Include="Shouldly" />
-        <PackageReference Include="xunit" />
-        <PackageReference Include="xunit.runner.visualstudio">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>
@@ -28,4 +17,5 @@
       <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>
 
+    <Import Project="../../Tests.Build.props" />
 </Project>

--- a/src/Weasel.SqlServer.Tests/advisory_lock_usage.cs
+++ b/src/Weasel.SqlServer.Tests/advisory_lock_usage.cs
@@ -148,14 +148,14 @@ public class AdvisoryLockSpecs : IAsyncLifetime
 {
     private AdvisoryLock theLock;
 
-    public Task InitializeAsync()
+    public ValueTask InitializeAsync()
     {
 
         theLock = new AdvisoryLock(() => new SqlConnection(ConnectionSource.ConnectionString), NullLogger.Instance, "Testing");
-        return Task.CompletedTask;
+        return ValueTask.CompletedTask;
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await theLock.DisposeAsync();
     }

--- a/src/Weasel.Sqlite.Tests/Weasel.Sqlite.Tests.csproj
+++ b/src/Weasel.Sqlite.Tests/Weasel.Sqlite.Tests.csproj
@@ -2,26 +2,16 @@
 
     <PropertyGroup>
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
-        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="NSubstitute" />
         <PackageReference Include="Shouldly" />
-        <PackageReference Include="xunit" />
-        <PackageReference Include="xunit.runner.visualstudio">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\Weasel.Sqlite\Weasel.Sqlite.csproj" />
     </ItemGroup>
 
+    <Import Project="../../Tests.Build.props" />
 </Project>


### PR DESCRIPTION
Converts all eight test projects from xUnit 2.9.3 to xUnit v3 (3.2.2), and cleans up the CI matrices along the way. Eight commits, one per phase, so the diff can be read in order.

## What changed

**Packages.** `xunit` 2.9.3 → `xunit.v3` 3.2.2, `xunit.runner.visualstudio` 2.8.2 → 3.1.5, `Microsoft.NET.Test.Sdk` 17.12.0 → 17.14.1. Staying on the 17.x VSTest line means CI test invocations are unchanged — the migration is the only variable.

New `Tests.Build.props` at the repo root (mirroring `Analysis.Build.props`) carries `OutputType=Exe` — required for self-executing v3 test assemblies — plus the runner packages, replacing the same block duplicated across eight csproj files.

**xunit.analyzers are disabled** via `ExcludeAssets="analyzers"`. This suite predates them, and xUnit1051 alone (pass `TestContext.Current.CancellationToken` to async calls) fires on hundreds of async database calls. Adopting them is worthwhile follow-up work, deliberately not bundled here.

**Source changes** are the two mechanical v3 breaks: 60 `IAsyncLifetime` members move from `Task` to `ValueTask` (v3's `IAsyncLifetime` inherits `IAsyncDisposable`), and the `Xunit.Abstractions` namespace is gone — the three files using it only wanted `ITestOutputHelper`, now in `Xunit`.

**The Postgres extensibility rewrite** is the only non-mechanical part. That project had a custom assembly-level `TestFramework` and custom Fact/Theory discoverers built on `XunitTestCaseDiscoverer(string, string)`, `IAttributeInfo`, `IMessageSink` and `XunitTestCase` subclassing — all removed in v3.

- `TestSetup` becomes a `[ModuleInitializer]`. Its only job was reading `USE_CASE_SENSITIVE_QUALIFIED_NAMES`; it now needs no test-framework hook and runs before discovery rather than alongside it.
- `PgVersionTargetedFact` / `PgVersionTargetedTheory` compute their own skip reason, dropping ~120 lines of discoverer plumbing. All 15 call sites are untouched. v3 seals `FactAttribute.Skip` rather than making it virtual, so the gate is applied from the `MinimumVersion`/`MaximumVersion` setters; this was confirmed empirically before being relied on.
- Version detection is consolidated into one `PgVersion` type. The v2 *theory* discoverer, unlike the fact discoverer, ignored the `postgresql_version` environment variable and always opened a connection. Both honour it now.

**DocSamples** is not a test project — it holds compilable mdsnippets sources and contains no xunit code at all, so its test packages are removed rather than migrated. Removing `Microsoft.NET.Test.Sdk` exposed that it was the thing generating an entry point for this Web SDK project, which has no `Main`; it now declares `OutputType=Library`, which is what it always was in practice.

## CI

The test invocations needed no changes for v3. What this cleans up is CI that was already wrong:

- **The `net8.0` matrix legs were vacuous, not merely dead.** `net8.0` was dropped from `Directory.Build.props` in the 9.0 bootstrap (a06f65a), but five workflows kept a `net8.0` leg. Verified locally that `dotnet test --framework net8.0` against a net9.0/net10.0 project **exits 0 having run zero tests and printing nothing** — so a third of the matrix has been reporting success while testing nothing.
- **`disable_test_parallelization` was read by nothing** — not by any test, csproj or props file. Parallelization is actually controlled by `SqlServer.Tests/xunit.runner.json` and the `DisableParallelization` collection definitions, both of which v3 still honours (verified: v3 reports `parallel test collections = off`).
- The sqlite and efcore workflows, which predate this change and were never listed, are added to the solution's Build folder.

## Verification

Discovered test counts are **identical to the v2 baseline** for all eight suites: Core 21, Sqlite 361, CommandLine 23, MySql 199, Oracle 186, SqlServer 321, EF Core 107, Postgresql 719.

Core and Sqlite — the two suites with no database dependency — execute green on both net9.0 and net10.0. The version-gating rewrite was checked against pre-migration master in a worktree: with `postgresql_version=9.0`, the six `MinimumVersion="10.0"` tests report 6 skipped / 0 run under both v2 and v3.

**The six database-backed suites have not been executed locally** — the local Docker daemon is returning a client/server API mismatch, so PostgreSQL, SQL Server, Oracle and MySQL could not be started. They compile and discover correctly, but their first real execution will be in CI on this PR. Worth a look at the checks before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)