### PR TITLE
fix(core): let an untyped parameter defer to the driver instead of throwing (weasel#404)

### DIFF
--- a/src/Weasel.Core/CommandBuilderBase.cs
+++ b/src/Weasel.Core/CommandBuilderBase.cs
@@ -199,9 +199,11 @@ public class CommandBuilderBase<TCommand, TParameter, TParameterType>: ICommandB
         {
             _provider.SetParameterType(parameter, dbType.Value);
         }
-        else if (value != null)
+        else if (value != null && _provider.TryGetDbTypeForValue(value) is { } inferred)
         {
-            _provider.SetParameterType(parameter, _provider.ToParameterTypeForValue(value));
+            // See DatabaseProvider.AddNamedParameter -- unmapped types defer to the driver
+            // rather than throwing, matching AddParameter. weasel#404.
+            _provider.SetParameterType(parameter, inferred);
         }
 
         parameter.Value = value ?? DBNull.Value;

--- a/src/Weasel.Core/DatabaseProvider.cs
+++ b/src/Weasel.Core/DatabaseProvider.cs
@@ -65,13 +65,29 @@ public interface IDatabaseProvider<in TCommand, in TParameter, TParameterType>: 
     TParameterType ToParameterType(Type type);
 
     /// <summary>
-    ///     Resolve the parameter type for a value the caller supplied without an explicit type.
-    ///     Defaults to keying off the value's CLR type. Providers whose choice depends on the
-    ///     <em>value</em> rather than its type override this — PostgreSQL picks
-    ///     <c>timestamptz</c> vs <c>timestamp</c> from <see cref="DateTime.Kind" />, which a
-    ///     per-type mapping cannot express. weasel#403.
+    ///     Resolve the parameter type for a value the caller supplied without an explicit type,
+    ///     or null when this provider has no mapping for it — in which case the parameter is
+    ///     left untyped and the driver infers it. Defaults to keying off the value's CLR type.
+    ///     Providers whose choice depends on the <em>value</em> rather than its type override
+    ///     this — PostgreSQL picks <c>timestamptz</c> vs <c>timestamp</c> from
+    ///     <see cref="DateTime.Kind" />, which a per-type mapping cannot express. weasel#403.
     /// </summary>
-    TParameterType ToParameterTypeForValue(object value) => ToParameterType(value.GetType());
+    /// <remarks>
+    ///     Stands to <see cref="ToParameterTypeForValue" /> as <see cref="TryGetDbType" /> does
+    ///     to <see cref="ToParameterType" />: null means "unmapped, defer". A provider that
+    ///     actively rejects a type — SQL Server and arrays, say — still throws. weasel#404.
+    /// </remarks>
+    TParameterType? TryGetDbTypeForValue(object value) => TryGetDbType(value.GetType());
+
+    /// <summary>
+    ///     Resolve the parameter type for a value, throwing when this provider has no mapping.
+    ///     Prefer <see cref="TryGetDbTypeForValue" /> where deferring to the driver is
+    ///     acceptable. weasel#403.
+    /// </summary>
+    TParameterType ToParameterTypeForValue(object value) =>
+        TryGetDbTypeForValue(value) ??
+        throw new NotSupportedException($"Can't infer {typeof(TParameterType).Name} for value of type " +
+                                        value.GetType());
 
     Type[] ResolveTypes(TParameterType parameterType);
     string GetDatabaseType(Type memberType, EnumStorage enumStyle);
@@ -137,13 +153,26 @@ public abstract class DatabaseProvider<TCommand, TParameter, TParameterType>
     }
 
     /// <summary>
-    ///     Resolve the parameter type for a value the caller supplied without an explicit type.
-    ///     Keys off the value's CLR type unless a provider overrides it because its choice
-    ///     depends on the value itself. weasel#403.
+    ///     Resolve the parameter type for a value the caller supplied without an explicit type,
+    ///     or null when this provider has no mapping for it. Keys off the value's CLR type
+    ///     unless a provider overrides it because its choice depends on the value itself.
+    ///     weasel#403, weasel#404.
     /// </summary>
-    public virtual TParameterType ToParameterTypeForValue(object value)
+    public virtual TParameterType? TryGetDbTypeForValue(object value)
     {
-        return ToParameterType(value.GetType());
+        return TryGetDbType(value.GetType());
+    }
+
+    /// <summary>
+    ///     Resolve the parameter type for a value, throwing when this provider has no mapping.
+    ///     Prefer <see cref="TryGetDbTypeForValue" /> where deferring to the driver is
+    ///     acceptable. weasel#403.
+    /// </summary>
+    public TParameterType ToParameterTypeForValue(object value)
+    {
+        return TryGetDbTypeForValue(value) ??
+               throw new NotSupportedException($"Can't infer {typeof(TParameterType).Name} for value of type " +
+                                               value.GetType());
     }
 
     public Type[] ResolveTypes(TParameterType parameterType)
@@ -283,9 +312,12 @@ public abstract class DatabaseProvider<TCommand, TParameter, TParameterType>
         {
             SetParameterType(parameter, dbType.Value);
         }
-        else if (value != null)
+        else if (value != null && TryGetDbTypeForValue(value) is { } inferred)
         {
-            SetParameterType(parameter, ToParameterTypeForValue(value));
+            // Unmapped types are left untyped for the driver to infer, which is what the
+            // sibling AddParameter has always done. Providers that actively reject a type
+            // still throw out of TryGetDbTypeForValue. weasel#404.
+            SetParameterType(parameter, inferred);
         }
 
         parameter.Value = value ?? DBNull.Value;

--- a/src/Weasel.Postgresql.Tests/PostgresqlProviderTests.cs
+++ b/src/Weasel.Postgresql.Tests/PostgresqlProviderTests.cs
@@ -145,6 +145,32 @@ public class PostgresqlProviderTests
     }
 
     [Fact]
+    public void add_named_parameter_leaves_an_unmapped_type_for_the_driver_to_infer()
+    {
+        // AddNamedParameter used to call ToParameterType and throw "Can't infer NpgsqlDbType
+        // for type ..." here, while the sibling AddParameter accepted the same value happily.
+        // Both now defer to Npgsql for anything Weasel has no mapping for. weasel#404.
+        var command = new NpgsqlCommand();
+
+        Should.NotThrow(() => command.AddNamedParameter("n", new UnmappedTarget()));
+        Should.NotThrow(() => command.AddParameter(new UnmappedTarget()));
+    }
+
+    [Fact]
+    public void try_get_db_type_for_value_returns_null_for_an_unmapped_type()
+    {
+        PostgresqlProvider.Instance.TryGetDbTypeForValue(new UnmappedTarget()).ShouldBeNull();
+    }
+
+    [Fact]
+    public void to_parameter_type_for_value_still_throws_for_an_unmapped_type()
+    {
+        // The throwing overload is kept for callers that want the diagnostic.
+        Should.Throw<NotSupportedException>(() =>
+            PostgresqlProvider.Instance.ToParameterTypeForValue(new UnmappedTarget()));
+    }
+
+    [Fact]
     public void ipnetwork_resolves_to_cidr()
     {
         PostgresqlProvider.Instance

--- a/src/Weasel.Postgresql/PostgresqlProvider.cs
+++ b/src/Weasel.Postgresql/PostgresqlProvider.cs
@@ -92,7 +92,7 @@ public class PostgresqlProvider: DatabaseProvider<NpgsqlCommand, NpgsqlParameter
     ///     A per-type mapping cannot express that, so resolve those from the value. Everything
     ///     else keys off the CLR type as usual. weasel#403.
     /// </summary>
-    public override NpgsqlDbType ToParameterTypeForValue(object value)
+    public override NpgsqlDbType? TryGetDbTypeForValue(object value)
     {
         switch (value)
         {
@@ -106,7 +106,7 @@ public class PostgresqlProvider: DatabaseProvider<NpgsqlCommand, NpgsqlParameter
                        (dateTimes.Count == 0 ? NpgsqlDbType.Timestamp : timestampTypeFor(dateTimes[0]));
         }
 
-        return base.ToParameterTypeForValue(value);
+        return base.TryGetDbTypeForValue(value);
     }
 
     private static NpgsqlDbType timestampTypeFor(DateTime value)


### PR DESCRIPTION
Closes #404. Follows #409.

## The divergence

Given a value and no explicit type, the two sibling APIs accepted different sets of values:

```csharp
provider.AddParameter(cmd, new SomethingWeaselHasNoMappingFor());        // fine, stamps nothing
provider.AddNamedParameter(cmd, "n", new SomethingWeaselHasNoMappingFor()); // NotSupportedException
```

`AddParameter` stamps nothing and lets the driver infer. `AddNamedParameter` called `ToParameterType` and threw `Can't infer NpgsqlDbType for type ...`.

#409 already removed the *other* half of this — the two now agree on `DateTime`, one by deferring and one by resolving per value. What remained was this accept/reject asymmetry.

## Change

New `TryGetDbTypeForValue(object)`, which stands to `ToParameterTypeForValue` exactly as the existing `TryGetDbType` stands to `ToParameterType` — **null means "no mapping, leave it untyped and let the driver decide"**. `AddNamedParameter` and `CommandBuilderBase.AppendParameter` use it and skip stamping on null, matching `AddParameter`.

`ToParameterTypeForValue` is kept as the throwing wrapper for callers that want the diagnostic, now implemented in terms of the new method. `PostgresqlProvider`'s `DateTime.Kind` resolution moves onto `TryGetDbTypeForValue`, so #403 behaviour is unchanged.

## This deliberately does not swallow every failure

Worth being explicit, because "stop throwing" could easily have meant losing a good error message. It doesn't:

| case | before | after |
|---|---|---|
| Weasel has no mapping (`determineParameterType` returns false) | throws `Can't infer ...` | **defers to the driver** |
| provider actively rejects the type (`"Sql Server does not support arrays"`) | throws | **still throws** |

`TryGetDbType` returns null only for the first; a provider's own `NotSupportedException` propagates out of its `determineParameterType` branch untouched. So only the generic "can't infer" case becomes a deferral, and the genuinely useful diagnostics survive.

## Direction chosen

#404 offered two options — defer everywhere, or stamp everywhere per value. This takes **defer**, because it introduces no new throw anywhere: every value accepted today is still accepted, and some previously rejected ones now work (a CLR type Npgsql knows via a custom handler but Weasel has no mapping for).

Stamping everywhere would also have been coherent, and would make parameter types independent of driver state — but it risks throwing where callers currently succeed, which is the worse failure mode for downstreams like Marten and Wolverine. Happy to flip it if you'd rather have the determinism.

## Verification

Postgres **801 passed**, Core **21**, SQLite **361**. Other providers unaffected — the default implementation is the previous behaviour minus the throw. Three new tests pin the parity, the null return, and that the throwing overload still throws.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
