### PR TITLE
refactor(core): make the migration logger redirectable per database (weasel#431)

### DIFF
--- a/docs/core/schema-migrations.md
+++ b/docs/core/schema-migrations.md
@@ -197,7 +197,16 @@ public interface IMigrationLogger_Sample
 <sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SchemaMigrationSamples.cs#L43-L49' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_imigrationlogger_interface' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-The default logger writes SQL to `Console.WriteLine` and rethrows exceptions.
+The default logger writes SQL to the console and rethrows exceptions. It also accepts a `TextWriter`, which is the simplest way to capture one database's DDL without implementing the interface:
+
+```cs
+var buffer = new StringWriter();
+database.MigrationLogger = new DefaultMigrationLogger(buffer);
+```
+
+Prefer this over a hand-rolled `IMigrationLogger` when all you want is redirection. Every provider checks `logger is DefaultMigrationLogger` to decide whether a failed migration statement is rethrown with its original stack trace or handed to `OnFailure`, so a custom type changes the stack trace you get on a failure, while the `TextWriter` overload does not.
+
+Databases implementing `IDatabaseWithMigrationLogger` — which includes everything deriving from `DatabaseBase<T>` — expose `MigrationLogger` as a settable property, so tooling that applies many databases can give each one its own destination rather than having them all write to a shared console.
 
 ## Schema Fingerprinting
 

--- a/src/Weasel.CommandLine.Tests/migration_logger_seam.cs
+++ b/src/Weasel.CommandLine.Tests/migration_logger_seam.cs
@@ -1,0 +1,92 @@
+using JasperFx;
+using Shouldly;
+using Weasel.Core.Migrations;
+using Xunit;
+
+namespace Weasel.CommandLine.Tests;
+
+/// <summary>
+///     Groundwork for weasel#431. Applying databases in parallel means several appliers writing at
+///     once, and today the migration DDL goes straight to <c>System.Console</c> from inside the apply
+///     -- so it would interleave line by line and stop being attributable to any one database. The
+///     logger has to be redirectable per database before that can be made safe.
+/// </summary>
+public class migration_logger_seam
+{
+    [Fact]
+    public void writes_to_the_supplied_writer_instead_of_the_console()
+    {
+        var writer = new StringWriter();
+        var logger = new DefaultMigrationLogger(writer);
+
+        logger.SchemaChange("create table foo ();");
+
+        writer.ToString().Trim().ShouldBe("create table foo ();");
+    }
+
+    [Fact]
+    public void will_not_accept_a_null_writer()
+    {
+        Should.Throw<ArgumentNullException>(() => new DefaultMigrationLogger(null!));
+    }
+
+    /// <summary>
+    ///     Every provider's <c>executeDelta</c> does <c>if (logger is DefaultMigrationLogger) throw;</c>
+    ///     so that a failed migration statement surfaces with its original stack trace rather than the
+    ///     reset one <c>OnFailure</c> would produce. A buffering logger has to stay on the right side of
+    ///     that check, which is why buffering is a constructor overload rather than a new type.
+    /// </summary>
+    [Fact]
+    public void a_buffering_logger_is_still_a_DefaultMigrationLogger()
+    {
+        new DefaultMigrationLogger(new StringWriter())
+            .ShouldBeOfType<DefaultMigrationLogger>();
+    }
+
+    [Fact]
+    public void the_logger_is_swappable_after_construction()
+    {
+        var database = new TestDatabaseWithTables(AutoCreate.CreateOrUpdate, "swappable");
+        var replacement = new DefaultMigrationLogger(new StringWriter());
+
+        database.ShouldBeAssignableTo<IDatabaseWithMigrationLogger>();
+
+        database.MigrationLogger = replacement;
+        database.MigrationLogger.ShouldBeSameAs(replacement);
+    }
+
+    [Fact]
+    public void will_not_accept_a_null_logger()
+    {
+        var database = new TestDatabaseWithTables(AutoCreate.CreateOrUpdate, "not_null");
+
+        Should.Throw<ArgumentNullException>(() => database.MigrationLogger = null!);
+    }
+}
+
+/// <summary>
+///     The seam is only worth anything if the DDL an actual apply emits follows it, so this drives a
+///     real migration against a real database rather than calling the logger directly.
+/// </summary>
+[Collection("integration")]
+public class migration_logger_seam_end_to_end: IntegrationContext
+{
+    [Fact]
+    public async Task applied_ddl_goes_to_the_swapped_in_logger()
+    {
+        await DropSchema("logger_seam");
+
+        var buffer = new StringWriter();
+        var database = Databases["logger_seam_db"];
+        database.Features["seam"].AddTable("logger_seam", "names");
+        database.MigrationLogger = new DefaultMigrationLogger(buffer);
+
+        await database.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var ddl = buffer.ToString();
+        ddl.ShouldContain("logger_seam.names");
+
+        // And the database really was migrated -- the DDL was redirected, not swallowed.
+        await database.AssertDatabaseMatchesConfigurationAsync();
+    }
+}

--- a/src/Weasel.Core/Migrations/DatabaseBase.cs
+++ b/src/Weasel.Core/Migrations/DatabaseBase.cs
@@ -6,11 +6,12 @@ using JasperFx.Descriptors;
 
 namespace Weasel.Core.Migrations;
 
-public abstract class DatabaseBase<TConnection>: IDatabase<TConnection> where TConnection : DbConnection, new()
+public abstract class DatabaseBase<TConnection>: IDatabase<TConnection>, IDatabaseWithMigrationLogger
+    where TConnection : DbConnection, new()
 {
     private readonly ConcurrentDictionary<Type, bool> _checks = new();
     private readonly Func<TConnection> _connectionSource;
-    private readonly IMigrationLogger _logger;
+    private IMigrationLogger _logger;
     private readonly TimedLock _migrateLocker = new();
     private readonly List<IDatabaseInitializer<TConnection>> _initializers = new();
 
@@ -29,6 +30,16 @@ public abstract class DatabaseBase<TConnection>: IDatabase<TConnection> where TC
     }
 
     public DatabaseId Id { get; protected set; }
+
+    /// <summary>
+    ///     Where this database's migration DDL is written. Swappable so that tooling applying many
+    ///     databases can give each one its own destination -- see <see cref="IDatabaseWithMigrationLogger" />.
+    /// </summary>
+    public IMigrationLogger MigrationLogger
+    {
+        get => _logger;
+        set => _logger = value ?? throw new ArgumentNullException(nameof(value));
+    }
 
     public abstract DatabaseDescriptor Describe();
 

--- a/src/Weasel.Core/Migrations/IDatabase.cs
+++ b/src/Weasel.Core/Migrations/IDatabase.cs
@@ -253,11 +253,47 @@ public interface IMigrationLogger
     void OnFailure(DbCommand command, Exception ex);
 }
 
+/// <summary>
+///     Implemented by databases whose migration logger can be replaced after construction, so that a
+///     caller applying many databases can route each one's DDL somewhere of its own -- a buffer it
+///     flushes as an attributable unit, rather than interleaved lines from several appliers at once.
+///     <para>
+///     Deliberately separate from <see cref="IDatabase" />: adding a member there would break every
+///     implementation outside this repository. A database that does not implement this simply keeps
+///     whatever logger it was constructed with.
+///     </para>
+/// </summary>
+public interface IDatabaseWithMigrationLogger
+{
+    IMigrationLogger MigrationLogger { get; set; }
+}
+
 public class DefaultMigrationLogger: IMigrationLogger
 {
+    private readonly TextWriter? _writer;
+
+    public DefaultMigrationLogger()
+    {
+    }
+
+    /// <summary>
+    ///     Route the migration DDL to <paramref name="writer" /> instead of the console. Pass a
+    ///     <see cref="StringWriter" /> to buffer one database's output so it can be emitted as a unit;
+    ///     the resulting logger is still a <see cref="DefaultMigrationLogger" />, which matters because
+    ///     every provider's <c>executeDelta</c> checks for exactly this type to decide whether to
+    ///     rethrow a failed statement with its original stack trace or hand it to
+    ///     <see cref="OnFailure" />.
+    /// </summary>
+    public DefaultMigrationLogger(TextWriter writer)
+    {
+        _writer = writer ?? throw new ArgumentNullException(nameof(writer));
+    }
+
     public void SchemaChange(string sql)
     {
-        Console.WriteLine(sql);
+        // Resolved per call rather than captured in the constructor: Console.Out is reassignable, and a
+        // host that redirects it after building its databases should still be obeyed.
+        (_writer ?? Console.Out).WriteLine(sql);
     }
 
     public void OnFailure(DbCommand command, Exception ex)


### PR DESCRIPTION
Groundwork for #431 (parallel `db-apply`). Not the parallelism itself — this is the prerequisite that makes parallel console output safe, so it can land and be reviewed on its own.

## The problem it removes

`DefaultMigrationLogger.SchemaChange` wrote the migration DDL straight to `System.Console`, from inside the apply, on whatever thread was running it. A lock around `ApplyCommand`'s own progress lines does nothing about that. With several appliers in flight the DDL interleaves line by line and — the worse half — stops being attributable: today the SQL between two progress lines belongs to the database named on the first one, and under parallelism it wouldn't.

This was the **only** direct `Console` write left in library code. The others are in `Weasel.Core.AotSmoke`, which is legitimately a console program.

## Shape

- `DefaultMigrationLogger` gains a `TextWriter` overload. Pass a `StringWriter` to buffer one database's DDL and flush it as a unit.
- New `IDatabaseWithMigrationLogger`, implemented by `DatabaseBase<T>`, exposes the logger as settable so a caller can install a per-database destination on an already-constructed database.

## Two decisions worth flagging

**Buffering is a constructor overload, not a new logger type.** All five providers do `if (logger is DefaultMigrationLogger) throw;` in `executeDelta`, so that a failed migration statement surfaces with its original stack trace rather than the reset one `OnFailure` produces ([PostgresqlMigrator.cs:147](https://github.com/JasperFx/weasel/blob/master/src/Weasel.Postgresql/PostgresqlMigrator.cs#L147) and four others). A separate buffering type would quietly fall to the other side of that check and degrade the diagnostics on every migration failure. There's a test pinning this.

**`IDatabaseWithMigrationLogger` is a separate interface, not a member on `IDatabase`.** `IDatabase` is implemented outside this repo; adding to it would break those implementations. A database that doesn't implement the new interface simply keeps the logger it was constructed with.

`Console.Out` is resolved per write rather than captured in the constructor, so a host that redirects it after building its databases still behaves exactly as it does today.

## Not in scope

Whether the parallel apply should *buffer* each database's DDL and flush on completion, or *prefix* each line with the database identity, is left to the parallelism PR. There's a real tension there — buffering costs liveness on a long-running migration, where you currently watch the SQL stream — and it should be decided alongside the progress display rather than pre-empted here. Either policy is now possible; neither was before.

## Tests

6 new tests, including an end-to-end one that drives a real migration against Postgres with a swapped-in logger and asserts the DDL landed in the buffer *and* that the database was actually migrated — the redirection is not swallowing anything.

Full solution builds. `Weasel.Core.Tests` 75, `Weasel.CommandLine.Tests` 41, `Weasel.Postgresql.Tests` 849 — all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)