### PR TITLE
fix(postgresql): type a DateTime parameter from its Kind, not its CLR type (weasel#403)

### DIFF
--- a/src/Weasel.Core/CommandBuilderBase.cs
+++ b/src/Weasel.Core/CommandBuilderBase.cs
@@ -201,7 +201,7 @@ public class CommandBuilderBase<TCommand, TParameter, TParameterType>: ICommandB
         }
         else if (value != null)
         {
-            _provider.SetParameterType(parameter, _provider.ToParameterType(value.GetType()));
+            _provider.SetParameterType(parameter, _provider.ToParameterTypeForValue(value));
         }
 
         parameter.Value = value ?? DBNull.Value;

--- a/src/Weasel.Core/DatabaseProvider.cs
+++ b/src/Weasel.Core/DatabaseProvider.cs
@@ -63,6 +63,16 @@ public interface IDatabaseProvider<in TCommand, in TParameter, TParameterType>: 
     TParameterType DoubleParameterType { get; }
     TParameterType? TryGetDbType(Type? type);
     TParameterType ToParameterType(Type type);
+
+    /// <summary>
+    ///     Resolve the parameter type for a value the caller supplied without an explicit type.
+    ///     Defaults to keying off the value's CLR type. Providers whose choice depends on the
+    ///     <em>value</em> rather than its type override this — PostgreSQL picks
+    ///     <c>timestamptz</c> vs <c>timestamp</c> from <see cref="DateTime.Kind" />, which a
+    ///     per-type mapping cannot express. weasel#403.
+    /// </summary>
+    TParameterType ToParameterTypeForValue(object value) => ToParameterType(value.GetType());
+
     Type[] ResolveTypes(TParameterType parameterType);
     string GetDatabaseType(Type memberType, EnumStorage enumStyle);
     void AddParameter(TCommand command, TParameter parameter);
@@ -124,6 +134,16 @@ public abstract class DatabaseProvider<TCommand, TParameter, TParameterType>
         }
 
         throw new NotSupportedException($"Can't infer {typeof(TParameterType).Name} for type " + type);
+    }
+
+    /// <summary>
+    ///     Resolve the parameter type for a value the caller supplied without an explicit type.
+    ///     Keys off the value's CLR type unless a provider overrides it because its choice
+    ///     depends on the value itself. weasel#403.
+    /// </summary>
+    public virtual TParameterType ToParameterTypeForValue(object value)
+    {
+        return ToParameterType(value.GetType());
     }
 
     public Type[] ResolveTypes(TParameterType parameterType)
@@ -265,7 +285,7 @@ public abstract class DatabaseProvider<TCommand, TParameter, TParameterType>
         }
         else if (value != null)
         {
-            SetParameterType(parameter, ToParameterType(value.GetType()));
+            SetParameterType(parameter, ToParameterTypeForValue(value));
         }
 
         parameter.Value = value ?? DBNull.Value;

--- a/src/Weasel.Postgresql.Tests/PostgresqlProviderTests.cs
+++ b/src/Weasel.Postgresql.Tests/PostgresqlProviderTests.cs
@@ -77,6 +77,73 @@ public class PostgresqlProviderTests
     {
     }
 
+    // PostgreSQL picks timestamptz vs timestamp from the *value's* Kind, so a per-type mapping
+    // cannot express it. GetDatabaseType stays per-type -- a column has one type -- while a
+    // parameter's type has to follow its value. weasel#403.
+
+    [Fact]
+    public void to_parameter_type_for_value_uses_timestamptz_for_a_utc_datetime()
+    {
+        PostgresqlProvider.Instance
+            .ToParameterTypeForValue(new DateTime(2026, 7, 30, 12, 0, 0, DateTimeKind.Utc))
+            .ShouldBe(NpgsqlDbType.TimestampTz);
+    }
+
+    [Theory]
+    [InlineData(DateTimeKind.Local)]
+    [InlineData(DateTimeKind.Unspecified)]
+    public void to_parameter_type_for_value_uses_timestamp_for_a_non_utc_datetime(DateTimeKind kind)
+    {
+        PostgresqlProvider.Instance
+            .ToParameterTypeForValue(new DateTime(2026, 7, 30, 12, 0, 0, kind))
+            .ShouldBe(NpgsqlDbType.Timestamp);
+    }
+
+    [Fact]
+    public void to_parameter_type_for_value_handles_datetime_collections()
+    {
+        var utc = new DateTime(2026, 7, 30, 12, 0, 0, DateTimeKind.Utc);
+        var local = new DateTime(2026, 7, 30, 12, 0, 0, DateTimeKind.Local);
+
+        // arrays and List<T> both arrive as IReadOnlyList<DateTime>
+        PostgresqlProvider.Instance.ToParameterTypeForValue(new[] { utc })
+            .ShouldBe(NpgsqlDbType.Array | NpgsqlDbType.TimestampTz);
+        PostgresqlProvider.Instance.ToParameterTypeForValue(new List<DateTime> { utc })
+            .ShouldBe(NpgsqlDbType.Array | NpgsqlDbType.TimestampTz);
+        PostgresqlProvider.Instance.ToParameterTypeForValue(new[] { local })
+            .ShouldBe(NpgsqlDbType.Array | NpgsqlDbType.Timestamp);
+        PostgresqlProvider.Instance.ToParameterTypeForValue(Array.Empty<DateTime>())
+            .ShouldBe(NpgsqlDbType.Array | NpgsqlDbType.Timestamp);
+    }
+
+    [Theory]
+    [InlineData("a", NpgsqlDbType.Text)]
+    [InlineData(42, NpgsqlDbType.Integer)]
+    [InlineData(true, NpgsqlDbType.Boolean)]
+    public void to_parameter_type_for_value_still_keys_off_the_clr_type_otherwise(object value,
+        NpgsqlDbType expected)
+    {
+        PostgresqlProvider.Instance.ToParameterTypeForValue(value).ShouldBe(expected);
+    }
+
+    [Fact]
+    public void column_types_stay_per_type_even_though_parameter_types_are_per_value()
+    {
+        PostgresqlProvider.Instance.GetDatabaseType(typeof(DateTime), EnumStorage.AsString)
+            .ShouldBe("timestamp without time zone");
+    }
+
+    [Fact]
+    public void add_named_parameter_types_a_utc_datetime_as_timestamptz()
+    {
+        // The regression: AddNamedParameter used to stamp Timestamp here, and Npgsql then threw
+        // "Cannot write DateTime with Kind=UTC to PostgreSQL type 'timestamp without time zone'"
+        // at execution time. weasel#403.
+        new NpgsqlCommand()
+            .AddNamedParameter("n", new DateTime(2026, 7, 30, 12, 0, 0, DateTimeKind.Utc))
+            .NpgsqlDbType.ShouldBe(NpgsqlDbType.TimestampTz);
+    }
+
     [Fact]
     public void ipnetwork_resolves_to_cidr()
     {

--- a/src/Weasel.Postgresql.Tests/command_extensions_integrated_test.cs
+++ b/src/Weasel.Postgresql.Tests/command_extensions_integrated_test.cs
@@ -116,4 +116,33 @@ public class command_extensions_integrated_test: IntegrationContext
         (await reader.GetFieldValueAsync<int>(2)).ShouldBe(11);
     }
 
+    [Fact]
+    public async Task round_trip_a_utc_datetime_through_an_untyped_named_parameter()
+    {
+        // This only ever failed at execution time: AddNamedParameter stamped Timestamp for any
+        // DateTime, and Npgsql rejects a Kind=Utc value written as 'timestamp without time
+        // zone'. A unit assertion on the stamped type would not have caught the original
+        // report, so exercise the real write. weasel#403.
+        var table = new Table("general.utc_things");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn("moment", "timestamptz");
+
+        await ResetSchema();
+        await CreateSchemaObjectInDatabase(table);
+
+        var moment = new DateTime(2026, 7, 30, 12, 34, 56, DateTimeKind.Utc);
+
+        await theConnection
+            .CreateCommand("insert into general.utc_things (id, moment) values (@id, @moment)")
+            .With("id", 1)
+            .With("moment", moment)
+            .ExecuteNonQueryAsync();
+
+        await using var reader = await theConnection
+            .CreateCommand("select moment from general.utc_things where id = 1")
+            .ExecuteReaderAsync();
+
+        await reader.ReadAsync();
+        (await reader.GetFieldValueAsync<DateTime>(0)).ShouldBe(moment);
+    }
 }

--- a/src/Weasel.Postgresql/CommandExtensions.cs
+++ b/src/Weasel.Postgresql/CommandExtensions.cs
@@ -59,7 +59,10 @@ public static class CommandExtensions
 
     public static NpgsqlCommand With(this NpgsqlCommand command, string name, DateTime value)
     {
-        PostgresqlProvider.Instance.AddNamedParameter(command, name, value, NpgsqlDbType.Timestamp);
+        // Not a hard-coded Timestamp: Npgsql rejects a Kind=Utc value written as 'timestamp
+        // without time zone', so the type has to follow the value's Kind. weasel#403.
+        PostgresqlProvider.Instance.AddNamedParameter(command, name, value,
+            PostgresqlProvider.Instance.ToParameterTypeForValue(value));
         return command;
     }
 

--- a/src/Weasel.Postgresql/PostgresqlProvider.cs
+++ b/src/Weasel.Postgresql/PostgresqlProvider.cs
@@ -85,6 +85,35 @@ public class PostgresqlProvider: DatabaseProvider<NpgsqlCommand, NpgsqlParameter
         return GetTypeMapping(dbType)?.ClrTypes ?? Type.EmptyTypes;
     }
 
+    /// <summary>
+    ///     PostgreSQL's choice between <c>timestamptz</c> and <c>timestamp</c> follows the
+    ///     <see cref="DateTime.Kind" /> of the value, not its CLR type: Npgsql rejects a
+    ///     <see cref="DateTimeKind.Utc" /> value written as <c>timestamp without time zone</c>.
+    ///     A per-type mapping cannot express that, so resolve those from the value. Everything
+    ///     else keys off the CLR type as usual. weasel#403.
+    /// </summary>
+    public override NpgsqlDbType ToParameterTypeForValue(object value)
+    {
+        switch (value)
+        {
+            case DateTime dateTime:
+                return timestampTypeFor(dateTime);
+
+            // Npgsql forbids mixing Kinds within one array, so the first element decides.
+            // Covers DateTime[] and List<DateTime>, both of which are IReadOnlyList<DateTime>.
+            case IReadOnlyList<DateTime> dateTimes:
+                return NpgsqlDbType.Array |
+                       (dateTimes.Count == 0 ? NpgsqlDbType.Timestamp : timestampTypeFor(dateTimes[0]));
+        }
+
+        return base.ToParameterTypeForValue(value);
+    }
+
+    private static NpgsqlDbType timestampTypeFor(DateTime value)
+    {
+        return value.Kind == DateTimeKind.Utc ? NpgsqlDbType.TimestampTz : NpgsqlDbType.Timestamp;
+    }
+
     private static NpgsqlTypeMapping? GetTypeMapping(Type type)
     {
         return NpgsqlTypeMapper


### PR DESCRIPTION
Closes #403. Narrows #404.

## The bug

```csharp
cmd.AddNamedParameter("n", DateTime.UtcNow);
await cmd.ExecuteScalarAsync();
```

```
ArgumentException: Cannot write DateTime with Kind=UTC to PostgreSQL type
'timestamp without time zone', consider using 'timestamp with time zone'.
```

Verified against a live Postgres. It only ever surfaced at **execution** time, so a unit assertion on the stamped type would not have caught the original report.

## Cause

With no explicit type, Weasel typed the parameter from the value's **CLR type**, and `PostgresqlProvider` maps `typeof(DateTime)` to `Timestamp` unconditionally. But Postgres' choice depends on the **value** — Npgsql resolves `Kind=Utc` to `timestamptz`, `Kind=Local`/`Unspecified` to `timestamp`. A per-type mapping cannot express that.

`DateTime[]` and `List<DateTime>` failed identically through the array branch.

## Change

New `IDatabaseProvider<,,>.ToParameterTypeForValue(object)`, defaulting to today's `ToParameterType(value.GetType())` — so **no other provider changes behaviour**. It is a default interface method plus a `public virtual` on `DatabaseProvider<,,>`, so external implementers are unaffected. `PostgresqlProvider` overrides it to read `DateTime.Kind`, for scalars and for `IReadOnlyList<DateTime>` (covers arrays and `List<T>`; Npgsql forbids mixing Kinds in one array, so the first element decides).

Three call sites were typing per-CLR-type and now route through it:

| site | note |
|---|---|
| `DatabaseProvider.AddNamedParameter` | the reported one |
| `CommandBuilderBase.AppendParameter` | same bug, reached via the interface |
| `CommandExtensions.With(cmd, name, DateTime)` | hard-coded `NpgsqlDbType.Timestamp`, so `.With(name, DateTime.UtcNow)` **always** threw |

The second and third were found while fixing the first; each would have left the bug reachable.

## Column types are deliberately untouched

A column has one type, so DDL stays per-type — `GetDatabaseType(typeof(DateTime))` still returns `timestamp without time zone`, now pinned by a test. Only *parameters* follow their value.

## Verification

Live Postgres, every case previously throwing:

| value | before | after |
|---|---|---|
| `DateTime.UtcNow` | ✗ throws | `TimestampTz` ✓ |
| `DateTime[]` all Utc | ✗ throws | `Array \| TimestampTz` ✓ |
| `List<DateTime>` all Utc | ✗ throws | `Array \| TimestampTz` ✓ |
| `DateTime.Now` | `Timestamp` ✓ | `Timestamp` ✓ |
| `DateTime[]` empty | `Array \| Timestamp` ✓ | unchanged ✓ |
| `string` / `Guid` / `int` / `DateTimeOffset` / `string[]` | ✓ | unchanged ✓ |

Includes an integration test that actually writes and reads back a UTC `DateTime`, since the unit-level assertion alone would not have caught this.

Suites: Postgres **798 passed** on all four matrix legs (net9.0/net10.0 × case-sensitive true/false), Core **21**, SQLite **361**. MSSQL / Oracle / MySQL covered by CI — unchanged by the default implementation.

## On #404

This removes the *observable* `AddParameter` / `AddNamedParameter` divergence for `DateTime`: both now yield `TimestampTz` for a UTC value, one by deferring to Npgsql and one by resolving per value. What remains of #404 is narrower — `AddNamedParameter` still throws for types with no mapping where `AddParameter` succeeds. Left open deliberately; it is an API-direction call, not a bug fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
