### PR TITLE
ManagedRangePartitions for PostgreSQL: rolling time-window partitions (weasel#401)

### DIFF
--- a/docs/postgresql/partitioning.md
+++ b/docs/postgresql/partitioning.md
@@ -20,7 +20,7 @@ table.PartitionByHash(new HashPartitioning
     Suffixes = new[] { "p0", "p1", "p2", "p3" }
 });
 ```
-<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/PostgresqlPartitioningSamples.cs#L13-L24' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_pg_hash_partitioning' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/PostgresqlPartitioningSamples.cs#L14-L25' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_pg_hash_partitioning' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The `Suffixes` property automatically calculates the modulus and remainder for each partition. The resulting partition tables are named `{table}_{suffix}`.
@@ -45,7 +45,7 @@ partitioning.AddRange("q2_2024",
     DateTimeOffset.Parse("2024-04-01"),
     DateTimeOffset.Parse("2024-07-01"));
 ```
-<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/PostgresqlPartitioningSamples.cs#L29-L42' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_pg_range_partitioning' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/PostgresqlPartitioningSamples.cs#L30-L43' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_pg_range_partitioning' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## List Partitioning
@@ -64,7 +64,7 @@ var partitioning = table.PartitionByList("region");
 partitioning.AddPartition("north", "US-NORTH", "CA-NORTH");
 partitioning.AddPartition("south", "US-SOUTH", "MX");
 ```
-<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/PostgresqlPartitioningSamples.cs#L47-L56' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_pg_list_partitioning' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/PostgresqlPartitioningSamples.cs#L48-L57' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_pg_list_partitioning' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 A default partition is enabled by default. Disable it with `partitioning.DisableDefaultPartition()`.
@@ -85,7 +85,7 @@ var manager = new ManagedListPartitions(
 var partitioning = table.PartitionByList("tenant_id");
 partitioning.UsePartitionManager(manager);
 ```
-<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/PostgresqlPartitioningSamples.cs#L61-L70' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_pg_managed_list_partitions' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/PostgresqlPartitioningSamples.cs#L62-L71' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_pg_managed_list_partitions' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 At runtime, add partitions across all managed tables:
@@ -99,7 +99,7 @@ var ct = CancellationToken.None;
 
 await manager.AddPartitionToAllTables(database, "tenant_a", "tenant_a", ct);
 ```
-<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/PostgresqlPartitioningSamples.cs#L75-L81' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_pg_add_partition_at_runtime' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/PostgresqlPartitioningSamples.cs#L76-L82' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_pg_add_partition_at_runtime' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Or add multiple partitions at once:
@@ -119,7 +119,7 @@ var values = new Dictionary<string, string>
 };
 await manager.AddPartitionToAllTables(logger, database, values, ct);
 ```
-<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/PostgresqlPartitioningSamples.cs#L86-L98' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_pg_add_multiple_partitions' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/PostgresqlPartitioningSamples.cs#L87-L99' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_pg_add_multiple_partitions' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Remove partitions when a tenant is deprovisioned:
@@ -134,8 +134,93 @@ var ct = CancellationToken.None;
 
 await manager.DropPartitionFromAllTablesForValue(database, logger, "tenant_a", ct);
 ```
-<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/PostgresqlPartitioningSamples.cs#L103-L110' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_pg_drop_partition' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/PostgresqlPartitioningSamples.cs#L104-L111' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_pg_drop_partition' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
+
+## ManagedRangePartitions
+
+Time-series tables -- telemetry, audit trails, events, logs -- want a partition set that *moves*. The
+declared window rolls forward every period, last period's partitions are still on disk, and the point of
+partitioning them at all is that retiring a period should be a `DROP TABLE` instead of a mass `DELETE`
+and the vacuum storm that follows.
+
+`ManagedRangePartitions` owns that window. Rather than declaring a static list of ranges, you declare
+intent -- a period, how many periods to provision ahead, and how many to retain behind -- and Weasel
+writes every DDL statement:
+
+<!-- snippet: sample_pg_managed_range_partitions -->
+<a id='snippet-sample_pg_managed_range_partitions'></a>
+```cs
+var table = new Table("metrics");
+table.AddColumn<Guid>("id").AsPrimaryKey();
+
+// PostgreSQL requires the partition key to be part of every unique
+// constraint on a partitioned table
+table.AddColumn<DateTimeOffset>("occurred_at").AsPrimaryKey().NotNull();
+table.AddColumn<double>("value");
+
+// One partition per month, three months provisioned ahead of now,
+// six completed months retained before a partition is aged out
+var manager = new ManagedRangePartitions(
+    RollingWindowPolicy.Monthly(periodsAhead: 3, periodsBehind: 6));
+
+table.PartitionByRange("occurred_at").UsePartitionManager(manager);
+```
+<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/PostgresqlPartitioningSamples.cs#L116-L131' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_pg_managed_range_partitions' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+`RollingWindowPolicy` supports `Hourly`, `Daily`, `Weekly`, `Monthly`, and `Yearly` windows. Weekly
+partitions begin on Monday by default; set `FirstDayOfWeek` to change that at create time. All boundary
+arithmetic is done in UTC.
+
+Partition tables are named `{table}_{suffix}`, where the suffix encodes the period start: `y2026`,
+`m202607`, `w20260727`, `d20260730`, `h2026073014`. A `DEFAULT` overflow partition is always created, so
+a row outside the provisioned window is never rejected.
+
+Roll the window forward and retire aged partitions at runtime:
+
+<!-- snippet: sample_pg_roll_range_window_forward -->
+<a id='snippet-sample_pg_roll_range_window_forward'></a>
+```cs
+PostgresqlDatabase database = null!; // your database instance
+ManagedRangePartitions manager = null!; // your partition manager
+ILogger logger = null!; // your logger
+var ct = CancellationToken.None;
+
+// Create any missing periods at the leading edge and drop everything
+// older than the retention floor. Idempotent, so this is safe on every
+// startup and from every node
+await manager.ApplyAsync(database, logger, ct);
+
+// ...or run just one half of it
+await manager.RollForwardAsync(database, logger, ct);
+await manager.DropAgedPartitionsAsync(database, logger, ct);
+```
+<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/PostgresqlPartitioningSamples.cs#L136-L150' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_pg_roll_range_window_forward' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+Both halves are idempotent and safe to run concurrently from several nodes, so calling `ApplyAsync` on
+startup and on a timer is the intended usage.
+
+Two properties make this different from a static range declaration:
+
+- **Rolling forward is always `Additive`, never `Rebuild`.** The declarative range strategy treats
+  "the actual database has partitions the declaration no longer names" as drift and rebuilds the table.
+  For a rolling window that is the normal steady state, and a rebuild of a multi-gigabyte table would be
+  triggered by nothing more than the calendar. With a partition manager attached, migration only ever
+  adds partitions.
+- **Aged partitions are a policy outcome, not drift.** Retention drops them, and only ever drops
+  partitions whose suffix this policy itself produced. A hand-created partition, or one left over from a
+  different period size, is left strictly alone.
+
+Because of that, a rolling time-partitioned table needs neither `IgnorePartitionsInMigration` nor an
+"externally managed" escape hatch -- so it keeps Weasel's ordering and dependency management instead of
+hand-writing `CREATE TABLE ... PARTITION OF` and `DROP TABLE` in application code.
+
+::: warning
+Dropping an aged partition removes its rows. That is the point -- it is what makes reclaim O(1) -- but
+choose `periodsBehind` with the retention policy you actually want.
+:::
 
 ## Thread Safety
 
@@ -150,3 +235,5 @@ Weasel detects partition changes during migration. The `PartitionDelta` enum ind
 - **Rebuild** -- partition strategy changed and requires table recreation
 
 Set `table.IgnorePartitionsInMigration = true` if an external tool like `pg_partman` manages your partitions.
+A table using `ManagedListPartitions` or `ManagedRangePartitions` does not need it -- those strategies are
+already exempt from the rebuild path.

--- a/src/DocSamples/PostgresqlPartitioningSamples.cs
+++ b/src/DocSamples/PostgresqlPartitioningSamples.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging;
 using Weasel.Core;
+using Weasel.Core.Partitioning;
 using Weasel.Postgresql;
 using Weasel.Postgresql.Tables;
 using Weasel.Postgresql.Tables.Partitioning;
@@ -107,6 +108,45 @@ public class PostgresqlPartitioningSamples
         var ct = CancellationToken.None;
 
         await manager.DropPartitionFromAllTablesForValue(database, logger, "tenant_a", ct);
+        #endregion
+    }
+
+    public void managed_range_partitions()
+    {
+        #region sample_pg_managed_range_partitions
+        var table = new Table("metrics");
+        table.AddColumn<Guid>("id").AsPrimaryKey();
+
+        // PostgreSQL requires the partition key to be part of every unique
+        // constraint on a partitioned table
+        table.AddColumn<DateTimeOffset>("occurred_at").AsPrimaryKey().NotNull();
+        table.AddColumn<double>("value");
+
+        // One partition per month, three months provisioned ahead of now,
+        // six completed months retained before a partition is aged out
+        var manager = new ManagedRangePartitions(
+            RollingWindowPolicy.Monthly(periodsAhead: 3, periodsBehind: 6));
+
+        table.PartitionByRange("occurred_at").UsePartitionManager(manager);
+        #endregion
+    }
+
+    public async Task roll_the_window_forward()
+    {
+        #region sample_pg_roll_range_window_forward
+        PostgresqlDatabase database = null!; // your database instance
+        ManagedRangePartitions manager = null!; // your partition manager
+        ILogger logger = null!; // your logger
+        var ct = CancellationToken.None;
+
+        // Create any missing periods at the leading edge and drop everything
+        // older than the retention floor. Idempotent, so this is safe on every
+        // startup and from every node
+        await manager.ApplyAsync(database, logger, ct);
+
+        // ...or run just one half of it
+        await manager.RollForwardAsync(database, logger, ct);
+        await manager.DropAgedPartitionsAsync(database, logger, ct);
         #endregion
     }
 }

--- a/src/Weasel.Core.Tests/Partitioning/RollingWindowPolicyTests.cs
+++ b/src/Weasel.Core.Tests/Partitioning/RollingWindowPolicyTests.cs
@@ -1,0 +1,193 @@
+using Shouldly;
+using Weasel.Core.Partitioning;
+using Xunit;
+
+namespace Weasel.Core.Tests.Partitioning;
+
+public class RollingWindowPolicyTests
+{
+    private static readonly DateTimeOffset TheMoment =
+        new(2026, 7, 30, 14, 37, 21, TimeSpan.Zero);
+
+    [Fact]
+    public void negative_periods_ahead_is_rejected()
+    {
+        Should.Throw<ArgumentOutOfRangeException>(() => new RollingWindowPolicy(PartitionPeriod.Month, -1, 3));
+    }
+
+    [Fact]
+    public void negative_periods_behind_is_rejected()
+    {
+        Should.Throw<ArgumentOutOfRangeException>(() => new RollingWindowPolicy(PartitionPeriod.Month, 3, -1));
+    }
+
+    [Theory]
+    [InlineData(PartitionPeriod.Hour, "2026-07-30T14:00:00+00:00")]
+    [InlineData(PartitionPeriod.Day, "2026-07-30T00:00:00+00:00")]
+    [InlineData(PartitionPeriod.Week, "2026-07-27T00:00:00+00:00")]
+    [InlineData(PartitionPeriod.Month, "2026-07-01T00:00:00+00:00")]
+    [InlineData(PartitionPeriod.Year, "2026-01-01T00:00:00+00:00")]
+    public void start_of_period(PartitionPeriod period, string expected)
+    {
+        new RollingWindowPolicy(period, 1, 1).StartOfPeriod(TheMoment)
+            .ShouldBe(DateTimeOffset.Parse(expected));
+    }
+
+    [Fact]
+    public void start_of_period_converts_to_utc_first()
+    {
+        // 2026-07-30 01:30 -06:00 is 2026-07-30 07:30 UTC, so the day partition is still the 30th.
+        var local = new DateTimeOffset(2026, 7, 30, 1, 30, 0, TimeSpan.FromHours(-6));
+
+        RollingWindowPolicy.Daily(1, 1).StartOfPeriod(local)
+            .ShouldBe(new DateTimeOffset(2026, 7, 30, 0, 0, 0, TimeSpan.Zero));
+
+        // ...but 2026-07-29 20:00 -06:00 is already the 30th in UTC.
+        var evening = new DateTimeOffset(2026, 7, 29, 20, 0, 0, TimeSpan.FromHours(-6));
+
+        RollingWindowPolicy.Daily(1, 1).StartOfPeriod(evening)
+            .ShouldBe(new DateTimeOffset(2026, 7, 30, 0, 0, 0, TimeSpan.Zero));
+    }
+
+    [Fact]
+    public void week_honors_first_day_of_week()
+    {
+        // 2026-07-30 is a Thursday.
+        var sundayBased = new RollingWindowPolicy(PartitionPeriod.Week, 1, 1) { FirstDayOfWeek = DayOfWeek.Sunday };
+
+        sundayBased.StartOfPeriod(TheMoment)
+            .ShouldBe(new DateTimeOffset(2026, 7, 26, 0, 0, 0, TimeSpan.Zero));
+    }
+
+    [Theory]
+    [InlineData(PartitionPeriod.Hour, "h2026073014")]
+    [InlineData(PartitionPeriod.Day, "d20260730")]
+    [InlineData(PartitionPeriod.Week, "w20260727")]
+    [InlineData(PartitionPeriod.Month, "m202607")]
+    [InlineData(PartitionPeriod.Year, "y2026")]
+    public void suffix_for(PartitionPeriod period, string expected)
+    {
+        new RollingWindowPolicy(period, 1, 1).SuffixFor(TheMoment).ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData(PartitionPeriod.Hour)]
+    [InlineData(PartitionPeriod.Day)]
+    [InlineData(PartitionPeriod.Week)]
+    [InlineData(PartitionPeriod.Month)]
+    [InlineData(PartitionPeriod.Year)]
+    public void suffix_round_trips(PartitionPeriod period)
+    {
+        var policy = new RollingWindowPolicy(period, 1, 1);
+        var suffix = policy.SuffixFor(TheMoment);
+
+        policy.TryParseSuffix(suffix, out var start).ShouldBeTrue();
+        start.ShouldBe(policy.StartOfPeriod(TheMoment));
+    }
+
+    [Fact]
+    public void suffixes_sort_lexically_in_chronological_order()
+    {
+        var policy = RollingWindowPolicy.Monthly(2, 12);
+        var suffixes = policy.Window(TheMoment).Select(x => x.Suffix).ToArray();
+
+        suffixes.OrderBy(x => x, StringComparer.Ordinal).ShouldBe(suffixes);
+    }
+
+    [Fact]
+    public void will_not_parse_a_suffix_from_another_period_size()
+    {
+        RollingWindowPolicy.Monthly(1, 1).TryParseSuffix("d20260730", out _).ShouldBeFalse();
+        RollingWindowPolicy.Daily(1, 1).TryParseSuffix("m202607", out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void will_not_parse_a_foreign_suffix()
+    {
+        var policy = RollingWindowPolicy.Monthly(1, 1);
+
+        policy.TryParseSuffix("default", out _).ShouldBeFalse();
+        policy.TryParseSuffix("twenties", out _).ShouldBeFalse();
+        policy.TryParseSuffix(null, out _).ShouldBeFalse();
+        policy.TryParseSuffix("", out _).ShouldBeFalse();
+        policy.TryParseSuffix("m20260x", out _).ShouldBeFalse();
+        policy.TryParseSuffix("m2026071", out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void will_not_parse_a_week_suffix_that_is_not_on_the_first_day_of_week()
+    {
+        var policy = RollingWindowPolicy.Weekly(1, 1);
+
+        // Monday-based weeks: 2026-07-27 is a Monday, 2026-07-28 is not.
+        policy.TryParseSuffix("w20260727", out _).ShouldBeTrue();
+        policy.TryParseSuffix("w20260728", out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void window_covers_retained_current_and_provisioned_periods()
+    {
+        var policy = RollingWindowPolicy.Monthly(periodsAhead: 2, periodsBehind: 3);
+
+        var window = policy.Window(TheMoment);
+
+        window.Count.ShouldBe(6);
+        window.Select(x => x.Suffix)
+            .ShouldBe(["m202604", "m202605", "m202606", "m202607", "m202608", "m202609"]);
+    }
+
+    [Fact]
+    public void window_partitions_are_contiguous_and_half_open()
+    {
+        var window = RollingWindowPolicy.Monthly(2, 2).Window(TheMoment);
+
+        for (var i = 1; i < window.Count; i++)
+        {
+            window[i].From.ShouldBe(window[i - 1].To);
+        }
+
+        window[0].From.ShouldBe(new DateTimeOffset(2026, 5, 1, 0, 0, 0, TimeSpan.Zero));
+        window[^1].To.ShouldBe(new DateTimeOffset(2026, 10, 1, 0, 0, 0, TimeSpan.Zero));
+    }
+
+    [Fact]
+    public void a_zero_retention_window_still_has_the_current_period()
+    {
+        var window = RollingWindowPolicy.Daily(periodsAhead: 0, periodsBehind: 0).Window(TheMoment);
+
+        window.Count.ShouldBe(1);
+        window[0].Suffix.ShouldBe("d20260730");
+    }
+
+    [Fact]
+    public void retention_floor_is_the_oldest_period_in_the_window()
+    {
+        var policy = RollingWindowPolicy.Monthly(2, 3);
+
+        policy.RetentionFloor(TheMoment).ShouldBe(policy.Window(TheMoment)[0].From);
+    }
+
+    [Fact]
+    public void rolling_the_clock_forward_one_period_adds_one_and_ages_one()
+    {
+        var policy = RollingWindowPolicy.Monthly(periodsAhead: 1, periodsBehind: 2);
+
+        var before = policy.Window(TheMoment).Select(x => x.Suffix).ToArray();
+        var after = policy.Window(TheMoment.AddMonths(1)).Select(x => x.Suffix).ToArray();
+
+        // This is the whole premise of #401: a window that has rolled forward differs from the database's
+        // by exactly one new partition and one aged one — never a wholesale change that reads as drift.
+        after.Except(before).ShouldHaveSingleItem().ShouldBe("m202609");
+        before.Except(after).ShouldHaveSingleItem().ShouldBe("m202605");
+    }
+
+    [Fact]
+    public void month_arithmetic_survives_short_months()
+    {
+        var policy = RollingWindowPolicy.Monthly(1, 1);
+        var lastDayOfJanuary = new DateTimeOffset(2026, 1, 31, 23, 59, 59, TimeSpan.Zero);
+
+        policy.Window(lastDayOfJanuary).Select(x => x.Suffix)
+            .ShouldBe(["m202512", "m202601", "m202602"]);
+    }
+}

--- a/src/Weasel.Core/Partitioning/PartitionPeriod.cs
+++ b/src/Weasel.Core/Partitioning/PartitionPeriod.cs
@@ -1,0 +1,33 @@
+namespace Weasel.Core.Partitioning;
+
+/// <summary>
+///     The size of a single partition in a rolling time-window partitioning scheme.
+/// </summary>
+public enum PartitionPeriod
+{
+    /// <summary>
+    ///     One partition per clock hour, starting at the top of the hour (UTC).
+    /// </summary>
+    Hour,
+
+    /// <summary>
+    ///     One partition per calendar day, starting at midnight (UTC).
+    /// </summary>
+    Day,
+
+    /// <summary>
+    ///     One partition per week, starting at midnight (UTC) on
+    ///     <see cref="RollingWindowPolicy.FirstDayOfWeek" />.
+    /// </summary>
+    Week,
+
+    /// <summary>
+    ///     One partition per calendar month, starting on the first of the month (UTC).
+    /// </summary>
+    Month,
+
+    /// <summary>
+    ///     One partition per calendar year, starting on January 1st (UTC).
+    /// </summary>
+    Year
+}

--- a/src/Weasel.Core/Partitioning/RollingWindowPolicy.cs
+++ b/src/Weasel.Core/Partitioning/RollingWindowPolicy.cs
@@ -1,0 +1,272 @@
+using System.Globalization;
+
+namespace Weasel.Core.Partitioning;
+
+/// <summary>
+///     One partition of a rolling time window: the half-open interval
+///     <c>[From, To)</c> and the table-name suffix that identifies it.
+/// </summary>
+/// <param name="Suffix">Partition table name suffix, e.g. <c>m202607</c>.</param>
+/// <param name="From">Inclusive lower bound of the partition, always UTC.</param>
+/// <param name="To">Exclusive upper bound of the partition, always UTC.</param>
+public sealed record TimeWindowPartition(string Suffix, DateTimeOffset From, DateTimeOffset To);
+
+/// <summary>
+///     Declarative description of a rolling time-window partitioning scheme: a period size, how many
+///     periods to provision <em>ahead</em> of now, and how many periods to retain <em>behind</em> now
+///     before a partition is aged out.
+///     <para>
+///         The whole point of the type is that the partition set is a pure function of the policy and
+///         the current time. Nothing about it is stored, so "now moved forward one month" produces a
+///         window that differs from the database's by exactly one <em>new</em> partition at the leading
+///         edge and one <em>aged</em> partition at the trailing edge — an additive create plus a
+///         retention drop, never a rebuild.
+///     </para>
+///     <para>
+///         All arithmetic is done in UTC. See JasperFx/weasel#401.
+///     </para>
+/// </summary>
+public class RollingWindowPolicy
+{
+    /// <summary>
+    ///     Create a rolling window policy.
+    /// </summary>
+    /// <param name="period">The size of a single partition.</param>
+    /// <param name="periodsAhead">
+    ///     How many periods beyond the current one to provision. Must be zero or greater, but at least
+    ///     one is strongly recommended so that rows written at the very end of a period always have a
+    ///     partition waiting for them.
+    /// </param>
+    /// <param name="periodsBehind">
+    ///     How many completed periods to retain. Partitions older than this are aged out. Zero means
+    ///     "keep only the current period and anything provisioned ahead of it".
+    /// </param>
+    public RollingWindowPolicy(PartitionPeriod period, int periodsAhead, int periodsBehind)
+    {
+        if (periodsAhead < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(periodsAhead), periodsAhead,
+                "The number of periods to provision ahead cannot be negative");
+        }
+
+        if (periodsBehind < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(periodsBehind), periodsBehind,
+                "The number of periods to retain behind cannot be negative");
+        }
+
+        Period = period;
+        PeriodsAhead = periodsAhead;
+        PeriodsBehind = periodsBehind;
+    }
+
+    /// <summary>
+    ///     The size of a single partition.
+    /// </summary>
+    public PartitionPeriod Period { get; }
+
+    /// <summary>
+    ///     How many periods beyond the current one are provisioned.
+    /// </summary>
+    public int PeriodsAhead { get; }
+
+    /// <summary>
+    ///     How many completed periods are retained before a partition is aged out.
+    /// </summary>
+    public int PeriodsBehind { get; }
+
+    /// <summary>
+    ///     The day a <see cref="PartitionPeriod.Week" /> partition begins on. Defaults to Monday, and is
+    ///     ignored by every other period. Changing this on a database that already holds weekly partitions
+    ///     re-bases every boundary, so treat it as a create-time decision.
+    /// </summary>
+    public DayOfWeek FirstDayOfWeek { get; init; } = DayOfWeek.Monday;
+
+    /// <summary>
+    ///     Hourly partitions: one partition per clock hour.
+    /// </summary>
+    public static RollingWindowPolicy Hourly(int periodsAhead, int periodsBehind)
+        => new(PartitionPeriod.Hour, periodsAhead, periodsBehind);
+
+    /// <summary>
+    ///     Daily partitions: one partition per calendar day.
+    /// </summary>
+    public static RollingWindowPolicy Daily(int periodsAhead, int periodsBehind)
+        => new(PartitionPeriod.Day, periodsAhead, periodsBehind);
+
+    /// <summary>
+    ///     Weekly partitions: one partition per week, beginning on <see cref="FirstDayOfWeek" />.
+    /// </summary>
+    public static RollingWindowPolicy Weekly(int periodsAhead, int periodsBehind)
+        => new(PartitionPeriod.Week, periodsAhead, periodsBehind);
+
+    /// <summary>
+    ///     Monthly partitions: one partition per calendar month.
+    /// </summary>
+    public static RollingWindowPolicy Monthly(int periodsAhead, int periodsBehind)
+        => new(PartitionPeriod.Month, periodsAhead, periodsBehind);
+
+    /// <summary>
+    ///     Yearly partitions: one partition per calendar year.
+    /// </summary>
+    public static RollingWindowPolicy Yearly(int periodsAhead, int periodsBehind)
+        => new(PartitionPeriod.Year, periodsAhead, periodsBehind);
+
+    /// <summary>
+    ///     The UTC instant at which the period containing <paramref name="moment" /> begins.
+    /// </summary>
+    public DateTimeOffset StartOfPeriod(DateTimeOffset moment)
+    {
+        var utc = moment.ToUniversalTime();
+
+        return Period switch
+        {
+            PartitionPeriod.Hour => new DateTimeOffset(utc.Year, utc.Month, utc.Day, utc.Hour, 0, 0, TimeSpan.Zero),
+            PartitionPeriod.Day => new DateTimeOffset(utc.Year, utc.Month, utc.Day, 0, 0, 0, TimeSpan.Zero),
+            PartitionPeriod.Week => startOfWeek(utc),
+            PartitionPeriod.Month => new DateTimeOffset(utc.Year, utc.Month, 1, 0, 0, 0, TimeSpan.Zero),
+            PartitionPeriod.Year => new DateTimeOffset(utc.Year, 1, 1, 0, 0, 0, TimeSpan.Zero),
+            _ => throw new ArgumentOutOfRangeException(nameof(moment), Period, "Unsupported partition period")
+        };
+    }
+
+    /// <summary>
+    ///     Shift a period start forward (or backward, for a negative count) by whole periods.
+    /// </summary>
+    public DateTimeOffset AddPeriods(DateTimeOffset periodStart, int periods)
+    {
+        return Period switch
+        {
+            PartitionPeriod.Hour => periodStart.AddHours(periods),
+            PartitionPeriod.Day => periodStart.AddDays(periods),
+            PartitionPeriod.Week => periodStart.AddDays(7 * periods),
+            PartitionPeriod.Month => periodStart.AddMonths(periods),
+            PartitionPeriod.Year => periodStart.AddYears(periods),
+            _ => throw new ArgumentOutOfRangeException(nameof(periodStart), Period, "Unsupported partition period")
+        };
+    }
+
+    /// <summary>
+    ///     The oldest period start this policy still retains at <paramref name="now" />. A partition whose
+    ///     period begins strictly before this instant is aged out.
+    /// </summary>
+    public DateTimeOffset RetentionFloor(DateTimeOffset now)
+        => AddPeriods(StartOfPeriod(now), -PeriodsBehind);
+
+    /// <summary>
+    ///     The full set of partitions this policy expects to exist at <paramref name="now" />, ordered
+    ///     oldest first: <see cref="PeriodsBehind" /> retained periods, the current period, then
+    ///     <see cref="PeriodsAhead" /> provisioned ahead.
+    /// </summary>
+    public IReadOnlyList<TimeWindowPartition> Window(DateTimeOffset now)
+    {
+        var current = StartOfPeriod(now);
+        var window = new List<TimeWindowPartition>(PeriodsBehind + PeriodsAhead + 1);
+
+        for (var i = -PeriodsBehind; i <= PeriodsAhead; i++)
+        {
+            var from = AddPeriods(current, i);
+            var to = AddPeriods(current, i + 1);
+            window.Add(new TimeWindowPartition(SuffixFor(from), from, to));
+        }
+
+        return window;
+    }
+
+    /// <summary>
+    ///     The partition table name suffix for the period containing <paramref name="moment" />. The
+    ///     encoding is a single period-type letter followed by the fixed-width, zero-padded period start:
+    ///     <c>y2026</c>, <c>m202607</c>, <c>w20260727</c>, <c>d20260730</c>, <c>h2026073014</c>. It is
+    ///     lexically sortable, unambiguous across period types, and round-trips through
+    ///     <see cref="TryParseSuffix" />.
+    /// </summary>
+    public string SuffixFor(DateTimeOffset moment)
+    {
+        var start = StartOfPeriod(moment);
+
+        return Period switch
+        {
+            PartitionPeriod.Hour => "h" + start.ToString("yyyyMMddHH", CultureInfo.InvariantCulture),
+            PartitionPeriod.Day => "d" + start.ToString("yyyyMMdd", CultureInfo.InvariantCulture),
+            PartitionPeriod.Week => "w" + start.ToString("yyyyMMdd", CultureInfo.InvariantCulture),
+            PartitionPeriod.Month => "m" + start.ToString("yyyyMM", CultureInfo.InvariantCulture),
+            PartitionPeriod.Year => "y" + start.ToString("yyyy", CultureInfo.InvariantCulture),
+            _ => throw new ArgumentOutOfRangeException(nameof(moment), Period, "Unsupported partition period")
+        };
+    }
+
+    /// <summary>
+    ///     Try to read a partition suffix back into the period start it encodes. Returns false for any
+    ///     suffix this policy did not produce — a different period size, a hand-created partition, or a
+    ///     date that is not actually a period start for this policy. Callers use that to leave partitions
+    ///     they do not own strictly alone.
+    /// </summary>
+    public bool TryParseSuffix(string? suffix, out DateTimeOffset periodStart)
+    {
+        periodStart = default;
+
+        if (string.IsNullOrWhiteSpace(suffix))
+        {
+            return false;
+        }
+
+        var value = suffix.Trim();
+
+        var (prefix, digitCount) = Period switch
+        {
+            PartitionPeriod.Hour => ('h', 10),
+            PartitionPeriod.Day => ('d', 8),
+            PartitionPeriod.Week => ('w', 8),
+            PartitionPeriod.Month => ('m', 6),
+            PartitionPeriod.Year => ('y', 4),
+            _ => throw new ArgumentOutOfRangeException(nameof(suffix), Period, "Unsupported partition period")
+        };
+
+        if (value.Length != digitCount + 1 || char.ToLowerInvariant(value[0]) != prefix)
+        {
+            return false;
+        }
+
+        var digits = value[1..];
+
+        // Pad the partial dates out to a full date so the parse never falls back on "today" for the
+        // components the suffix does not carry.
+        var (text, format) = Period switch
+        {
+            PartitionPeriod.Hour => (digits, "yyyyMMddHH"),
+            PartitionPeriod.Year => (digits + "0101", "yyyyMMdd"),
+            PartitionPeriod.Month => (digits + "01", "yyyyMMdd"),
+            _ => (digits, "yyyyMMdd")
+        };
+
+        if (!DateTime.TryParseExact(text, format, CultureInfo.InvariantCulture,
+                DateTimeStyles.None | DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                out var parsed))
+        {
+            return false;
+        }
+
+        var candidate = new DateTimeOffset(parsed, TimeSpan.Zero);
+
+        // A weekly suffix that does not land on FirstDayOfWeek was not produced by this policy.
+        if (candidate != StartOfPeriod(candidate))
+        {
+            return false;
+        }
+
+        periodStart = candidate;
+        return true;
+    }
+
+    private DateTimeOffset startOfWeek(DateTimeOffset utc)
+    {
+        var day = new DateTimeOffset(utc.Year, utc.Month, utc.Day, 0, 0, 0, TimeSpan.Zero);
+        var delta = ((int)day.DayOfWeek - (int)FirstDayOfWeek + 7) % 7;
+
+        return day.AddDays(-delta);
+    }
+
+    /// <inheritdoc />
+    public override string ToString()
+        => $"{Period}, {PeriodsAhead} ahead, {PeriodsBehind} retained";
+}

--- a/src/Weasel.Postgresql.Tests/Tables/partitioning/managed_range_partitions.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/partitioning/managed_range_partitions.cs
@@ -1,0 +1,381 @@
+using System.Data;
+using JasperFx;
+using Microsoft.Extensions.Logging.Abstractions;
+using Npgsql;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Core.Migrations;
+using Weasel.Core.Partitioning;
+using Weasel.Postgresql.Tables;
+using Weasel.Postgresql.Tables.Partitioning;
+using Xunit;
+
+namespace Weasel.Postgresql.Tests.Tables.partitioning;
+
+[Collection("managed_ranges")]
+public class managed_range_partitions: IntegrationContext
+{
+    // Mid-July so that neither the leading nor the trailing edge of the window sits on a boundary.
+    private static readonly DateTimeOffset July = new(2026, 7, 15, 12, 0, 0, TimeSpan.Zero);
+
+    public managed_range_partitions(): base("managed_ranges")
+    {
+    }
+
+    public override ValueTask InitializeAsync() => new(ResetSchema());
+
+    [Fact]
+    public void the_window_is_a_pure_function_of_policy_and_clock()
+    {
+        var clock = new TestClock(July);
+        var manager = new ManagedRangePartitions(RollingWindowPolicy.Monthly(1, 2), clock);
+
+        manager.Partitions().Select(x => x.Suffix)
+            .ShouldBe(["m202605", "m202606", "m202607", "m202608"]);
+
+        clock.UtcNow = July.AddMonths(1);
+
+        manager.Partitions().Select(x => x.Suffix)
+            .ShouldBe(["m202606", "m202607", "m202608", "m202609"]);
+    }
+
+    [Fact]
+    public async Task the_whole_window_is_provisioned_when_the_table_is_created()
+    {
+        await using var database = new ManagedRangeDatabase(July);
+        await database.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var partitioning = await fetchPartitioning(database);
+
+        partitioning.Ranges.Select(x => x.Suffix).OrderBy(x => x)
+            .ShouldBe(["m202605", "m202606", "m202607", "m202608"]);
+        partitioning.HasExistingDefault.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task migrating_twice_without_moving_the_clock_is_a_no_op()
+    {
+        await using var database = new ManagedRangeDatabase(July);
+        await database.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var migration = await database.CreateMigrationAsync();
+
+        migration.Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task rolling_the_window_forward_is_additive_never_rebuild()
+    {
+        await using var database = new ManagedRangeDatabase(July);
+        await database.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        database.Clock.UtcNow = July.AddMonths(1);
+
+        var delta = await fetchTableDelta(database);
+
+        delta.PartitionDelta.ShouldBe(PartitionDelta.Additive);
+        delta.MissingPartitions.OfType<RangePartition>().Select(x => x.Suffix)
+            .ShouldBe(["m202609"]);
+    }
+
+    [Fact]
+    public async Task partitions_that_have_aged_out_of_the_window_are_not_drift()
+    {
+        await using var database = new ManagedRangeDatabase(July);
+        await database.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        // Six months on, EVERY partition the database holds has fallen out of the declared window. The
+        // declarative RANGE strategy reads that as "the actual table has partitions we no longer expect"
+        // and rebuilds; a rolling window must not, because that is a multi-gigabyte table copy triggered
+        // by nothing more than the calendar. weasel#401.
+        database.Clock.UtcNow = July.AddMonths(6);
+
+        var delta = await fetchTableDelta(database);
+
+        delta.PartitionDelta.ShouldBe(PartitionDelta.Additive);
+    }
+
+    [Fact]
+    public async Task rolling_forward_through_migration_preserves_the_existing_data()
+    {
+        await using var database = new ManagedRangeDatabase(July);
+        await database.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        await insertEvent("in-july", July);
+
+        database.Clock.UtcNow = July.AddMonths(1);
+        await database.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        (await countEvents()).ShouldBe(1);
+
+        var partitioning = await fetchPartitioning(database);
+
+        // The new leading-edge partition was added, and nothing that already existed was disturbed —
+        // aged partitions are removed by the retention pass, not by migration.
+        partitioning.Ranges.Select(x => x.Suffix).OrderBy(x => x)
+            .ShouldBe(["m202605", "m202606", "m202607", "m202608", "m202609"]);
+    }
+
+    [Fact]
+    public async Task apply_provisions_the_window_out_of_band_and_is_idempotent()
+    {
+        await using var database = new ManagedRangeDatabase(July);
+        await database.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        database.Clock.UtcNow = July.AddMonths(1);
+
+        var statuses = await database.Partitions.ApplyAsync(database, NullLogger.Instance, CancellationToken.None);
+        statuses.Single().Status.ShouldBe(PartitionMigrationStatus.Complete);
+
+        // Running it a second time changes nothing and throws nothing — this is what makes it safe on
+        // every startup and from every node.
+        await database.Partitions.ApplyAsync(database, NullLogger.Instance, CancellationToken.None);
+
+        var partitioning = await fetchPartitioning(database);
+        partitioning.Ranges.Select(x => x.Suffix).OrderBy(x => x)
+            .ShouldBe(["m202606", "m202607", "m202608", "m202609"]);
+    }
+
+    [Fact]
+    public async Task aged_partitions_are_dropped_by_the_retention_pass()
+    {
+        await using var database = new ManagedRangeDatabase(July);
+        await database.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        await insertEvent("may", new DateTimeOffset(2026, 5, 10, 0, 0, 0, TimeSpan.Zero));
+        await insertEvent("july", July);
+
+        // Two months on, the retention floor is 2026-07-01, so May and June are aged out.
+        database.Clock.UtcNow = July.AddMonths(2);
+
+        await database.Partitions.DropAgedPartitionsAsync(database, NullLogger.Instance, CancellationToken.None);
+
+        // Retention only retires — provisioning the leading edge is RollForwardAsync's job — so the two
+        // partitions that are still inside the window survive untouched.
+        (await partitionTableNames())
+            .ShouldBe(["events_default", "events_m202607", "events_m202608"]);
+
+        // Dropping the partition is what reclaims the storage — the May row went with it.
+        (await countEvents()).ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task apply_rolls_the_leading_edge_forward_and_retires_the_trailing_edge_in_one_pass()
+    {
+        await using var database = new ManagedRangeDatabase(July);
+        await database.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        database.Clock.UtcNow = July.AddMonths(2);
+
+        await database.Partitions.ApplyAsync(database, NullLogger.Instance, CancellationToken.None);
+
+        (await partitionTableNames())
+            .ShouldBe(["events_default", "events_m202607", "events_m202608", "events_m202609", "events_m202610"]);
+    }
+
+    [Fact]
+    public async Task two_nodes_provisioning_the_same_window_at_once_is_safe()
+    {
+        await using var database = new ManagedRangeDatabase(July);
+        await database.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        // Separate manager instances standing in for separate application nodes, racing on the same
+        // window. CREATE TABLE IF NOT EXISTS is not atomic against a concurrent creator, so this is the
+        // case that has to not throw.
+        await using var nodeA = new ManagedRangeDatabase(July.AddMonths(3));
+        await using var nodeB = new ManagedRangeDatabase(July.AddMonths(3));
+
+        await Task.WhenAll(
+            nodeA.Partitions.RollForwardAsync(nodeA, NullLogger.Instance, CancellationToken.None),
+            nodeB.Partitions.RollForwardAsync(nodeB, NullLogger.Instance, CancellationToken.None));
+
+        (await partitionTableNames()).ShouldContain("events_m202611");
+    }
+
+    [Fact]
+    public async Task retention_leaves_partitions_this_policy_does_not_own_alone()
+    {
+        await using var database = new ManagedRangeDatabase(July);
+        await database.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        // A hand-created archive partition well below the retention floor. Weasel did not name it, so
+        // Weasel does not get to drop it.
+        await ensureOpen();
+        await theConnection.CreateCommand(
+                "create table managed_ranges.events_archive partition of managed_ranges.events for values from ('2019-01-01 00:00:00+00') to ('2020-01-01 00:00:00+00');")
+            .ExecuteNonQueryAsync();
+
+        database.Clock.UtcNow = July.AddMonths(2);
+        await database.Partitions.DropAgedPartitionsAsync(database, NullLogger.Instance, CancellationToken.None);
+
+        (await partitionTableNames()).ShouldContain("events_archive");
+    }
+
+    [Fact]
+    public async Task the_default_partition_catches_rows_outside_the_window()
+    {
+        await using var database = new ManagedRangeDatabase(July);
+        await database.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        // Years beyond anything provisioned. Without the DEFAULT overflow partition this insert fails
+        // with 23514 "no partition of relation found for row".
+        await insertEvent("far-future", new DateTimeOffset(2030, 1, 1, 0, 0, 0, TimeSpan.Zero));
+
+        await ensureOpen();
+        var count = await theConnection.CreateCommand("select count(*) from managed_ranges.events_default")
+            .ExecuteScalarAsync();
+
+        Convert.ToInt32(count).ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task retention_skips_a_table_that_is_not_present_on_this_database()
+    {
+        // A configured parent that was never physically migrated here — a sharded deployment where this
+        // table does not live yet. Nothing to provision, nothing to retire, and no 42P01.
+        await using var database = new ManagedRangeDatabase(July);
+
+        var statuses = await database.Partitions.ApplyAsync(database, NullLogger.Instance, CancellationToken.None);
+
+        statuses.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void declaring_static_ranges_alongside_a_manager_is_rejected()
+    {
+        var table = new Table(new DbObjectName("managed_ranges", "events"));
+        table.AddColumn<Guid>("id").AsPrimaryKey();
+        table.AddColumn<DateTimeOffset>("occurred_at").AsPrimaryKey().NotNull();
+
+        var partitioning = table.PartitionByRange("occurred_at")
+            .UsePartitionManager(new ManagedRangePartitions(RollingWindowPolicy.Monthly(1, 1)));
+
+        Should.Throw<InvalidOperationException>(() => partitioning.AddRange("twenties", 20, 29));
+    }
+
+    private async Task ensureOpen()
+    {
+        if (theConnection.State != ConnectionState.Open)
+        {
+            await theConnection.OpenAsync();
+        }
+    }
+
+    private static async Task<RangePartitioning> fetchPartitioning(ManagedRangeDatabase database)
+    {
+        var tables = await database.FetchExistingTablesAsync();
+        var table = tables.Single(x => x.Identifier.Name == "events");
+
+        return table.Partitioning.ShouldBeOfType<RangePartitioning>();
+    }
+
+    private static async Task<TableDelta> fetchTableDelta(ManagedRangeDatabase database)
+    {
+        var migration = await database.CreateMigrationAsync();
+
+        return migration.Deltas.OfType<TableDelta>().Single(x => x.Expected.Identifier.Name == "events");
+    }
+
+    private async Task<string[]> partitionTableNames()
+    {
+        await ensureOpen();
+
+        var names = new List<string>();
+        await using var reader = await theConnection.CreateCommand(
+                """
+                select c.relname
+                from pg_inherits i
+                join pg_class c on c.oid = i.inhrelid
+                join pg_class p on p.oid = i.inhparent
+                where p.relname = 'events'
+                order by c.relname
+                """)
+            .ExecuteReaderAsync();
+
+        while (await reader.ReadAsync())
+        {
+            names.Add(reader.GetString(0));
+        }
+
+        return names.ToArray();
+    }
+
+    private async Task insertEvent(string name, DateTimeOffset occurredAt)
+    {
+        await ensureOpen();
+
+        await theConnection
+            .CreateCommand("insert into managed_ranges.events (id, occurred_at, name) values (:id, :at, :name)")
+            .With("id", Guid.NewGuid())
+            .With("at", occurredAt)
+            .With("name", name)
+            .ExecuteNonQueryAsync();
+    }
+
+    private async Task<int> countEvents()
+    {
+        await ensureOpen();
+
+        var count = await theConnection.CreateCommand("select count(*) from managed_ranges.events")
+            .ExecuteScalarAsync();
+
+        return Convert.ToInt32(count);
+    }
+}
+
+/// <summary>
+/// Deterministic clock so the tests can roll the window forward without waiting for the calendar.
+/// </summary>
+public class TestClock: TimeProvider
+{
+    public TestClock(DateTimeOffset now) => UtcNow = now;
+
+    public DateTimeOffset UtcNow { get; set; }
+
+    public override DateTimeOffset GetUtcNow() => UtcNow;
+}
+
+public class ManagedRangeDatabase: PostgresqlDatabase, IAsyncDisposable
+{
+    private readonly Events _feature;
+
+    public ManagedRangeDatabase(DateTimeOffset now, RollingWindowPolicy? policy = null): base(
+        new DefaultMigrationLogger(), AutoCreate.CreateOrUpdate, new PostgresqlMigrator(), "Ranges",
+        NpgsqlDataSource.Create(ConnectionSource.ConnectionString))
+    {
+        Clock = new TestClock(now);
+        Partitions = new ManagedRangePartitions(policy ?? RollingWindowPolicy.Monthly(1, 2), Clock);
+        _feature = new Events(Partitions);
+    }
+
+    public TestClock Clock { get; }
+
+    public ManagedRangePartitions Partitions { get; }
+
+    public override IFeatureSchema[] BuildFeatureSchemas() => [_feature];
+
+    public ValueTask DisposeAsync() => DataSource.DisposeAsync();
+}
+
+public class Events: FeatureSchemaBase
+{
+    private readonly Table _events;
+
+    public Events(ManagedRangePartitions partitions): base("Events", new PostgresqlMigrator())
+    {
+        _events = new Table(new DbObjectName("managed_ranges", "events"));
+        _events.AddColumn<Guid>("id").AsPrimaryKey();
+
+        // PostgreSQL requires the partition key to be part of every unique constraint on a partitioned
+        // table, so occurred_at is in the primary key.
+        _events.AddColumn<DateTimeOffset>("occurred_at").AsPrimaryKey().NotNull();
+        _events.AddColumn<string>("name");
+
+        _events.PartitionByRange("occurred_at").UsePartitionManager(partitions);
+    }
+
+    protected override IEnumerable<ISchemaObject> schemaObjects()
+    {
+        yield return _events;
+    }
+}

--- a/src/Weasel.Postgresql/Tables/Partitioning/ManagedRangePartitions.cs
+++ b/src/Weasel.Postgresql/Tables/Partitioning/ManagedRangePartitions.cs
@@ -1,0 +1,355 @@
+using JasperFx.Core;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Npgsql;
+using Weasel.Core;
+using Weasel.Core.Partitioning;
+
+namespace Weasel.Postgresql.Tables.Partitioning;
+
+/// <summary>
+///     Supplies the partition set of a <see cref="RangePartitioning" /> at runtime instead of the table
+///     declaring a static list of ranges.
+/// </summary>
+public interface IRangePartitionManager
+{
+    /// <summary>
+    ///     The partitions that should exist right now.
+    /// </summary>
+    IEnumerable<RangePartition> Partitions();
+}
+
+/// <summary>
+///     A runtime-managed RANGE partition strategy for rolling time windows — the range analogue of
+///     <see cref="ManagedListPartitions" />. Consumers declare intent ("monthly, 12 ahead, retain 6")
+///     through a <see cref="RollingWindowPolicy" /> and Weasel owns every DDL statement: it creates the
+///     periods at the leading edge additively and drops the aged ones at the trailing edge.
+///     <para>
+///         This is what makes range partitioning worth having on a time-series table. Reclaiming a
+///         period is a <c>DROP TABLE</c> against one partition — O(1), no mass <c>DELETE</c>, no bloat,
+///         no vacuum storm. And because the window is a pure function of the policy and the clock, a
+///         window that has rolled forward is never mistaken for schema drift: see
+///         <see cref="RangePartitioning.CreateDelta" />, which is purely additive whenever a manager is
+///         attached. No consumer needs <see cref="Table.IgnorePartitionsInMigration" /> or an
+///         "externally managed" escape hatch, so nothing gives up Weasel's ordering and dependency
+///         management to run a rolling time-partitioned table.
+///     </para>
+///     <para>
+///         Usage: attach the manager to the table's range partitioning, then call
+///         <see cref="ApplyAsync(PostgresqlDatabase,ILogger,CancellationToken)" /> at startup and on
+///         whatever cadence the period demands. Both halves are idempotent and safe to run concurrently
+///         from multiple nodes.
+///     </para>
+///     <code>
+///     var manager = new ManagedRangePartitions(RollingWindowPolicy.Monthly(periodsAhead: 3, periodsBehind: 6));
+///     table.PartitionByRange("occurred_at").UsePartitionManager(manager);
+///     </code>
+///     <para>JasperFx/weasel#401.</para>
+/// </summary>
+public class ManagedRangePartitions: IRangePartitionManager
+{
+    private readonly TimeProvider _timeProvider;
+
+    /// <summary>
+    ///     Create a rolling-window partition manager.
+    /// </summary>
+    /// <param name="policy">The rolling window: period size, periods provisioned ahead, periods retained.</param>
+    /// <param name="timeProvider">
+    ///     Clock used to resolve "now". Defaults to <see cref="TimeProvider.System" />; supply a fake to
+    ///     roll the window forward deterministically in tests.
+    /// </param>
+    public ManagedRangePartitions(RollingWindowPolicy policy, TimeProvider? timeProvider = null)
+    {
+        Policy = policy ?? throw new ArgumentNullException(nameof(policy));
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    /// <summary>
+    ///     The rolling window this manager provisions against.
+    /// </summary>
+    public RollingWindowPolicy Policy { get; }
+
+    /// <summary>
+    ///     "Now" according to this manager's clock, in UTC.
+    /// </summary>
+    public DateTimeOffset UtcNow => _timeProvider.GetUtcNow();
+
+    /// <summary>
+    ///     The window this manager expects to exist right now, oldest period first.
+    /// </summary>
+    public IReadOnlyList<TimeWindowPartition> CurrentWindow() => Policy.Window(UtcNow);
+
+    /// <inheritdoc />
+    public IEnumerable<RangePartition> Partitions()
+        => CurrentWindow().Select(ToRangePartition);
+
+    /// <summary>
+    ///     Translate one window period into the Weasel partition that represents it. PostgreSQL RANGE
+    ///     partition bounds are already half-open — <c>FROM (x) TO (y)</c> includes x and excludes y — so
+    ///     the window's interval maps across without adjustment.
+    /// </summary>
+    internal static RangePartition ToRangePartition(TimeWindowPartition period)
+        => new(period.Suffix, period.From.FormatSqlValue(), period.To.FormatSqlValue());
+
+    /// <summary>
+    ///     Roll the window forward and retire aged partitions across every table wired to this manager.
+    ///     Idempotent, and safe to run on every startup and from several nodes at once.
+    /// </summary>
+    public async Task<TablePartitionStatus[]> ApplyAsync(PostgresqlDatabase database, ILogger logger,
+        CancellationToken token)
+    {
+        await using var conn = database.CreateConnection();
+        await conn.OpenAsync(token).ConfigureAwait(false);
+
+        try
+        {
+            return await applyAsync(conn, database, logger, rollForward: true, dropAged: true, token)
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            await conn.CloseAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    ///     Roll the window forward and retire aged partitions, with no logging.
+    /// </summary>
+    public Task<TablePartitionStatus[]> ApplyAsync(PostgresqlDatabase database, CancellationToken token)
+        => ApplyAsync(database, NullLogger.Instance, token);
+
+    /// <summary>
+    ///     Create any partitions in the current window that do not exist yet, plus the DEFAULT overflow
+    ///     partition. Purely additive — nothing is ever dropped here, so this is the half that is safe to
+    ///     run without a retention decision.
+    /// </summary>
+    public async Task<TablePartitionStatus[]> RollForwardAsync(PostgresqlDatabase database, ILogger logger,
+        CancellationToken token)
+    {
+        await using var conn = database.CreateConnection();
+        await conn.OpenAsync(token).ConfigureAwait(false);
+
+        try
+        {
+            return await applyAsync(conn, database, logger, rollForward: true, dropAged: false, token)
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            await conn.CloseAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    ///     Drop every partition older than <see cref="RollingWindowPolicy.RetentionFloor" />. Only
+    ///     partitions this manager's own naming scheme produced are considered — a partition whose suffix
+    ///     this policy cannot parse (hand-created, or created under a different period size) is left
+    ///     strictly alone.
+    ///     <para>
+    ///         This is a data-removing operation by design: dropping the partition is what reclaims the
+    ///         storage in O(1).
+    ///     </para>
+    /// </summary>
+    public async Task<TablePartitionStatus[]> DropAgedPartitionsAsync(PostgresqlDatabase database, ILogger logger,
+        CancellationToken token)
+    {
+        await using var conn = database.CreateConnection();
+        await conn.OpenAsync(token).ConfigureAwait(false);
+
+        try
+        {
+            return await applyAsync(conn, database, logger, rollForward: false, dropAged: true, token)
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            await conn.CloseAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    ///     Every table in <paramref name="database" /> whose range partitioning is wired to this manager.
+    /// </summary>
+    public IReadOnlyList<Table> ResolveManagedTables(PostgresqlDatabase database)
+    {
+        return database
+            .AllObjects()
+            .OfType<Table>()
+            .Where(x => x.Partitioning is RangePartitioning range && ReferenceEquals(range.PartitionManager, this))
+            .ToArray();
+    }
+
+    private async Task<TablePartitionStatus[]> applyAsync(NpgsqlConnection conn, PostgresqlDatabase database,
+        ILogger logger, bool rollForward, bool dropAged, CancellationToken token)
+    {
+        // Resolve "now" ONCE for the whole pass. Reading the clock per table could straddle a period
+        // boundary and leave one table provisioned a period further ahead than another.
+        var now = UtcNow;
+        var window = Policy.Window(now);
+        var floor = Policy.RetentionFloor(now);
+
+        var statuses = new List<TablePartitionStatus>();
+
+        foreach (var table in ResolveManagedTables(database))
+        {
+            // A configured partition parent may never have been physically migrated onto this database
+            // (a sharded deployment where this table does not live yet). There is genuinely nothing to
+            // provision or retire, and every statement below would fail with 42P01. Same reasoning as
+            // ManagedListPartitions.DropPartitionFromAllTables (weasel#344).
+            if (!await parentExistsAsync(conn, table, token).ConfigureAwait(false))
+            {
+                logger.LogInformation(
+                    "Skipped managed range partitions for table {Table} because it is not physically present on this database",
+                    table.Identifier);
+                continue;
+            }
+
+            try
+            {
+                if (rollForward)
+                {
+                    await rollForwardAsync(conn, table, window, logger, token).ConfigureAwait(false);
+                }
+
+                if (dropAged)
+                {
+                    await dropAgedAsync(conn, table, floor, logger, token).ConfigureAwait(false);
+                }
+
+                statuses.Add(new TablePartitionStatus(table.Identifier, PartitionMigrationStatus.Complete));
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "Error managing rolling range partitions for {Table}", table.Identifier);
+                statuses.Add(new TablePartitionStatus(table.Identifier, PartitionMigrationStatus.Failed));
+            }
+        }
+
+        return statuses.ToArray();
+    }
+
+    private static async Task<bool> parentExistsAsync(NpgsqlConnection conn, Table table, CancellationToken token)
+    {
+        var exists = await conn
+            .CreateCommand("select to_regclass(:qualified) is not null")
+            .With("qualified", table.Identifier.QualifiedName)
+            .ExecuteScalarAsync(token).ConfigureAwait(false);
+
+        return exists is true;
+    }
+
+    private async Task rollForwardAsync(NpgsqlConnection conn, Table table,
+        IReadOnlyList<TimeWindowPartition> window, ILogger logger, CancellationToken token)
+    {
+        // The DEFAULT partition goes first so a row outside the provisioned window is never rejected,
+        // even in the sliver of time before the window partitions land.
+        var defaultWriter = new StringWriter();
+        defaultWriter.WriteDefaultPartition(table.Identifier);
+        await executeIdempotentCreateAsync(conn, defaultWriter.ToString(), token).ConfigureAwait(false);
+
+        var existing = await fetchPartitionNamesAsync(conn, table, token).ConfigureAwait(false);
+
+        foreach (var period in window)
+        {
+            var partitionName = table.Identifier.Name + "_" + period.Suffix;
+            if (existing.Contains(partitionName))
+            {
+                continue;
+            }
+
+            var writer = new StringWriter();
+            ((IPartition)ToRangePartition(period)).WriteCreateStatement(writer, table);
+
+            await executeIdempotentCreateAsync(conn, writer.ToString(), token).ConfigureAwait(false);
+
+            logger.LogInformation("Created range partition {Partition} covering [{From}, {To}) on table {Table}",
+                partitionName, period.From, period.To, table.Identifier);
+        }
+    }
+
+    private async Task dropAgedAsync(NpgsqlConnection conn, Table table, DateTimeOffset floor, ILogger logger,
+        CancellationToken token)
+    {
+        var parentName = PostgresqlObjectName.From(table.Identifier);
+
+        foreach (var partitionName in await fetchPartitionNamesAsync(conn, table, token).ConfigureAwait(false))
+        {
+            var suffix = table.Identifier.GetSuffixName(partitionName);
+
+            // Only ever retire partitions this policy itself named. A suffix it cannot parse belongs to
+            // somebody else — a hand-created partition, a leftover from a different period size, or the
+            // DEFAULT overflow partition — and dropping it would be destroying data we were never asked
+            // to manage.
+            if (!Policy.TryParseSuffix(suffix, out var periodStart) || periodStart >= floor)
+            {
+                continue;
+            }
+
+            var child = PostgresqlObjectName.From(new DbObjectName(table.Identifier.Schema, partitionName));
+
+            try
+            {
+                // Deliberately NOT "DETACH ... CONCURRENTLY": PostgreSQL rejects a concurrent detach on a
+                // parent that has a DEFAULT partition, and a managed range table always has one.
+                await conn.CreateCommand($"alter table {parentName} detach partition {child};")
+                    .ExecuteNonQueryAsync(token).ConfigureAwait(false);
+            }
+            catch (PostgresException e) when (e.SqlState == PostgresErrorCodes.UndefinedTable)
+            {
+                // Another node got there first. The drop below is a no-op then.
+            }
+
+            await conn.CreateCommand($"drop table if exists {child} cascade;")
+                .ExecuteNonQueryAsync(token).ConfigureAwait(false);
+
+            logger.LogInformation(
+                "Dropped aged range partition {Partition} (period starting {PeriodStart}, retention floor {Floor}) from table {Table}",
+                partitionName, periodStart, floor, table.Identifier);
+        }
+    }
+
+    private static async Task<HashSet<string>> fetchPartitionNamesAsync(NpgsqlConnection conn, Table table,
+        CancellationToken token)
+    {
+        var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        await using var reader = await conn
+            .CreateCommand(
+                """
+                select c.relname
+                from pg_inherits i
+                join pg_class c on c.oid = i.inhrelid
+                join pg_class p on p.oid = i.inhparent
+                join pg_namespace n on n.oid = p.relnamespace
+                where n.nspname = :schema and p.relname = :name
+                """)
+            .With("schema", table.Identifier.Schema)
+            .With("name", table.Identifier.Name)
+            .ExecuteReaderAsync(token).ConfigureAwait(false);
+
+        while (await reader.ReadAsync(token).ConfigureAwait(false))
+        {
+            names.Add(await reader.GetFieldValueAsync<string>(0, token).ConfigureAwait(false));
+        }
+
+        return names;
+    }
+
+    /// <summary>
+    ///     CREATE TABLE IF NOT EXISTS is not actually atomic against a concurrent creator: PostgreSQL
+    ///     checks for the name, then inserts, so two nodes provisioning the same window at the same moment
+    ///     can still collide on pg_class. Swallowing those two states is what makes this safe to run from
+    ///     every node on every startup.
+    /// </summary>
+    private static async Task executeIdempotentCreateAsync(NpgsqlConnection conn, string sql, CancellationToken token)
+    {
+        try
+        {
+            await conn.CreateCommand(sql).ExecuteNonQueryAsync(token).ConfigureAwait(false);
+        }
+        catch (PostgresException e) when (e.SqlState is PostgresErrorCodes.DuplicateTable
+                                              or PostgresErrorCodes.UniqueViolation)
+        {
+        }
+    }
+}

--- a/src/Weasel.Postgresql/Tables/Partitioning/RangePartitioning.cs
+++ b/src/Weasel.Postgresql/Tables/Partitioning/RangePartitioning.cs
@@ -17,6 +17,31 @@ public class RangePartitioning: IPartitionStrategy
 
     public bool HasExistingDefault { get; private set; }
 
+    /// <summary>
+    /// The runtime partition manager that owns this table's partition set, if any. Set through
+    /// <see cref="UsePartitionManager"/>.
+    /// </summary>
+    public IRangePartitionManager? PartitionManager { get; private set; }
+
+    /// <summary>
+    /// Hand ownership of the partition set to a runtime manager — typically a
+    /// <see cref="ManagedRangePartitions"/> rolling time window — instead of declaring a static list of
+    /// ranges. The manager recomputes the expected partitions on every read, and delta detection becomes
+    /// purely additive so that a window rolling forward never triggers a table rebuild.
+    /// </summary>
+    public RangePartitioning UsePartitionManager(IRangePartitionManager manager)
+    {
+        PartitionManager = manager ?? throw new ArgumentNullException(nameof(manager));
+        return this;
+    }
+
+    /// <summary>
+    /// The partitions this strategy currently expects: the manager's set when one is attached, otherwise
+    /// the statically declared ranges.
+    /// </summary>
+    private IReadOnlyList<RangePartition> expectedRanges()
+        => PartitionManager == null ? _ranges : PartitionManager.Partitions().ToList();
+
     void IPartitionStrategy.WritePartitionBy(TextWriter writer)
     {
         writer.WriteLine($") PARTITION BY RANGE ({Columns.Join(", ")});");
@@ -34,10 +59,36 @@ public class RangePartitioning: IPartitionStrategy
 
             if (parent.IgnorePartitionsInMigration) return PartitionDelta.None;
 
-            var match = _ranges.OrderBy(x => x.Suffix).ToArray()
+            var expected = expectedRanges();
+
+            var match = expected.OrderBy(x => x.Suffix).ToArray()
                 .SequenceEqual(other._ranges.OrderBy(x => x.Suffix).ToArray());
 
             if (match) return PartitionDelta.None;
+
+            if (PartitionManager != null)
+            {
+                // weasel#401: a managed rolling window OWNS its partition set, and that set is a function
+                // of the clock. Every time "now" crosses a period boundary the declared window gains a
+                // partition at the leading edge and loses one at the trailing edge, so the two conditions
+                // the declarative branch below reads as drift — the actual database has partitions the
+                // declaration no longer names, and it has more of them than we asked for — are the normal
+                // steady state of a time-series table, not an anomaly. Rebuilding a multi-gigabyte table
+                // because last month rolled off would be catastrophic. Aged partitions are retired by the
+                // manager's retention pass (ManagedRangePartitions.DropAgedPartitionsAsync), which is a
+                // policy outcome rather than a migration, so migration only ever ADDS here.
+                //
+                // Match on the suffix rather than on full equality. The suffix already determines the
+                // bounds for a given policy, and the create path is CREATE TABLE IF NOT EXISTS keyed on
+                // the partition's NAME — so a partition reported as missing while a table of that name
+                // already exists would be silently skipped and then reported missing again on the next
+                // migration, forever. Matching on the name the create path actually uses keeps migration
+                // convergent.
+                var actualSuffixes = other._ranges.Select(x => x.Suffix).ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+                missing = expected.Where(x => !actualSuffixes.Contains(x.Suffix)).OfType<IPartition>().ToArray();
+                return missing.Length != 0 ? PartitionDelta.Additive : PartitionDelta.None;
+            }
 
             // We've already done a SequenceEqual, so we know the counts aren't the same
             // and if there are more actual partitions than expected, we need to do a rebalance
@@ -57,7 +108,7 @@ public class RangePartitioning: IPartitionStrategy
 
     public IEnumerable<string> PartitionTableNames(Table parent)
     {
-        foreach (var partition in _ranges)
+        foreach (var partition in expectedRanges())
         {
             yield return $"{parent.Identifier.Name.ToLowerInvariant()}_{partition.Suffix.ToLowerInvariant()}";
         }
@@ -75,6 +126,12 @@ public class RangePartitioning: IPartitionStrategy
     /// <returns></returns>
     public RangePartitioning AddRange<T>(string suffix, T from, T to)
     {
+        if (PartitionManager != null)
+        {
+            throw new InvalidOperationException(
+                "This table's partitions are owned by a partition manager, so statically declared ranges would be silently ignored. Remove the UsePartitionManager() call or the AddRange() call.");
+        }
+
         var partition = new RangePartition(suffix, from.FormatSqlValue(), to.FormatSqlValue());
         _ranges.Add(partition);
 
@@ -83,7 +140,7 @@ public class RangePartitioning: IPartitionStrategy
 
     void IPartitionStrategy.WriteCreateStatement(TextWriter writer, Table parent)
     {
-        foreach (IPartition partition in _ranges)
+        foreach (IPartition partition in expectedRanges())
         {
             partition.WriteCreateStatement(writer, parent);
             writer.WriteLine();


### PR DESCRIPTION
Part one of #401 — the PostgreSQL side. SQL Server parity is a follow-up on the same issue.

## The gap

`RangePartitioning.CreateDelta` compares a *declared* list of ranges against actual, and reads two conditions as drift:

- actual has ranges the declaration no longer contains → `Rebuild`
- actual has more ranges than declared → `Rebuild`

For a time-series table those are the normal steady state, not an anomaly. The declared window moves forward every period; last period's partitions are still on disk and are supposed to be *dropped* per a retention policy. On a multi-gigabyte table a `Rebuild` is catastrophic, so the only options were `IgnorePartitionsInMigration` or an externally-managed mode — both of which mean the application hand-writes `CREATE TABLE … PARTITION OF` and `DROP TABLE` itself, and loses Weasel's ordering and dependency management along with it (JasperFx/CritterWatch#886).

## What this adds

**`RollingWindowPolicy`** (`Weasel.Core.Partitioning`) — period, periods ahead, periods retained. Nothing else; the surface stays declarative on purpose.

```csharp
var manager = new ManagedRangePartitions(
    RollingWindowPolicy.Monthly(periodsAhead: 3, periodsBehind: 6));

table.PartitionByRange("occurred_at").UsePartitionManager(manager);
```

`Hourly`/`Daily`/`Weekly`/`Monthly`/`Yearly`. All arithmetic in UTC. A `TimeProvider` is injectable so the window can be rolled forward deterministically in tests.

The window is a pure function of the policy and the clock, so a window that has rolled forward differs from the database's by exactly one new partition at the leading edge and one aged one at the trailing edge. Suffixes encode the period start — `y2026`, `m202607`, `w20260727`, `d20260730`, `h2026073014` — so they sort chronologically and parse back, which is what lets retention identify the partitions it owns and leave every other one strictly alone.

**`ManagedRangePartitions`** (`Weasel.Postgresql`), the range analogue of `ManagedListPartitions`:

- `RollForwardAsync` — creates missing window periods plus the `DEFAULT` overflow partition. Purely additive.
- `DropAgedPartitionsAsync` — `DETACH` + `DROP TABLE` for everything below the retention floor. O(1) reclaim instead of a mass `DELETE`.
- `ApplyAsync` — both, idempotent, safe on every startup and from several nodes at once.

With a manager attached, `CreateDelta` never returns `Rebuild` for a partition-set difference. A column change still does.

## Against the acceptance criteria

| | |
|---|---|
| No `IgnorePartitionsInMigration` or externally-managed escape hatch | ✅ neither is needed; docs updated to say so |
| Rolling forward is `Additive`, never `Rebuild` | ✅ `rolling_the_window_forward_is_additive_never_rebuild`, and `partitions_that_have_aged_out_of_the_window_are_not_drift` covers the case where *every* partition on disk has fallen out of the window |
| Dropping an aged partition is a policy outcome | ✅ retention pass, not migration; `retention_leaves_partitions_this_policy_does_not_own_alone` |
| Idempotent, safe concurrently from multiple nodes | ✅ `apply_provisions_the_window_out_of_band_and_is_idempotent`, `two_nodes_provisioning_the_same_window_at_once_is_safe` |
| DEFAULT/overflow partition | ✅ always created, `the_default_partition_catches_rows_outside_the_window` |

## Notes for review

- `CreateDelta`'s managed branch matches on the partition **suffix**, not on full range equality. The create path is `CREATE TABLE IF NOT EXISTS` keyed on the partition's name, so a mismatch on bounds alone would be silently skipped and then re-reported forever — matching on the name the create path actually uses keeps migration convergent.
- Retention deliberately uses a plain `DETACH`, not `DETACH ... CONCURRENTLY`: PostgreSQL rejects a concurrent detach on a parent that has a `DEFAULT` partition, and a managed range table always has one.
- `AddRange` now throws if a partition manager is attached, rather than silently ignoring the declared range.

## Tests

- 29 unit tests on `RollingWindowPolicy` (boundaries, UTC conversion, suffix round-trip, short-month arithmetic, foreign-suffix rejection).
- 14 PostgreSQL integration tests.
- Full PostgreSQL suite green: 819 passed, 0 failed, against a clean database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PefhUPhDZcmSUhfQFBqXxR