### PR TITLE
ManagedRangePartitions for SQL Server: rolling time-window partitions (weasel#401)

### DIFF
--- a/docs/sqlserver/partitioning.md
+++ b/docs/sqlserver/partitioning.md
@@ -8,7 +8,8 @@ server objects:
 
 The table is then created *on* the partition scheme. Weasel models this through the
 `ISqlServerPartitioning` strategy on `Table`, with `RangePartitioning` for declarative date/numeric
-ranges and `ManagedTenantPartitions` for runtime, per-tenant partitioning.
+ranges, `ManagedRangePartitions` for rolling time windows, and `ManagedTenantPartitions` for runtime,
+per-tenant partitioning.
 
 ## Range Partitioning
 
@@ -99,7 +100,84 @@ declared boundary list and let migration add the new partitions.
 Changing the partition **column** or **data type**, or *removing* a boundary that exists in the database,
 cannot be done with an in-place `SPLIT`. Weasel reports these as `SchemaPatchDifference.Invalid` rather
 than silently rebuilding the table and moving every row. Trimming aged partitions for data retention is a
-runtime operation (`MERGE RANGE` / `SWITCH OUT`) rather than a declarative schema change.
+runtime operation rather than a declarative schema change — see
+[Rolling time windows](#rolling-time-windows), which owns both halves for you.
+
+## Rolling Time Windows
+
+Extending a declared boundary list by hand works, but it is not what a time-series table actually wants.
+The window *moves*: every period a new partition is needed at the leading edge, and the period that has
+fallen out of the retention policy at the trailing edge should be reclaimed — cheaply, by deallocating
+its pages rather than by a mass `DELETE`. Doing that on SQL Server is otherwise a hand-rolled T-SQL
+chore; the published recipes amount to "write a script that sets `NEXT USED` and `SPLIT`s, and another
+that `MERGE`s".
+
+`ManagedRangePartitions` owns both halves. Declare intent — a period, how many periods to provision
+ahead, how many to retain behind — and Weasel writes every statement:
+
+```cs
+var manager = new ManagedRangePartitions(
+    RollingWindowPolicy.Monthly(periodsAhead: 3, periodsBehind: 6),
+    column: "occurred_at");
+
+var table = new Table("dbo.metrics");
+table.AddColumn<int>("id");
+table.AddColumn("occurred_at", "datetime2").NotNull();
+table.AddColumn("value", "float");
+
+// On SQL Server the partition column MUST participate in the primary key.
+table.ModifyColumn("id").AsPrimaryKey();
+table.ModifyColumn("occurred_at").AsPrimaryKey();
+
+table.PartitionByRollingWindow(manager);
+```
+
+`RollingWindowPolicy` supports `Hourly`, `Daily`, `Weekly`, `Monthly`, and `Yearly` windows, and all
+boundary arithmetic is done in UTC. The strategy is `RANGE RIGHT`, so each boundary is the inclusive
+lower bound of its period.
+
+The boundaries are the window's period starts **plus** the exclusive end of the newest provisioned
+period. That trailing boundary matters: without it the top partition would be
+`[newest period start, +infinity)` and would hold the newest period's rows, so the next roll-forward
+would `SPLIT` a partition containing data — a fully logged row-movement operation. With it, the top
+partition is always beyond everything provisioned and therefore empty, and every `SPLIT` stays
+metadata-only.
+
+At runtime:
+
+```cs
+// Split in any missing boundaries at the leading edge, then truncate and merge
+// away everything below the retention floor. Idempotent, so this is safe on
+// every startup and on a timer.
+await manager.ApplyAsync(database, logger, token);
+
+// ...or run just one half
+await manager.RollForwardAsync(database, logger, token);
+await manager.DropAgedPartitionsAsync(database, logger, token);
+```
+
+Two properties make this different from extending a static boundary list:
+
+- **Rolling forward is always additive, never a rebuild.** A boundary the declaration no longer names is
+  a period that has aged out — the normal steady state of a rolling window, not drift. `CreateDelta`
+  reports `Additive` or `None`, never `Rebuild`, for a boundary-set difference. A column or type change
+  still rebuilds.
+- **Retiring a period is `TRUNCATE` then `MERGE RANGE`, in that order.** `MERGE RANGE` on a partition
+  that still holds rows does not reclaim anything — it *moves* those rows into the neighbouring
+  partition, which is the opposite of the point. Truncating the partition first (`TRUNCATE TABLE ...
+  WITH (PARTITIONS (n))`, SQL Server 2016+) deallocates its pages in O(1), and the merge that follows is
+  then metadata-only against an empty partition. If the truncate fails, the boundary is deliberately
+  left in place.
+
+Retention only retires boundaries that land exactly on a period start for the policy, so a hand-added
+boundary is left strictly alone. It also reclaims the partition below the oldest boundary once that
+boundary ages out — that partition holds late-arriving rows dated before the window ever started, and it
+is entirely below the retention floor.
+
+::: warning
+Retiring a period removes its rows. That is the point — it is what makes reclaim O(1) — but choose
+`periodsBehind` to match the retention policy you actually want.
+:::
 
 ## Managed Tenant Partitioning
 

--- a/src/Weasel.SqlServer.Tests/Tables/partitioning/managed_range_partitions.cs
+++ b/src/Weasel.SqlServer.Tests/Tables/partitioning/managed_range_partitions.cs
@@ -1,0 +1,386 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Core.Partitioning;
+using Weasel.SqlServer.Tables;
+using Weasel.SqlServer.Tables.Partitioning;
+using Xunit;
+
+namespace Weasel.SqlServer.Tests.Tables.partitioning;
+
+/// <summary>
+///     Rolling time-window RANGE partitioning on SQL Server: NEXT USED + SPLIT RANGE to roll the leading
+///     edge forward, partition TRUNCATE + MERGE RANGE to retire the trailing edge. Weasel #401.
+/// </summary>
+[Collection("integration")]
+public class managed_range_partitions: IntegrationContext
+{
+    // Mid-July so neither edge of the window sits on a period boundary.
+    private static readonly DateTimeOffset July = new(2026, 7, 15, 12, 0, 0, TimeSpan.Zero);
+
+    public managed_range_partitions(): base("mrp")
+    {
+    }
+
+    // ---------------------------------------------------------------------
+    // Unit — no database
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public void boundaries_are_the_period_starts_plus_a_trailing_bound()
+    {
+        var manager = theManager(July, RollingWindowPolicy.Monthly(1, 2));
+
+        // May, June, July, August starts... plus September 1st, which keeps the top partition beyond
+        // everything provisioned and therefore empty, so rolling forward is a metadata-only SPLIT.
+        manager.Boundaries().ShouldBe([
+            "'2026-05-01 00:00:00'",
+            "'2026-06-01 00:00:00'",
+            "'2026-07-01 00:00:00'",
+            "'2026-08-01 00:00:00'",
+            "'2026-09-01 00:00:00'"
+        ]);
+    }
+
+    [Fact]
+    public void create_ddl_carries_the_window()
+    {
+        var table = theMetricsTable(theManager(July, RollingWindowPolicy.Monthly(0, 1)));
+
+        var writer = new StringWriter();
+        table.WriteCreateStatement(new SqlServerMigrator(), writer);
+        var ddl = writer.ToString();
+
+        ddl.ShouldContain(
+            "CREATE PARTITION FUNCTION [pf_metrics_occurred_at] (datetime2) AS RANGE RIGHT FOR VALUES ('2026-06-01 00:00:00', '2026-07-01 00:00:00', '2026-08-01 00:00:00');");
+        ddl.ShouldContain(
+            "CREATE PARTITION SCHEME [ps_metrics_occurred_at] AS PARTITION [pf_metrics_occurred_at] ALL TO ([PRIMARY]);");
+        ddl.ShouldContain("ON [ps_metrics_occurred_at]([occurred_at])");
+    }
+
+    [Fact]
+    public void rolling_forward_is_additive_never_rebuild()
+    {
+        var manager = theManager(July.AddMonths(1), RollingWindowPolicy.Monthly(1, 2));
+
+        // What the database holds is the window as it stood in July.
+        var actual = theActualInfo(theManager(July, RollingWindowPolicy.Monthly(1, 2)));
+
+        manager.CreateDelta(actual).ShouldBe(PartitionDelta.Additive);
+    }
+
+    [Fact]
+    public void boundaries_that_have_aged_out_of_the_window_are_not_drift()
+    {
+        var manager = theManager(July, RollingWindowPolicy.Monthly(1, 2));
+
+        // Everything the window wants, plus a pile of boundaries from periods that have since aged out.
+        var actual = theActualInfo(manager);
+        actual.BoundaryValues.Insert(0, "'2025-01-01 00:00:00'");
+        actual.BoundaryValues.Insert(0, "'2024-01-01 00:00:00'");
+
+        // Retention retires those, not a rebuild of the partition function and every table on it.
+        manager.CreateDelta(actual).ShouldBe(PartitionDelta.None);
+    }
+
+    [Fact]
+    public void a_changed_partition_column_is_still_a_rebuild()
+    {
+        var manager = theManager(July, RollingWindowPolicy.Monthly(1, 2));
+
+        var actual = theActualInfo(manager);
+        actual.Column = "something_else";
+
+        manager.CreateDelta(actual).ShouldBe(PartitionDelta.Rebuild);
+    }
+
+    [Fact]
+    public void split_statements_only_cover_the_boundaries_that_are_missing()
+    {
+        var manager = theManager(July.AddMonths(1), RollingWindowPolicy.Monthly(1, 2));
+        var actual = theActualInfo(theManager(July, RollingWindowPolicy.Monthly(1, 2)));
+
+        var writer = new StringWriter();
+        manager.WriteSplitStatements(writer, theMetricsTable(manager), actual);
+        var sql = writer.ToString();
+
+        sql.ShouldContain("ALTER PARTITION SCHEME [ps_metrics_occurred_at] NEXT USED [PRIMARY];");
+        sql.ShouldContain(
+            "ALTER PARTITION FUNCTION [pf_metrics_occurred_at]() SPLIT RANGE ('2026-10-01 00:00:00');");
+        sql.ShouldNotContain("'2026-09-01 00:00:00'");
+    }
+
+    // ---------------------------------------------------------------------
+    // Integration
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public async Task the_whole_window_is_provisioned_when_the_table_is_created()
+    {
+        var manager = theManager(July, RollingWindowPolicy.Monthly(1, 2));
+        await resetSchemaAndPartitionObjects();
+        await CreateSchemaObjectInDatabase(theMetricsTable(manager));
+
+        (await actualBoundaries()).ShouldBe([
+            new DateTime(2026, 5, 1), new DateTime(2026, 6, 1), new DateTime(2026, 7, 1),
+            new DateTime(2026, 8, 1), new DateTime(2026, 9, 1)
+        ]);
+    }
+
+    [Fact]
+    public async Task migrating_twice_without_moving_the_clock_is_a_no_op()
+    {
+        var manager = theManager(July, RollingWindowPolicy.Monthly(1, 2));
+        await resetSchemaAndPartitionObjects();
+
+        var database = theDatabase(manager);
+        await database.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var migration = await database.CreateMigrationAsync();
+
+        migration.Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task rolling_forward_through_migration_splits_and_preserves_data()
+    {
+        var clock = new TestClock(July);
+        var manager = new ManagedRangePartitions(RollingWindowPolicy.Monthly(1, 2), "occurred_at", "datetime2", clock);
+
+        await resetSchemaAndPartitionObjects();
+
+        var database = theDatabase(manager);
+        await database.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        await insertMetric(1, new DateTime(2026, 7, 20));
+
+        clock.UtcNow = July.AddMonths(1);
+        await database.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        // The August window added exactly one boundary at the leading edge, and nothing that already
+        // existed was disturbed — aged periods are retired by retention, not by migration.
+        (await actualBoundaries()).ShouldBe([
+            new DateTime(2026, 5, 1), new DateTime(2026, 6, 1), new DateTime(2026, 7, 1),
+            new DateTime(2026, 8, 1), new DateTime(2026, 9, 1), new DateTime(2026, 10, 1)
+        ]);
+
+        (await countMetrics()).ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task aged_partitions_are_truncated_and_merged_away()
+    {
+        var clock = new TestClock(July);
+        var manager = new ManagedRangePartitions(RollingWindowPolicy.Monthly(1, 2), "occurred_at", "datetime2", clock);
+
+        await resetSchemaAndPartitionObjects();
+
+        var database = theDatabase(manager);
+        await database.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        await insertMetric(1, new DateTime(2026, 5, 10));
+        await insertMetric(2, new DateTime(2026, 6, 10));
+        await insertMetric(3, new DateTime(2026, 7, 10));
+
+        // Two months on the retention floor is 2026-07-01, so May and June have aged out.
+        clock.UtcNow = July.AddMonths(2);
+
+        await manager.DropAgedPartitionsAsync(database, NullLogger.Instance, CancellationToken.None);
+
+        (await actualBoundaries()).ShouldBe([
+            new DateTime(2026, 7, 1), new DateTime(2026, 8, 1), new DateTime(2026, 9, 1)
+        ]);
+
+        // TRUNCATE deallocated the aged partitions' pages — that O(1) reclaim is the whole point.
+        (await countMetrics()).ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task rows_older_than_the_oldest_boundary_are_reclaimed_too()
+    {
+        var clock = new TestClock(July);
+        var manager = new ManagedRangePartitions(RollingWindowPolicy.Monthly(1, 2), "occurred_at", "datetime2", clock);
+
+        await resetSchemaAndPartitionObjects();
+
+        var database = theDatabase(manager);
+        await database.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        // A late-arriving row dated before the window ever started. It lands in the underflow partition,
+        // which is entirely below the retention floor once the oldest boundary ages out.
+        await insertMetric(1, new DateTime(2024, 3, 3));
+        await insertMetric(2, new DateTime(2026, 7, 10));
+
+        clock.UtcNow = July.AddMonths(2);
+        await manager.DropAgedPartitionsAsync(database, NullLogger.Instance, CancellationToken.None);
+
+        (await countMetrics()).ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task retention_leaves_boundaries_this_policy_does_not_own_alone()
+    {
+        var clock = new TestClock(July);
+        var manager = new ManagedRangePartitions(RollingWindowPolicy.Monthly(1, 2), "occurred_at", "datetime2", clock);
+
+        await resetSchemaAndPartitionObjects();
+
+        var database = theDatabase(manager);
+        await database.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        // A hand-added mid-month boundary well below the retention floor. It is not a period start for
+        // this policy, so Weasel did not create it and Weasel does not get to merge it away.
+        await theConnection.CreateCommand(
+                "ALTER PARTITION SCHEME [ps_metrics_occurred_at] NEXT USED [PRIMARY];ALTER PARTITION FUNCTION [pf_metrics_occurred_at]() SPLIT RANGE ('2026-05-15 00:00:00');")
+            .ExecuteNonQueryAsync();
+
+        clock.UtcNow = July.AddMonths(2);
+        await manager.DropAgedPartitionsAsync(database, NullLogger.Instance, CancellationToken.None);
+
+        (await actualBoundaries()).ShouldContain(new DateTime(2026, 5, 15));
+    }
+
+    [Fact]
+    public async Task apply_rolls_the_leading_edge_forward_and_retires_the_trailing_edge_and_is_idempotent()
+    {
+        var clock = new TestClock(July);
+        var manager = new ManagedRangePartitions(RollingWindowPolicy.Monthly(1, 2), "occurred_at", "datetime2", clock);
+
+        await resetSchemaAndPartitionObjects();
+
+        var database = theDatabase(manager);
+        await database.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        clock.UtcNow = July.AddMonths(2);
+
+        var statuses = await manager.ApplyAsync(database, NullLogger.Instance, CancellationToken.None);
+        statuses.Single().Status.ShouldBe(PartitionMigrationStatus.Complete);
+
+        // A second pass changes nothing and throws nothing — safe on every startup.
+        await manager.ApplyAsync(database, NullLogger.Instance, CancellationToken.None);
+
+        (await actualBoundaries()).ShouldBe([
+            new DateTime(2026, 7, 1), new DateTime(2026, 8, 1), new DateTime(2026, 9, 1),
+            new DateTime(2026, 10, 1), new DateTime(2026, 11, 1)
+        ]);
+    }
+
+    [Fact]
+    public async Task skips_a_table_whose_partition_function_is_not_present()
+    {
+        var manager = theManager(July, RollingWindowPolicy.Monthly(1, 2));
+        await resetSchemaAndPartitionObjects();
+
+        // Configured, but never migrated onto this database.
+        var statuses = await manager.ApplyAsync(theDatabase(manager), NullLogger.Instance, CancellationToken.None);
+
+        statuses.ShouldBeEmpty();
+    }
+
+    // ---------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------
+
+    private static ManagedRangePartitions theManager(DateTimeOffset now, RollingWindowPolicy policy)
+        => new(policy, "occurred_at", "datetime2", new TestClock(now));
+
+    private static Table theMetricsTable(ManagedRangePartitions manager)
+    {
+        var table = new Table("mrp.metrics");
+        table.AddColumn<int>("id");
+        table.AddColumn("occurred_at", "datetime2").NotNull();
+        table.AddColumn("value", "float");
+
+        // The partition column has to participate in the primary key on SQL Server.
+        table.ModifyColumn("id").AsPrimaryKey();
+        table.ModifyColumn("occurred_at").AsPrimaryKey();
+
+        table.PartitionByRollingWindow(manager);
+
+        return table;
+    }
+
+    private static DatabaseWithTables theDatabase(ManagedRangePartitions manager)
+    {
+        var database = new DatabaseWithTables("mrp_integration", ConnectionSource.ConnectionString);
+        database.AddTable(theMetricsTable(manager));
+
+        return database;
+    }
+
+    /// <summary>
+    /// The partition info a database holding <paramref name="manager"/>'s window would report.
+    /// </summary>
+    private static SqlServerPartitionInfo theActualInfo(ManagedRangePartitions manager)
+        => new()
+        {
+            PartitionFunctionName = "pf_metrics_occurred_at",
+            PartitionSchemeName = "ps_metrics_occurred_at",
+            Column = "occurred_at",
+            SqlDataType = "datetime2",
+            IsRangeRight = true,
+            BoundaryValues = manager.Boundaries().ToList()
+        };
+
+    private async Task resetSchemaAndPartitionObjects()
+    {
+        await ResetSchema();
+
+        await theConnection.CreateCommand("""
+                                          IF EXISTS (SELECT 1 FROM sys.partition_schemes WHERE name = 'ps_metrics_occurred_at')
+                                              DROP PARTITION SCHEME [ps_metrics_occurred_at];
+                                          IF EXISTS (SELECT 1 FROM sys.partition_functions WHERE name = 'pf_metrics_occurred_at')
+                                              DROP PARTITION FUNCTION [pf_metrics_occurred_at];
+                                          """)
+            .ExecuteNonQueryAsync();
+    }
+
+    private async Task<DateTime[]> actualBoundaries()
+    {
+        var values = new List<DateTime>();
+
+        await using var reader = await theConnection.CreateCommand("""
+                                                                   SELECT prv.value
+                                                                   FROM sys.partition_functions pf
+                                                                   JOIN sys.partition_range_values prv ON pf.function_id = prv.function_id
+                                                                   WHERE pf.name = 'pf_metrics_occurred_at'
+                                                                   ORDER BY prv.boundary_id;
+                                                                   """).ExecuteReaderAsync();
+
+        while (await reader.ReadAsync())
+        {
+            values.Add((DateTime)reader.GetValue(0));
+        }
+
+        return values.ToArray();
+    }
+
+    private Task insertMetric(int id, DateTime occurredAt)
+    {
+        var command = theConnection.CreateCommand(
+            "insert into mrp.metrics (id, occurred_at, value) values (@id, @at, 1.0)");
+        command.Parameters.AddWithValue("@id", id);
+        command.Parameters.AddWithValue("@at", occurredAt);
+
+        return command.ExecuteNonQueryAsync();
+    }
+
+    private async Task<int> countMetrics()
+    {
+        var count = await theConnection.CreateCommand("select count(*) from mrp.metrics").ExecuteScalarAsync();
+
+        return (int)count!;
+    }
+}
+
+/// <summary>
+/// Deterministic clock so the tests can roll the window forward without waiting for the calendar.
+/// </summary>
+public class TestClock: TimeProvider
+{
+    public TestClock(DateTimeOffset now) => UtcNow = now;
+
+    public DateTimeOffset UtcNow { get; set; }
+
+    public override DateTimeOffset GetUtcNow() => UtcNow;
+}

--- a/src/Weasel.SqlServer/Tables/Partitioning/ISqlServerPartitioning.cs
+++ b/src/Weasel.SqlServer/Tables/Partitioning/ISqlServerPartitioning.cs
@@ -51,6 +51,28 @@ public interface ISqlServerPartitioning
     PartitionDelta CreateDelta(SqlServerPartitionInfo? actual);
 }
 
+/// <summary>
+///     A partitioning strategy whose boundary changes can be migrated in place with
+///     <c>ALTER PARTITION FUNCTION ... SPLIT RANGE</c> rather than requiring the partition function and
+///     scheme to be rebuilt. <see cref="TableDelta" /> only migrates boundaries for strategies that
+///     implement this; a strategy that owns its boundaries purely at runtime (e.g.
+///     <see cref="ManagedTenantPartitions" />) deliberately does not, and is left alone by migration.
+/// </summary>
+public interface ISplittablePartitioning: ISqlServerPartitioning
+{
+    /// <summary>
+    ///     Write <c>ALTER PARTITION SCHEME ... NEXT USED</c> + <c>ALTER PARTITION FUNCTION ... SPLIT
+    ///     RANGE</c> for every expected boundary missing from <paramref name="actual" />.
+    /// </summary>
+    void WriteSplitStatements(TextWriter writer, Table parent, SqlServerPartitionInfo actual);
+
+    /// <summary>
+    ///     Write the <c>MERGE RANGE</c> statements that undo <see cref="WriteSplitStatements" />, so an
+    ///     additive partition migration can be rolled back.
+    /// </summary>
+    void WriteMergeStatements(TextWriter writer, Table parent, SqlServerPartitionInfo actual);
+}
+
 public enum PartitionDelta
 {
     /// <summary>No changes needed.</summary>

--- a/src/Weasel.SqlServer/Tables/Partitioning/ManagedRangePartitions.cs
+++ b/src/Weasel.SqlServer/Tables/Partitioning/ManagedRangePartitions.cs
@@ -1,0 +1,568 @@
+using JasperFx.Core;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Weasel.Core.Migrations;
+using Weasel.Core.Partitioning;
+
+namespace Weasel.SqlServer.Tables.Partitioning;
+
+/// <summary>
+///     A runtime-managed SQL Server RANGE partition strategy for rolling time windows — the SQL Server
+///     edition of PostgreSQL's <c>Weasel.Postgresql.Tables.Partitioning.ManagedRangePartitions</c>.
+///     Consumers declare intent ("monthly, 3 ahead, retain 6") through a <see cref="RollingWindowPolicy" />
+///     and Weasel owns every DDL statement: <c>NEXT USED</c> + <c>SPLIT RANGE</c> to roll the leading edge
+///     forward, and partition <c>TRUNCATE</c> + <c>MERGE RANGE</c> to retire the trailing edge.
+///     <para>
+///         Sliding-window partition management on SQL Server is otherwise a hand-rolled T-SQL chore with
+///         no standard tooling — published recipes amount to "write a script that sets NEXT USED and
+///         SPLITs, and another that MERGEs". This is that, owned by the application's schema model and
+///         versioned with its code.
+///     </para>
+///     <para>
+///         The window is a pure function of the policy and the clock, so a window that has rolled forward
+///         is never mistaken for schema drift: <see cref="CreateDelta" /> is purely additive, and the
+///         boundaries that have fallen behind the retention floor are retired by
+///         <see cref="DropAgedPartitionsAsync" /> as a policy outcome rather than a rebuild.
+///     </para>
+///     <code>
+///     var manager = new ManagedRangePartitions(
+///         RollingWindowPolicy.Monthly(periodsAhead: 3, periodsBehind: 6), "occurred_at");
+///     table.PartitionByRollingWindow(manager);
+///     </code>
+///     <para>JasperFx/weasel#401.</para>
+/// </summary>
+public class ManagedRangePartitions: ISplittablePartitioning
+{
+    private readonly TimeProvider _timeProvider;
+
+    /// <summary>
+    ///     Create a rolling-window partition strategy.
+    /// </summary>
+    /// <param name="policy">The rolling window: period size, periods provisioned ahead, periods retained.</param>
+    /// <param name="column">
+    ///     The date/time column to partition on. It must participate in the table's primary key, as SQL
+    ///     Server requires of any partitioned table's unique constraints.
+    /// </param>
+    /// <param name="sqlDataType">
+    ///     The partition function's parameter type. Defaults to <c>datetime2</c>. Use the bare type name
+    ///     with no precision — that is what <c>sys.types</c> reports on read-back, and delta detection
+    ///     compares against it.
+    /// </param>
+    /// <param name="timeProvider">
+    ///     Clock used to resolve "now". Defaults to <see cref="TimeProvider.System" />; supply a fake to
+    ///     roll the window forward deterministically in tests.
+    /// </param>
+    public ManagedRangePartitions(RollingWindowPolicy policy, string column, string sqlDataType = "datetime2",
+        TimeProvider? timeProvider = null)
+    {
+        if (string.IsNullOrWhiteSpace(column))
+        {
+            throw new ArgumentException("column must not be null or blank", nameof(column));
+        }
+
+        Policy = policy ?? throw new ArgumentNullException(nameof(policy));
+        Column = column;
+        SqlDataType = sqlDataType;
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    /// <summary>
+    ///     The rolling window this strategy provisions against.
+    /// </summary>
+    public RollingWindowPolicy Policy { get; }
+
+    /// <inheritdoc />
+    public string Column { get; }
+
+    /// <inheritdoc />
+    public string SqlDataType { get; }
+
+    /// <summary>
+    ///     Filegroup every partition is mapped to, and the one handed to <c>NEXT USED</c> when the window
+    ///     rolls forward. Defaults to PRIMARY.
+    /// </summary>
+    public string Filegroup { get; set; } = "PRIMARY";
+
+    /// <summary>
+    ///     Always RANGE RIGHT: a boundary is the inclusive lower bound of its period, which matches the
+    ///     half-open <c>[From, To)</c> intervals a <see cref="RollingWindowPolicy" /> produces.
+    /// </summary>
+    public bool IsRangeRight => true;
+
+    /// <summary>
+    ///     "Now" according to this strategy's clock, in UTC.
+    /// </summary>
+    public DateTimeOffset UtcNow => _timeProvider.GetUtcNow();
+
+    /// <summary>
+    ///     The window this strategy expects to exist right now, oldest period first.
+    /// </summary>
+    public IReadOnlyList<TimeWindowPartition> CurrentWindow() => Policy.Window(UtcNow);
+
+    /// <summary>
+    ///     The partition function boundaries for the current window, ascending, as SQL literals.
+    ///     <para>
+    ///         These are the period starts PLUS the exclusive end of the newest provisioned period. That
+    ///         trailing boundary is not decoration: without it the top partition would be
+    ///         <c>[newest period start, +infinity)</c> and would hold the newest period's rows, so the next
+    ///         roll-forward would <c>SPLIT</c> a partition containing data — a fully logged row-movement
+    ///         operation. With it, the top partition is always beyond everything provisioned and therefore
+    ///         empty, and every <c>SPLIT</c> stays metadata-only.
+    ///     </para>
+    /// </summary>
+    public string[] Boundaries()
+    {
+        var window = CurrentWindow();
+
+        return window.Select(x => x.From)
+            .Append(window[^1].To)
+            .Select(FormatBoundary)
+            .ToArray();
+    }
+
+    /// <summary>
+    ///     Render one boundary instant as the SQL literal this strategy declares and compares against.
+    ///     Routed through the same formatter <see cref="Table.FetchExistingAsync" /> uses on read-back so
+    ///     a round-trip compares equal.
+    /// </summary>
+    public string FormatBoundary(DateTimeOffset moment)
+    {
+        // Boxed deliberately, and NOT through a conditional expression: DateTime converts implicitly to
+        // DateTimeOffset, so a ternary over the two would silently type itself as DateTimeOffset and
+        // render every boundary in the offset-carrying shape regardless of the column's type.
+        object value = moment.UtcDateTime;
+        if (SqlDataType.StartsWith("datetimeoffset", StringComparison.OrdinalIgnoreCase))
+        {
+            value = moment.ToUniversalTime();
+        }
+
+        return RangePartitioning.FormatSqlValue(value);
+    }
+
+    /// <inheritdoc />
+    public string PartitionFunctionName(Table parent) => $"pf_{parent.Identifier.Name}_{Column}";
+
+    /// <inheritdoc />
+    public string PartitionSchemeName(Table parent) => $"ps_{parent.Identifier.Name}_{Column}";
+
+    /// <inheritdoc />
+    public void WritePartitionDdl(TextWriter writer, Table parent)
+    {
+        var pfName = PartitionFunctionName(parent);
+        var psName = PartitionSchemeName(parent);
+
+        writer.WriteLine($"IF EXISTS (SELECT 1 FROM sys.partition_schemes WHERE name = '{psName}')");
+        writer.WriteLine($"    DROP PARTITION SCHEME [{psName}];");
+        writer.WriteLine($"IF EXISTS (SELECT 1 FROM sys.partition_functions WHERE name = '{pfName}')");
+        writer.WriteLine($"    DROP PARTITION FUNCTION [{pfName}];");
+
+        writer.Write($"CREATE PARTITION FUNCTION [{pfName}] ({SqlDataType}) AS RANGE RIGHT");
+        writer.Write($" FOR VALUES ({Boundaries().Join(", ")})");
+        writer.WriteLine(";");
+
+        writer.WriteLine($"CREATE PARTITION SCHEME [{psName}] AS PARTITION [{pfName}] ALL TO ([{Filegroup}]);");
+    }
+
+    /// <inheritdoc />
+    public void WriteOnClause(TextWriter writer, Table parent)
+    {
+        writer.Write($" ON [{PartitionSchemeName(parent)}]([{Column}])");
+    }
+
+    /// <inheritdoc />
+    public void WriteDropDdl(TextWriter writer, Table parent)
+    {
+        var psName = PartitionSchemeName(parent);
+        var pfName = PartitionFunctionName(parent);
+
+        writer.WriteLine($"IF EXISTS (SELECT 1 FROM sys.partition_schemes WHERE name = '{psName}')");
+        writer.WriteLine($"    DROP PARTITION SCHEME [{psName}];");
+        writer.WriteLine($"IF EXISTS (SELECT 1 FROM sys.partition_functions WHERE name = '{pfName}')");
+        writer.WriteLine($"    DROP PARTITION FUNCTION [{pfName}];");
+    }
+
+    /// <inheritdoc />
+    public PartitionDelta CreateDelta(SqlServerPartitionInfo? actual)
+    {
+        if (actual == null)
+        {
+            return PartitionDelta.Rebuild;
+        }
+
+        if (!actual.Column.EqualsIgnoreCase(Column))
+        {
+            return PartitionDelta.Rebuild;
+        }
+
+        if (!actual.SqlDataType.EqualsIgnoreCase(SqlDataType))
+        {
+            return PartitionDelta.Rebuild;
+        }
+
+        if (actual.IsRangeRight != IsRangeRight)
+        {
+            return PartitionDelta.Rebuild;
+        }
+
+        var expected = new HashSet<string>(Boundaries(), StringComparer.OrdinalIgnoreCase);
+        var actualSet = new HashSet<string>(actual.BoundaryValues, StringComparer.OrdinalIgnoreCase);
+
+        if (actualSet.SetEquals(expected))
+        {
+            return PartitionDelta.None;
+        }
+
+        // weasel#401: a boundary the declaration no longer names is a period that has aged out, which is
+        // the normal steady state of a rolling window and not drift. Retiring it is the retention pass's
+        // job (a MERGE RANGE against a truncated partition), never a rebuild of the partition function
+        // and every table sitting on it. So migration only ever splits.
+        return expected.IsSubsetOf(actualSet) ? PartitionDelta.None : PartitionDelta.Additive;
+    }
+
+    /// <inheritdoc />
+    public void WriteSplitStatements(TextWriter writer, Table parent, SqlServerPartitionInfo actual)
+    {
+        var pfName = PartitionFunctionName(parent);
+        var psName = PartitionSchemeName(parent);
+        var actualSet = new HashSet<string>(actual.BoundaryValues, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var boundary in Boundaries().Where(x => !actualSet.Contains(x)))
+        {
+            writer.WriteLine($"ALTER PARTITION SCHEME [{psName}] NEXT USED [{Filegroup}];");
+            writer.WriteLine($"ALTER PARTITION FUNCTION [{pfName}]() SPLIT RANGE ({boundary});");
+        }
+    }
+
+    /// <inheritdoc />
+    public void WriteMergeStatements(TextWriter writer, Table parent, SqlServerPartitionInfo actual)
+    {
+        var pfName = PartitionFunctionName(parent);
+        var actualSet = new HashSet<string>(actual.BoundaryValues, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var boundary in Boundaries().Where(x => !actualSet.Contains(x)))
+        {
+            writer.WriteLine($"ALTER PARTITION FUNCTION [{pfName}]() MERGE RANGE ({boundary});");
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Runtime API — mirrors the PostgreSQL ManagedRangePartitions
+    // ---------------------------------------------------------------------
+
+    /// <summary>
+    ///     Roll the window forward and retire aged periods across every table wired to this strategy.
+    ///     Idempotent, and safe to run on every startup.
+    /// </summary>
+    public async Task<TablePartitionStatus[]> ApplyAsync(IDatabase<SqlConnection> database, ILogger logger,
+        CancellationToken token)
+    {
+        await using var conn = database.CreateConnection();
+        await conn.OpenAsync(token).ConfigureAwait(false);
+
+        try
+        {
+            return await applyAsync(conn, database, logger, rollForward: true, dropAged: true, token)
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            await conn.CloseAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    ///     Roll the window forward and retire aged periods, with no logging.
+    /// </summary>
+    public Task<TablePartitionStatus[]> ApplyAsync(IDatabase<SqlConnection> database, CancellationToken token)
+        => ApplyAsync(database, NullLogger.Instance, token);
+
+    /// <summary>
+    ///     Split in any boundaries of the current window that the partition function does not have yet.
+    ///     Purely additive — nothing is truncated or merged here.
+    /// </summary>
+    public async Task<TablePartitionStatus[]> RollForwardAsync(IDatabase<SqlConnection> database, ILogger logger,
+        CancellationToken token)
+    {
+        await using var conn = database.CreateConnection();
+        await conn.OpenAsync(token).ConfigureAwait(false);
+
+        try
+        {
+            return await applyAsync(conn, database, logger, rollForward: true, dropAged: false, token)
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            await conn.CloseAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    ///     Retire every period below <see cref="RollingWindowPolicy.RetentionFloor" />: the partition is
+    ///     truncated — an O(1) page deallocation, which is what makes retention on a partitioned table
+    ///     worth having versus a mass <c>DELETE</c> — and then its boundary is merged away against an
+    ///     already-empty partition, so the merge itself is metadata-only.
+    ///     <para>
+    ///         Only boundaries that land exactly on a period start for this policy are retired; a
+    ///         hand-added boundary is left strictly alone. This is a data-removing operation by design.
+    ///     </para>
+    /// </summary>
+    public async Task<TablePartitionStatus[]> DropAgedPartitionsAsync(IDatabase<SqlConnection> database,
+        ILogger logger, CancellationToken token)
+    {
+        await using var conn = database.CreateConnection();
+        await conn.OpenAsync(token).ConfigureAwait(false);
+
+        try
+        {
+            return await applyAsync(conn, database, logger, rollForward: false, dropAged: true, token)
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            await conn.CloseAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    ///     Every table in <paramref name="database" /> whose partitioning is wired to this strategy.
+    /// </summary>
+    public IReadOnlyList<Table> ResolveManagedTables(IDatabase database)
+    {
+        return database.AllObjects()
+            .OfType<Table>()
+            .Where(t => ReferenceEquals(t.SqlServerPartitioning, this))
+            .ToArray();
+    }
+
+    private async Task<TablePartitionStatus[]> applyAsync(SqlConnection conn, IDatabase<SqlConnection> database,
+        ILogger logger, bool rollForward, bool dropAged, CancellationToken token)
+    {
+        // Resolve "now" ONCE for the whole pass so two tables can never end up provisioned a period apart
+        // because the clock crossed a boundary mid-loop.
+        var now = UtcNow;
+        var expected = Boundaries();
+        var floor = Policy.RetentionFloor(now);
+
+        var statuses = new List<TablePartitionStatus>();
+
+        foreach (var table in ResolveManagedTables(database))
+        {
+            var pfName = PartitionFunctionName(table);
+
+            try
+            {
+                var actual = await fetchActualBoundariesAsync(conn, pfName, token).ConfigureAwait(false);
+
+                // A configured table that was never physically migrated onto this database has no
+                // partition function to split or merge. Nothing to do, and every statement below would
+                // fail — same reasoning as the PostgreSQL half skipping an absent parent table.
+                if (actual == null)
+                {
+                    logger.LogInformation(
+                        "Skipped managed range partitions for table {Table} because partition function {Function} is not present on this database",
+                        table.Identifier, pfName);
+                    continue;
+                }
+
+                if (rollForward)
+                {
+                    await rollForwardAsync(conn, table, pfName, expected, actual, logger, token)
+                        .ConfigureAwait(false);
+                }
+
+                if (dropAged)
+                {
+                    await dropAgedAsync(conn, table, pfName, actual, floor, logger, token).ConfigureAwait(false);
+                }
+
+                statuses.Add(new TablePartitionStatus(table.Identifier, PartitionMigrationStatus.Complete));
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "Error managing rolling range partitions for {Table}", table.Identifier);
+                statuses.Add(new TablePartitionStatus(table.Identifier, PartitionMigrationStatus.Failed));
+            }
+        }
+
+        return statuses.ToArray();
+    }
+
+    private async Task rollForwardAsync(SqlConnection conn, Table table, string pfName, string[] expected,
+        IReadOnlyList<ActualBoundary> actual, ILogger logger, CancellationToken token)
+    {
+        var psName = PartitionSchemeName(table);
+        var present = new HashSet<string>(actual.Select(x => x.Literal), StringComparer.OrdinalIgnoreCase);
+
+        foreach (var boundary in expected.Where(x => !present.Contains(x)))
+        {
+            await using (var nextUsed = conn.CreateCommand())
+            {
+                nextUsed.CommandText = $"ALTER PARTITION SCHEME [{psName}] NEXT USED [{Filegroup}];";
+                await nextUsed.ExecuteNonQueryAsync(token).ConfigureAwait(false);
+            }
+
+            await using (var split = conn.CreateCommand())
+            {
+                split.CommandText = $"ALTER PARTITION FUNCTION [{pfName}]() SPLIT RANGE ({boundary});";
+                await split.ExecuteNonQueryAsync(token).ConfigureAwait(false);
+            }
+
+            logger.LogInformation("Split partition function {Function} at boundary {Boundary} for table {Table}",
+                pfName, boundary, table.Identifier);
+        }
+    }
+
+    private async Task dropAgedAsync(SqlConnection conn, Table table, string pfName,
+        IReadOnlyList<ActualBoundary> actual, DateTimeOffset floor, ILogger logger, CancellationToken token)
+    {
+        var ordered = actual.Where(x => x.Moment.HasValue).OrderBy(x => x.Moment!.Value).ToArray();
+
+        // Only retire boundaries this policy itself would have produced. A boundary that does not land on
+        // a period start belongs to somebody else, and merging it away would silently reshape a partition
+        // scheme we were never asked to manage.
+        var aged = ordered
+            .Where(x => x.Moment!.Value < floor && Policy.StartOfPeriod(x.Moment!.Value) == x.Moment!.Value)
+            .ToArray();
+
+        if (aged.Length == 0)
+        {
+            return;
+        }
+
+        // Partition 1 is everything below the lowest boundary. When that lowest boundary is itself aged,
+        // partition 1 lies entirely below the retention floor — rows that arrived late, dated before the
+        // window ever started — and retention owns it too. Guarded, because if the lowest boundary is one
+        // we do not own, partition 1 sits behind data we were told to leave alone.
+        if (ReferenceEquals(ordered[0], aged[0]))
+        {
+            await truncatePartitionAsync(conn, table, 1, logger, token).ConfigureAwait(false);
+        }
+
+        foreach (var boundary in aged)
+        {
+            // Recomputed per boundary on purpose: every MERGE below renumbers the partitions.
+            var partitionNumber = await resolvePartitionNumberAsync(conn, pfName, boundary.Literal, token)
+                .ConfigureAwait(false);
+
+            if (partitionNumber == null)
+            {
+                logger.LogWarning(
+                    "Could not resolve the partition number for boundary {Boundary} of {Function} — skipping",
+                    boundary.Literal, pfName);
+                continue;
+            }
+
+            // Truncate BEFORE merging. MERGE RANGE on a partition that still holds rows does not reclaim
+            // anything — it moves those rows into the neighbouring partition, which is the opposite of the
+            // point. If the truncate fails the boundary is deliberately left in place.
+            if (!await truncatePartitionAsync(conn, table, partitionNumber.Value, logger, token)
+                    .ConfigureAwait(false))
+            {
+                continue;
+            }
+
+            await using var merge = conn.CreateCommand();
+            merge.CommandText = $"ALTER PARTITION FUNCTION [{pfName}]() MERGE RANGE ({boundary.Literal});";
+            await merge.ExecuteNonQueryAsync(token).ConfigureAwait(false);
+
+            logger.LogInformation(
+                "Retired aged partition at boundary {Boundary} (retention floor {Floor}) from table {Table}",
+                boundary.Literal, floor, table.Identifier);
+        }
+    }
+
+    private static async Task<bool> truncatePartitionAsync(SqlConnection conn, Table table, int partitionNumber,
+        ILogger logger, CancellationToken token)
+    {
+        try
+        {
+            await using var truncate = conn.CreateCommand();
+            truncate.CommandText =
+                $"TRUNCATE TABLE {table.Identifier.QualifiedName} WITH (PARTITIONS ({partitionNumber}));";
+            await truncate.ExecuteNonQueryAsync(token).ConfigureAwait(false);
+
+            return true;
+        }
+        catch (SqlException e)
+        {
+            logger.LogError(e, "Could not truncate partition {Partition} of table {Table}", partitionNumber,
+                table.Identifier);
+
+            return false;
+        }
+    }
+
+    private static async Task<int?> resolvePartitionNumberAsync(SqlConnection conn, string pfName, string literal,
+        CancellationToken token)
+    {
+        // $PARTITION takes the partition function by name, which cannot be parameterized. pfName is
+        // Weasel-generated from the table and column names, not user input.
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"SELECT $PARTITION.[{pfName}]({literal});";
+
+        var result = await cmd.ExecuteScalarAsync(token).ConfigureAwait(false);
+
+        return result is int number ? number : null;
+    }
+
+    /// <summary>
+    ///     The boundaries a partition function actually carries, or null when no such function exists.
+    ///     <c>sys.partition_range_values.value</c> is a sql_variant holding the boundary as its native CLR
+    ///     type, so it is read raw and then formatted through the same canonical formatter the declared
+    ///     side uses — a <c>CAST(... AS NVARCHAR)</c> would render a date in a completely different shape
+    ///     and never compare equal.
+    /// </summary>
+    private async Task<IReadOnlyList<ActualBoundary>?> fetchActualBoundariesAsync(SqlConnection conn, string pfName,
+        CancellationToken token)
+    {
+        var boundaries = new List<ActualBoundary>();
+
+        await using (var cmd = conn.CreateCommand())
+        {
+            cmd.CommandText = """
+                              SELECT prv.value
+                              FROM sys.partition_functions pf
+                              JOIN sys.partition_range_values prv ON pf.function_id = prv.function_id
+                              WHERE pf.name = @pf
+                              ORDER BY prv.boundary_id;
+                              """;
+            cmd.Parameters.AddWithValue("@pf", pfName);
+
+            await using var reader = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+            while (await reader.ReadAsync(token).ConfigureAwait(false))
+            {
+                var value = reader.GetValue(0);
+                boundaries.Add(new ActualBoundary(RangePartitioning.FormatSqlValue(value), AsMoment(value)));
+            }
+        }
+
+        if (boundaries.Count > 0)
+        {
+            return boundaries;
+        }
+
+        // No rows means either "no such function" or "a function with zero boundaries" — the two need
+        // different handling, so ask directly.
+        await using var exists = conn.CreateCommand();
+        exists.CommandText = "SELECT COUNT(*) FROM sys.partition_functions WHERE name = @pf";
+        exists.Parameters.AddWithValue("@pf", pfName);
+
+        var count = (int?)await exists.ExecuteScalarAsync(token).ConfigureAwait(false) ?? 0;
+
+        return count > 0 ? boundaries : null;
+    }
+
+    private static DateTimeOffset? AsMoment(object? value)
+    {
+        return value switch
+        {
+            DateTime dt => new DateTimeOffset(DateTime.SpecifyKind(dt, DateTimeKind.Utc), TimeSpan.Zero),
+            DateTimeOffset dto => dto.ToUniversalTime(),
+            _ => null
+        };
+    }
+
+    private sealed record ActualBoundary(string Literal, DateTimeOffset? Moment);
+}

--- a/src/Weasel.SqlServer/Tables/Partitioning/RangePartitioning.cs
+++ b/src/Weasel.SqlServer/Tables/Partitioning/RangePartitioning.cs
@@ -6,7 +6,7 @@ namespace Weasel.SqlServer.Tables.Partitioning;
 ///     SQL Server RANGE partitioning via partition function + partition scheme.
 ///     Supports RANGE LEFT (default) and RANGE RIGHT boundary semantics.
 /// </summary>
-public class RangePartitioning : ISqlServerPartitioning
+public class RangePartitioning : ISplittablePartitioning
 {
     private readonly List<string> _boundaryValues = new();
 

--- a/src/Weasel.SqlServer/Tables/Table.cs
+++ b/src/Weasel.SqlServer/Tables/Table.cs
@@ -125,6 +125,24 @@ public partial class Table: TableBase<TableColumn, IndexDefinition, ForeignKey>
         return manager;
     }
 
+    /// <summary>
+    ///     Configure SQL Server RANGE partitioning driven by a rolling time window: a period size, how
+    ///     many periods to provision ahead of now, and how many to retain behind before a period is aged
+    ///     out. Weasel owns the <c>SPLIT RANGE</c> that rolls the window forward and the partition
+    ///     <c>TRUNCATE</c> + <c>MERGE RANGE</c> that retires an aged period. See
+    ///     <see cref="Partitioning.ManagedRangePartitions" />. Weasel #401.
+    /// </summary>
+    /// <param name="manager">
+    ///     The rolling-window strategy. The same instance is typically assigned to every table sharing a
+    ///     retention policy, so one call rolls them all forward.
+    /// </param>
+    public Partitioning.ManagedRangePartitions PartitionByRollingWindow(
+        Partitioning.ManagedRangePartitions manager)
+    {
+        SqlServerPartitioning = manager ?? throw new ArgumentNullException(nameof(manager));
+        return manager;
+    }
+
     public override void WriteCreateStatement(Migrator migrator, TextWriter writer)
     {
         // Write partition function and scheme DDL before the table if partitioning is configured

--- a/src/Weasel.SqlServer/Tables/TableDelta.cs
+++ b/src/Weasel.SqlServer/Tables/TableDelta.cs
@@ -65,10 +65,12 @@ public class TableDelta: SchemaObjectDelta<Table>
             PrimaryKeyDifference = SchemaPatchDifference.Update;
         }
 
-        // Declarative RANGE partitioning round-trip. Only RangePartitioning is migrated here; managed
-        // strategies (e.g. ManagedTenantPartitions) own their boundaries at runtime and are left alone.
+        // RANGE partitioning round-trip. Only strategies that can migrate a boundary change in place are
+        // handled here; a strategy that owns its boundaries purely at runtime (ManagedTenantPartitions,
+        // whose ordinals are allocated on tenant sign-up) does not implement ISplittablePartitioning and
+        // is left alone.
         PartitioningDifference = SchemaPatchDifference.None;
-        if (expected.SqlServerPartitioning is Partitioning.RangePartitioning rangePartitioning)
+        if (expected.SqlServerPartitioning is Partitioning.ISplittablePartitioning rangePartitioning)
         {
             PartitioningDifference = rangePartitioning.CreateDelta(actual.PartitionInfo) switch
             {
@@ -146,7 +148,7 @@ public class TableDelta: SchemaObjectDelta<Table>
 
         // Additive RANGE partition boundaries -> ALTER PARTITION FUNCTION ... SPLIT RANGE
         if (PartitioningDifference == SchemaPatchDifference.Update
-            && Expected.SqlServerPartitioning is Partitioning.RangePartitioning rangePartitioning
+            && Expected.SqlServerPartitioning is Partitioning.ISplittablePartitioning rangePartitioning
             && Actual?.PartitionInfo != null)
         {
             rangePartitioning.WriteSplitStatements(writer, Expected, Actual.PartitionInfo);
@@ -256,7 +258,7 @@ public class TableDelta: SchemaObjectDelta<Table>
 
         // Roll an additive partition split back out -> ALTER PARTITION FUNCTION ... MERGE RANGE
         if (PartitioningDifference == SchemaPatchDifference.Update
-            && Expected.SqlServerPartitioning is Partitioning.RangePartitioning rangePartitioning
+            && Expected.SqlServerPartitioning is Partitioning.ISplittablePartitioning rangePartitioning
             && Actual?.PartitionInfo != null)
         {
             rangePartitioning.WriteMergeStatements(writer, Expected, Actual.PartitionInfo);


### PR DESCRIPTION
Part two of #401 — SQL Server parity for the PostgreSQL `ManagedRangePartitions` that shipped in #413. Closes the issue.

## The gap

`Weasel.SqlServer.Tables.Partitioning.RangePartitioning` takes a static list of boundary values, so rolling a new period forward (`NEXT USED` + `SPLIT`) and retiring an aged one was left to the application. There is essentially no tooling for this on SQL Server — sliding-window management is a hand-rolled T-SQL chore whose published guidance amounts to "write a script that sets `NEXT USED` and `SPLIT`s, and another that `MERGE`s".

## What this adds

`ManagedRangePartitions` over the same `RollingWindowPolicy` the Postgres half uses:

```csharp
var manager = new ManagedRangePartitions(
    RollingWindowPolicy.Monthly(periodsAhead: 3, periodsBehind: 6),
    column: "occurred_at");

table.PartitionByRollingWindow(manager);
```

- `RollForwardAsync` — `ALTER PARTITION SCHEME … NEXT USED` + `ALTER PARTITION FUNCTION … SPLIT RANGE` for boundaries the window has gained.
- `DropAgedPartitionsAsync` — retire everything below the retention floor.
- `ApplyAsync` — both, idempotent.

`CreateDelta` never returns `Rebuild` for a boundary-set difference; a column or type change still does.

## Two decisions worth the review time

**Retention is `TRUNCATE` and *then* `MERGE RANGE`, in that order.** This is the point you flagged when we scoped it. Bare `MERGE RANGE` against a partition that still holds rows reclaims nothing — it *moves* those rows into the neighbouring partition. `TRUNCATE TABLE … WITH (PARTITIONS (n))` (SQL Server 2016+) deallocates the pages in O(1), and the merge that follows is metadata-only against an empty partition. No staging table, so none of `SWITCH OUT`'s structural preconditions. If the truncate fails the boundary is deliberately left in place rather than merging rows we failed to reclaim.

**The declared boundaries are the window's period starts _plus_ the exclusive end of the newest provisioned period.** Without that trailing boundary the top partition is `[newest period start, +infinity)` and holds the newest period's rows — so every roll-forward would `SPLIT` a partition containing data, a fully logged row movement. With it the top partition is always beyond everything provisioned, therefore empty, and `SPLIT` stays metadata-only.

Smaller notes:

- `TableDelta` now dispatches boundary migration on a new `ISplittablePartitioning` rather than the concrete `RangePartitioning`, so declarative and rolling-window strategies both migrate in place. `ManagedTenantPartitions` deliberately does not implement it and stays exempt, exactly as before.
- Retention only retires boundaries landing exactly on a period start for the policy — the SQL Server analogue of the Postgres side's suffix parsing — so a hand-added boundary survives.
- It *does* reclaim the underflow partition when the oldest boundary ages out. That partition holds late-arriving rows dated before the window ever started and is entirely below the retention floor; leaving it would mean data that retention can never reach.
- Boundary literals are boxed through an explicit `if`, not a ternary: `DateTime` converts implicitly to `DateTimeOffset`, so a ternary over the two silently types itself as `DateTimeOffset` and renders every boundary in the offset-carrying shape regardless of the column type. Caught by the round-trip test.

## Tests

14 new tests (6 pure-DDL/delta, 8 integration) covering the window boundaries, additive roll-forward, aged boundaries not reading as drift, column change still rebuilding, truncate+merge retention, underflow reclaim, leaving foreign boundaries alone, idempotent apply, and skipping a table whose partition function is absent.

Full SQL Server suite green: 337 passed, 0 failed, 8 skipped. PostgreSQL (819) and Core (50) suites re-run green as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PefhUPhDZcmSUhfQFBqXxR