### PR TITLE
feat(cli): report database discovery progress (weasel#432)

### DIFF
--- a/docs/cli/db-apply.md
+++ b/docs/cli/db-apply.md
@@ -25,7 +25,17 @@ The command reports one of:
 
 ## Many databases
 
-Databases are applied one at a time, in sequence, and each one's progress is reported as `(n/total)` so a long walk over a sharded or multi-tenanted store can be watched.
+Before anything can be applied, the databases have to be discovered -- each registered `IDatabaseSource` is asked to build its list, and for a sharded tenancy source that is real work, not bookkeeping. Discovery is therefore announced before it starts and reported per source as it goes:
+
+```
+Discovering databases...
+  MartenDatabaseSource: 512 databases in 28.1s
+Found 1037 databases in 30.6s
+```
+
+The per-source line is the useful one when discovery is slow: it says which tenancy source the time went to, which is otherwise invisible from the command. This reporting applies to every command that resolves databases, not just `db-apply`.
+
+Databases are then applied one at a time, in sequence, and each one's progress is reported as `(n/total)` so a long walk over a sharded or multi-tenanted store can be watched.
 
 Because `db-apply` is a one-shot command that owns its data sources, each database's connection pool is released as soon as that database is done, rather than being left to age out on its own idle lifetime. Peak connection usage therefore stays at roughly the one database being applied, instead of trailing an idle pool per recently-applied database -- which matters when applying across hundreds of databases on a server that is near `max_connections`.
 

--- a/src/Weasel.CommandLine.Tests/DatabaseDiscoveryProgressTests.cs
+++ b/src/Weasel.CommandLine.Tests/DatabaseDiscoveryProgressTests.cs
@@ -1,0 +1,131 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NSubstitute;
+using Shouldly;
+using Spectre.Console;
+using Weasel.Core.CommandLine;
+using Weasel.Core.Migrations;
+using Xunit;
+
+namespace Weasel.CommandLine.Tests;
+
+/// <summary>
+///     Coverage for weasel#432: database discovery ran in silence. At 512 shard databases that was
+///     30.6 seconds with no output before the apply loop's counter appeared, which an operator cannot
+///     tell apart from a hung connection -- runs that were doing fine got killed.
+/// </summary>
+public class DatabaseDiscoveryProgressTests
+{
+    private readonly StringWriter theOutput = new();
+    private readonly WeaselInput theInput = new();
+
+    public DatabaseDiscoveryProgressTests()
+    {
+        var console = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Ansi = AnsiSupport.No,
+            ColorSystem = ColorSystemSupport.NoColors,
+            Out = new AnsiConsoleOutput(theOutput)
+        });
+
+        // Otherwise Spectre wraps at the default width and splits the lines being asserted on.
+        console.Profile.Width = 500;
+
+        theInput.ProgressConsole = console;
+    }
+
+    private IHost BuildHost(params IDatabaseSource[] sources)
+    {
+        var builder = new HostBuilder();
+        builder.ConfigureServices(services =>
+        {
+            foreach (var source in sources)
+            {
+                services.AddSingleton(source);
+            }
+        });
+
+        theInput.HostBuilder = builder;
+        return theInput.BuildHost();
+    }
+
+    private static IDatabaseSource SourceOf(int count, Func<IReadOnlyList<IDatabase>>? onBuild = null)
+    {
+        var databases = Enumerable.Range(1, count).Select(_ => Substitute.For<IDatabase>()).ToArray();
+
+        var source = Substitute.For<IDatabaseSource>();
+        source.BuildDatabases().Returns(_ => onBuild?.Invoke() ?? databases);
+
+        return source;
+    }
+
+    private string[] Lines() => theOutput.ToString()
+        .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries)
+        .Select(x => x.TrimEnd())
+        .ToArray();
+
+    [Fact]
+    public async Task announces_discovery_before_any_source_is_built()
+    {
+        // The whole point of the issue: the announcement has to precede the wait, not describe it
+        // afterwards. So look at what has been written at the moment a source is asked to build.
+        var outputWhenCalled = string.Empty;
+        var source = SourceOf(2, () =>
+        {
+            outputWhenCalled = theOutput.ToString();
+            return [Substitute.For<IDatabase>(), Substitute.For<IDatabase>()];
+        });
+
+        using var host = BuildHost(source);
+        await theInput.AllDatabases(host);
+
+        outputWhenCalled.ShouldContain("Discovering databases...");
+    }
+
+    [Fact]
+    public async Task reports_each_source_and_then_the_total()
+    {
+        using var host = BuildHost(SourceOf(3), SourceOf(2));
+
+        var databases = await theInput.AllDatabases(host);
+        databases.Count.ShouldBe(5);
+
+        var lines = Lines();
+        lines[0].ShouldBe("Discovering databases...");
+        lines[1].ShouldContain(": 3 databases in ");
+        lines[2].ShouldContain(": 2 databases in ");
+        lines[3].ShouldStartWith("Found 5 databases in ");
+    }
+
+    [Fact]
+    public async Task reports_a_run_with_no_sources_at_all()
+    {
+        using var host = BuildHost();
+        await theInput.AllDatabases(host);
+
+        Lines().Last().ShouldStartWith("Found 0 databases in ");
+    }
+
+    [Theory]
+    [InlineData(1, "1 database")]
+    [InlineData(0, "0 databases")]
+    [InlineData(1037, "1037 databases")]
+    public void counts_are_pluralized(int count, string expected)
+    {
+        WeaselInput.DescribeTotal(count, TimeSpan.Zero)
+            .ShouldBe($"[gray]Found {expected} in 0.0s[/]");
+    }
+
+    [Theory]
+    [InlineData(0.04, "0.0s")]
+    [InlineData(30.64, "30.6s")]
+    [InlineData(59.9, "59.9s")]
+    [InlineData(60, "1m 0s")]
+    [InlineData(312, "5m 12s")]
+    [InlineData(5400, "1h 30m")]
+    public void durations_stay_readable_at_every_scale(double seconds, string expected)
+    {
+        WeaselInput.DescribeTotal(1, TimeSpan.FromSeconds(seconds))
+            .ShouldBe($"[gray]Found 1 database in {expected}[/]");
+    }
+}

--- a/src/Weasel.Core/CommandLine/WeaselInput.cs
+++ b/src/Weasel.Core/CommandLine/WeaselInput.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using JasperFx.CommandLine;
 using JasperFx.Core;
 using Microsoft.Extensions.DependencyInjection;
@@ -9,21 +10,78 @@ namespace Weasel.Core.CommandLine;
 
 public class WeaselInput: NetCoreInput
 {
+    private IAnsiConsole? _console;
+
     [Description("Identify which database to dump in the case of multiple databases. Can be a partial Uri match")]
     public string? DatabaseFlag { get; set; }
+
+    /// <summary>
+    ///     Where discovery progress is written. Resolved lazily so that a host which replaces
+    ///     <see cref="AnsiConsole.Console" /> after this input is constructed is still respected.
+    /// </summary>
+    internal IAnsiConsole ProgressConsole
+    {
+        get => _console ?? AnsiConsole.Console;
+        set => _console = value;
+    }
 
     public async ValueTask<List<IDatabase>> AllDatabases(IHost host)
     {
         var databases = host.Services.GetServices<IDatabase>().ToList();
-        var sources = host.Services.GetServices<IDatabaseSource>();
+        var sources = host.Services.GetServices<IDatabaseSource>().ToArray();
+
+        // Discovery is not free: a sharded tenancy source resolving 512 databases took an operator
+        // 30.6 silent seconds before the apply loop's counter appeared, which from outside is
+        // indistinguishable from a hung connection -- runs that were doing fine got killed (weasel#432).
+        // So this is announced *before* the work rather than reported after it.
+        ProgressConsole.MarkupLine("[gray]Discovering databases...[/]");
+
+        var total = Stopwatch.StartNew();
 
         foreach (var source in sources)
         {
+            var timer = Stopwatch.StartNew();
             var found = await source.BuildDatabases().ConfigureAwait(false);
+            timer.Stop();
+
             databases.AddRange(found);
+
+            // Per source, not just a grand total: when one tenancy source accounts for nearly all of
+            // the wait, that points at which implementation to go look at -- which is otherwise
+            // invisible from here.
+            ProgressConsole.MarkupLine(DescribeSource(source, found.Count, timer.Elapsed));
         }
 
+        total.Stop();
+
+        ProgressConsole.MarkupLine(DescribeTotal(databases.Count, total.Elapsed));
+
         return databases;
+    }
+
+    internal static string DescribeSource(IDatabaseSource source, int count, TimeSpan duration) =>
+        $"[gray]  {Markup.Escape(source.GetType().Name)}: {Count(count)} in {Duration(duration)}[/]";
+
+    internal static string DescribeTotal(int count, TimeSpan duration) =>
+        $"[gray]Found {Count(count)} in {Duration(duration)}[/]";
+
+    private static string Count(int count) => count == 1 ? "1 database" : $"{count} databases";
+
+    /// <summary>
+    ///     Elapsed time an operator can read at a glance. Sub-minute waits are the common case and want
+    ///     the tenth of a second; a restore-and-migrate pass runs into the hours, where "5400.0s" is
+    ///     arithmetic the reader should not have to do.
+    /// </summary>
+    private static string Duration(TimeSpan duration)
+    {
+        if (duration.TotalMinutes < 1)
+        {
+            return $"{duration.TotalSeconds:0.0}s";
+        }
+
+        return duration.TotalHours < 1
+            ? $"{duration.Minutes}m {duration.Seconds}s"
+            : $"{(int)duration.TotalHours}h {duration.Minutes}m";
     }
 
     public async ValueTask<IList<IDatabase>> FilterDatabases(IHost host)
@@ -68,12 +126,7 @@ public class WeaselInput: NetCoreInput
 
     public async ValueTask<(bool, IDatabase?)> TryChooseSingleDatabase(IHost host)
     {
-        var databases = host.Services.GetServices<IDatabase>().ToList();
-        var sources = host.Services.GetServices<IDatabaseSource>();
-        foreach (var source in sources)
-        {
-            databases.AddRange(await source.BuildDatabases().ConfigureAwait(false));
-        }
+        var databases = await AllDatabases(host).ConfigureAwait(false);
 
         if (!databases.Any())
         {


### PR DESCRIPTION
Closes #432.

Database discovery — `BuildDatabases()` on each registered `IDatabaseSource` — ran with no output at all, and the apply loop's `(n/total)` counter only starts afterwards. At 512 shard databases that is 30.6 seconds of a silent container, which an operator cannot tell apart from a hung connection. Per the issue, two `db-apply` runs that were doing fine got killed because of it.

## Output

```
Discovering databases...
  MartenDatabaseSource: 512 databases in 28.1s
Found 1037 databases in 30.6s
```

Three deliberate choices:

- **Announced before the work, not summarized after it.** A report printed once discovery finishes is precisely the output the operator did not have during the wait.
- **Per source as well as in total.** This is the diagnostic half of @erdtsieck's suggestion, and the more valuable one: if one tenancy source accounts for 28 of the 30 seconds, that says which implementation to go look at. From here that is invisible.
- **Plain `MarkupLine`, not a Spectre `Status()` spinner.** This output is read through `kubectl logs` on a non-TTY, where a spinner degrades to escape-sequence noise or nothing at all.

## Scope

Reporting lives in `WeaselInput.AllDatabases`, so `db-list`, `db-assert` and `db-patch` get it too, not just `db-apply`. `TryChooseSingleDatabase` had its own copy of the discovery loop and now calls `AllDatabases`, which is what extends it to `db-dump`/`db-patch`.

Durations are formatted for the scale they occur at — tenths of a second under a minute, then `5m 12s`, then `1h 30m`. The issue's other row is a >90 minute restore-and-migrate pass, where `5400.0s` is arithmetic the reader shouldn't have to do.

## Not in scope

Making discovery itself faster. As the issue says, that belongs with whichever `IDatabaseSource` is doing the work — and the per-source line is what will point at it.

## Tests

12 new tests in `DatabaseDiscoveryProgressTests`, including one that asserts the announcement has already been written at the moment a source is asked to build (the actual requirement, and the thing a summary-after-the-fact implementation would fail). Full `Weasel.CommandLine.Tests`: 35 passing. `Weasel.Core.Tests`: 75 passing.

## Related

#431 is the other half of this operator's deploy-time pain — the sequential apply loop. Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)