### PR TITLE
Fold PostgresqlMigrator.AssertValidIdentifier onto the shared helper (weasel#416)

### DIFF
--- a/src/Weasel.Core/IdentifierValidation.cs
+++ b/src/Weasel.Core/IdentifierValidation.cs
@@ -20,14 +20,15 @@ namespace Weasel.Core;
 ///         <c>'</c> closes a string literal, and object names do reach string literals on every provider --
 ///         the existence checks and introspection queries interpolate them (SQL Server's
 ///         <c>IF OBJECT_ID('...')</c>, Oracle's <c>WHERE table_name = '...'</c> inside an anonymous PL/SQL
-///         block, SQLite's <c>pragma_table_info('...')</c>). Whitespace is rejected in full rather than just
-///         the literal space character, so that a newline cannot introduce a <c>--</c> comment into an
-///         unquoted name.
+///         block, SQLite's <c>pragma_table_info('...')</c>), and PostgreSQL writes a sequence's name into
+///         one when a column defaults from it (<c>DEFAULT nextval('...')</c>). Whitespace is rejected in
+///         full rather than just the literal space character, so that a newline cannot introduce a
+///         <c>--</c> comment into an unquoted name.
 ///     </para>
 ///     <para>
 ///         The rest is per-provider, because the character that closes an identifier is not: SQL Server
-///         delimits with <c>[...]</c> as well as <c>"..."</c>, MySQL with backticks, Oracle and SQLite with
-///         <c>"</c>. Weasel's quoting helpers do not double an embedded delimiter (SQLite's
+///         delimits with <c>[...]</c> as well as <c>"..."</c>, MySQL with backticks, and Oracle, SQLite and
+///         PostgreSQL with <c>"</c>. Weasel's quoting helpers do not double an embedded delimiter (SQLite's
 ///         <c>SchemaUtils.QuoteName</c> does, but only quotes at all for keywords, spaces, dashes and
 ///         leading digits), so a name carrying one does not stay inside its own quotes.
 ///     </para>

--- a/src/Weasel.Postgresql.Tests/PostgresqlMigratorTests.cs
+++ b/src/Weasel.Postgresql.Tests/PostgresqlMigratorTests.cs
@@ -104,6 +104,13 @@ public class PostgresqlMigratorTests
     ///     the characters that let a name escape the statement it is written into. A '"' closes a quoted
     ///     identifier -- Weasel quotes without doubling an embedded quote -- and a ';' starts a new
     ///     statement. Both were permitted before this.
+    ///     <para>
+    ///         The single quote came with the move onto the shared IdentifierValidation. It is not
+    ///         uniformity for its own sake: Table.ColumnExpression.DefaultValueFromSequence writes a
+    ///         sequence's name into a string literal, DEFAULT nextval('{name}'), so a name carrying one
+    ///         closes that literal. PostgreSQL's introspection queries parameterise the name, which is why
+    ///         this is narrower here than on the providers that interpolate it.
+    ///     </para>
     /// </summary>
     [Theory]
     [InlineData("users\"", "a trailing double quote")]
@@ -111,6 +118,9 @@ public class PostgresqlMigratorTests
     [InlineData("us\"ers", "an embedded double quote")]
     [InlineData("\"users\"", "a fully quote-wrapped name")]
     [InlineData("users\"; drop table users; --", "a quote-and-semicolon payload")]
+    [InlineData("users'", "a trailing single quote")]
+    [InlineData("us'ers", "an embedded single quote")]
+    [InlineData("users'); drop table users; --", "a literal-breaking payload")]
     [InlineData("users;", "a trailing semicolon")]
     [InlineData("us;ers", "an embedded semicolon")]
     public void assert_identifier_rejects_quote_and_semicolon(string name, string description)
@@ -153,7 +163,7 @@ public class PostgresqlMigratorTests
 
     /// <summary>
     ///     Names Weasel and its consumers actually generate must keep working -- the tightening is aimed at
-    ///     two characters, not at narrowing the identifier grammar.
+    ///     a handful of characters, not at narrowing the identifier grammar.
     /// </summary>
     [Theory]
     [InlineData("mt_doc_user")]

--- a/src/Weasel.Postgresql/PostgresqlMigrator.cs
+++ b/src/Weasel.Postgresql/PostgresqlMigrator.cs
@@ -335,45 +335,29 @@ $$;
     public override bool IsSystemColumn(string columnName) => SystemColumns.Contains(columnName);
 
     /// <summary>
+    ///     The character PostgreSQL delimits identifiers with. A <c>"</c> closes a quoted identifier, and
+    ///     <see cref="SchemaUtils.QuoteName" /> does not double an embedded one -- so a name carrying one
+    ///     does not stay inside its own quotes. The rest of what is rejected is universal and lives in
+    ///     <see cref="IdentifierValidation" />.
+    /// </summary>
+    private const string UnsafeIdentifierCharacters = "\"";
+
+    /// <summary>
     ///     Validates a database object name before it is written into DDL.
     /// </summary>
     /// <remarks>
     ///     This is the only identifier check in the stack -- <see cref="DbObjectName" /> and
-    ///     <see cref="PostgresqlObjectName" /> do no validation of their own -- so it rejects the two
-    ///     characters that let a name escape the statement it is written into (weasel#416):
-    ///     <list type="bullet">
-    ///         <item>
-    ///             <c>"</c>, which closes a quoted identifier. Weasel quotes identifiers without doubling
-    ///             an embedded quote, so a name carrying one does not stay inside its own quotes.
-    ///         </item>
-    ///         <item><c>;</c>, which ends the statement and starts another.</item>
-    ///     </list>
-    ///     Whitespace is rejected in full rather than just the literal space it used to check, so that a
-    ///     newline cannot introduce a <c>--</c> comment into an unquoted name either.
+    ///     <see cref="PostgresqlObjectName" /> do no validation of their own -- so it rejects the characters
+    ///     that let a name escape the statement it is written into: the double quote above, plus the
+    ///     semicolon, the single quote and whitespace that <see cref="IdentifierValidation.FindProblem" />
+    ///     rejects for every provider (weasel#416).
     /// </remarks>
     public override void AssertValidIdentifier(string name)
     {
-        if (string.IsNullOrWhiteSpace(name))
+        var problem = IdentifierValidation.FindProblem(name, UnsafeIdentifierCharacters);
+        if (problem != null)
         {
-            throw new PostgresqlIdentifierInvalidException(name, "it is null, empty, or entirely whitespace");
-        }
-
-        foreach (var c in name)
-        {
-            if (char.IsWhiteSpace(c))
-            {
-                throw new PostgresqlIdentifierInvalidException(name, "it contains whitespace");
-            }
-
-            if (c == '"')
-            {
-                throw new PostgresqlIdentifierInvalidException(name, "it contains a double quote");
-            }
-
-            if (c == ';')
-            {
-                throw new PostgresqlIdentifierInvalidException(name, "it contains a semicolon");
-            }
+            throw new PostgresqlIdentifierInvalidException(name, problem);
         }
 
         if (name.Length < NameDataLength)


### PR DESCRIPTION
Follow-on to #420, which left PostgreSQL on its own hand-rolled loop — the reasoning there was that folding it in would be a no-behaviour-change edit to code shipped in 9.23.0. That turns out to be half right, so the delta is worth stating plainly up front.

**Unchanged:** the rules PostgreSQL already had come back identical — null/empty/whitespace-only, whitespace anywhere, `"`, `;` — with the same reason strings, so `PostgresqlIdentifierInvalidException.Reason` and the exception message are byte-for-byte what they were. The length check and `PostgresqlIdentifierTooLongException` stay in the provider, since `NameDataLength` is PostgreSQL's own and configurable.

**Changed:** the shared helper also rejects `'`, and PostgreSQL did not.

That is not uniformity for its own sake. [Table.cs:584](src/Weasel.Postgresql/Tables/Table.cs#L584) — `DefaultValueFromSequence` — writes a sequence's `DbObjectName` into a string literal:

```csharp
return DefaultValueByExpression($"nextval('{sequenceName}')");
```

so a sequence name carrying a `'` closes that literal and the rest of the `DEFAULT` clause is whatever the name says next. PostgreSQL's introspection queries do parameterise names (`Table.FetchExisting`, `Function`), which is why the exposure here is narrower than on SQL Server, Oracle and SQLite, where the existence checks interpolate them — but it is not zero.

An apostrophe in a schema object name has no legitimate use that survives Weasel's quoting anyway: `SchemaUtils.QuoteName` only quotes keywords and names containing an uppercase character, so such a name is written out raw. Still, it is a tightening layered on a released one, and anyone with a `'` in an object name will now get an exception where 9.23.0 gave them DDL.

The three single-quote cases are added to `assert_identifier_rejects_quote_and_semicolon` rather than to a new test, since it is the same rule.

## Regression pass

Full suites on net9.0, PostgreSQL container from `docker compose up`:

| Suite | Result |
|---|---|
| Weasel.Postgresql | 849 passed, 3 pre-existing skips (846 before, plus the three new cases) |
| Weasel.Core | 75 passed |
| Weasel.EntityFrameworkCore | 106 passed, 1 skip |
| Weasel.CommandLine | 23 passed |

The other four providers are untouched by this — their behaviour landed in #420.

🤖 Generated with [Claude Code](https://claude.com/claude-code)