### PR TITLE
fix(postgresql): make the Npgsql type-mapping registry safe for concurrent registration (weasel#406)

### DIFF
--- a/src/Weasel.Postgresql.Tests/NpgsqlTypeMappingRegistryTests.cs
+++ b/src/Weasel.Postgresql.Tests/NpgsqlTypeMappingRegistryTests.cs
@@ -1,0 +1,116 @@
+using System.Data;
+using NpgsqlTypes;
+using Shouldly;
+using Xunit;
+
+namespace Weasel.Postgresql.Tests;
+
+/// <remarks>
+/// Exercises its own registry instances rather than the static NpgsqlTypeMapper.Mappings.
+/// Registering tens of thousands of mappings into the global one would linger for the rest of
+/// the run, and PostgresqlProvider.GetTypeMapping scans it linearly, so every other test that
+/// resolves an unmapped type would slow to a crawl. weasel#406.
+/// </remarks>
+public class NpgsqlTypeMappingRegistryTests
+{
+    private static NpgsqlTypeMappingRegistry EmptyRegistry()
+    {
+        return new NpgsqlTypeMappingRegistry(new Dictionary<NpgsqlDbType, NpgsqlTypeMapping>());
+    }
+
+    private static NpgsqlTypeMapping AnyMapping()
+    {
+        return new NpgsqlTypeMapping(NpgsqlDbType.Varchar, DbType.String, "varchar", typeof(string));
+    }
+
+    [Fact]
+    public void concurrent_registrations_are_not_lost()
+    {
+        // The regression: backed by a JasperFx Cache, the indexer setter was a non-atomic
+        // read-modify-write over an ImHashMap, and this landed 7,660 of 40,000 -- an 81% loss,
+        // silently. weasel#406.
+        const int threads = 8;
+        const int perThread = 2000;
+        var registry = EmptyRegistry();
+
+        Parallel.For(0, threads, t =>
+        {
+            for (var i = 0; i < perThread; i++)
+            {
+                registry[(NpgsqlDbType)(t * perThread + i)] = AnyMapping();
+            }
+        });
+
+        registry.Count.ShouldBe(threads * perThread);
+    }
+
+    [Fact]
+    public void enumerating_while_registrations_land_neither_throws_nor_tears()
+    {
+        const int seeded = 500;
+        const int added = 5000;
+
+        var registry = EmptyRegistry();
+        for (var i = 0; i < seeded; i++)
+        {
+            registry[(NpgsqlDbType)i] = AnyMapping();
+        }
+
+        // Bounded on both sides: the writer stops after a fixed number of registrations and the
+        // reader stops with it, so the dictionary cannot grow without limit underneath repeated
+        // full enumerations.
+        var writer = Task.Run(() =>
+        {
+            for (var i = 0; i < added; i++)
+            {
+                registry[(NpgsqlDbType)(100_000 + i)] = AnyMapping();
+            }
+        });
+
+        var passes = 0;
+        while (!writer.IsCompleted)
+        {
+            // Each read must see a coherent snapshot: never fewer than what was there before the
+            // writer started, and never a null hole.
+            var seen = registry.ToList();
+            seen.Count.ShouldBeGreaterThanOrEqualTo(seeded);
+            seen.ShouldAllBe(mapping => mapping != null);
+            passes++;
+        }
+
+        writer.GetAwaiter().GetResult();
+        registry.Count.ShouldBe(seeded + added);
+        passes.ShouldBeGreaterThan(0);
+    }
+
+    [Fact]
+    public void seeded_mappings_are_readable_by_key_and_by_enumeration()
+    {
+        var mapping = AnyMapping();
+        var registry = new NpgsqlTypeMappingRegistry(new Dictionary<NpgsqlDbType, NpgsqlTypeMapping>
+        {
+            { NpgsqlDbType.Varchar, mapping }
+        });
+
+        registry[NpgsqlDbType.Varchar].ShouldBeSameAs(mapping);
+        registry.TryGetValue(NpgsqlDbType.Varchar, out var found).ShouldBeTrue();
+        found.ShouldBeSameAs(mapping);
+        registry.ShouldContain(mapping);
+
+        registry.TryGetValue(NpgsqlDbType.Bigint, out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void registering_over_an_existing_key_replaces_it()
+    {
+        var registry = EmptyRegistry();
+        var first = AnyMapping();
+        var second = AnyMapping();
+
+        registry[NpgsqlDbType.Varchar] = first;
+        registry[NpgsqlDbType.Varchar] = second;
+
+        registry[NpgsqlDbType.Varchar].ShouldBeSameAs(second);
+        registry.Count.ShouldBe(1);
+    }
+}

--- a/src/Weasel.Postgresql/NpgsqlTypeMapping.cs
+++ b/src/Weasel.Postgresql/NpgsqlTypeMapping.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Collections.Specialized;
 using System.Data;
@@ -6,7 +7,6 @@ using System.Net;
 using System.Net.NetworkInformation;
 using System.Numerics;
 using System.Text.Json;
-using JasperFx.Core;
 using NetTopologySuite.Geometries;
 using NpgsqlTypes;
 
@@ -31,6 +31,63 @@ public class NpgsqlTypeMapping
 }
 
 /// <summary>
+///     Registry of <see cref="NpgsqlDbType" /> to <see cref="NpgsqlTypeMapping" />, keyed for
+///     lookup and enumerable by mapping. Consuming code registers custom mappings through the
+///     indexer, from any thread.
+/// </summary>
+/// <remarks>
+///     <para>
+///         This used to be a <c>JasperFx.Core.Cache</c>. Reads were already safe there — it is
+///         backed by an immutable <c>ImHashMap</c>, so an enumerating reader sees a snapshot and
+///         cannot tear. Writes were not: the indexer setter is a non-atomic read-modify-write
+///         over that map, so concurrent registrations silently clobbered one another. Eight
+///         threads registering 5,000 distinct keys each landed 7,660 of 40,000 — an 81% loss,
+///         with nothing to indicate a mapping had gone missing. weasel#406.
+///     </para>
+///     <para>
+///         <see cref="ConcurrentDictionary{TKey,TValue}" /> fixes the writes and keeps reads
+///         safe: <c>Values</c> hands back a snapshot, so enumeration never throws
+///         mid-registration. The surface is deliberately the same as the <c>Cache</c> it
+///         replaces — an indexer plus <see cref="IEnumerable{T}" /> over the mappings — so
+///         existing registration code is unaffected.
+///     </para>
+/// </remarks>
+public class NpgsqlTypeMappingRegistry: IEnumerable<NpgsqlTypeMapping>
+{
+    private readonly ConcurrentDictionary<NpgsqlDbType, NpgsqlTypeMapping> _values;
+
+    public NpgsqlTypeMappingRegistry(IDictionary<NpgsqlDbType, NpgsqlTypeMapping> seed)
+    {
+        _values = new ConcurrentDictionary<NpgsqlDbType, NpgsqlTypeMapping>(seed);
+    }
+
+    public NpgsqlTypeMapping this[NpgsqlDbType key]
+    {
+        get => _values[key];
+        set => _values[key] = value;
+    }
+
+    public int Count => _values.Count;
+
+    public bool TryGetValue(NpgsqlDbType key, out NpgsqlTypeMapping? value)
+    {
+        return _values.TryGetValue(key, out value);
+    }
+
+    public IEnumerator<NpgsqlTypeMapping> GetEnumerator()
+    {
+        // ConcurrentDictionary.Values is a point-in-time snapshot, so a registration landing
+        // mid-enumeration cannot disturb this.
+        return _values.Values.GetEnumerator();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
+}
+
+/// <summary>
 ///     Class defining custom NpgsqlType <=> DbType <=> CLR types
 /// </summary>
 /// <remarks>
@@ -39,7 +96,7 @@ public class NpgsqlTypeMapping
 /// </remarks>
 public class NpgsqlTypeMapper
 {
-    public static readonly Cache<NpgsqlDbType, NpgsqlTypeMapping> Mappings = new(new Dictionary<NpgsqlDbType, NpgsqlTypeMapping>
+    public static readonly NpgsqlTypeMappingRegistry Mappings = new(new Dictionary<NpgsqlDbType, NpgsqlTypeMapping>
     {
         // Numeric types
         {NpgsqlDbType.Smallint,new NpgsqlTypeMapping(NpgsqlDbType.Smallint, DbType.Int16, "smallint", typeof(short), typeof(byte),


### PR DESCRIPTION
Closes #406.

`NpgsqlTypeMapper.Mappings` is the documented extension point for consuming code to register custom Npgsql mappings:

> This is lazily calculated instead of precached because it allows consuming code to register custom npgsql mappings prior to execution.

It was a `JasperFx.Core.Cache`.

## Reads were already fine — writes were not

**Reads:** `Cache` is backed by an immutable `ImHashMap`, so an enumerating reader sees a snapshot and cannot tear or throw `Collection was modified`. A **4.3M-read** stress run against concurrent writers produced **zero** failures.

> This corrects the reader-side race I speculated about in #402. That hypothesis was wrong, and I'd rather say so than leave it standing.

**Writes:** the indexer setter is a non-atomic read-modify-write over that map, so concurrent registrations clobber each other:

```
8 threads x 5,000 distinct keys
expected 40,000 entries, observed 7,660  ->  LOST 32,340  (81%)
```

Silently. A lost registration surfaces much later as a missing or wrong type mapping, with nothing pointing back at the registration that vanished.

## Change

Replace the `Cache` with `NpgsqlTypeMappingRegistry` — a small `ConcurrentDictionary`-backed type that keeps **the same surface**: an indexer plus `IEnumerable<NpgsqlTypeMapping>`. Existing registration code and anything enumerating `Mappings` compiles and behaves unchanged. `ConcurrentDictionary` fixes the writes, and its `Values` snapshot keeps reads safe.

## Ordering is not a concern

`GetTypeMapping` breaks ties with `LastOrDefault`, so it's worth being explicit that this doesn't disturb resolution:

- The `Cache` enumerated in **ImHashMap hash order**, not insertion order, so nothing depended on a defined order to begin with.
- #405 removed the only doubly-claimed CLR type (`IPNetwork`) and added `no_clr_type_is_claimed_by_more_than_one_mapping` to stop another appearing.

With no CLR type claimed twice, which element `LastOrDefault` lands on is immaterial.

## Tests

Four new tests, exercising **their own registry instances** rather than the static `Mappings` — registering tens of thousands of entries globally would persist for the rest of the run, and `GetTypeMapping` scans linearly, so every other test resolving an unmapped type would slow to a crawl. (Measured: a registry grown to ~16M entries dropped a reader to 506 reads in 8 seconds.)

- `concurrent_registrations_are_not_lost` — 8 × 2,000; would have lost ~80% before
- `enumerating_while_registrations_land_neither_throws_nor_tears`
- `seeded_mappings_are_readable_by_key_and_by_enumeration`
- `registering_over_an_existing_key_replaces_it`

## Verification

Postgres **802 passed** on all four matrix legs (net9.0/net10.0 × case-sensitive true/false), Core **21**, SQLite **361**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
