### PR TITLE
Bump JasperFx and JasperFx.Events to 2.38.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,8 +8,8 @@
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.12.19" />
     <PackageVersion Include="DistributedLock.Postgres" Version="1.3.0" />
     <PackageVersion Include="DotNet.ReproducibleBuilds" Version="1.2.39" />
-    <PackageVersion Include="JasperFx" Version="2.37.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.37.0" />
+    <PackageVersion Include="JasperFx" Version="2.38.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.38.0" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.9" />
     <!-- Override the transitive SQLitePCLRaw 2.1.11 (vulnerable native lib,
          GHSA-2m69-gcr7-jv3q) with 3.0.3, which ships the patched SQLite build. -->


### PR DESCRIPTION
Routine dependency bump: `JasperFx` and `JasperFx.Events` 2.37.0 → 2.38.0.

2.38.0 carries the lifted `ProjectionScenario` test harness (JasperFx/jasperfx#616) and the container-scoped projection fixes for live aggregation and validation (JasperFx/jasperfx#617). Neither touches anything Weasel consumes — this just keeps the dependency line current so Marten can take one coherent bump of both JasperFx and Weasel.

## Verification

`Weasel.Postgresql.Tests` on net9.0: **849 passed / 0 failed / 3 skipped** — byte-identical to the baseline I ran on unbumped `master` first, so nothing here is attributable to the bump. Release build of the full solution is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)