### PR TITLE
Bump JasperFx to 2.37.0 and Weasel to 9.22.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>9.21.1</Version>
+        <Version>9.22.0</Version>
         <LangVersion>13.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,8 +8,8 @@
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.12.19" />
     <PackageVersion Include="DistributedLock.Postgres" Version="1.3.0" />
     <PackageVersion Include="DotNet.ReproducibleBuilds" Version="1.2.39" />
-    <PackageVersion Include="JasperFx" Version="2.36.3" />
-    <PackageVersion Include="JasperFx.Events" Version="2.36.3" />
+    <PackageVersion Include="JasperFx" Version="2.37.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.37.0" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.9" />
     <!-- Override the transitive SQLitePCLRaw 2.1.11 (vulnerable native lib,
          GHSA-2m69-gcr7-jv3q) with 3.0.3, which ships the patched SQLite build. -->


### PR DESCRIPTION
Second link in the coordinated release train. JasperFx **2.37.0** is live on nuget.org — it carries jasperfx#590 (the `OptionsDescription` getter guard), the #594 patch half, #595 `BatchingChannel`, and #597. Weasel needs the same pin before Marten and Polecat can move.

Dependency versions only — no source changes.

## Version choice

`9.21.1` → **`9.22.0`**, minor rather than patch, because it raises the JasperFx floor for every downstream consumer. Say the word if you'd rather it were `9.21.2`.

## Verification

Local, against 2.37.0:

| suite | result |
|---|---|
| full solution build | 0 errors |
| `Weasel.Core.Tests` | 50 passed |
| `Weasel.Postgresql.Tests` | 825 passed, 3 skipped |
| `Weasel.SqlServer.Tests` | 340 passed, 8 skipped |

All on both `net9.0` and `net10.0`.

**Oracle and MySQL were not run locally** — no containers for them in this environment. CI covers that gap, which is the main reason this is a PR rather than a push to `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)