### PR TITLE
fix(postgresql): stop declaring IPNetwork on both the cidr and inet mappings (weasel#405)

### DIFF
--- a/src/Weasel.Postgresql.Tests/PostgresqlProviderTests.cs
+++ b/src/Weasel.Postgresql.Tests/PostgresqlProviderTests.cs
@@ -86,6 +86,34 @@ public class PostgresqlProviderTests
     }
 
     [Fact]
+    public void ipnetwork_is_claimed_by_exactly_one_mapping()
+    {
+        // Guards the test above. IPNetwork used to be declared on both the cidr and the inet
+        // mapping, and GetTypeMapping breaks a tie with LastOrDefault over a Cache backed by
+        // an ImHashMap -- so "cidr" was winning on hash layout, not on anything declared.
+        // weasel#405.
+        NpgsqlTypeMapper.Mappings
+            .Count(mapping => mapping.ClrTypes.Contains(typeof(IPNetwork)))
+            .ShouldBe(1);
+    }
+
+    [Fact]
+    public void no_clr_type_is_claimed_by_more_than_one_mapping()
+    {
+        // Any CLR type reachable from two mappings has an order-dependent, effectively
+        // arbitrary resolution. Keep that structurally impossible rather than relying on
+        // enumeration order. weasel#405.
+        var doubleClaimed = NpgsqlTypeMapper.Mappings
+            .SelectMany(mapping => mapping.ClrTypes.Select(clrType => (clrType, mapping)))
+            .GroupBy(x => x.clrType)
+            .Where(g => g.Count() > 1)
+            .Select(g => $"{g.Key.Name} <- {string.Join(", ", g.Select(x => x.mapping.NpgsqlDbType))}")
+            .ToArray();
+
+        doubleClaimed.ShouldBeEmpty();
+    }
+
+    [Fact]
     public void canonicizesql_supports_tabs_as_whitespace()
     {
         var noTabsCanonized =

--- a/src/Weasel.Postgresql/NpgsqlTypeMapping.cs
+++ b/src/Weasel.Postgresql/NpgsqlTypeMapping.cs
@@ -82,9 +82,12 @@ public class NpgsqlTypeMapper
         {NpgsqlDbType.Multirange | NpgsqlDbType.TimestampTz, new NpgsqlTypeMapping(NpgsqlDbType.Multirange | NpgsqlDbType.TimestampTz, DbType.Object, "tstzmultirange")},
 
         // Network types
+        // IPNetwork belongs to cidr only. It used to be listed on inet as well, and which of
+        // the two won was decided by LastOrDefault over a hash-ordered ImHashMap -- i.e. by
+        // accident rather than by declaration. See weasel#405.
         {NpgsqlDbType.Cidr, new NpgsqlTypeMapping(NpgsqlDbType.Cidr, DbType.Object, "cidr", typeof(IPNetwork))},
         {NpgsqlDbType.Inet, new NpgsqlTypeMapping(NpgsqlDbType.Inet, DbType.Object, "inet", typeof(IPAddress),
-            typeof((IPAddress Address, int Subnet)), typeof(NpgsqlInet), typeof(IPNetwork), IPAddress.Loopback.GetType())},
+            typeof((IPAddress Address, int Subnet)), typeof(NpgsqlInet), IPAddress.Loopback.GetType())},
         {NpgsqlDbType.MacAddr, new NpgsqlTypeMapping(NpgsqlDbType.MacAddr, DbType.Object, "macaddr", typeof(PhysicalAddress))},
         {NpgsqlDbType.MacAddr8, new NpgsqlTypeMapping(NpgsqlDbType.MacAddr8, DbType.Object, "macaddr8")},
 


### PR DESCRIPTION
Closes #405.

`PostgresqlProvider.GetTypeMapping` breaks a CLR-type tie with `LastOrDefault`:

```csharp
NpgsqlTypeMapper.Mappings.LastOrDefault(mapping => mapping.ClrTypes.Contains(type));
```

`LastOrDefault` only means something over an ordered sequence. `Mappings` is a `JasperFx.Core.Cache` backed by an **`ImHashMap`**, so it enumerates in hash-tree order:

```
enumeration order : <custom>, <custom>, Bigint, Boolean, Box, Bytea, Circle, Char
source declares   : Smallint, Integer, Bigint, Real, Double, Numeric, Money, Text
```

`IPNetwork` was the one CLR type claimed by two mappings — `Cidr` (line 85) and `Inet` (line 86):

```
mappings claiming IPNetwork : Inet/inet  |  Cidr/cidr   (LastOrDefault wins)
GetDatabaseType(IPNetwork)  : cidr
```

`cidr` is the right answer and `ipnetwork_resolves_to_cidr` passes — **but only by accident**. The source declares `Cidr` *before* `Inet`, so under genuine insertion order `LastOrDefault` would return `inet` and that test would fail today. It passes because the hash layout happens to enumerate `Cidr` last, which is a function of the current key set — and consuming code is explicitly invited to add mappings.

## Change

Drop the stray `typeof(IPNetwork)` from the `Inet` mapping. `IPAddress`, `NpgsqlInet` and the `(IPAddress, int)` tuple stay on `Inet`. Resolution becomes unambiguous and order-independent.

Two guards so this cannot silently come back:

- `ipnetwork_is_claimed_by_exactly_one_mapping`
- `no_clr_type_is_claimed_by_more_than_one_mapping` — general, reports offenders as `Type <- Mapping, Mapping`

Counterfactual — restoring the duplicate fails both:

```
PostgresqlProviderTests.ipnetwork_is_claimed_by_exactly_one_mapping [FAIL]
PostgresqlProviderTests.no_clr_type_is_claimed_by_more_than_one_mapping [FAIL]
```

## Verification

All four CI matrix legs (net9.0/net10.0 × case-sensitive true/false): **788 passed, 0 failed, 3 skipped**.

One unrelated intermittent failure surfaced during validation — `DatabaseWithTablesTests.detect_and_apply_schema_changes`, which races other collections over the shared `public` schema. Confirmed **pre-existing on clean `master`** (reproduced in 3 runs there) and filed separately as #407. It is not affected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
