### PR TITLE
Bring the other four providers' AssertValidIdentifier in line with PostgreSQL (weasel#416)

### DIFF
--- a/src/Weasel.Core.Tests/IdentifierValidationTests.cs
+++ b/src/Weasel.Core.Tests/IdentifierValidationTests.cs
@@ -1,0 +1,81 @@
+using Shouldly;
+using Xunit;
+
+namespace Weasel.Core.Tests;
+
+public class IdentifierValidationTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void null_empty_and_all_whitespace_are_rejected(string? name)
+    {
+        IdentifierValidation.FindProblem(name, "\"").ShouldBe("it is null, empty, or entirely whitespace");
+    }
+
+    [Theory]
+    [InlineData("us ers")]
+    [InlineData("us\ters")]
+    [InlineData("us\ners")]
+    [InlineData("us\rers")]
+    public void all_whitespace_characters_are_rejected_not_just_the_space(string name)
+    {
+        IdentifierValidation.FindProblem(name, "\"").ShouldBe("it contains whitespace");
+    }
+
+    /// <summary>
+    ///     The semicolon and the single quote are unsafe for every provider, so they are checked whatever
+    ///     the caller passes as its own unsafe set: a ';' starts a new statement, and object names reach
+    ///     string literals on all of them via the existence checks and introspection queries.
+    /// </summary>
+    [Theory]
+    [InlineData("us;ers", "it contains a semicolon")]
+    [InlineData("us'ers", "it contains a single quote")]
+    public void the_universal_characters_are_rejected_without_being_asked_for(string name, string expected)
+    {
+        IdentifierValidation.FindProblem(name, "").ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("us\"ers", "\"", "it contains a double quote")]
+    [InlineData("us`ers", "`", "it contains a backtick")]
+    [InlineData("us]ers", "[]", "it contains a closing square bracket")]
+    [InlineData("[users]", "[]", "it contains an opening square bracket")]
+    [InlineData("users\\", "\\", "it contains a backslash")]
+    [InlineData("us~ers", "~", "it contains the character '~'")]
+    public void the_provider_specific_characters_are_named_in_the_reason(
+        string name,
+        string unsafeCharacters,
+        string expected
+    )
+    {
+        IdentifierValidation.FindProblem(name, unsafeCharacters).ShouldBe(expected);
+    }
+
+    /// <summary>
+    ///     A character one provider delimits with is not necessarily unsafe for another -- a backtick is
+    ///     nothing special to PostgreSQL or SQL Server -- so the set has to stay per-provider.
+    /// </summary>
+    [Theory]
+    [InlineData("us`ers", "\"")]
+    [InlineData("us\"ers", "`")]
+    [InlineData("us]ers", "\"")]
+    public void characters_outside_the_supplied_set_pass(string name, string unsafeCharacters)
+    {
+        IdentifierValidation.FindProblem(name, unsafeCharacters).ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData("mt_doc_user")]
+    [InlineData("users$1")]
+    [InlineData("_leading_underscore")]
+    [InlineData("MixedCaseName")]
+    [InlineData("naïve_café")]
+    [InlineData("table-with-dashes")]
+    [InlineData("mt_doc_target.p_tenant_one")]
+    public void ordinary_names_pass(string name)
+    {
+        IdentifierValidation.FindProblem(name, "\"[]`").ShouldBeNull();
+    }
+}

--- a/src/Weasel.Core/IdentifierValidation.cs
+++ b/src/Weasel.Core/IdentifierValidation.cs
@@ -1,0 +1,85 @@
+namespace Weasel.Core;
+
+/// <summary>
+///     The identifier checks every provider needs, factored out so each provider's
+///     <see cref="Migrator.AssertValidIdentifier" /> only has to supply what is specific to it: the
+///     characters its own dialect delimits with, its length limit, and the exception type it has always
+///     thrown (weasel#416).
+/// </summary>
+/// <remarks>
+///     <para>
+///         <see cref="Migrator.AssertValidIdentifier" /> is the only identifier check in the stack --
+///         <see cref="DbObjectName" /> and its provider-specific subclasses do no validation of their own --
+///         and the migration path runs every schema object's name through it
+///         (<c>DatabaseBase.ApplyAllConfiguredChangesToDatabaseAsync</c> and
+///         <c>DatabaseBase.generateOrUpdateFeature</c>). So it has to reject the characters that let a name
+///         escape the statement it is written into.
+///     </para>
+///     <para>
+///         Two of those are the same for everyone. A <c>;</c> ends the statement and starts another. A
+///         <c>'</c> closes a string literal, and object names do reach string literals on every provider --
+///         the existence checks and introspection queries interpolate them (SQL Server's
+///         <c>IF OBJECT_ID('...')</c>, Oracle's <c>WHERE table_name = '...'</c> inside an anonymous PL/SQL
+///         block, SQLite's <c>pragma_table_info('...')</c>). Whitespace is rejected in full rather than just
+///         the literal space character, so that a newline cannot introduce a <c>--</c> comment into an
+///         unquoted name.
+///     </para>
+///     <para>
+///         The rest is per-provider, because the character that closes an identifier is not: SQL Server
+///         delimits with <c>[...]</c> as well as <c>"..."</c>, MySQL with backticks, Oracle and SQLite with
+///         <c>"</c>. Weasel's quoting helpers do not double an embedded delimiter (SQLite's
+///         <c>SchemaUtils.QuoteName</c> does, but only quotes at all for keywords, spaces, dashes and
+///         leading digits), so a name carrying one does not stay inside its own quotes.
+///     </para>
+/// </remarks>
+public static class IdentifierValidation
+{
+    /// <summary>
+    ///     Returns why <paramref name="name" /> is unsafe to write into DDL, phrased to follow "because",
+    ///     or <c>null</c> when it passes. Length is deliberately not checked here -- the limit and the
+    ///     exception that reports it differ per provider.
+    /// </summary>
+    /// <param name="name">The identifier to check. Null, empty and all-whitespace are rejected.</param>
+    /// <param name="unsafeCharacters">
+    ///     The characters that are unsafe for this provider on top of the universal ones: its identifier
+    ///     delimiters, plus anything else that can break out of the context a name lands in -- MySQL's
+    ///     backslash escape, for instance.
+    /// </param>
+    public static string? FindProblem(string? name, string unsafeCharacters)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return "it is null, empty, or entirely whitespace";
+        }
+
+        foreach (var c in name)
+        {
+            if (char.IsWhiteSpace(c))
+            {
+                return "it contains whitespace";
+            }
+
+            if (c is ';' or '\'' || unsafeCharacters.Contains(c))
+            {
+                return $"it contains {Describe(c)}";
+            }
+        }
+
+        return null;
+    }
+
+    private static string Describe(char c)
+    {
+        return c switch
+        {
+            ';' => "a semicolon",
+            '\'' => "a single quote",
+            '"' => "a double quote",
+            '`' => "a backtick",
+            '[' => "an opening square bracket",
+            ']' => "a closing square bracket",
+            '\\' => "a backslash",
+            _ => $"the character '{c}'"
+        };
+    }
+}

--- a/src/Weasel.MySql.Tests/MySqlMigratorTests.cs
+++ b/src/Weasel.MySql.Tests/MySqlMigratorTests.cs
@@ -28,6 +28,87 @@ public class MySqlMigratorTests
         table.Identifier.ShouldBe(identifier);
     }
 
+    /// <summary>
+    ///     weasel#416. AssertValidIdentifier is the only identifier check in the stack, and this provider's
+    ///     checked length only until now, so it has to reject the characters that let a name escape the
+    ///     statement it is written into. MySQL delimits identifiers with backticks -- and with <c>"</c>
+    ///     under ANSI_QUOTES -- a <c>'</c> closes a string literal, a <c>\</c> escapes the character after
+    ///     it inside one, and a <c>;</c> starts a new statement.
+    /// </summary>
+    [Theory]
+    [InlineData("users`", "a trailing backtick")]
+    [InlineData("`users`", "a fully backtick-wrapped name")]
+    [InlineData("us`ers", "an embedded backtick")]
+    [InlineData("users`; drop table users; --", "a backtick-and-semicolon payload")]
+    [InlineData("us\"ers", "an embedded double quote")]
+    [InlineData("us'ers", "an embedded single quote")]
+    [InlineData("users\\", "a trailing backslash")]
+    [InlineData("users;", "a trailing semicolon")]
+    [InlineData("us;ers", "an embedded semicolon")]
+    public void assert_identifier_rejects_quote_backtick_backslash_and_semicolon(string name, string description)
+    {
+        var migrator = new MySqlMigrator();
+
+        Should.Throw<ArgumentException>(
+            () => migrator.AssertValidIdentifier(name),
+            $"Expected {description} to be rejected");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("us ers")]
+    [InlineData("us\ters")]
+    [InlineData("us\ners")]
+    [InlineData("us\rers")]
+    [InlineData("users\n-- the rest of this statement is now a comment")]
+    public void assert_identifier_rejects_null_empty_and_whitespace(string? name)
+    {
+        var migrator = new MySqlMigrator();
+
+        Should.Throw<ArgumentException>(() => migrator.AssertValidIdentifier(name!));
+    }
+
+    [Fact]
+    public void assert_identifier_rejects_names_past_the_length_limit()
+    {
+        var migrator = new MySqlMigrator();
+
+        Should.NotThrow(() => migrator.AssertValidIdentifier(new string('a', 64)));
+        Should.Throw<ArgumentException>(() => migrator.AssertValidIdentifier(new string('a', 65)));
+    }
+
+    [Fact]
+    public void invalid_identifier_message_says_which_rule_was_broken()
+    {
+        var migrator = new MySqlMigrator();
+
+        var ex = Should.Throw<ArgumentException>(() => migrator.AssertValidIdentifier("us`ers"));
+
+        ex.Message.ShouldContain("us`ers");
+        ex.Message.ShouldContain("backtick");
+    }
+
+    /// <summary>
+    ///     Names Weasel and its consumers actually generate must keep working -- the tightening is aimed at
+    ///     a handful of characters, not at narrowing the identifier grammar.
+    /// </summary>
+    [Theory]
+    [InlineData("mt_doc_user")]
+    [InlineData("mt_stream")]
+    [InlineData("mt_doc_user_hilo")]
+    [InlineData("users$1")]
+    [InlineData("_leading_underscore")]
+    [InlineData("MixedCaseName")]
+    [InlineData("naïve_café")]
+    [InlineData("table-with-dashes")]
+    [InlineData("mt_doc_target.p_tenant_one")]
+    public void assert_identifier_still_accepts_ordinary_names(string name)
+    {
+        Should.NotThrow(() => new MySqlMigrator().AssertValidIdentifier(name));
+    }
+
     [Fact]
     public async Task can_ensure_database_that_does_not_exist()
     {

--- a/src/Weasel.MySql/MySqlMigrator.cs
+++ b/src/Weasel.MySql/MySqlMigrator.cs
@@ -107,12 +107,39 @@ public class MySqlMigrator: Migrator
         return $"source {scriptName}";
     }
 
+    /// <summary>
+    ///     The characters that are unsafe in a MySQL identifier beyond the universal ones: the backtick
+    ///     MySQL delimits identifiers with (<see cref="SchemaUtils.QuoteName" /> wraps every name in
+    ///     backticks and does not double an embedded one), the double quote that delimits identifiers under
+    ///     <c>ANSI_QUOTES</c> and string literals otherwise, and the backslash, which is an escape character
+    ///     inside MySQL string literals unless <c>NO_BACKSLASH_ESCAPES</c> is set -- a trailing one would
+    ///     otherwise swallow the closing quote of the literal a name is written into.
+    /// </summary>
+    private const string UnsafeIdentifierCharacters = "`\"\\";
+
+    /// <summary>
+    ///     MySQL's identifier length limit.
+    /// </summary>
+    public int MaxIdentifierLength { get; set; } = 64;
+
+    /// <summary>
+    ///     Validates a database object name before it is written into DDL. See
+    ///     <see cref="IdentifierValidation" /> for why each rule is here; before weasel#416 this checked
+    ///     length only, and threw <see cref="NullReferenceException" /> on a null name.
+    /// </summary>
+    /// <exception cref="ArgumentException">The name cannot be safely written into DDL.</exception>
     public override void AssertValidIdentifier(string name)
     {
-        // MySQL identifiers can be up to 64 characters
-        if (name.Length > 64)
+        var problem = IdentifierValidation.FindProblem(name, UnsafeIdentifierCharacters);
+        if (problem != null)
         {
-            throw new ArgumentException($"MySQL identifier '{name}' exceeds the 64 character limit.");
+            throw new ArgumentException($"MySQL identifier '{name}' is not valid because {problem}.");
+        }
+
+        if (name.Length > MaxIdentifierLength)
+        {
+            throw new ArgumentException(
+                $"MySQL identifier '{name}' exceeds the {MaxIdentifierLength} character limit.");
         }
     }
 

--- a/src/Weasel.Oracle.Tests/OracleMigratorTests.cs
+++ b/src/Weasel.Oracle.Tests/OracleMigratorTests.cs
@@ -28,6 +28,88 @@ public class OracleMigratorTests
         table.Identifier.ShouldBe(identifier);
     }
 
+    /// <summary>
+    ///     weasel#416. AssertValidIdentifier is the only identifier check in the stack, and this provider's
+    ///     checked length only until now, so it has to reject the characters that let a name escape the
+    ///     statement it is written into. A <c>"</c> closes a quoted identifier and a <c>;</c> starts a new
+    ///     statement. The <c>'</c> matters especially here: Weasel wraps Oracle DDL in an anonymous PL/SQL
+    ///     block and runs it via EXECUTE IMMEDIATE, so the name is written inside a string literal.
+    /// </summary>
+    [Theory]
+    [InlineData("USERS\"", "a trailing double quote")]
+    [InlineData("\"USERS", "a leading double quote")]
+    [InlineData("US\"ERS", "an embedded double quote")]
+    [InlineData("\"USERS\"", "a fully quote-wrapped name")]
+    [InlineData("USERS\"; DROP TABLE USERS; --", "a quote-and-semicolon payload")]
+    [InlineData("USERS'", "a trailing single quote")]
+    [InlineData("US'ERS", "an embedded single quote")]
+    [InlineData("USERS'; EXECUTE IMMEDIATE 'DROP TABLE USERS", "a literal-breaking payload")]
+    [InlineData("USERS;", "a trailing semicolon")]
+    [InlineData("US;ERS", "an embedded semicolon")]
+    public void assert_identifier_rejects_quote_and_semicolon(string name, string description)
+    {
+        var migrator = new OracleMigrator();
+
+        Should.Throw<InvalidOperationException>(
+            () => migrator.AssertValidIdentifier(name),
+            $"Expected {description} to be rejected");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("US ERS")]
+    [InlineData("US\tERS")]
+    [InlineData("US\nERS")]
+    [InlineData("US\rERS")]
+    [InlineData("USERS\n-- the rest of this statement is now a comment")]
+    public void assert_identifier_rejects_null_empty_and_whitespace(string? name)
+    {
+        var migrator = new OracleMigrator();
+
+        Should.Throw<InvalidOperationException>(() => migrator.AssertValidIdentifier(name!));
+    }
+
+    [Fact]
+    public void assert_identifier_rejects_names_past_the_length_limit()
+    {
+        var migrator = new OracleMigrator();
+
+        Should.NotThrow(() => migrator.AssertValidIdentifier(new string('A', 128)));
+        Should.Throw<InvalidOperationException>(() => migrator.AssertValidIdentifier(new string('A', 129)));
+    }
+
+    [Fact]
+    public void invalid_identifier_message_says_which_rule_was_broken()
+    {
+        var migrator = new OracleMigrator();
+
+        var ex = Should.Throw<InvalidOperationException>(() => migrator.AssertValidIdentifier("US\"ERS"));
+
+        ex.Message.ShouldContain("US\"ERS");
+        ex.Message.ShouldContain("double quote");
+    }
+
+    /// <summary>
+    ///     Names Weasel and its consumers actually generate must keep working -- the tightening is aimed at
+    ///     a handful of characters, not at narrowing the identifier grammar.
+    /// </summary>
+    [Theory]
+    [InlineData("MT_DOC_USER")]
+    [InlineData("MT_STREAM")]
+    [InlineData("mt_doc_user_hilo")]
+    [InlineData("USERS$1")]
+    [InlineData("_LEADING_UNDERSCORE")]
+    [InlineData("MixedCaseName")]
+    [InlineData("naïve_café")]
+    [InlineData("TABLE-WITH-DASHES")]
+    [InlineData("MT_DOC_TARGET.P_TENANT_ONE")]
+    public void assert_identifier_still_accepts_ordinary_names(string name)
+    {
+        Should.NotThrow(() => new OracleMigrator().AssertValidIdentifier(name));
+    }
+
     [Fact]
     public async Task ensure_database_is_idempotent()
     {

--- a/src/Weasel.Oracle/OracleMigrator.cs
+++ b/src/Weasel.Oracle/OracleMigrator.cs
@@ -116,11 +116,40 @@ END;");
         return $"@{scriptName}";
     }
 
+    /// <summary>
+    ///     The character Oracle delimits identifiers with. A <c>"</c> closes a quoted identifier, and
+    ///     <see cref="SchemaUtils.QuoteName" /> does not double an embedded one.
+    /// </summary>
+    private const string UnsafeIdentifierCharacters = "\"";
+
+    /// <summary>
+    ///     Oracle's identifier length limit (12.2 and later).
+    /// </summary>
+    public int MaxIdentifierLength { get; set; } = 128;
+
+    /// <summary>
+    ///     Validates a database object name before it is written into DDL. See
+    ///     <see cref="IdentifierValidation" /> for why each rule is here; before weasel#416 this checked
+    ///     length only, and threw <see cref="NullReferenceException" /> on a null name.
+    /// </summary>
+    /// <remarks>
+    ///     The single quote matters more on Oracle than elsewhere: Weasel wraps Oracle DDL in an anonymous
+    ///     PL/SQL block and runs it through <c>EXECUTE IMMEDIATE</c>, so the whole statement -- object name
+    ///     included -- is written inside a string literal.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">The name cannot be safely written into DDL.</exception>
     public override void AssertValidIdentifier(string name)
     {
-        if (name.Length > 128)
+        var problem = IdentifierValidation.FindProblem(name, UnsafeIdentifierCharacters);
+        if (problem != null)
         {
-            throw new InvalidOperationException($"Oracle identifiers cannot exceed 128 characters. '{name}' is {name.Length} characters.");
+            throw new InvalidOperationException($"Oracle identifier '{name}' is not valid because {problem}.");
+        }
+
+        if (name.Length > MaxIdentifierLength)
+        {
+            throw new InvalidOperationException(
+                $"Oracle identifiers cannot exceed {MaxIdentifierLength} characters. '{name}' is {name.Length} characters.");
         }
     }
 

--- a/src/Weasel.SqlServer.Tests/SqlServerMigratorTests.cs
+++ b/src/Weasel.SqlServer.Tests/SqlServerMigratorTests.cs
@@ -29,6 +29,93 @@ public class SqlServerMigratorTests
         table.Identifier.ShouldBe(identifier);
     }
 
+    /// <summary>
+    ///     weasel#416. AssertValidIdentifier is the only identifier check in the stack, and this provider's
+    ///     was an empty method body until now, so it has to reject the characters that let a name escape the
+    ///     statement it is written into. SQL Server delimits identifiers with <c>[...]</c> as well as
+    ///     <c>"..."</c>, so <c>]</c> matters alongside <c>"</c>; a <c>'</c> closes a string literal, which is
+    ///     where names land in the existence checks (<c>IF OBJECT_ID('...')</c>); a <c>;</c> starts a new
+    ///     statement.
+    /// </summary>
+    [Theory]
+    [InlineData("users\"", "a trailing double quote")]
+    [InlineData("\"users", "a leading double quote")]
+    [InlineData("us\"ers", "an embedded double quote")]
+    [InlineData("\"users\"", "a fully quote-wrapped name")]
+    [InlineData("users]", "a bracket that closes a delimited identifier")]
+    [InlineData("[users]", "a fully bracket-wrapped name")]
+    [InlineData("us]ers", "an embedded closing bracket")]
+    [InlineData("users]; drop table users; --", "a bracket-and-semicolon payload")]
+    [InlineData("users'", "a trailing single quote")]
+    [InlineData("us'ers", "an embedded single quote")]
+    [InlineData("users'); drop table users; --", "a quote-and-semicolon payload")]
+    [InlineData("users;", "a trailing semicolon")]
+    [InlineData("us;ers", "an embedded semicolon")]
+    public void assert_identifier_rejects_quote_bracket_and_semicolon(string name, string description)
+    {
+        var migrator = new SqlServerMigrator();
+
+        Should.Throw<InvalidOperationException>(
+            () => migrator.AssertValidIdentifier(name),
+            $"Expected {description} to be rejected");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("us ers")]
+    [InlineData("us\ters")]
+    [InlineData("us\ners")]
+    [InlineData("us\rers")]
+    [InlineData("users\n-- the rest of this statement is now a comment")]
+    public void assert_identifier_rejects_null_empty_and_whitespace(string? name)
+    {
+        var migrator = new SqlServerMigrator();
+
+        Should.Throw<InvalidOperationException>(() => migrator.AssertValidIdentifier(name!));
+    }
+
+    [Fact]
+    public void assert_identifier_rejects_names_past_the_sysname_limit()
+    {
+        var migrator = new SqlServerMigrator();
+
+        Should.NotThrow(() => migrator.AssertValidIdentifier(new string('a', 128)));
+        Should.Throw<InvalidOperationException>(() => migrator.AssertValidIdentifier(new string('a', 129)));
+    }
+
+    [Fact]
+    public void invalid_identifier_message_says_which_rule_was_broken()
+    {
+        var migrator = new SqlServerMigrator();
+
+        var ex = Should.Throw<InvalidOperationException>(() => migrator.AssertValidIdentifier("us]ers"));
+
+        ex.Message.ShouldContain("us]ers");
+        ex.Message.ShouldContain("closing square bracket");
+    }
+
+    /// <summary>
+    ///     Names Weasel and its consumers actually generate must keep working -- the tightening is aimed at
+    ///     a handful of characters, not at narrowing the identifier grammar.
+    /// </summary>
+    [Theory]
+    [InlineData("mt_doc_user")]
+    [InlineData("mt_stream")]
+    [InlineData("mt_doc_user_hilo")]
+    [InlineData("users$1")]
+    [InlineData("_leading_underscore")]
+    [InlineData("MixedCaseName")]
+    [InlineData("naïve_café")]
+    [InlineData("table-with-dashes")]
+    [InlineData("#temp_table")]
+    [InlineData("mt_doc_target.p_tenant_one")]
+    public void assert_identifier_still_accepts_ordinary_names(string name)
+    {
+        Should.NotThrow(() => new SqlServerMigrator().AssertValidIdentifier(name));
+    }
+
     [Fact]
     public async Task can_ensure_database_that_does_not_exist()
     {

--- a/src/Weasel.SqlServer/SqlServerMigrator.cs
+++ b/src/Weasel.SqlServer/SqlServerMigrator.cs
@@ -137,9 +137,40 @@ $$;
         return $":r {scriptName}";
     }
 
+    /// <summary>
+    ///     The characters SQL Server delimits identifiers with. <c>]</c> is what closes a
+    ///     <c>[...]</c> delimited identifier and <c>"</c> what closes a quoted one (SQL Server accepts both,
+    ///     the latter under <c>QUOTED_IDENTIFIER ON</c>); <c>[</c> is rejected alongside <c>]</c> so that an
+    ///     already-bracketed name is caught rather than being bracketed a second time.
+    /// </summary>
+    private const string UnsafeIdentifierCharacters = "[]\"";
+
+    /// <summary>
+    ///     SQL Server's identifier length limit -- <c>sysname</c> is <c>nvarchar(128)</c>, so anything
+    ///     longer is rejected by the server itself.
+    /// </summary>
+    public int MaxIdentifierLength { get; set; } = 128;
+
+    /// <summary>
+    ///     Validates a database object name before it is written into DDL. See
+    ///     <see cref="IdentifierValidation" /> for why each rule is here; this method had no body at all
+    ///     before weasel#416.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">The name cannot be safely written into DDL.</exception>
     public override void AssertValidIdentifier(string name)
     {
-        // Nothing yet
+        var problem = IdentifierValidation.FindProblem(name, UnsafeIdentifierCharacters);
+        if (problem != null)
+        {
+            throw new InvalidOperationException(
+                $"SQL Server identifier '{name}' is not valid because {problem}.");
+        }
+
+        if (name.Length > MaxIdentifierLength)
+        {
+            throw new InvalidOperationException(
+                $"SQL Server identifiers cannot exceed {MaxIdentifierLength} characters. '{name}' is {name.Length} characters.");
+        }
     }
 
     private static async Task createSchemas(

--- a/src/Weasel.Sqlite.Tests/SqliteMigratorTests.cs
+++ b/src/Weasel.Sqlite.Tests/SqliteMigratorTests.cs
@@ -105,6 +105,82 @@ public class SqliteMigratorTests
         Should.Throw<InvalidOperationException>(() => migrator.AssertValidIdentifier(longName));
     }
 
+    /// <summary>
+    ///     weasel#416. AssertValidIdentifier is the only identifier check in the stack, so it has to reject
+    ///     the characters that let a name escape the statement it is written into. A <c>"</c> closes a
+    ///     quoted identifier -- SchemaUtils.QuoteName doubles an embedded quote but only quotes at all for
+    ///     keywords, spaces, dashes and leading digits, so an ordinary-looking name carrying one is written
+    ///     out raw -- a <c>'</c> closes the string literal the introspection path interpolates names into
+    ///     (<c>pragma_table_info('...')</c>), and a <c>;</c> starts a new statement.
+    /// </summary>
+    [Theory]
+    [InlineData("users\"", "a trailing double quote")]
+    [InlineData("\"users", "a leading double quote")]
+    [InlineData("us\"ers", "an embedded double quote")]
+    [InlineData("\"users\"", "a fully quote-wrapped name")]
+    [InlineData("users\"; drop table users; --", "a quote-and-semicolon payload")]
+    [InlineData("users'", "a trailing single quote")]
+    [InlineData("us'ers", "an embedded single quote")]
+    [InlineData("users'; drop table users; --", "a literal-breaking payload")]
+    [InlineData("users;", "a trailing semicolon")]
+    [InlineData("us;ers", "an embedded semicolon")]
+    public void assert_identifier_rejects_quote_and_semicolon(string name, string description)
+    {
+        var migrator = new SqliteMigrator();
+
+        Should.Throw<InvalidOperationException>(
+            () => migrator.AssertValidIdentifier(name),
+            $"Expected {description} to be rejected");
+    }
+
+    /// <summary>
+    ///     Only null and all-whitespace names used to be checked, so a name could still carry an interior
+    ///     newline and smuggle a '--' comment into the statement.
+    /// </summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("us ers")]
+    [InlineData("us\ters")]
+    [InlineData("us\ners")]
+    [InlineData("us\rers")]
+    [InlineData("users\n-- the rest of this statement is now a comment")]
+    public void assert_identifier_rejects_null_and_interior_whitespace(string? name)
+    {
+        var migrator = new SqliteMigrator();
+
+        Should.Throw<InvalidOperationException>(() => migrator.AssertValidIdentifier(name!));
+    }
+
+    [Fact]
+    public void invalid_identifier_message_says_which_rule_was_broken()
+    {
+        var migrator = new SqliteMigrator();
+
+        var ex = Should.Throw<InvalidOperationException>(() => migrator.AssertValidIdentifier("us\"ers"));
+
+        ex.Message.ShouldContain("us\"ers");
+        ex.Message.ShouldContain("double quote");
+    }
+
+    /// <summary>
+    ///     Names Weasel and its consumers actually generate must keep working -- the tightening is aimed at
+    ///     a handful of characters, not at narrowing the identifier grammar.
+    /// </summary>
+    [Theory]
+    [InlineData("mt_doc_user")]
+    [InlineData("mt_stream")]
+    [InlineData("mt_doc_user_hilo")]
+    [InlineData("users$1")]
+    [InlineData("_leading_underscore")]
+    [InlineData("MixedCaseName")]
+    [InlineData("naïve_café")]
+    [InlineData("table-with-dashes")]
+    [InlineData("mt_doc_target.p_tenant_one")]
+    public void assert_identifier_still_accepts_ordinary_names(string name)
+    {
+        Should.NotThrow(() => new SqliteMigrator().AssertValidIdentifier(name));
+    }
+
     [Fact]
     public async Task ensure_database_exists_is_noop_for_memory()
     {

--- a/src/Weasel.Sqlite/SqliteMigrator.cs
+++ b/src/Weasel.Sqlite/SqliteMigrator.cs
@@ -84,19 +84,42 @@ public class SqliteMigrator: Migrator
         return $".read {scriptName}";
     }
 
+    /// <summary>
+    ///     The character SQLite delimits identifiers with. <see cref="SchemaUtils.QuoteName" /> does double
+    ///     an embedded <c>"</c>, but only quotes at all for reserved keywords, spaces, dashes and leading
+    ///     digits -- an ordinary-looking name carrying a quote is written out raw.
+    /// </summary>
+    private const string UnsafeIdentifierCharacters = "\"";
+
+    /// <summary>
+    ///     SQLite itself allows identifiers up to 1073741824 characters, which is not a useful limit; this
+    ///     is the practical one Weasel enforces, in line with the other providers.
+    /// </summary>
+    public int MaxIdentifierLength { get; set; } = 255;
+
+    /// <summary>
+    ///     Validates a database object name before it is written into DDL. See
+    ///     <see cref="IdentifierValidation" /> for why each rule is here; before weasel#416 this checked
+    ///     null/whitespace and length only.
+    /// </summary>
+    /// <remarks>
+    ///     The single quote matters here because SQLite's introspection path interpolates the table name
+    ///     into string literals -- <c>WHERE name = '...'</c> against <c>sqlite_master</c> and
+    ///     <c>pragma_table_info('...')</c> in <c>Table.FetchExisting</c>.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">The name cannot be safely written into DDL.</exception>
     public override void AssertValidIdentifier(string name)
     {
-        if (string.IsNullOrWhiteSpace(name))
+        var problem = IdentifierValidation.FindProblem(name, UnsafeIdentifierCharacters);
+        if (problem != null)
         {
-            throw new InvalidOperationException($"SQLite identifier cannot be empty or whitespace");
+            throw new InvalidOperationException($"SQLite identifier '{name}' is not valid because {problem}.");
         }
 
-        // SQLite is quite permissive with identifier names, but we should check for basic issues
-        // SQLite allows up to 1073741824 characters, but that's impractical
-        // We'll use a reasonable limit similar to other databases
-        if (name.Length > 255)
+        if (name.Length > MaxIdentifierLength)
         {
-            throw new InvalidOperationException($"SQLite identifier '{name}' is too long ({name.Length} characters). Maximum recommended length is 255.");
+            throw new InvalidOperationException(
+                $"SQLite identifier '{name}' is too long ({name.Length} characters). Maximum recommended length is {MaxIdentifierLength}.");
         }
     }
 


### PR DESCRIPTION
Follow-up to #416, which was closed after #419 (`b4ffbe4`) hardened PostgreSQL alone. That commit's own notes listed the rest as deliberately not ridden along; this is that work.

`AssertValidIdentifier` is the only identifier check in the stack on every provider — `DbObjectName` and its provider subclasses do no validation, and `DatabaseBase` runs every schema object's name through the migrator on the migration path ([DatabaseBase.cs:330](src/Weasel.Core/Migrations/DatabaseBase.cs#L330), [:544](src/Weasel.Core/Migrations/DatabaseBase.cs#L544)). What the four providers did with that responsibility before this:

| Provider | Before |
|---|---|
| SQL Server | `// Nothing yet` — empty method body |
| Oracle | length > 128 only; NRE on null |
| MySQL | length > 64 only; NRE on null |
| SQLite | null/all-whitespace and length > 255 |

None rejected a delimiter or a `;`.

## What each now rejects

Universal (in `IdentifierValidation`, the shared helper): `;`, `'`, whitespace anywhere, null/empty. The single quote is there because object names genuinely reach string literals on these providers — SQL Server's `IF OBJECT_ID('…')` and `sys.objects.name = '…'`, Oracle's `WHERE table_name = '…'` inside the anonymous PL/SQL block it wraps DDL in, SQLite's `pragma_table_info('…')`. MySQL parameterises its introspection, so there it is uniformity rather than a live hole. Whitespace is rejected in full rather than just the space character, as on PostgreSQL, so a newline can't introduce a `--` comment.

Per provider, its own delimiters:

- **SQL Server** — `]` (closes a `[…]` identifier) and `[` with it, so an already-bracketed name is caught rather than bracketed twice; `"` for `QUOTED_IDENTIFIER ON`. New length limit of 128, the `sysname` bound.
- **MySQL** — the backtick; `"` (identifier delimiter under `ANSI_QUOTES`, string delimiter otherwise); `\`, which escapes the next character inside a literal unless `NO_BACKSLASH_ESCAPES` is set, so a trailing one swallows the literal's closing quote.
- **Oracle** and **SQLite** — `"`.

Weasel's quoting helpers do not double an embedded delimiter, so a name carrying one does not stay inside its own quotes. SQLite's `SchemaUtils.QuoteName` does double it, but only quotes at all for keywords, spaces, dashes and leading digits — an ordinary-looking name carrying a quote is written out raw.

## Shape

One PR, five commits: the shared helper, then one per provider. The rule set is one decision and reviews better in one place, but each provider's commit stands alone and is revertable on its own if one of them turns out to bite a downstream consumer.

Two judgement calls worth flagging:

- **No new exception types.** Each provider keeps what it already threw — `InvalidOperationException` for SQL Server/Oracle/SQLite, `ArgumentException` for MySQL — so existing `catch` sites and the existing SQLite tests are unaffected. The message now names the rule that was broken. PostgreSQL's typed `PostgresqlIdentifierInvalidException` with its `Reason` property is the nicer shape; matching it across four providers is a wider API change than this needs, and can follow.
- **`PostgresqlMigrator` is not refactored onto the helper.** Its rules are the same minus the single quote, so folding it in would be a no-behaviour-change edit to code that shipped in 9.23.0, on top of a change already touching four providers.

## Behaviour change

This tightens what four providers accept, so it is a breaking change for anyone whose schema object names contain these characters. The one plausible case is a SQL Server name with a space in it (`Order Details`), which used to reach DDL and would have worked bracketed. Nothing in any suite generates such a name, and `assert_identifier_still_accepts_ordinary_names` pins `mt_*` names, `$`, leading underscores, mixed case, non-ASCII letters, dashes, dotted partition suffixes and (SQL Server) `#temp` names as still valid.

## Regression pass

Full suite per provider, containers from `docker compose up`, all on net9.0:

| Suite | Result |
|---|---|
| Weasel.SqlServer | 376 passed, 8 pre-existing skips |
| Weasel.Oracle | 215 passed |
| Weasel.MySql | 227 passed |
| Weasel.Sqlite | 387 passed |
| Weasel.Core | 75 passed |
| Weasel.EntityFrameworkCore | 106 passed, 1 skip |
| Weasel.CommandLine | 23 passed |

The last two are the nearest downstream consumers of all four providers in-repo.

Closes the identifier half of #416 for the remaining providers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)