### PR TITLE
TableColumn.MatchesForDelta must compare through the virtual Equals (#399)

### DIFF
--- a/src/Weasel.Postgresql.Tests/Tables/TableDeltaTests.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/TableDeltaTests.cs
@@ -38,6 +38,72 @@ public class TableDeltaTests
         delta.Difference.ShouldBe(SchemaPatchDifference.Invalid);
     }
 
+    // weasel#399: consumers declare "this wider actual column is acceptable" by overriding the
+    // virtual Equals(object) on their own TableColumn subclass — that is the seam Marten uses so
+    // an integer mt_version tolerates a column an earlier release already migrated to bigint
+    // (marten#4614/#4742). Computed-column detection (weasel#373) routed every column through
+    // MatchesForDelta, where a bare Equals(actual) binds to the protected, NON-virtual
+    // Equals(TableColumn) overload and skips the override. The column then landed in
+    // Columns.Different, so the table was classified Update while the writer emitted nothing —
+    // AssertDatabaseMatchesConfiguration threw with an empty change set.
+    [Fact]
+    public void a_subclass_equality_override_decides_whether_a_column_matches()
+    {
+        var expected = new Table("people");
+        expected.AddColumn<int>("id").AsPrimaryKey();
+        expected.AddColumn(new ToleratesWiderColumn("mt_version", "integer"));
+
+        var actual = new Table("people");
+        actual.AddColumn<int>("id").AsPrimaryKey();
+        actual.AddColumn(new TableColumn("mt_version", "bigint"));
+
+        var delta = new TableDelta(expected, actual);
+
+        delta.Columns.Matched.Select(x => x.Name).ShouldContain("mt_version");
+        delta.Columns.Different.ShouldBeEmpty();
+        delta.Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public void a_subclass_equality_override_that_rejects_still_reports_a_difference()
+    {
+        var expected = new Table("people");
+        expected.AddColumn<int>("id").AsPrimaryKey();
+        expected.AddColumn(new ToleratesWiderColumn("mt_version", "integer"));
+
+        // uuid is NOT the tolerated type, so the override falls through to the base comparison
+        var actual = new Table("people");
+        actual.AddColumn<int>("id").AsPrimaryKey();
+        actual.AddColumn(new TableColumn("mt_version", "uuid"));
+
+        var delta = new TableDelta(expected, actual);
+
+        delta.Columns.Different.Select(x => x.Expected.Name).ShouldContain("mt_version");
+    }
+
+    // Mirrors Marten's RevisionColumn: an integer column that accepts an on-disk bigint rather
+    // than emitting a lossy narrowing cast.
+    public class ToleratesWiderColumn: TableColumn
+    {
+        public ToleratesWiderColumn(string name, string type): base(name, type)
+        {
+        }
+
+        public override bool Equals(object? obj)
+        {
+            if (obj is TableColumn actual
+                && string.Equals(Name, actual.Name, StringComparison.OrdinalIgnoreCase)
+                && actual.RawType().Equals("bigint", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            return base.Equals(obj);
+        }
+
+        public override int GetHashCode() => base.GetHashCode();
+    }
+
     public class CannotAddColumn: TableColumn
     {
         public CannotAddColumn(string name, string type): base(name, type)

--- a/src/Weasel.Postgresql/Tables/TableColumn.cs
+++ b/src/Weasel.Postgresql/Tables/TableColumn.cs
@@ -131,7 +131,7 @@ public class TableColumn: ITableColumn
         {
             // the generation expression is the column's identity — defaults and
             // nullability drift don't apply to generated columns
-            return Equals(actual) && HasSameComputedDefinition(actual);
+            return equalsVirtual(actual) && HasSameComputedDefinition(actual);
         }
 
         if (actual.ComputedExpression.IsNotEmpty())
@@ -141,7 +141,7 @@ public class TableColumn: ITableColumn
             return true;
         }
 
-        return Equals(actual) && (!detectDrift || HasSameDefaultAndNullability(actual));
+        return equalsVirtual(actual) && (!detectDrift || HasSameDefaultAndNullability(actual));
     }
 
     internal bool HasSameComputedDefinition(TableColumn actual)
@@ -171,6 +171,17 @@ public class TableColumn: ITableColumn
                 : $"alter table {parent.Identifier} alter column {QuotedName} drop default;");
         }
     }
+
+    // weasel#399: MatchesForDelta must compare through the VIRTUAL Equals(object). Calling
+    // Equals(actual) there binds at compile time to the protected, non-virtual
+    // Equals(TableColumn) overload below, which silently bypasses any subclass override of
+    // Equals(object) — the seam consumers use to declare a wider actual column acceptable
+    // (Marten's integer mt_version tolerating an existing bigint, marten#4614/#4742). Before
+    // computed-column detection (weasel#373) the no-drift path passed a null comparer and
+    // ItemDelta fell back to the virtual Equals, so such columns compared equal; routing every
+    // comparison through MatchesForDelta changed that silently and classified the table as
+    // needing an update while emitting no SQL — an empty-change-set assert failure.
+    private bool equalsVirtual(TableColumn actual) => Equals((object)actual);
 
     protected bool Equals(TableColumn other)
     {

--- a/src/Weasel.SqlServer/Tables/TableColumn.cs
+++ b/src/Weasel.SqlServer/Tables/TableColumn.cs
@@ -114,8 +114,13 @@ public class TableColumn: ITableColumn
             return true;
         }
 
-        return Equals(actual) && (!detectDrift || HasSameDefaultAndNullability(actual));
+        return equalsVirtual(actual) && (!detectDrift || HasSameDefaultAndNullability(actual));
     }
+
+    // weasel#399: compare through the VIRTUAL Equals(object) so a subclass override
+    // participates. A bare Equals(actual) binds to the protected, non-virtual
+    // Equals(TableColumn) overload and silently bypasses it. See the PostgreSQL twin.
+    private bool equalsVirtual(TableColumn actual) => Equals((object)actual);
 
     internal bool HasSameComputedDefinition(TableColumn actual)
     {


### PR DESCRIPTION
Closes #399. Regression from #373, found while bumping Marten from Weasel 9.17.0 to 9.20.1.

`MatchesForDelta` compares with `Equals(actual)` where `actual` is statically typed `TableColumn`, so it binds to the **protected, non-virtual** `Equals(TableColumn)` overload rather than `public override bool Equals(object?)`. Any subclass override of `Equals(object)` is silently bypassed. Before #373 the no-drift path passed a `null` comparer and `ItemDelta` fell back to the virtual `Equals(object)`, so overrides did participate.

That override is a real extension seam. Marten's `RevisionColumn` uses it to declare that an `integer` `mt_version` tolerates a column an earlier release already migrated to `bigint`, instead of emitting a lossy `USING mt_version::integer` narrowing cast (marten#4614 / #4742). With the override skipped the column lands in `Columns.Different`, so the table is classified `SchemaPatchDifference.Update` — while the writer still emits nothing for it, because the consumer's `AlterColumnTypeSql` correctly returns empty. The result is a validation failure with an **empty** change set:

```
Weasel.Core.Migrations.DatabaseValidationException
    "Configuration to Schema Validation for Database 'Main' Failed! These changes detected:

    "
```

Bisected against Marten's `Bug_4614_revision_column_int_for_IRevisioned` assert-check test: 9.17.0 passes, 9.18.0 / 9.19.0 / 9.20.0 / 9.20.1 all fail.

## Change

Both the PostgreSQL and SQL Server `TableColumn.MatchesForDelta` now compare through `Equals((object)actual)`. No behaviour change for a column that does not override `Equals(object)`, since the base override just delegates to `Equals(TableColumn)`.

## Tests

- `TableDeltaTests.a_subclass_equality_override_decides_whether_a_column_matches` — an `integer` expected column whose subclass accepts a `bigint` actual must land in `Columns.Matched` with `Difference == None`. **Verified RED before the fix.**
- `a_subclass_equality_override_that_rejects_still_reports_a_difference` — an override that declines (a `uuid` actual) still produces a difference.

Local: `Weasel.Postgresql.Tests` 787 passed / 0 failed / 3 skipped on net10.0, three consecutive runs.

Note for follow-up: `Equals(TableColumn)` being protected and non-virtual makes this easy to reintroduce — a virtual, publicly overridable equality member for columns would make the seam explicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)