### PR TITLE
test(postgresql): move DatabaseWithTablesTests off the shared public schema (weasel#407)

### DIFF
--- a/src/Weasel.Postgresql.Tests/DatabaseWithTablesTests.cs
+++ b/src/Weasel.Postgresql.Tests/DatabaseWithTablesTests.cs
@@ -5,6 +5,14 @@ using Xunit;
 
 namespace Weasel.Postgresql.Tests;
 
+/// <remarks>
+/// Every table here lives in the "integration" schema, which is what <see cref="IntegrationContext.ResetSchema" />
+/// actually resets for this class. They used to be created in "public", which nothing here
+/// isolates and which at least nine other test files also write to. xUnit serialises this
+/// collection against itself but runs other collections in parallel, so a concurrent drop in
+/// "public" would surface as either "relation ... does not exist" or, when it landed mid-scan
+/// of pg_index, "could not open relation with OID". See weasel#407.
+/// </remarks>
 [Collection("integration")]
 public class DatabaseWithTablesTests: IntegrationContext
 {
@@ -33,7 +41,7 @@ public class DatabaseWithTablesTests: IntegrationContext
     public void create_table_returns_configurable_table()
     {
         var db = new DatabaseWithTables("test", theDataSource);
-        var table = db.AddTable(new PostgresqlObjectName("public", "dwt_people"));
+        var table = db.AddTable(new PostgresqlObjectName("integration", "dwt_people"));
         table.ShouldNotBeNull();
         db.Tables.Count.ShouldBe(1);
         db.Tables[0].ShouldBeSameAs(table);
@@ -45,7 +53,7 @@ public class DatabaseWithTablesTests: IntegrationContext
         await ResetSchema();
 
         var db = new DatabaseWithTables("test", theDataSource);
-        var table = db.AddTable(new PostgresqlObjectName("public", "dwt_users"));
+        var table = db.AddTable(new PostgresqlObjectName("integration", "dwt_users"));
         table.AddPrimaryKeyColumn("id", typeof(int));
         table.AddColumn("name", typeof(string));
 
@@ -59,7 +67,7 @@ public class DatabaseWithTablesTests: IntegrationContext
         await ResetSchema();
 
         var db = new DatabaseWithTables("test", theDataSource);
-        var table = db.AddTable(new PostgresqlObjectName("public", "dwt_contacts"));
+        var table = db.AddTable(new PostgresqlObjectName("integration", "dwt_contacts"));
         table.AddPrimaryKeyColumn("id", typeof(int));
         table.AddColumn("name", typeof(string));
 


### PR DESCRIPTION
Closes #407.

## Symptom

`DatabaseWithTablesTests.detect_and_apply_schema_changes` failed intermittently in full-suite runs, **~1 in 3–6 locally**, with either:

```
Npgsql.PostgresException : XX000: could not open relation with OID 659774
  at Weasel.Postgresql.Tables.Table.readIndexesAsync(...) Table.FetchExisting.cs:365
```

```
Npgsql.PostgresException : 42P01: relation "public.dwt_contacts" does not exist
```

Reproduced on clean `master`. It **never** failed with the class run in isolation (8 filtered runs), so it was cross-collection interference, not a bug in the test's own logic.

## Cause

The class is `[Collection("integration")]` and `ResetSchema()` resets its `SchemaName` — `"integration"` — but the tables were created in **`public`**:

```csharp
var table = db.AddTable(new PostgresqlObjectName("public", "dwt_contacts"));
```

Nothing here isolates `public`, and at least nine other test files also write to it: `PostgresqlMigratorTests`, `create_and_teardown_schemas`, `Tables/TableTests`, `Tables/IndexDefinitionTests`, `Tables/creating_tables_in_database`, `Tables/ForeignKeyTests`, `Tables/Indexes/FullTextIndexDefinitionTests`, `Functions/FunctionBodyTests`, `Views/ViewTests`.

xUnit serialises a collection against itself but runs *different* collections in parallel, so another collection could drop objects in `public` mid-test:

- directly between apply and assert → `42P01`
- between the `pg_index` catalog row being read and the relation being opened → `XX000: could not open relation with OID`, the classic Postgres catalog race

## Change

Create the tables in `integration`, so `ResetSchema()` actually covers them. Same for the siblings `dwt_users` and `dwt_people`, which had identical exposure. A class-level comment records why, so they don't drift back.

Test-only — no product code touched.

## Verification

**12 consecutive full-suite runs** on the exact configuration that used to fail (net10.0, case-sensitive), **zero failures** — against a prior rate of roughly 1 in 3–6.

## Note

The broader hazard remains: tests sharing `public` across parallel collections is a standing source of this failure mode. Worth deciding separately whether `public` should be off-limits to anything that creates or drops objects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
