### PR TITLE
fix(sqlite,mysql): implement the non-generic Weasel.Core.ICommandBuilder

### DIFF
--- a/src/Weasel.MySql.Tests/CommandBuilderNeutralContractTests.cs
+++ b/src/Weasel.MySql.Tests/CommandBuilderNeutralContractTests.cs
@@ -1,0 +1,69 @@
+using Shouldly;
+using Xunit;
+
+namespace Weasel.MySql.Tests;
+
+/// <summary>
+/// weasel#423: Weasel.MySql.CommandBuilder shipped without the non-generic
+/// Weasel.Core.ICommandBuilder, which is the surface every Weasel.Storage closed-shape operation
+/// configures itself against. SQLite was the provider where this actually blocked a consumer, but
+/// MySql had the identical gap and would have hit it the moment a Weasel.Storage consumer targeted
+/// it. These guard the members the base class cannot supply on its own.
+/// </summary>
+public class CommandBuilderNeutralContractTests
+{
+    [Fact]
+    public void implements_the_dialect_neutral_command_builder()
+    {
+        typeof(Weasel.Core.ICommandBuilder).IsAssignableFrom(typeof(CommandBuilder)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void append_parameter_returns_the_created_parameter()
+    {
+        Weasel.Core.ICommandBuilder builder = new CommandBuilder();
+
+        builder.Append("select * from foo where bar = ");
+        var parameter = builder.AppendParameter("baz");
+
+        parameter.ShouldNotBeNull();
+        parameter.Value.ShouldBe("baz");
+        builder.ToString().ShouldBe("select * from foo where bar = @p0");
+    }
+
+    [Fact]
+    public void append_parameters_writes_each_value_comma_separated()
+    {
+        Weasel.Core.ICommandBuilder builder = new CommandBuilder();
+
+        builder.Append("select * from foo where bar in (");
+        builder.AppendParameters("one", "two", "three");
+        builder.Append(")");
+
+        builder.ToString().ShouldBe("select * from foo where bar in (@p0, @p1, @p2)");
+    }
+
+    [Fact]
+    public void append_parameters_rejects_an_empty_set()
+    {
+        Weasel.Core.ICommandBuilder builder = new CommandBuilder();
+
+        Should.Throw<ArgumentOutOfRangeException>(() => builder.AppendParameters());
+    }
+
+    [Fact]
+    public void creates_a_grouped_parameter_builder()
+    {
+        Weasel.Core.ICommandBuilder builder = new CommandBuilder();
+
+        builder.CreateGroupedParameterBuilder().ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void carries_a_tenant_id()
+    {
+        Weasel.Core.ICommandBuilder builder = new CommandBuilder { TenantId = "tenant-a" };
+
+        builder.TenantId.ShouldBe("tenant-a");
+    }
+}

--- a/src/Weasel.MySql/CommandBuilder.cs
+++ b/src/Weasel.MySql/CommandBuilder.cs
@@ -4,7 +4,7 @@ using Weasel.Core;
 
 namespace Weasel.MySql;
 
-public class CommandBuilder: CommandBuilderBase<MySqlCommand, MySqlParameter, MySqlDbType>
+public class CommandBuilder: CommandBuilderBase<MySqlCommand, MySqlParameter, MySqlDbType>, ICommandBuilder
 {
     public CommandBuilder(): this(new MySqlCommand())
     {
@@ -12,6 +12,47 @@ public class CommandBuilder: CommandBuilderBase<MySqlCommand, MySqlParameter, My
 
     public CommandBuilder(MySqlCommand command): base(MySqlProvider.Instance, '@', command)
     {
+    }
+
+    /// <summary>
+    /// It became so common, that it's turned out to be convenient to place
+    /// this here
+    /// </summary>
+    public string TenantId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Append a single parameter through the dialect-neutral value path, returning the newly created
+    /// parameter upcast to <see cref="DbParameter" />.
+    /// <para>
+    /// Explicitly implemented, as in Weasel.Oracle: the base class already exposes void-returning
+    /// <c>AppendParameter</c> overloads, so a public member here would hide them and silently change
+    /// which one existing call sites bind to.
+    /// </para>
+    /// </summary>
+    DbParameter ICommandBuilder.AppendParameter(object value)
+    {
+        base.AppendParameter(value);
+        return _command.Parameters[^1];
+    }
+
+    void ICommandBuilder.AppendParameters(params object[] parameters)
+    {
+        if (parameters.Length == 0)
+            throw new ArgumentOutOfRangeException(nameof(parameters),
+                "Must be at least one parameter value, but got " + parameters.Length);
+
+        AppendParameter(parameters[0]);
+
+        for (var i = 1; i < parameters.Length; i++)
+        {
+            Append(", ");
+            AppendParameter(parameters[i]);
+        }
+    }
+
+    public IGroupedParameterBuilder CreateGroupedParameterBuilder(char? seperator = null)
+    {
+        return new GroupedParameterBuilder(this, seperator);
     }
 }
 

--- a/src/Weasel.Sqlite.Tests/CommandBuilderTests.cs
+++ b/src/Weasel.Sqlite.Tests/CommandBuilderTests.cs
@@ -116,3 +116,67 @@ public class CommandBuilderTests
         builder.ToString().ShouldBe("SELECT * FROM users");
     }
 }
+
+/// <summary>
+/// weasel#423: Weasel.Sqlite.CommandBuilder shipped without the non-generic
+/// Weasel.Core.ICommandBuilder, which is the surface every Weasel.Storage closed-shape operation
+/// configures itself against — so no document or event operation could execute against SQLite at
+/// all. These guard the members the base class cannot supply on its own.
+/// </summary>
+public class CommandBuilderNeutralContractTests
+{
+    [Fact]
+    public void implements_the_dialect_neutral_command_builder()
+    {
+        typeof(Weasel.Core.ICommandBuilder).IsAssignableFrom(typeof(CommandBuilder)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void append_parameter_returns_the_created_parameter()
+    {
+        Weasel.Core.ICommandBuilder builder = new CommandBuilder();
+
+        builder.Append("select * from foo where bar = ");
+        var parameter = builder.AppendParameter("baz");
+
+        parameter.ShouldNotBeNull();
+        parameter.Value.ShouldBe("baz");
+        builder.ToString().ShouldBe("select * from foo where bar = @p0");
+    }
+
+    [Fact]
+    public void append_parameters_writes_each_value_comma_separated()
+    {
+        Weasel.Core.ICommandBuilder builder = new CommandBuilder();
+
+        builder.Append("select * from foo where bar in (");
+        builder.AppendParameters("one", "two", "three");
+        builder.Append(")");
+
+        builder.ToString().ShouldBe("select * from foo where bar in (@p0, @p1, @p2)");
+    }
+
+    [Fact]
+    public void append_parameters_rejects_an_empty_set()
+    {
+        Weasel.Core.ICommandBuilder builder = new CommandBuilder();
+
+        Should.Throw<ArgumentOutOfRangeException>(() => builder.AppendParameters());
+    }
+
+    [Fact]
+    public void creates_a_grouped_parameter_builder()
+    {
+        Weasel.Core.ICommandBuilder builder = new CommandBuilder();
+
+        builder.CreateGroupedParameterBuilder().ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void carries_a_tenant_id()
+    {
+        Weasel.Core.ICommandBuilder builder = new CommandBuilder { TenantId = "tenant-a" };
+
+        builder.TenantId.ShouldBe("tenant-a");
+    }
+}

--- a/src/Weasel.Sqlite/CommandBuilder.cs
+++ b/src/Weasel.Sqlite/CommandBuilder.cs
@@ -4,7 +4,7 @@ using Weasel.Core;
 
 namespace Weasel.Sqlite;
 
-public class CommandBuilder: CommandBuilderBase<SqliteCommand, SqliteParameter, SqliteType>
+public class CommandBuilder: CommandBuilderBase<SqliteCommand, SqliteParameter, SqliteType>, ICommandBuilder
 {
     public CommandBuilder(): this(new SqliteCommand())
     {
@@ -13,6 +13,51 @@ public class CommandBuilder: CommandBuilderBase<SqliteCommand, SqliteParameter, 
     public CommandBuilder(SqliteCommand command): base(SqliteProvider.Instance, '@', command)
     {
     }
+
+    /// <summary>
+    /// It became so common, that it's turned out to be convenient to place
+    /// this here
+    /// </summary>
+    public string TenantId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Append a single parameter through the dialect-neutral value path, returning the newly created
+    /// parameter upcast to <see cref="DbParameter" />.
+    /// <para>
+    /// Explicitly implemented, as in Weasel.Oracle: the base class already exposes void-returning
+    /// <c>AppendParameter</c> overloads, so a public member here would hide them and silently change
+    /// which one existing call sites bind to.
+    /// </para>
+    /// </summary>
+    DbParameter ICommandBuilder.AppendParameter(object value)
+    {
+        base.AppendParameter(value);
+        return _command.Parameters[^1];
+    }
+
+    void ICommandBuilder.AppendParameters(params object[] parameters)
+    {
+        if (parameters.Length == 0)
+            throw new ArgumentOutOfRangeException(nameof(parameters),
+                "Must be at least one parameter value, but got " + parameters.Length);
+
+        AppendParameter(parameters[0]);
+
+        for (var i = 1; i < parameters.Length; i++)
+        {
+            Append(", ");
+            AppendParameter(parameters[i]);
+        }
+    }
+
+    public IGroupedParameterBuilder CreateGroupedParameterBuilder(char? seperator = null)
+    {
+        return new GroupedParameterBuilder(this, seperator);
+    }
+
+    // StartNewCommand is deliberately not overridden: the base is already a no-op, which is correct
+    // here because Microsoft.Data.Sqlite executes several semicolon-separated statements from one
+    // command.
 }
 
 public static class CommandBuilderExtensions


### PR DESCRIPTION
Fixes #423.

`Weasel.Sqlite.CommandBuilder` and `Weasel.MySql.CommandBuilder` derive from `CommandBuilderBase<,,>` but never declared the non-generic `Weasel.Core.ICommandBuilder`, so nothing targeting the neutral contract could be handed one.

That contract is what every `Weasel.Storage` closed-shape operation configures itself against:

```csharp
void ConfigureCommand(ICommandBuilder builder, IStorageSession session);
```

so the practical effect was that **no Weasel.Storage document or event operation could execute against SQLite at all** — there was no way to construct the builder argument. Found while building [Fisher](https://github.com/JasperFx/fisher) on Weasel.Storage.

Postgresql, SqlServer and Oracle already carry the interface; Sqlite and MySql were the two left behind by #327. Only SQLite was blocking a consumer today, but MySql had the identical gap and would hit it the moment a Weasel.Storage consumer targeted it, so both are fixed here.

### Missing members

Four on each provider — everything else the interface needs was already inherited from `CommandBuilderBase`:

| Member | Before |
|---|---|
| `string TenantId { get; set; }` | absent |
| `void AppendParameters(params object[])` | absent |
| `DbParameter AppendParameter(object)` | absent — the inherited overloads all return `void`, so none satisfied the interface |
| `IGroupedParameterBuilder CreateGroupedParameterBuilder(char?)` | absent |

### Two deliberate choices

**`AppendParameter` / `AppendParameters` are implemented explicitly**, following `Weasel.Oracle` rather than `Weasel.SqlServer`. The base class already exposes void-returning `AppendParameter` overloads; a public member would hide them and silently change which overload existing call sites bind to. Explicit implementation adds the interface without touching the public surface, so this is additive for existing users.

**`StartNewCommand` is not overridden.** `Weasel.SqlServer` overrides it to a no-op, but the base is *already* a no-op ("multi-statement providers just keep appending"), which is correct for both of these — `Microsoft.Data.Sqlite` and MySqlConnector both execute several semicolon-separated statements from one command. An override would be noise implying a difference that does not exist.

### Tests

A contract test per provider covering the interface itself plus each of the four members, so the set cannot drift again:

- `src/Weasel.Sqlite.Tests/CommandBuilderTests.cs` — `CommandBuilderNeutralContractTests`
- `src/Weasel.MySql.Tests/CommandBuilderNeutralContractTests.cs`

Both are pure type/behaviour tests needing no database server.

### Verification

- Full `Weasel.slnx` builds clean.
- `Weasel.Sqlite.Tests`: 393 passed, 0 failed, on net9.0 and net10.0.
- `Weasel.MySql.Tests` `CommandBuilderNeutralContractTests`: 6 passed (the rest of that suite needs a MySQL server and was not run).

Fisher currently carries a local `FisherCommandBuilder` shim and will delete it once this ships.
