### PR TITLE
fix(postgresql): seed Npgsql's global type mapper before the test suite runs (weasel#398)

### DIFF
--- a/src/Weasel.Postgresql.Tests/CommandExtensionsTests.cs
+++ b/src/Weasel.Postgresql.Tests/CommandExtensionsTests.cs
@@ -21,9 +21,40 @@ public class CommandExtensionsTests
         param.Value.ShouldBe("a");
         param.ParameterName.ShouldBe("p0");
 
+        // AddParameter was given no explicit type, so this asserts *Npgsql's* inference from
+        // the value rather than anything Weasel stamped on. That inference reads Npgsql's
+        // process-global type mapper and answers Unknown until the mapper has been seeded,
+        // which TestSetup does once at module load. Do not delete that warm-up. weasel#398.
         param.NpgsqlDbType.ShouldBe(NpgsqlDbType.Text);
 
         command.Parameters.ShouldContain(param);
+    }
+
+    [Fact]
+    public void add_parameter_honors_an_explicit_type()
+    {
+        var command = new NpgsqlCommand();
+
+        var param = command.AddParameter("a", NpgsqlDbType.Varchar);
+
+        // The explicit-type path is the one Weasel actually controls, so unlike the test
+        // above it holds no matter what state Npgsql's global type mapper is in.
+        param.NpgsqlDbType.ShouldBe(NpgsqlDbType.Varchar);
+    }
+
+    [Fact]
+    public void add_parameter_without_a_type_defers_to_npgsql_rather_than_weasels_mapping()
+    {
+        var command = new NpgsqlCommand();
+
+        var param = command.AddParameter(new DateTime(2026, 7, 30, 12, 0, 0, DateTimeKind.Utc));
+
+        // Weasel must NOT start stamping its own CLR-type mapping onto untyped parameters.
+        // Weasel maps DateTime to "timestamp without time zone" for every value, while
+        // Npgsql resolves per value: a Kind=Utc DateTime is "timestamp with time zone", and
+        // writing one as "timestamp without time zone" throws at execution time. weasel#398.
+        param.NpgsqlDbType.ShouldBe(NpgsqlDbType.TimestampTz);
+        Instance.ToParameterType(typeof(DateTime)).ShouldBe(NpgsqlDbType.Timestamp);
     }
 
     [Fact]

--- a/src/Weasel.Postgresql.Tests/TestSetup.cs
+++ b/src/Weasel.Postgresql.Tests/TestSetup.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using Npgsql;
 
 namespace Weasel.Postgresql.Tests;
 
@@ -23,5 +24,36 @@ internal static class TestSetup
         {
             PostgresqlProvider.Instance.UseCaseSensitiveQualifiedNames = useCaseSensitiveQualifiedNames;
         }
+
+        WarmUpNpgsqlTypeInference();
+    }
+
+    /// <summary>
+    /// Populate Npgsql's process-global type mapper before any test runs.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When a parameter is added without an explicit type, Weasel leaves
+    /// <see cref="NpgsqlParameter.NpgsqlDbType" /> unset and lets Npgsql infer it from the
+    /// value. That getter answers out of Npgsql's process-global type mapper, which stays
+    /// empty until the process constructs its first <see cref="NpgsqlDataSource" /> or
+    /// <see cref="NpgsqlConnection" /> with a connection string — until then it reports
+    /// <c>NpgsqlDbType.Unknown</c> for every value.
+    /// </para>
+    /// <para>
+    /// So a test asserting an inferred parameter type silently depends on some *other*
+    /// test in the same process having built a data source first. Under xUnit v3's parallel
+    /// collections that is a race, and it is exactly what made
+    /// <c>CommandExtensionsTests.add_first_parameter</c> fail in three of the four Postgres
+    /// CI jobs and then pass on an unchanged re-run. See weasel#398.
+    /// </para>
+    /// <para>
+    /// Constructing a builder is enough to seed the global mapper; it opens no sockets and
+    /// needs no connection string, so it is safe to do unconditionally at load.
+    /// </para>
+    /// </remarks>
+    private static void WarmUpNpgsqlTypeInference()
+    {
+        _ = new NpgsqlDataSourceBuilder();
     }
 }


### PR DESCRIPTION
Closes #398.

## TL;DR

The parameter type is not silently wrong. `add_first_parameter` asserts on **Npgsql's** inference, and that inference depends on process-global state that another test happens to initialize first. In a cold process it fails 100% of the time.

## What actually happens

`command.AddParameter("a")` passes `dbType: null`, so `DatabaseProvider.AddParameter` never calls `SetParameterType`:

```csharp
parameter.Value = value ?? DBNull.Value;
if (dbType.HasValue)   // <-- false
{
    SetParameterType(parameter, dbType.Value);
}
```

`PostgresqlProvider.determineParameterType`, `ResolveNpgsqlDbType` and `ParameterTypeMemo` are **not on this path at all**. So the fix suggested in the issue — seeding `ParameterTypeMemo` in `storeMappings()` — would not have changed this test's outcome. Neither would anything about `NpgsqlTypeMapper.Mappings`; that static `Cache` is only read by Weasel's own resolution, which never runs here.

`_npgsqlDbType` is left null, so the `param.NpgsqlDbType` **getter** infers from `Value` via Npgsql's process-global type mapper. That mapper stays empty — reporting `Unknown` for every value — until the process constructs its first `NpgsqlDataSource` or `NpgsqlConnection` with a connection string. Measured, one fresh process per row:

| what ran first in the process | `new NpgsqlCommand().AddParameter("a").NpgsqlDbType` |
|---|---|
| nothing | **`Unknown`** |
| `new NpgsqlConnection()` (parameterless) | **`Unknown`** |
| `new NpgsqlConnectionStringBuilder(cs)` | **`Unknown`** |
| `new NpgsqlConnection(cs)` | `Text` |
| `new NpgsqlDataSourceBuilder(cs)` / `.Build()` | `Text` |
| `new NpgsqlDataSourceBuilder()` | `Text` |

So the test passes only when some *other* test in the same process built a data source first. Under xUnit v3's parallel collections that is a race — hence 3 of 4 jobs failing and a clean re-run going green. It did not reproduce locally because a local full-suite run almost always wins that race.

This is a test-visibility artifact, not a wire-level defect: with `_npgsqlDbType` unset, Npgsql resolves the type at execution time against the real connection, and a command cannot execute without a connection existing.

## The fix

Seed the mapper once from the existing module initializer, before any test runs. `new NpgsqlDataSourceBuilder()` is enough — no sockets, no connection string.

## Why not make `AddParameter` set the type

That was the tempting fix (`AddNamedParameter` already does it) and it is a **regression**. Weasel's mapping is per-type; Npgsql's inference is per-value. Across the common CLR types `DateTime` is the only divergence, and it is a breaking one:

| value | Npgsql infers | Weasel would set |
|---|---|---|
| `DateTime.UtcNow` | `TimestampTz` | `Timestamp` |
| `DateTime.Now` | `Timestamp` | `Timestamp` |

Verified against a live Postgres:

```
untyped (today's AddParameter behavior)     -> OK
NpgsqlDbType=Timestamp (Weasel's mapping)   -> ArgumentException: Cannot write DateTime
    with Kind=UTC to PostgreSQL type 'timestamp without time zone' ...
```

All other checked types agree exactly: `string`, `char`, `int`, `long`, `short`, `double`, `float`, `decimal`, `bool`, `Guid`, `DateTimeOffset`, `TimeSpan`, `DateOnly`, `TimeOnly`, `byte[]`, `string[]`, `int[]`, `List<int>`, `IPAddress`.

Two new tests pin this so the trap is not walked into later:

- `add_parameter_honors_an_explicit_type` — the path Weasel controls, independent of global mapper state.
- `add_parameter_without_a_type_defers_to_npgsql_rather_than_weasels_mapping` — fails if `AddParameter` ever starts stamping Weasel's mapping onto untyped parameters.

## Verification

Counterfactual, with the warm-up commented out, cold process:

```
Failed  CommandExtensionsTests.add_first_parameter
Failed  CommandExtensionsTests.add_parameter_without_a_type_defers_to_npgsql_rather_than_weasels_mapping
```

— the exact CI failure. With the warm-out restored, green, including 5 consecutive cold-process runs of that class alone.

Full suite, all four CI matrix legs (net9.0/net10.0 x `USE_CASE_SENSITIVE_QUALIFIED_NAMES` true/false): **786 passed, 0 failed, 3 skipped** each.

No product code changed.

## Follow-ups, deliberately not in this PR

1. `AddParameter` vs `AddNamedParameter` disagree on untyped values — the former defers to the driver, the latter calls `ToParameterType`. Worth reconciling, but it needs the `DateTime`-`Kind` question answered first.
2. `AddNamedParameter(cmd, name, DateTime.UtcNow)` already sets `Timestamp` and so already throws on write. Pre-existing, separate from this flake.
3. `NpgsqlTypeMapper.Mappings` really is a mutable static `Cache` enumerated without synchronization, and `PostgresqlProviderTests` writes to it while other collections read. Not the cause here, but still a genuine hazard for anything that *does* go through Weasel's resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
