### PR TITLE
fix(postgresql): reject quote and semicolon in AssertValidIdentifier (weasel#416)

### DIFF
--- a/src/Weasel.Core/DbObjectName.cs
+++ b/src/Weasel.Core/DbObjectName.cs
@@ -3,6 +3,13 @@ namespace Weasel.Core;
 /// <summary>
 ///     Models a database object with both schema name and object name
 /// </summary>
+/// <remarks>
+///     This type does no validation whatsoever, and neither do its provider-specific subclasses. It is a
+///     value holder, not a sanitizing boundary -- constructing one, or going through a <c>Parse</c> or
+///     <c>From</c> factory, does not make a name safe to interpolate into DDL. Identifier validation lives
+///     in <c>Migrator.AssertValidIdentifier</c>, which the migration path applies to
+///     <see cref="Name" /> (weasel#416).
+/// </remarks>
 public class DbObjectName
 {
     [Obsolete("Use PostgresqlObjectName, SqlServerObjectName, or Parse method with IDatabaseProvider instead.")]

--- a/src/Weasel.Postgresql.Tests/PostgresqlMigratorTests.cs
+++ b/src/Weasel.Postgresql.Tests/PostgresqlMigratorTests.cs
@@ -99,6 +99,77 @@ public class PostgresqlMigratorTests
         });
     }
 
+    /// <summary>
+    ///     weasel#416. AssertValidIdentifier is the only identifier check in the stack, so it has to reject
+    ///     the characters that let a name escape the statement it is written into. A '"' closes a quoted
+    ///     identifier -- Weasel quotes without doubling an embedded quote -- and a ';' starts a new
+    ///     statement. Both were permitted before this.
+    /// </summary>
+    [Theory]
+    [InlineData("users\"", "a trailing double quote")]
+    [InlineData("\"users", "a leading double quote")]
+    [InlineData("us\"ers", "an embedded double quote")]
+    [InlineData("\"users\"", "a fully quote-wrapped name")]
+    [InlineData("users\"; drop table users; --", "a quote-and-semicolon payload")]
+    [InlineData("users;", "a trailing semicolon")]
+    [InlineData("us;ers", "an embedded semicolon")]
+    public void assert_identifier_rejects_quote_and_semicolon(string name, string description)
+    {
+        var options = new PostgresqlMigrator();
+
+        Should.Throw<PostgresqlIdentifierInvalidException>(
+            () => options.AssertValidIdentifier(name),
+            $"Expected {description} to be rejected");
+    }
+
+    /// <summary>
+    ///     Only the literal space character used to be checked, so a newline could still smuggle a '--'
+    ///     comment into an otherwise unquoted name.
+    /// </summary>
+    [Theory]
+    [InlineData("us\ters")]
+    [InlineData("us\ners")]
+    [InlineData("us\rers")]
+    [InlineData("users\n-- the rest of this statement is now a comment")]
+    public void assert_identifier_rejects_all_whitespace_not_just_the_space_character(string name)
+    {
+        var options = new PostgresqlMigrator();
+
+        Should.Throw<PostgresqlIdentifierInvalidException>(() => options.AssertValidIdentifier(name));
+    }
+
+    [Fact]
+    public void invalid_identifier_exception_says_which_rule_was_broken()
+    {
+        var options = new PostgresqlMigrator();
+
+        var ex = Should.Throw<PostgresqlIdentifierInvalidException>(
+            () => options.AssertValidIdentifier("us\"ers"));
+
+        ex.Name.ShouldBe("us\"ers");
+        ex.Reason.ShouldBe("it contains a double quote");
+        ex.Message.ShouldContain("double quote");
+    }
+
+    /// <summary>
+    ///     Names Weasel and its consumers actually generate must keep working -- the tightening is aimed at
+    ///     two characters, not at narrowing the identifier grammar.
+    /// </summary>
+    [Theory]
+    [InlineData("mt_doc_user")]
+    [InlineData("mt_stream")]
+    [InlineData("mt_doc_user_hilo")]
+    [InlineData("users$1")]
+    [InlineData("_leading_underscore")]
+    [InlineData("MixedCaseName")]
+    [InlineData("naïve_café")]
+    [InlineData("table-with-dashes")]
+    [InlineData("mt_doc_target.p_tenant_one")]
+    public void assert_identifier_still_accepts_ordinary_names(string name)
+    {
+        Should.NotThrow(() => new PostgresqlMigrator().AssertValidIdentifier(name));
+    }
+
     [Fact]
     public async Task can_ensure_database_that_does_not_exist()
     {

--- a/src/Weasel.Postgresql/PostgresqlIdentifierInvalidException.cs
+++ b/src/Weasel.Postgresql/PostgresqlIdentifierInvalidException.cs
@@ -5,11 +5,33 @@ namespace Weasel.Postgresql;
 public class PostgresqlIdentifierInvalidException: Exception
 {
     public PostgresqlIdentifierInvalidException(string name)
-        : base(
-            $"Database identifier {name} is not valid. See https://www.postgresql.org/docs/current/static/sql-syntax-lexical.html for valid unquoted identifiers (Marten does not quote identifiers).")
+        : base(MessageFor(name, null))
     {
         Name = name;
     }
 
+    /// <summary>
+    ///     Names the rule the identifier broke, so the message says more than "not valid" (weasel#416).
+    /// </summary>
+    public PostgresqlIdentifierInvalidException(string name, string reason)
+        : base(MessageFor(name, reason))
+    {
+        Name = name;
+        Reason = reason;
+    }
+
     public string Name { get; set; }
+
+    /// <summary>
+    ///     Why the identifier was rejected, when the thrower said. Null for the legacy constructor.
+    /// </summary>
+    public string? Reason { get; }
+
+    private static string MessageFor(string name, string? reason)
+    {
+        var because = reason is null ? "" : $" because {reason}";
+
+        return
+            $"Database identifier {name} is not valid{because}. See https://www.postgresql.org/docs/current/static/sql-syntax-lexical.html for valid unquoted identifiers (Weasel does not quote identifiers).";
+    }
 }

--- a/src/Weasel.Postgresql/PostgresqlMigrator.cs
+++ b/src/Weasel.Postgresql/PostgresqlMigrator.cs
@@ -334,16 +334,46 @@ $$;
 
     public override bool IsSystemColumn(string columnName) => SystemColumns.Contains(columnName);
 
+    /// <summary>
+    ///     Validates a database object name before it is written into DDL.
+    /// </summary>
+    /// <remarks>
+    ///     This is the only identifier check in the stack -- <see cref="DbObjectName" /> and
+    ///     <see cref="PostgresqlObjectName" /> do no validation of their own -- so it rejects the two
+    ///     characters that let a name escape the statement it is written into (weasel#416):
+    ///     <list type="bullet">
+    ///         <item>
+    ///             <c>"</c>, which closes a quoted identifier. Weasel quotes identifiers without doubling
+    ///             an embedded quote, so a name carrying one does not stay inside its own quotes.
+    ///         </item>
+    ///         <item><c>;</c>, which ends the statement and starts another.</item>
+    ///     </list>
+    ///     Whitespace is rejected in full rather than just the literal space it used to check, so that a
+    ///     newline cannot introduce a <c>--</c> comment into an unquoted name either.
+    /// </remarks>
     public override void AssertValidIdentifier(string name)
     {
         if (string.IsNullOrWhiteSpace(name))
         {
-            throw new PostgresqlIdentifierInvalidException(name);
+            throw new PostgresqlIdentifierInvalidException(name, "it is null, empty, or entirely whitespace");
         }
 
-        if (name.IndexOf(' ') >= 0)
+        foreach (var c in name)
         {
-            throw new PostgresqlIdentifierInvalidException(name);
+            if (char.IsWhiteSpace(c))
+            {
+                throw new PostgresqlIdentifierInvalidException(name, "it contains whitespace");
+            }
+
+            if (c == '"')
+            {
+                throw new PostgresqlIdentifierInvalidException(name, "it contains a double quote");
+            }
+
+            if (c == ';')
+            {
+                throw new PostgresqlIdentifierInvalidException(name, "it contains a semicolon");
+            }
         }
 
         if (name.Length < NameDataLength)

--- a/src/Weasel.Postgresql/PostgresqlObjectName.cs
+++ b/src/Weasel.Postgresql/PostgresqlObjectName.cs
@@ -2,6 +2,12 @@ using Weasel.Core;
 
 namespace Weasel.Postgresql;
 
+/// <remarks>
+///     Like <see cref="DbObjectName" />, this type does not validate. <see cref="From" /> is sometimes
+///     assumed to be a sanitizing boundary and is not -- it quotes for rendering, which is not the same as
+///     checking that a name is safe. Use <see cref="PostgresqlMigrator.AssertValidIdentifier" /> for that
+///     (weasel#416).
+/// </remarks>
 public class PostgresqlObjectName: DbObjectName
 {
     private readonly SchemaUtils.IdentifierUsage _usage;


### PR DESCRIPTION
Closes #416.

Finishes what `26421ba` (9.21.1) left on the issue. That change fixed the partition bound literals; this one closes the identifier side and clears the remaining checkboxes.

## The gap

`AssertValidIdentifier` is the only identifier check in the stack — `DbObjectName` and `PostgresqlObjectName` contain no validation at all — yet it rejected only null/whitespace, a literal space, and over-length. It permitted the two characters that let a name escape the statement it is written into:

- **`"`** closes a quoted identifier. Weasel quotes identifiers without doubling an embedded quote, so a name carrying one does not stay inside its own quotes.
- **`;`** ends the statement and starts another.

Whitespace is now rejected in full rather than just the literal space character — the old check missed tab, newline and carriage return, so a newline could introduce a `--` comment into an otherwise unquoted name.

## Also

- `PostgresqlIdentifierInvalidException` gained a constructor that names the rule that was broken, so the message says *which* character was the problem instead of just "not valid". The existing single-argument constructor is untouched. The message also stopped blaming Marten for a decision that is Weasel's.
- Doc comments on `DbObjectName` and `PostgresqlObjectName` now say plainly that they do not validate. `PostgresqlObjectName.From` is sometimes assumed to be a sanitizing boundary; it quotes for rendering, which is not the same thing.

## Verification

This is the regression pass `26421ba` asked for before tightening this method.

- Full `Weasel.Postgresql` suite green: **846 passed, 3 pre-existing skips**.
- `Weasel.Core` green (**50**).
- No name Weasel or its consumers generate was affected. `assert_identifier_still_accepts_ordinary_names` pins `mt_*` names, `$`, leading underscores, mixed case, non-ASCII letters, dashes and dotted partition suffixes as still valid.

## Deliberately not ridden along

**The other providers' `AssertValidIdentifier`**, which #416 listed as unestablished. Now established: `SqlServerMigrator`'s is an empty method body (`// Nothing yet`), Oracle and MySql check length only, Sqlite checks null/whitespace and length. None reject `"` or `;`. Bringing four providers' validation into line is a behaviour change per provider and wants its own change.

**`SchemaUtils.QuoteName`** and the other quote-without-escape helpers from the issue's table. `QuoteName` cannot simply double an embedded `"` — it only quotes at all when the name is a keyword or has an uppercase character, so the fix also has to force quoting for such names, and `PostgresqlProvider.ToQualifiedName`'s pre-quoted-passthrough guard is evidence that quote-wrapped names do circulate on that path. Object names now can't carry a quote past `AssertValidIdentifier`; what remains exposed are schema names, index columns and collations, which don't route through it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)