### PR TITLE
fix(core): key schema fingerprint stamps by fingerprint, not one shared row (weasel#439)

### DIFF
--- a/docs/core/schema-migrations.md
+++ b/docs/core/schema-migrations.md
@@ -211,10 +211,10 @@ migrator.UseSchemaFingerprinting = true;
 ```
 
 With the flag enabled, a successful **full** apply stamps a SHA-256 fingerprint of the configured
-schema's expected DDL into `{DefaultSchemaName}.weasel_schema_fingerprint`. The next full apply
-recomputes the fingerprint in memory and, when it matches the stamp, returns immediately — no global
-lock, no catalog introspection. Any configuration change (a new table, column, index, or managed
-partition) changes the fingerprint and re-enables the real apply, which then refreshes the stamp.
+schema's expected DDL into `{DefaultSchemaName}.weasel_schema_fingerprints`. The next full apply
+recomputes the fingerprint in memory and, when that exact fingerprint is present, returns immediately —
+no global lock, no catalog introspection. Any configuration change (a new table, column, index, or
+managed partition) changes the fingerprint and re-enables the real apply, which then adds a new stamp.
 
 Semantics to be aware of:
 
@@ -226,3 +226,16 @@ Semantics to be aware of:
   (`EnsureStorageExistsAsync`) behave exactly as before.
 * Concurrent appliers re-check the stamp after attaining the global migration lock, so replicas racing
   through a rolling update do the introspection work at most once per configuration.
+* Rows are keyed by the **fingerprint itself**, not by any per-database identity, so several logical
+  databases sharing one physical database each keep their own stamp instead of overwriting each other's.
+  A configuration change therefore leaves the previous row in place rather than replacing it; the table
+  is capped at the 25 most recent stamps. Eviction is harmless — a database whose stamp was pruned runs
+  one full apply and stamps again.
+
+::: warning
+Before weasel#439 the stamp was a single row in `weasel_schema_fingerprint` (singular), which meant two
+logical databases on the same physical database silently overwrote each other's fingerprint and neither
+ever short-circuited — measurably slower than leaving the feature off. If you evaluated fingerprinting
+on a multi-store deployment and saw no benefit, that was why. The obsolete table is dropped
+automatically on the first stamp after upgrading.
+:::

--- a/src/Weasel.Core/Migrations/DatabaseBase.cs
+++ b/src/Weasel.Core/Migrations/DatabaseBase.cs
@@ -352,9 +352,9 @@ public abstract class DatabaseBase<TConnection>: IDatabase<TConnection> where TC
             // after a successful full apply of this exact configuration.
             if (fingerprint != null)
             {
-                var stored = await SchemaFingerprint.TryReadAsync(conn, Migrator.DefaultSchemaName, ct)
-                    .ConfigureAwait(false);
-                if (fingerprint == stored)
+                var stamped = await SchemaFingerprint
+                    .HasStampAsync(conn, Migrator.DefaultSchemaName, fingerprint, ct).ConfigureAwait(false);
+                if (stamped)
                 {
                     MarkAllFeaturesAsChecked();
                     return SchemaPatchDifference.None;
@@ -386,9 +386,9 @@ public abstract class DatabaseBase<TConnection>: IDatabase<TConnection> where TC
                 // replica racing this one) may have applied + stamped while we waited.
                 if (fingerprint != null)
                 {
-                    var stored = await SchemaFingerprint.TryReadAsync(conn, Migrator.DefaultSchemaName, ct)
-                        .ConfigureAwait(false);
-                    if (fingerprint == stored)
+                    var stamped = await SchemaFingerprint
+                        .HasStampAsync(conn, Migrator.DefaultSchemaName, fingerprint, ct).ConfigureAwait(false);
+                    if (stamped)
                     {
                         MarkAllFeaturesAsChecked();
                         await globalLock.ReleaseLock(conn, ct).ConfigureAwait(false);

--- a/src/Weasel.Core/Migrations/SchemaFingerprint.cs
+++ b/src/Weasel.Core/Migrations/SchemaFingerprint.cs
@@ -28,7 +28,23 @@ namespace Weasel.Core.Migrations;
 /// </summary>
 internal static class SchemaFingerprint
 {
-    public const string TableName = "weasel_schema_fingerprint";
+    public const string TableName = "weasel_schema_fingerprints";
+
+    /// <summary>
+    /// The pre-weasel#439 table: a single row (<c>id = 1</c>) holding one fingerprint. Dropped
+    /// best-effort on the first record, because two logical databases sharing a physical database
+    /// overwrote each other in it. It is a cache, so discarding it costs one full apply.
+    /// </summary>
+    private const string LegacyTableName = "weasel_schema_fingerprint";
+
+    /// <summary>
+    /// How many stamps to keep. Rows are keyed by fingerprint rather than by any per-database identity
+    /// -- there is no identity available here that is reliably distinct between two stores sharing a
+    /// physical database -- so a configuration change leaves the old row behind rather than replacing
+    /// it, and co-located databases each add their own. Every eviction is self-healing: a database
+    /// whose stamp was pruned simply runs one full apply and re-stamps.
+    /// </summary>
+    private const int MaxStamps = 25;
 
     public static string ComputeFingerprint(Migrator migrator, ISchemaObject[] objects)
     {
@@ -46,26 +62,35 @@ internal static class SchemaFingerprint
     }
 
     /// <summary>
-    /// Reads the stored fingerprint. A missing table (fresh database, feature never used) simply
-    /// reads as "no stamp".
+    /// Is this exact configuration already stamped? Asking for one fingerprint rather than reading
+    /// "the" fingerprint is what makes co-located databases independent: each looks only for its own
+    /// hash and is indifferent to its neighbours' rows. A missing table (fresh database, feature never
+    /// used) simply reads as "no stamp".
     /// </summary>
-    public static async Task<string?> TryReadAsync(DbConnection conn, string schemaName, CancellationToken ct)
+    public static async Task<bool> HasStampAsync(DbConnection conn, string schemaName, string fingerprint,
+        CancellationToken ct)
     {
         try
         {
             await using var cmd = conn.CreateCommand();
-            cmd.CommandText = $"select fingerprint from {schemaName}.{TableName} where id = 1";
-            return await cmd.ExecuteScalarAsync(ct).ConfigureAwait(false) as string;
+            cmd.CommandText = $"select fingerprint from {schemaName}.{TableName} where fingerprint = @fingerprint";
+
+            var parameter = cmd.CreateParameter();
+            parameter.ParameterName = "@fingerprint";
+            parameter.Value = fingerprint;
+            cmd.Parameters.Add(parameter);
+
+            return await cmd.ExecuteScalarAsync(ct).ConfigureAwait(false) is string;
         }
         catch (DbException)
         {
             // Table (or schema) does not exist yet — no stamp, run the full apply.
-            return null;
+            return false;
         }
     }
 
     /// <summary>
-    /// Upserts the stamp after a successful full apply. Table creation is attempted first and an
+    /// Records the stamp after a successful full apply. Table creation is attempted first and an
     /// "already exists" failure is swallowed — plain CREATE TABLE keeps this provider-neutral
     /// (not every provider supports IF NOT EXISTS).
     /// </summary>
@@ -76,7 +101,7 @@ internal static class SchemaFingerprint
         {
             await using var create = conn.CreateCommand();
             create.CommandText =
-                $"create table {schemaName}.{TableName} (id int not null primary key, fingerprint varchar(128) not null, applied_at varchar(64) not null)";
+                $"create table {schemaName}.{TableName} (fingerprint varchar(128) not null primary key, applied_at varchar(64) not null)";
             await create.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
         }
         catch (DbException)
@@ -84,24 +109,92 @@ internal static class SchemaFingerprint
             // Already exists — fine.
         }
 
-        await using var delete = conn.CreateCommand();
-        delete.CommandText = $"delete from {schemaName}.{TableName} where id = 1";
-        await delete.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+        await dropLegacyTableAsync(conn, schemaName, ct).ConfigureAwait(false);
 
-        await using var insert = conn.CreateCommand();
-        insert.CommandText =
-            $"insert into {schemaName}.{TableName} (id, fingerprint, applied_at) values (1, @fingerprint, @appliedAt)";
+        // Delete-then-insert rather than an upsert: the syntax for the latter is not portable, and
+        // this runs only on the slow path, immediately after a full apply.
+        await using (var delete = conn.CreateCommand())
+        {
+            delete.CommandText = $"delete from {schemaName}.{TableName} where fingerprint = @fingerprint";
+            AddParameter(delete, "@fingerprint", fingerprint);
+            await delete.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+        }
 
-        var fingerprintParam = insert.CreateParameter();
-        fingerprintParam.ParameterName = "@fingerprint";
-        fingerprintParam.Value = fingerprint;
-        insert.Parameters.Add(fingerprintParam);
+        await using (var insert = conn.CreateCommand())
+        {
+            insert.CommandText =
+                $"insert into {schemaName}.{TableName} (fingerprint, applied_at) values (@fingerprint, @appliedAt)";
+            AddParameter(insert, "@fingerprint", fingerprint);
+            AddParameter(insert, "@appliedAt", DateTimeOffset.UtcNow.ToString("O"));
+            await insert.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+        }
 
-        var appliedAtParam = insert.CreateParameter();
-        appliedAtParam.ParameterName = "@appliedAt";
-        appliedAtParam.Value = DateTimeOffset.UtcNow.ToString("O");
-        insert.Parameters.Add(appliedAtParam);
+        await pruneAsync(conn, schemaName, ct).ConfigureAwait(false);
+    }
 
-        await insert.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+    private static void AddParameter(DbCommand command, string name, string value)
+    {
+        var parameter = command.CreateParameter();
+        parameter.ParameterName = name;
+        parameter.Value = value;
+        command.Parameters.Add(parameter);
+    }
+
+    /// <summary>
+    /// Removes the single-row table this replaced, so a database upgrading to weasel#439 does not carry
+    /// a dead table around forever. Best effort: it is housekeeping, and a caller without DROP rights
+    /// should still get a working stamp.
+    /// </summary>
+    private static async Task dropLegacyTableAsync(DbConnection conn, string schemaName, CancellationToken ct)
+    {
+        try
+        {
+            await using var drop = conn.CreateCommand();
+            drop.CommandText = $"drop table {schemaName}.{LegacyTableName}";
+            await drop.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+        }
+        catch (DbException)
+        {
+            // Not there, or not ours to drop.
+        }
+    }
+
+    /// <summary>
+    /// Caps the table at <see cref="MaxStamps" /> rows, oldest first. The ranking is done client-side
+    /// against the ISO-8601 timestamps (which sort lexicographically, being fixed-width UTC) because
+    /// "delete all but the newest N" has no portable spelling — LIMIT, TOP and FETCH FIRST are all
+    /// provider-specific. Best effort for the same reason as the legacy drop: an apply that succeeded
+    /// must not be reported as failed because its housekeeping could not run.
+    /// </summary>
+    private static async Task pruneAsync(DbConnection conn, string schemaName, CancellationToken ct)
+    {
+        try
+        {
+            var timestamps = new List<string>();
+
+            await using (var read = conn.CreateCommand())
+            {
+                read.CommandText = $"select applied_at from {schemaName}.{TableName} order by applied_at desc";
+                await using var reader = await read.ExecuteReaderAsync(ct).ConfigureAwait(false);
+                while (await reader.ReadAsync(ct).ConfigureAwait(false))
+                {
+                    timestamps.Add(reader.GetString(0));
+                }
+            }
+
+            if (timestamps.Count <= MaxStamps)
+            {
+                return;
+            }
+
+            await using var delete = conn.CreateCommand();
+            delete.CommandText = $"delete from {schemaName}.{TableName} where applied_at < @threshold";
+            AddParameter(delete, "@threshold", timestamps[MaxStamps - 1]);
+            await delete.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+        }
+        catch (DbException)
+        {
+            // Housekeeping only — an uncapped table still works correctly.
+        }
     }
 }

--- a/src/Weasel.Postgresql.Tests/Migrations/schema_fingerprint_colocated_tests.cs
+++ b/src/Weasel.Postgresql.Tests/Migrations/schema_fingerprint_colocated_tests.cs
@@ -1,0 +1,169 @@
+using JasperFx;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Core.Migrations;
+using Xunit;
+
+namespace Weasel.Postgresql.Tests.Migrations;
+
+/// <summary>
+/// Coverage for weasel#439. The stamp used to be a single row (<c>where id = 1</c>) in the migrator's
+/// default schema, and <c>PostgresqlMigrator</c> hardcodes that schema to "public" -- so two logical
+/// databases sharing a physical database overwrote each other's fingerprint. Neither ever read back
+/// its own, every apply ran in full, and each one paid an extra SELECT and upsert for the privilege:
+/// measurably slower than leaving fingerprinting off. Exactly the topology it was meant to help.
+/// </summary>
+// Same collection as schema_fingerprint_tests: both fixtures share public.weasel_schema_fingerprints
+// and drop it on setup, so they must not run in parallel.
+[Collection("fingerprint")]
+public class schema_fingerprint_colocated_tests: IntegrationContext, IAsyncLifetime
+{
+    private const string OtherSchema = "fingerprint_colocated_other";
+
+    private readonly TestDatabaseWithTables theFirst;
+    private readonly TestDatabaseWithTables theSecond;
+
+    public schema_fingerprint_colocated_tests(): base("fingerprint_colocated")
+    {
+        // Two logical databases, different schemas, one physical database -- a Marten deployment with
+        // more than one store per database, which is what #431's reporter runs at 512 shards.
+        theFirst = new TestDatabaseWithTables(AutoCreate.CreateOrUpdate, "First", theDataSource);
+        theSecond = new TestDatabaseWithTables(AutoCreate.CreateOrUpdate, "Second", theDataSource);
+
+        theFirst.Migrator.UseSchemaFingerprinting = true;
+        theSecond.Migrator.UseSchemaFingerprinting = true;
+
+        theFirst.Features["One"].AddTable(SchemaName, "one");
+        theSecond.Features["Two"].AddTable(OtherSchema, "two");
+    }
+
+    public override async ValueTask InitializeAsync()
+    {
+        await ResetSchema();
+        await theConnection.ResetSchemaAsync(OtherSchema);
+
+        await theConnection.CreateCommand("drop table if exists public.weasel_schema_fingerprints")
+            .ExecuteNonQueryAsync();
+        await theConnection.CreateCommand("drop table if exists public.weasel_schema_fingerprint")
+            .ExecuteNonQueryAsync();
+    }
+
+    private async Task<bool> tableExistsAsync(string qualifiedName)
+    {
+        var result = await theConnection
+            .CreateCommand($"select to_regclass('{qualifiedName}') is not null")
+            .ExecuteScalarAsync();
+        return result is true;
+    }
+
+    private async Task<long> stampCountAsync()
+    {
+        var result = await theConnection
+            .CreateCommand("select count(*) from public.weasel_schema_fingerprints")
+            .ExecuteScalarAsync();
+        return (long)result!;
+    }
+
+    [Fact]
+    public async Task co_located_databases_each_keep_their_own_stamp()
+    {
+        await theFirst.ApplyAllConfiguredChangesToDatabaseAsync();
+        await theSecond.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        (await tableExistsAsync($"{SchemaName}.one")).ShouldBeTrue();
+        (await tableExistsAsync($"{OtherSchema}.two")).ShouldBeTrue();
+
+        // One stamp each, rather than one row the two of them fight over.
+        (await stampCountAsync()).ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task the_second_apply_short_circuits_for_both_databases()
+    {
+        await theFirst.ApplyAllConfiguredChangesToDatabaseAsync();
+        await theSecond.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        // Drift applied outside Weasel. A matching stamp is trusted, so an apply that genuinely
+        // short-circuits will NOT bring these back -- that is the observable proof the introspection
+        // was skipped. Before #439 the second database's stamp had clobbered the first's, so both
+        // applies ran in full and both tables reappeared.
+        await theConnection.CreateCommand($"drop table {SchemaName}.one").ExecuteNonQueryAsync();
+        await theConnection.CreateCommand($"drop table {OtherSchema}.two").ExecuteNonQueryAsync();
+
+        (await theFirst.ApplyAllConfiguredChangesToDatabaseAsync()).ShouldBe(SchemaPatchDifference.None);
+        (await theSecond.ApplyAllConfiguredChangesToDatabaseAsync()).ShouldBe(SchemaPatchDifference.None);
+
+        (await tableExistsAsync($"{SchemaName}.one")).ShouldBeFalse();
+        (await tableExistsAsync($"{OtherSchema}.two")).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task interleaved_applies_do_not_invalidate_each_other()
+    {
+        // The failure mode was order-dependent: A stamps, B stamps over it, A reads B's stamp and
+        // re-applies. Walk them repeatedly to make sure neither ever loses its short-circuit.
+        await theFirst.ApplyAllConfiguredChangesToDatabaseAsync();
+        await theSecond.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        for (var i = 0; i < 3; i++)
+        {
+            await theFirst.ApplyAllConfiguredChangesToDatabaseAsync();
+            await theSecond.ApplyAllConfiguredChangesToDatabaseAsync();
+        }
+
+        // Still exactly two stamps -- a re-stamp per pass would mean the short-circuit never fired.
+        (await stampCountAsync()).ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task the_legacy_single_row_table_is_cleaned_up_on_the_first_stamp()
+    {
+        // A database upgrading to weasel#439 has the old one-row table sitting there. It is a cache
+        // and nothing reads it any more, so it should not be left behind forever.
+        await theConnection.CreateCommand(
+                "create table public.weasel_schema_fingerprint (id int not null primary key, fingerprint varchar(128) not null, applied_at varchar(64) not null)")
+            .ExecuteNonQueryAsync();
+
+        await theFirst.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        (await tableExistsAsync("public.weasel_schema_fingerprint")).ShouldBeFalse();
+        (await tableExistsAsync("public.weasel_schema_fingerprints")).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task stamps_are_capped_so_the_table_cannot_grow_without_bound()
+    {
+        // Keying rows by fingerprint means a configuration change leaves the previous row behind
+        // rather than replacing it. 30 distinct configurations must not leave 30 rows.
+        for (var i = 0; i < 30; i++)
+        {
+            theFirst.Features["One"].AddTable(SchemaName, $"table_{i}");
+            await theFirst.ApplyAllConfiguredChangesToDatabaseAsync();
+        }
+
+        var count = await stampCountAsync();
+        count.ShouldBeLessThanOrEqualTo(25);
+
+        // And the newest configuration still short-circuits — pruning evicts the oldest, not the live one.
+        await theConnection.CreateCommand($"drop table {SchemaName}.table_29").ExecuteNonQueryAsync();
+        (await theFirst.ApplyAllConfiguredChangesToDatabaseAsync()).ShouldBe(SchemaPatchDifference.None);
+        (await tableExistsAsync($"{SchemaName}.table_29")).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task a_configuration_change_still_re_enables_the_apply()
+    {
+        await theFirst.ApplyAllConfiguredChangesToDatabaseAsync();
+        await theSecond.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        theFirst.Features["One"].AddTable(SchemaName, "one_more");
+
+        (await theFirst.ApplyAllConfiguredChangesToDatabaseAsync()).ShouldBe(SchemaPatchDifference.Create);
+        (await tableExistsAsync($"{SchemaName}.one_more")).ShouldBeTrue();
+
+        // ...and the other database is undisturbed by its neighbour's new stamp.
+        await theConnection.CreateCommand($"drop table {OtherSchema}.two").ExecuteNonQueryAsync();
+        (await theSecond.ApplyAllConfiguredChangesToDatabaseAsync()).ShouldBe(SchemaPatchDifference.None);
+        (await tableExistsAsync($"{OtherSchema}.two")).ShouldBeFalse();
+    }
+}

--- a/src/Weasel.Postgresql.Tests/Migrations/schema_fingerprint_tests.cs
+++ b/src/Weasel.Postgresql.Tests/Migrations/schema_fingerprint_tests.cs
@@ -30,16 +30,24 @@ public class schema_fingerprint_tests: IntegrationContext, IAsyncLifetime
 
         // The stamp lives in the migrator's default schema ('public') — clear it so tests are
         // order-independent.
+        await theConnection.CreateCommand("drop table if exists public.weasel_schema_fingerprints")
+            .ExecuteNonQueryAsync();
         await theConnection.CreateCommand("drop table if exists public.weasel_schema_fingerprint")
             .ExecuteNonQueryAsync();
     }
 
+    /// <summary>
+    /// The newest stamp. Since weasel#439 the table holds a row per configuration rather than a single
+    /// row, so that co-located databases don't overwrite each other; for this one-database fixture the
+    /// most recent row is "the" stamp.
+    /// </summary>
     private async Task<string?> readStampAsync()
     {
         try
         {
             return await theConnection
-                .CreateCommand("select fingerprint from public.weasel_schema_fingerprint where id = 1")
+                .CreateCommand(
+                    "select fingerprint from public.weasel_schema_fingerprints order by applied_at desc limit 1")
                 .ExecuteScalarAsync() as string;
         }
         catch (Npgsql.PostgresException e) when (e.SqlState == Npgsql.PostgresErrorCodes.UndefinedTable)


### PR DESCRIPTION
Closes #439.

## The bug

The stamp was a single row — literally `where id = 1` — in `{Migrator.DefaultSchemaName}.weasel_schema_fingerprint`, and `PostgresqlMigrator` has only a parameterless constructor hardcoding that schema to `public`. So **every** logical database on a physical database read and wrote the same row. With two or more of them, each apply overwrote the previous one's fingerprint, nobody ever read back their own, every apply ran in full anyway, and each paid an extra `SELECT` plus an upsert for the privilege.

Correctness was never affected — the full apply still ran — which is exactly what made it silent.

Measured on local PG15, no-op applies, 8 tables per store:

| | 2 stores | 4 stores |
|---|---|---|
| fingerprinting off | 69.5ms | 141.6ms |
| fingerprinting on | 73.6ms | **162.8ms — 15% slower** |
| fingerprinting on, single store | 0.3ms | 0.4ms |

It hit precisely the deployments the feature was written for. #431's reporter runs 512 shard databases with two stores each, and I had already recommended they enable it.

## The fix

Rows are keyed by the **fingerprint value** rather than by a shared row id, so each database looks only for its own hash and is indifferent to its neighbours' rows.

Keying by fingerprint rather than by a per-database identity is deliberate: there is no identity available at that point that is reliably distinct between two stores sharing a physical database. `IDatabase.Identifier` is typically the *shard* name — the same for both.

After, same benchmark:

| | 2 stores | 4 stores |
|---|---|---|
| fingerprinting off | 60.1ms | 123.3ms |
| fingerprinting on | **0.9ms** | **1.7ms** |
| speedup | **68x** | **71x** |
| stamp rows | 2 | 4 |

## Trade-offs taken

**Rows accumulate.** A configuration change leaves the old row behind instead of replacing it, because we can't distinguish our own stale row from a neighbour's live one. The table is capped at 25 stamps, pruned oldest-first. Every eviction is self-healing — a pruned database runs one full apply and stamps again — which is what makes the cap safe to set arbitrarily.

**Pruning ranks client-side.** "Delete all but the newest N" has no portable spelling; `LIMIT`, `TOP` and `FETCH FIRST` are all provider-specific. The timestamps are fixed-width ISO-8601 UTC, so they sort lexicographically. This runs only on the slow path, right after a full apply.

**The obsolete singular table is dropped** best-effort on the first stamp, so upgrades don't carry a dead table around forever. Both that and the pruning swallow failures — an apply that succeeded must not be reported as failed because its housekeeping couldn't run.

## Tests

6 new tests in `schema_fingerprint_colocated_tests`, **4 of which fail on `master`**. They cover: co-located databases each keeping their own stamp; both short-circuiting on the second apply; interleaved applies not invalidating each other (the failure was order-dependent); a configuration change still re-enabling the apply without disturbing the neighbour; the legacy table being cleaned up; and the row cap holding while the live stamp survives pruning.

Short-circuiting is asserted the way the existing tests do it — drop a table out-of-band and check it does *not* come back, since a matching stamp is trusted. That's the observable proof introspection was skipped.

The three pre-existing tests are updated for the new table shape. They only ever exercised a single database, which is why this got through.

`Weasel.Postgresql.Tests` 855, `Weasel.Core.Tests` 75 — all passing.

## Related

Found while benchmarking #438, which the same measurements killed (merging co-located databases into one apply came out at 4-6%). Stacked behind nothing — independent of #437.

🤖 Generated with [Claude Code](https://claude.com/claude-code)