### PR TITLE
Fix Oracle EF Core mapping test and run the Oracle suite in CI (#394)

### DIFF
--- a/.github/workflows/ci-build-efcore.yml
+++ b/.github/workflows/ci-build-efcore.yml
@@ -16,7 +16,8 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Oracle takes several minutes to become healthy on the net9.0 leg
+    timeout-minutes: 45
 
     strategy:
         matrix:
@@ -61,6 +62,15 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
+    # Oracle needs the init SQL in docker/oracle mounted to grant the weasel user
+    # its schema privileges, which a GitHub service container cannot do - so it
+    # comes up through docker compose, the same way ci-build-oracle.yml does it.
+    # Only net9.0 needs it: the Oracle EF provider has no net10.0 support, so the
+    # Oracle test folder is excluded from that build entirely.
+    - name: Start Oracle via docker-compose
+      if: matrix.framework == 'net9.0'
+      run: docker compose up -d oracle
+
     - name: Install .NET
       uses: actions/setup-dotnet@v5
       with:
@@ -74,8 +84,21 @@ jobs:
     - name: Build
       run: dotnet build src/Weasel.EntityFrameworkCore.Tests/Weasel.EntityFrameworkCore.Tests.csproj --no-restore --framework ${{ matrix.framework }}
 
-    # The Oracle EF provider has no database service in this workflow; its
-    # end-to-end suite only runs locally against docker-compose. MySql tests
-    # exist on net9.0 only (the provider does not yet support net10.0).
+    # Waiting here rather than straight after `up -d` lets Oracle warm up during
+    # the SDK install, restore and build.
+    - name: Wait for Oracle to be healthy
+      if: matrix.framework == 'net9.0'
+      run: |
+        echo "Waiting for Oracle to be ready..."
+        timeout 300 bash -c 'until docker compose exec -T oracle healthcheck.sh; do sleep 10; done'
+        echo "Oracle is ready"
+
+    # No test filter: the Oracle and MySql suites are compiled out of the net10.0
+    # build (neither provider supports it yet), so each framework runs everything
+    # it actually built.
     - name: Test
-      run: dotnet test src/Weasel.EntityFrameworkCore.Tests/Weasel.EntityFrameworkCore.Tests.csproj --no-build --verbosity normal --framework ${{ matrix.framework }} --filter "FullyQualifiedName!~Oracle"
+      run: dotnet test src/Weasel.EntityFrameworkCore.Tests/Weasel.EntityFrameworkCore.Tests.csproj --no-build --verbosity normal --framework ${{ matrix.framework }}
+
+    - name: Stop Oracle
+      if: always() && matrix.framework == 'net9.0'
+      run: docker compose down

--- a/src/Weasel.EntityFrameworkCore.Tests/Oracle/end_to_end.cs
+++ b/src/Weasel.EntityFrameworkCore.Tests/Oracle/end_to_end.cs
@@ -47,34 +47,41 @@ public class end_to_end : IAsyncLifetime
         var table = migrator.MapToTable(entityType);
 
         table.ShouldNotBeNull();
-        // Oracle uses uppercase identifiers by default
         table.Identifier.Name.ShouldBe("MY_ENTITIES");
 
-        // Oracle lowercases column names in Weasel
-        // Verify columns are mapped
-        table.HasColumn("id").ShouldBeTrue();
-        table.HasColumn("intvalue").ShouldBeTrue();
-        table.HasColumn("boolvalue").ShouldBeTrue();
-        table.HasColumn("stringvalue").ShouldBeTrue();
-        table.HasColumn("guidvalue").ShouldBeTrue();
-        table.HasColumn("dateonlyvalue").ShouldBeTrue();
-        table.HasColumn("timeonlyvalue").ShouldBeTrue();
-        table.HasColumn("datetimevalue").ShouldBeTrue();
-        table.HasColumn("dt_offset_val").ShouldBeTrue();
-        table.HasColumn("cascade_val").ShouldBeTrue();
+        // MapToTable sets PreserveIdentifierCase, so column names carry EF Core's
+        // casing verbatim: the names configured via HasColumnName() where the model
+        // gives one, and the CLR property name otherwise. Nothing is lowercased.
+        //
+        // Asserting the whole set, rather than a series of HasColumn() calls, is
+        // deliberate. Oracle's Table compares names with OrdinalIgnoreCase, so
+        // HasColumn("intvalue") succeeds against a column named "IntValue" and
+        // proves nothing about casing - which is how this test came to assert a
+        // lowercase "id" that the mapping has never produced (weasel#394).
+        table.Columns.Select(x => x.Name).OrderBy(x => x, StringComparer.Ordinal)
+            .ShouldBe([
+                "BoolValue",
+                "CASCADE_VAL",
+                "DT_OFFSET_VAL",
+                "DateOnlyValue",
+                "DateTimeValue",
+                "GuidValue",
+                "Id",
+                "IntValue",
+                "NULL_BOOL_VAL",
+                "NULL_CASCADE_VAL",
+                "NULL_DATE_VAL",
+                "NULL_DT_OFFSET_VAL",
+                "NULL_DT_VAL",
+                "NULL_GUID_VAL",
+                "NULL_INT_VAL",
+                "NULL_TIME_VAL",
+                "StringValue",
+                "TimeOnlyValue"
+            ]);
 
-        // Verify nullable columns (using Oracle-specific short names, lowercased)
-        table.HasColumn("null_int_val").ShouldBeTrue();
-        table.HasColumn("null_bool_val").ShouldBeTrue();
-        table.HasColumn("null_guid_val").ShouldBeTrue();
-        table.HasColumn("null_date_val").ShouldBeTrue();
-        table.HasColumn("null_time_val").ShouldBeTrue();
-        table.HasColumn("null_dt_val").ShouldBeTrue();
-        table.HasColumn("null_dt_offset_val").ShouldBeTrue();
-        table.HasColumn("null_cascade_val").ShouldBeTrue();
-
-        // Verify primary key
-        table.PrimaryKeyColumns.ShouldContain("id");
+        // MyEntity.Id has no HasColumnName(), so the key column is EF's "Id"
+        table.PrimaryKeyColumns.ShouldBe(["Id"]);
         table.PrimaryKeyName.ShouldBe("PK_MY_ENTITIES");
     }
 


### PR DESCRIPTION
Fixes #394. Two parts: the failing assertion, and the CI gap that let it stay failing.

## 1. The test asserted a casing the mapping never produced

`Oracle.end_to_end.can_map_entity_to_table` failed against a live Oracle instance:

```
Shouldly.ShouldAssertException : table.PrimaryKeyColumns
    should contain "id"
    but was actually ["Id"]
```

There is no product bug. `MapToTable` sets `PreserveIdentifierCase = true` deliberately, so column names carry EF Core's casing verbatim. Dumping the mapped table confirms it:

```
Id, BoolValue, CASCADE_VAL, DateOnlyValue, DT_OFFSET_VAL, DateTimeValue,
GuidValue, IntValue, NULL_*, StringValue, TimeOnlyValue
```

Columns take the name given to `HasColumnName()` where the model configures one, and the CLR property name otherwise. Nothing is lowercased. `MyEntity.Id` has no `HasColumnName()`, so `PrimaryKeyColumns` returning `["Id"]` is correct.

My initial reading in #394 — that `PrimaryKeyColumns` was failing to lowercase along with the other columns — was mistaken, and I have corrected the issue.

**Why it went unnoticed, and why this is not a one-character fix.** `Weasel.Oracle`'s `Table` compares names with `OrdinalIgnoreCase`, and `HasColumn` uses that comparison, so

```csharp
table.HasColumn("intvalue").ShouldBeTrue();
```

succeeds against a column actually named `"IntValue"` — and would succeed for any casing whatsoever. The test held fourteen assertions that could not fail plus one case-sensitive assertion written against a convention the code never had. Flipping `"id"` to `"Id"` would leave it just as unable to catch a casing regression, so the `HasColumn` series is replaced with a single assertion on the full column-name set, and the `// Oracle lowercases column names in Weasel` comment is corrected.

## 2. CI could not see any of this

`ci-build-efcore.yml` ran with `--filter "FullyQualifiedName!~Oracle"` because the workflow had no Oracle service, so the `Oracle/` folder never executed. Fixing the assertion without fixing that would leave the next Oracle EF regression equally invisible.

Oracle now comes up through docker compose rather than as a GitHub service container, matching `ci-build-oracle.yml` — the container needs `docker/oracle` mounted as init SQL to grant the `weasel` user its schema privileges, which a service container cannot do.

- Scoped to the **net9.0 leg only**. The Oracle EF provider has no net10.0 support, so the csproj already compiles that folder out of the net10.0 build; starting a database it cannot use would only add several minutes.
- The start step runs before the SDK install and the health wait after the build, so Oracle warms up during restore and build instead of blocking on its own.
- Job timeout raised to 45 minutes to match `ci-build-oracle.yml`, with `docker compose down` on `if: always()`.
- The filter is dropped entirely rather than narrowed: with Oracle available on net9.0, and both the Oracle and MySql folders compiled out of net10.0, each framework runs everything it actually built.

## Verification

Locally against Docker: EF Core Oracle tests 3 passed / 1 skipped — the skip is the pre-existing `ORA-03048` one, untouched — and `Weasel.Oracle.Tests` 186 passed on both net9.0 and net10.0.

**The CI wiring itself can only be verified in CI**, since this is the first time these tests will run there. The EF Core net9.0 check on this PR is the real test of part 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)