### PR TITLE
db-apply and db-assert walk large database fleets in parallel (--parallel N)

### DIFF
--- a/docs/cli/db-apply.md
+++ b/docs/cli/db-apply.md
@@ -35,11 +35,27 @@ Found 1037 databases in 30.6s
 
 The per-source line is the useful one when discovery is slow: it says which tenancy source the time went to, which is otherwise invisible from the command. This reporting applies to every command that resolves databases, not just `db-apply`.
 
-Databases are then applied one at a time, in sequence, and each one's progress is reported as `(n/total)` so a long walk over a sharded or multi-tenanted store can be watched.
+Databases are then applied one at a time by default, and each one's progress is reported as `(n/total)` so a long walk over a sharded or multi-tenanted store can be watched. The counter counts *completions*, incremented as each database finishes.
+
+### Parallelism
+
+At fleet scale the sequential walk is the deployment cost: 1,037 databases at ~0.5s apiece is 8m41s of wall time even when every one of them reports `No changes detected`. The `--parallel` flag bounds how many databases are applied concurrently:
+
+```bash
+dotnet run -- db-apply --parallel 8
+```
+
+Details worth knowing:
+
+- **The unit is the physical database.** Targets are grouped by their `DatabaseUri`, the parallelism applies *across* groups, and a group is always applied sequentially *within* itself. Parallel DDL against the same physical database only contends on its locks, so `--parallel 8` means "8 physical databases in flight" -- which is also the right number to reason about against the server's `max_connections` ceiling. (With connection-pool release per finished database, peak usage stays at roughly the pools actually in flight.)
+- **Output stays attributable.** When running in parallel, each database's migration DDL is buffered and flushed as a single block directly above that database's completion line, instead of interleaving line by line with other appliers. At `--parallel 1` (the default) the DDL still streams live as it always has -- on a genuinely long migration the streaming SQL is how an operator sees the run is alive.
+- **Failures never stop the rest, at any parallelism.** Every database is attempted; each failure is reported when it happens; and the command ends with a summary block (`N unchanged, M migrated, K failed`, failures listed) and, if anything failed, throws an `AggregateException` carrying every per-database failure with its original stack trace -- which is what makes the process exit code non-zero. This is deliberately *not* a function of the parallelism value: sequential runs aggregate too, rather than failing fast on the first bad database.
+
+The default is `1` -- strictly sequential, exactly the behavior before the flag existed. `db-assert` honors the same flag with the same physical-database grouping.
 
 Because `db-apply` is a one-shot command that owns its data sources, each database's connection pool is released as soon as that database is done, rather than being left to age out on its own idle lifetime. Peak connection usage therefore stays at roughly the one database being applied, instead of trailing an idle pool per recently-applied database -- which matters when applying across hundreds of databases on a server that is near `max_connections`.
 
-For the same reason, a database whose apply fails with a *transient connection refusal* is retried twice with an exponential backoff (3 attempts in total), so ambient connection pressure doesn't fail an entire deployment step. Migration failures themselves are **not** retried and fail the command immediately.
+For the same reason, a database whose apply fails with a *transient connection refusal* is retried twice with an exponential backoff (3 attempts in total), so ambient connection pressure doesn't fail an entire deployment step. Migration failures themselves are **not** retried -- they are reported when they happen, the remaining databases are still applied, and the command fails at the end with an `AggregateException` over every per-database failure.
 
 What counts as a transient refusal is decided per provider:
 

--- a/docs/cli/db-assert.md
+++ b/docs/cli/db-assert.md
@@ -16,7 +16,15 @@ dotnet run -- db-assert -d MyDatabase
 
 ## Behavior
 
-This command calls `AssertDatabaseMatchesConfigurationAsync()` on each discovered database. If the actual database state differs from the expected configuration, it throws a `DatabaseValidationException` and the process exits with a non-zero exit code.
+This command calls `AssertDatabaseMatchesConfigurationAsync()` on each discovered database. Every database is checked -- a failure never stops the rest of the walk -- and each failing database's `DatabaseValidationException` is printed as it happens. If any database failed, the process exits with a non-zero exit code.
+
+Like [db-apply](/cli/db-apply), the walk honors `--parallel` for fleets of databases:
+
+```bash
+dotnet run -- db-assert --parallel 8
+```
+
+Targets sharing a `DatabaseUri` (the same physical database) are always checked sequentially within the group; the parallelism counts physical databases in flight. The default is `1`, strictly sequential.
 
 ## CI/CD Usage
 

--- a/src/Weasel.CommandLine.Tests/IntegrationContext.cs
+++ b/src/Weasel.CommandLine.Tests/IntegrationContext.cs
@@ -26,7 +26,8 @@ public abstract class IntegrationContext
         await conn.DropSchemaAsync(schemaName);
     }
 
-    internal Task<bool> ExecuteCommand<TCommand>() where TCommand : JasperFxAsyncCommand<WeaselInput>, new()
+    internal Task<bool> ExecuteCommand<TCommand>(Action<WeaselInput>? configure = null,
+        params IDatabase[] additionalDatabases) where TCommand : JasperFxAsyncCommand<WeaselInput>, new()
     {
         var command = new TCommand();
         var builder = Host.CreateDefaultBuilder().ConfigureServices(services =>
@@ -35,10 +36,15 @@ public abstract class IntegrationContext
             {
                 services.AddSingleton<IDatabase>(database);
             }
+
+            foreach (var database in additionalDatabases)
+            {
+                services.AddSingleton(database);
+            }
         });
 
         var input = new WeaselInput() { HostBuilder = builder };
-
+        configure?.Invoke(input);
 
         return command.Execute(input);
     }

--- a/src/Weasel.CommandLine.Tests/NamedTable.cs
+++ b/src/Weasel.CommandLine.Tests/NamedTable.cs
@@ -42,7 +42,17 @@ public class TestDatabaseWithTables: PostgresqlDatabase
 {
     /// <inheritdoc />
     public TestDatabaseWithTables(AutoCreate autoCreate, string identifier) :
-        base(new DefaultMigrationLogger(), autoCreate, new PostgresqlMigrator(), identifier, new NpgsqlDataSourceBuilder(ConnectionSource.ConnectionString).Build())
+        this(autoCreate, identifier, ConnectionSource.ConnectionString)
+    {
+    }
+
+    /// <summary>
+    ///     Targets a specific connection string, so a test can spread databases across more than one
+    ///     physical database — which is what makes db-apply's physical-database grouping (weasel#431)
+    ///     actually exercise cross-group parallelism.
+    /// </summary>
+    public TestDatabaseWithTables(AutoCreate autoCreate, string identifier, string connectionString) :
+        base(new DefaultMigrationLogger(), autoCreate, new PostgresqlMigrator(), identifier, new NpgsqlDataSourceBuilder(connectionString).Build())
     {
     }
 

--- a/src/Weasel.CommandLine.Tests/parallel_db_apply.cs
+++ b/src/Weasel.CommandLine.Tests/parallel_db_apply.cs
@@ -1,0 +1,427 @@
+using System.Collections.Concurrent;
+using JasperFx;
+using JasperFx.Descriptors;
+using Npgsql;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Shouldly;
+using Spectre.Console;
+using Weasel.Core;
+using Weasel.Core.CommandLine;
+using Weasel.Core.Migrations;
+using Weasel.Postgresql;
+using Weasel.Postgresql.Tests;
+using Xunit;
+
+namespace Weasel.CommandLine.Tests;
+
+/// <summary>
+///     Coverage for weasel#431: db-apply walked its databases strictly sequentially, which at 1,037
+///     target databases cost a field deployment 8m41s of dead time for a no-op apply. These pin the
+///     shared bounded-parallel batch runner both db-apply and db-assert now use.
+/// </summary>
+public class DatabaseBatchTests
+{
+    private static IDatabase fakeDatabase(string databaseName, string schema = "public")
+    {
+        var descriptor = new DatabaseDescriptor
+        {
+            Engine = "postgresql", ServerName = "localhost", DatabaseName = databaseName, SchemaOrNamespace = schema
+        };
+
+        var database = Substitute.For<IDatabase>();
+        database.Describe().Returns(descriptor);
+
+        return database;
+    }
+
+    [Fact]
+    public async Task runs_every_database_exactly_once()
+    {
+        var databases = Enumerable.Range(0, 10).Select(i => fakeDatabase($"db{i}")).ToArray();
+
+        var ran = new ConcurrentQueue<IDatabase>();
+
+        var failures = await DatabaseBatch.RunAsync(databases, 4, (database, _) =>
+        {
+            ran.Enqueue(database);
+            return Task.CompletedTask;
+        });
+
+        failures.ShouldBeEmpty();
+        ran.Count.ShouldBe(10);
+        ran.Distinct().Count().ShouldBe(10);
+    }
+
+    /// <summary>
+    ///     The scheduling contract from the issue thread: parallelize *across* physical databases,
+    ///     stay sequential *within* one -- parallel DDL against the same physical database only
+    ///     contends on its locks -- and never exceed the requested parallelism overall.
+    /// </summary>
+    [Fact]
+    public async Task bounds_parallelism_and_never_overlaps_databases_sharing_a_physical_database()
+    {
+        // Eight logical targets over four physical databases, two apiece -- the field topology
+        // (1,037 targets at ~2 per physical database) in miniature.
+        var databases = Enumerable.Range(0, 8)
+            .Select(i => fakeDatabase($"db{i / 2}", schema: $"schema{i}"))
+            .ToArray();
+
+        var perDatabaseInFlight = new ConcurrentDictionary<Uri, int>();
+        var inFlight = 0;
+        var maxInFlight = 0;
+
+        var failures = await DatabaseBatch.RunAsync(databases, 2, async (database, token) =>
+        {
+            var key = database.Describe().DatabaseUri();
+
+            // No sibling of the same physical database may already be in flight.
+            perDatabaseInFlight.AddOrUpdate(key, 1, (_, current) => current + 1).ShouldBe(1);
+
+            var current = Interlocked.Increment(ref inFlight);
+            interlockedMax(ref maxInFlight, current);
+
+            await Task.Delay(25, token);
+
+            Interlocked.Decrement(ref inFlight);
+            perDatabaseInFlight.AddOrUpdate(key, 0, (_, c) => c - 1);
+        });
+
+        failures.ShouldBeEmpty();
+        maxInFlight.ShouldBeLessThanOrEqualTo(2);
+    }
+
+    private static void interlockedMax(ref int location, int value)
+    {
+        int current;
+        while (value > (current = Volatile.Read(ref location)))
+        {
+            Interlocked.CompareExchange(ref location, value, current);
+        }
+    }
+
+    [Fact]
+    public async Task a_failure_in_one_database_does_not_stop_the_others()
+    {
+        var databases = Enumerable.Range(0, 5).Select(i => fakeDatabase($"db{i}")).ToArray();
+        var poisoned = databases[2];
+        var boom = new InvalidOperationException("boom");
+
+        var ran = new ConcurrentQueue<IDatabase>();
+
+        var failures = await DatabaseBatch.RunAsync(databases, 3, (database, _) =>
+        {
+            ran.Enqueue(database);
+            return ReferenceEquals(database, poisoned) ? Task.FromException(boom) : Task.CompletedTask;
+        });
+
+        // Every database was still attempted...
+        ran.Count.ShouldBe(5);
+
+        // ...and the one failure came back attributed to its database, exception intact.
+        var failure = failures.ShouldHaveSingleItem();
+        failure.Database.ShouldBeSameAs(poisoned);
+        failure.Exception.ShouldBeSameAs(boom);
+    }
+
+    [Fact]
+    public async Task collects_every_failure_not_just_the_first()
+    {
+        var databases = Enumerable.Range(0, 6).Select(i => fakeDatabase($"db{i}")).ToArray();
+
+        var failures = await DatabaseBatch.RunAsync(databases, 2, (database, _) =>
+        {
+            var name = database.Describe().DatabaseName;
+            return name is "db1" or "db4"
+                ? Task.FromException(new InvalidOperationException(name))
+                : Task.CompletedTask;
+        });
+
+        failures.Count.ShouldBe(2);
+        failures.Select(x => x.Exception.Message).OrderBy(x => x).ShouldBe(new[] { "db1", "db4" });
+    }
+
+    [Fact]
+    public async Task cancellation_stops_the_batch_and_propagates()
+    {
+        var databases = Enumerable.Range(0, 5).Select(i => fakeDatabase($"db{i}")).ToArray();
+
+        using var cts = new CancellationTokenSource();
+        var ran = 0;
+
+        var exception = await Record.ExceptionAsync(() =>
+            DatabaseBatch.RunAsync(databases, 1, (_, _) =>
+            {
+                Interlocked.Increment(ref ran);
+                cts.Cancel();
+                return Task.CompletedTask;
+            }, cts.Token));
+
+        exception.ShouldBeAssignableTo<OperationCanceledException>();
+
+        // The batch stopped -- it did not keep grinding through the remaining databases.
+        ran.ShouldBeLessThan(5);
+    }
+
+    /// <summary>
+    ///     Sequential is just parallelism 1, and nonsense values fall back to it rather than throwing --
+    ///     the flag defaults to 1 precisely so that nothing changes for anyone who does not opt in.
+    /// </summary>
+    [Theory]
+    [InlineData(1)]
+    [InlineData(0)]
+    [InlineData(-5)]
+    public async Task parallelism_of_one_or_less_runs_strictly_sequentially(int maxParallel)
+    {
+        var databases = Enumerable.Range(0, 4).Select(i => fakeDatabase($"db{i}")).ToArray();
+
+        var inFlight = 0;
+        var ran = 0;
+
+        var failures = await DatabaseBatch.RunAsync(databases, maxParallel, async (_, _) =>
+        {
+            Interlocked.Increment(ref inFlight).ShouldBe(1);
+            Interlocked.Increment(ref ran);
+            await Task.Delay(10);
+            Interlocked.Decrement(ref inFlight);
+        });
+
+        failures.ShouldBeEmpty();
+        ran.ShouldBe(4);
+    }
+}
+
+[Collection("integration")]
+public class parallel_db_apply: IntegrationContext
+{
+    /// <summary>
+    ///     A second physical database on the same server (the stock `postgres` maintenance database), so
+    ///     the physical-database grouping actually produces more than one group to parallelize across.
+    /// </summary>
+    private static string alternateConnectionString()
+    {
+        return new NpgsqlConnectionStringBuilder(ConnectionSource.ConnectionString) { Database = "postgres" }
+            .ConnectionString;
+    }
+
+    private static async Task dropAlternateSchema(string schemaName)
+    {
+        await using var conn = new NpgsqlConnection(alternateConnectionString());
+        await conn.DropSchemaAsync(schemaName);
+    }
+
+    private static IDatabase poisonedDatabase(string databaseName)
+    {
+        var poisoned = Substitute.For<IDatabase>();
+        poisoned.Describe().Returns(new DatabaseDescriptor
+        {
+            Engine = "postgresql", ServerName = "localhost", DatabaseName = databaseName
+        });
+        poisoned.Migrator.Returns(new PostgresqlMigrator());
+        poisoned.ApplyAllConfiguredChangesToDatabaseAsync(
+                Arg.Any<AutoCreate?>(), Arg.Any<ReconnectionOptions?>(), Arg.Any<CancellationToken>())
+            .Throws(new InvalidOperationException("boom"));
+
+        return poisoned;
+    }
+
+    [Fact]
+    public async Task parallel_apply_touches_every_database_across_physical_databases()
+    {
+        await DropSchema("par_one");
+        await DropSchema("par_two");
+        await DropSchema("par_three");
+        await dropAlternateSchema("par_alt");
+
+        Databases["one"].Features["one"].AddTable("par_one", "names");
+        Databases["two"].Features["two"].AddTable("par_two", "names");
+        Databases["three"].Features["three"].AddTable("par_three", "names");
+
+        var alternate = new TestDatabaseWithTables(AutoCreate.CreateOrUpdate, "alternate", alternateConnectionString());
+        alternate.Features["alt"].AddTable("par_alt", "names");
+
+        var success = await ExecuteCommand<ApplyCommand>(input => input.ParallelFlag = 4, alternate);
+        success.ShouldBeTrue();
+
+        await AssertAllDatabasesMatchConfiguration();
+        await alternate.AssertDatabaseMatchesConfigurationAsync();
+    }
+
+    [Fact]
+    public async Task a_failing_database_does_not_stop_the_rest_and_surfaces_an_aggregate()
+    {
+        await DropSchema("agg_one");
+        await DropSchema("agg_two");
+
+        Databases["one"].Features["one"].AddTable("agg_one", "names");
+        Databases["two"].Features["two"].AddTable("agg_two", "names");
+
+        var aggregate = await Should.ThrowAsync<AggregateException>(() =>
+            ExecuteCommand<ApplyCommand>(input => input.ParallelFlag = 4, poisonedDatabase("does_not_exist")));
+
+        // The one failure came through wrapped with its database identity, original exception intact
+        // -- and letting the AggregateException escape Execute is what turns the exit code non-zero.
+        var failure = aggregate.InnerExceptions.ShouldHaveSingleItem().ShouldBeOfType<DatabaseApplyException>();
+        failure.Message.ShouldContain("does_not_exist");
+        failure.InnerException!.Message.ShouldBe("boom");
+
+        // The healthy databases were still fully applied.
+        await AssertAllDatabasesMatchConfiguration();
+    }
+
+    /// <summary>
+    ///     Exactly the same failure policy at --parallel 1: always finish the rest, always aggregate.
+    ///     Making the policy a function of the parallelism value ("fail fast at 1, aggregate at 8") is
+    ///     the kind of thing that reads as a bug later, per the issue thread.
+    /// </summary>
+    [Fact]
+    public async Task sequential_apply_also_finishes_the_rest_and_aggregates_failures()
+    {
+        await DropSchema("seq_agg");
+
+        Databases["one"].Features["one"].AddTable("seq_agg", "names");
+
+        var aggregate = await Should.ThrowAsync<AggregateException>(() =>
+            ExecuteCommand<ApplyCommand>(null, poisonedDatabase("poisoned_sequential")));
+
+        aggregate.InnerExceptions.ShouldHaveSingleItem().ShouldBeOfType<DatabaseApplyException>()
+            .Message.ShouldContain("poisoned_sequential");
+
+        await AssertAllDatabasesMatchConfiguration();
+    }
+
+    [Fact]
+    public async Task per_database_ddl_is_flushed_as_an_attributable_unit_with_completion_counter_and_summary()
+    {
+        await DropSchema("attribution_one");
+        await DropSchema("attribution_two");
+
+        Databases["one"].Features["one"].AddTable("attribution_one", "alpha");
+        Databases["two"].Features["two"].AddTable("attribution_two", "beta");
+
+        var text = await captureConsole(() => ExecuteCommand<ApplyCommand>(input => input.ParallelFlag = 2));
+
+        // The completion counter counts completions -- under parallelism a positional (i+1)/total
+        // stops meaning anything.
+        text.ShouldContain("(1/2)");
+        text.ShouldContain("(2/2)");
+
+        // The rollup block.
+        text.ShouldContain("Applied 2 database(s): 0 unchanged, 2 migrated, 0 failed.");
+
+        // Each database's DDL was flushed as one unit directly above its own completion line: the text
+        // before each "Successfully applied" line mentions exactly one of the two schemas.
+        var lines = text.Split('\n');
+        var statusIndexes = lines.Select((line, index) => (line, index))
+            .Where(x => x.line.Contains("Successfully applied migrations"))
+            .Select(x => x.index)
+            .ToArray();
+        statusIndexes.Length.ShouldBe(2);
+
+        var firstSegment = string.Join('\n', lines[..statusIndexes[0]]);
+        var secondSegment = string.Join('\n', lines[(statusIndexes[0] + 1)..statusIndexes[1]]);
+
+        foreach (var segment in new[] { firstSegment, secondSegment })
+        {
+            var mentionsOne = segment.Contains("attribution_one");
+            var mentionsTwo = segment.Contains("attribution_two");
+
+            mentionsOne.ShouldNotBe(mentionsTwo, customMessage:
+                $"Expected exactly one database's DDL per segment, but got one:{mentionsOne} two:{mentionsTwo} in segment:\n{segment}");
+        }
+
+        (firstSegment + secondSegment).ShouldContain("attribution_one");
+        (firstSegment + secondSegment).ShouldContain("attribution_two");
+    }
+
+    [Fact]
+    public async Task no_op_reapply_reports_every_database_unchanged()
+    {
+        await DropSchema("noop_one");
+        await DropSchema("noop_two");
+
+        Databases["one"].Features["one"].AddTable("noop_one", "names");
+        Databases["two"].Features["two"].AddTable("noop_two", "names");
+
+        (await ExecuteCommand<ApplyCommand>()).ShouldBeTrue();
+
+        // The erdtsieck deploy in miniature: everything already applied, run it again in parallel.
+        var text = await captureConsole(async () =>
+            (await ExecuteCommand<ApplyCommand>(input => input.ParallelFlag = 2)).ShouldBeTrue());
+
+        text.ShouldContain("Applied 2 database(s): 2 unchanged, 0 migrated, 0 failed.");
+    }
+
+    /// <summary>
+    ///     Everything ApplyCommand writes goes through the static <see cref="AnsiConsole" />, so the
+    ///     capture swaps the global console for the duration. Safe here because the "integration"
+    ///     collection runs serially.
+    /// </summary>
+    internal static async Task<string> captureConsole(Func<Task> action)
+    {
+        var output = new StringWriter();
+        var testConsole = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Ansi = AnsiSupport.No,
+            ColorSystem = ColorSystemSupport.NoColors,
+            Out = new AnsiConsoleOutput(output)
+        });
+        testConsole.Profile.Width = 500;
+
+        var original = AnsiConsole.Console;
+        AnsiConsole.Console = testConsole;
+
+        try
+        {
+            await action();
+        }
+        finally
+        {
+            AnsiConsole.Console = original;
+        }
+
+        return output.ToString();
+    }
+}
+
+[Collection("integration")]
+public class parallel_db_assert: IntegrationContext
+{
+    [Fact]
+    public async Task assert_honors_the_parallel_flag_and_still_checks_every_database()
+    {
+        await DropSchema("passert_one");
+        await DropSchema("passert_two");
+
+        Databases["one"].Features["one"].AddTable("passert_one", "names");
+        Databases["two"].Features["two"].AddTable("passert_two", "names");
+
+        (await ExecuteCommand<ApplyCommand>()).ShouldBeTrue();
+
+        var success = await ExecuteCommand<AssertCommand>(input => input.ParallelFlag = 2);
+        success.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task a_failed_assertion_fails_the_command_but_every_database_is_still_checked()
+    {
+        await DropSchema("passert_three");
+        await DropSchema("passert_four");
+
+        Databases["one"].Features["one"].AddTable("passert_three", "names");
+        Databases["two"].Features["two"].AddTable("passert_four", "names");
+
+        // Only apply database one; database two's schema is missing and must fail the assertion.
+        await Databases["one"].ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var text = await parallel_db_apply.captureConsole(async () =>
+        {
+            var success = await ExecuteCommand<AssertCommand>(input => input.ParallelFlag = 2);
+            success.ShouldBeFalse();
+        });
+
+        // The failure did not stop the batch: the healthy database was still asserted and reported.
+        text.ShouldContain("No database differences detected for 'one'.");
+        text.ShouldContain("does not match the configuration!");
+    }
+}

--- a/src/Weasel.Core/CommandLine/ApplyCommand.cs
+++ b/src/Weasel.Core/CommandLine/ApplyCommand.cs
@@ -1,4 +1,6 @@
 using JasperFx.CommandLine;
+using JasperFx.Core;
+using JasperFx.Descriptors;
 using Spectre.Console;
 using Weasel.Core;
 using Weasel.Core.CommandLine;
@@ -28,53 +30,195 @@ public class ApplyCommand: JasperFxAsyncCommand<WeaselInput>
         }
 
         var total = databases.Count;
-        for (var i = 0; i < total; i++)
+        var completed = 0;
+        var unchanged = 0;
+        var migrated = 0;
+
+        // AnsiConsole is not safe for concurrent writers -- interleaved MarkupLine calls tear. Every
+        // write from inside the batch goes through this lock, and everything belonging to one database
+        // (its buffered DDL plus its completion line) is written under a single acquisition so it lands
+        // as an attributable unit.
+        var console = new object();
+
+        // Only redirect the DDL when appliers actually run concurrently. At --parallel 1 the logger is
+        // left alone so a long migration still streams its SQL live -- on a >90 minute restore-and-migrate
+        // pass, that stream is what tells the operator the run is alive, and buffering it until completion
+        // would trade that away for attribution nothing is threatening.
+        var buffer = input.ParallelFlag > 1;
+
+        var failures = await DatabaseBatch.RunAsync(databases, input.ParallelFlag, async (database, token) =>
         {
-            var database = databases[i];
             var descriptor = database.Describe();
 
-            // A 512-database walk with no output until it finishes (or fails) is its own small cruelty --
-            // an operator watching this needs to see it moving and be able to estimate completion.
-            var progress = $"({i + 1}/{total})";
+            var ddl = buffer ? redirectMigrationLogger(database) : null;
 
             try
             {
                 // TODO -- it'd be cool to get a rundown of everything that changed.
-                var difference = await database.ApplyAllConfiguredChangesWithRetriesAsync().ConfigureAwait(false);
+                var difference = await database.ApplyAllConfiguredChangesWithRetriesAsync(ct: token).ConfigureAwait(false);
+
+                // A 512-database walk with no output until it finishes (or fails) is its own small cruelty --
+                // an operator watching this needs to see it moving and be able to estimate completion. Under
+                // parallelism a positional (i+1)/total stops meaning anything, so this is a completion
+                // counter, incremented as each database finishes.
+                var progress = $"({Interlocked.Increment(ref completed)}/{total})";
+
                 switch (difference)
                 {
                     case SchemaPatchDifference.None:
-                        AnsiConsole.MarkupLine($"[gray]{progress} No changes detected for DatabaseUri {descriptor.DatabaseUri()} with SubjectUri {descriptor.SubjectUri}.[/]");
+                        Interlocked.Increment(ref unchanged);
+                        writeCompletion(console, ddl,
+                            $"[gray]{progress} No changes detected for DatabaseUri {descriptor.DatabaseUri()} with SubjectUri {descriptor.SubjectUri}.[/]");
                         break;
 
                     case SchemaPatchDifference.Create:
                     case SchemaPatchDifference.Update:
-                        AnsiConsole.MarkupLine(
+                        Interlocked.Increment(ref migrated);
+                        writeCompletion(console, ddl,
                             $"[bold green]{progress} Successfully applied migrations for DatabaseUri {descriptor.DatabaseUri()} with SubjectUri {descriptor.SubjectUri}.[/]");
                         break;
                 }
             }
+            catch (OperationCanceledException) when (token.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception e)
+            {
+                // Reported as it happens so an operator watching a long run sees the failure when it
+                // occurs, not minutes later in the summary. The partial DDL still flushes -- what ran
+                // before the failing statement is prime diagnostic material.
+                var progress = $"({Interlocked.Increment(ref completed)}/{total})";
+                writeCompletion(console, ddl,
+                    $"[bold red]{progress} Failed to apply migrations for DatabaseUri {descriptor.DatabaseUri()} with SubjectUri {descriptor.SubjectUri}: {Markup.Escape(e.Message)}[/]");
+
+                // The batch runner collects this and keeps going -- one bad shard must not leave the
+                // remaining databases unmigrated.
+                throw;
+            }
             finally
             {
+                restoreMigrationLogger(database, ddl);
+
                 // Nothing else needs this database's connections once its apply is done, and this command
                 // owns its data sources -- there are no application sessions sharing them. Releasing here
-                // keeps peak connection usage at ~the one database being applied, instead of trailing an
+                // keeps peak connection usage at ~the pools actually in flight, instead of trailing an
                 // idle pool per database until the connection idle lifetime expires (weasel#356).
                 try
                 {
-                    await database.ReleaseConnectionPoolAsync().ConfigureAwait(false);
+                    // Deliberately not the batch token: the pool should be released even when the run is
+                    // being cancelled -- that is exactly when abandoning idle connections hurts most.
+                    await database.ReleaseConnectionPoolAsync(CancellationToken.None).ConfigureAwait(false);
                 }
                 catch (Exception e)
                 {
                     // Releasing the pool is housekeeping. If it throws while an apply is already failing,
                     // letting it out of the finally would discard the migration exception the operator
                     // actually needs to see.
-                    AnsiConsole.MarkupLine(
-                        $"[yellow]{progress} Unable to release the connection pool for DatabaseUri {descriptor.DatabaseUri()}: {Markup.Escape(e.Message)}[/]");
+                    lock (console)
+                    {
+                        AnsiConsole.MarkupLine(
+                            $"[yellow]Unable to release the connection pool for DatabaseUri {descriptor.DatabaseUri()}: {Markup.Escape(e.Message)}[/]");
+                    }
                 }
             }
+        }).ConfigureAwait(false);
+
+        writeSummary(total, unchanged, migrated, failures);
+
+        if (failures.Any())
+        {
+            // Both halves matter: the AggregateException carries every inner failure with its original
+            // stack trace, and letting it out of Execute is what turns the process exit code non-zero.
+            // Deliberately not a function of the parallelism value -- "fail fast at 1, aggregate at 8"
+            // reads as a bug later, so the policy is: always finish the rest, always aggregate.
+            throw new AggregateException(
+                $"db-apply failed for {failures.Count} of {total} database(s). See the inner exceptions for the per-database failures.",
+                failures.Select(x => new DatabaseApplyException(x.Database, x.Exception)));
         }
 
         return true;
+    }
+
+    /// <summary>
+    ///     Points a console-bound migration logger at a per-database buffer so several concurrent
+    ///     appliers' DDL doesn't interleave line by line on the console. A logger the host already
+    ///     redirected somewhere deliberate -- a custom <see cref="IMigrationLogger" />, or a
+    ///     <see cref="DefaultMigrationLogger" /> with its own writer -- is left alone.
+    /// </summary>
+    private static StringWriter? redirectMigrationLogger(IDatabase database)
+    {
+        if (database is not IDatabaseWithMigrationLogger redirectable) return null;
+        if (redirectable.MigrationLogger is not DefaultMigrationLogger { Writer: null }) return null;
+
+        var buffer = new StringWriter();
+        redirectable.MigrationLogger = new DefaultMigrationLogger(buffer);
+        return buffer;
+    }
+
+    private static void restoreMigrationLogger(IDatabase database, StringWriter? ddl)
+    {
+        if (ddl == null) return;
+
+        // Only ever reached when redirectMigrationLogger swapped a console-bound DefaultMigrationLogger
+        // out, so a plain one is the correct restoration.
+        ((IDatabaseWithMigrationLogger)database).MigrationLogger = new DefaultMigrationLogger();
+    }
+
+    /// <summary>
+    ///     Writes one database's completed story as a unit: its buffered DDL (if any) first, then the
+    ///     completion line -- the same visual order a sequential run produces, where the SQL streams and
+    ///     the line for that database follows it.
+    /// </summary>
+    private static void writeCompletion(object console, StringWriter? ddl, string markup)
+    {
+        lock (console)
+        {
+            var sql = ddl?.ToString();
+            if (sql.IsNotEmpty())
+            {
+                AnsiConsole.Write(sql);
+            }
+
+            AnsiConsole.MarkupLine(markup);
+        }
+    }
+
+    /// <summary>
+    ///     The closing rollup. Under parallelism the interleaved per-database lines get genuinely hard
+    ///     to read back, and one block of "N unchanged, M migrated, K failed" with the failures listed
+    ///     is the cheapest possible answer to "so how did the deploy actually go?".
+    /// </summary>
+    private static void writeSummary(int total, int unchanged, int migrated, IReadOnlyList<DatabaseFailure> failures)
+    {
+        var color = failures.Any() ? "bold red" : "bold green";
+        AnsiConsole.MarkupLine(
+            $"[{color}]Applied {total} database(s): {unchanged} unchanged, {migrated} migrated, {failures.Count} failed.[/]");
+
+        foreach (var failure in failures)
+        {
+            var descriptor = failure.Database.Describe();
+            AnsiConsole.MarkupLine(
+                $"[red]  DatabaseUri {descriptor.DatabaseUri()} with SubjectUri {descriptor.SubjectUri}: {Markup.Escape(failure.Exception.Message)}[/]");
+        }
+    }
+}
+
+/// <summary>
+///     One database's failure inside a <c>db-apply</c> run, wrapped so the database's identity travels
+///     with the original exception (and its stack trace) inside the terminal
+///     <see cref="AggregateException" />.
+/// </summary>
+public class DatabaseApplyException: Exception
+{
+    internal DatabaseApplyException(IDatabase database, Exception inner)
+        : base(describe(database), inner)
+    {
+    }
+
+    private static string describe(IDatabase database)
+    {
+        var descriptor = database.Describe();
+        return $"Failed to apply migrations for DatabaseUri {descriptor.DatabaseUri()} with SubjectUri {descriptor.SubjectUri}";
     }
 }

--- a/src/Weasel.Core/CommandLine/AssertCommand.cs
+++ b/src/Weasel.Core/CommandLine/AssertCommand.cs
@@ -8,30 +8,6 @@ namespace Weasel.Core.CommandLine;
 [Description("Assert that the existing database(s) matches the current configuration", Name = "db-assert")]
 public class AssertCommand: JasperFxAsyncCommand<WeaselInput>
 {
-    /// <summary>
-    ///     Uses <see cref="AnsiConsole.WriteException(Exception, ExceptionFormats)" /> to
-    ///     pretty-print database validation failures. Spectre.Console's exception
-    ///     formatter uses runtime IL generation that isn't available under
-    ///     <c>PublishAot</c>, which surfaced as IL3050 with <c>IsAotCompatible=true</c>
-    ///     on Weasel.Core.
-    ///     <para>
-    ///     This is a dev-time CLI tool (the <c>db-assert</c> command), not on any
-    ///     hot path. Earlier passes tried <c>[RequiresDynamicCode]</c> on this
-    ///     override to propagate the diagnostic; the analyzer rejects that with
-    ///     IL3051 because the base member
-    ///     (<c>JasperFx.CommandLine.JasperFxAsyncCommand&lt;T&gt;.Execute</c>)
-    ///     doesn't carry the same annotation. The
-    ///     <see cref="UnconditionalSuppressMessageAttribute" /> below silences the
-    ///     underlying IL3050 with a Justification — end users targeting AOT can
-    ///     either avoid this command or substitute a non-Spectre exception
-    ///     formatter in their own host. Surfaced by Weasel.Core.AotSmoke
-    ///     (weasel#263 / JasperFx/jasperfx#213).
-    ///     </para>
-    /// </summary>
-    [UnconditionalSuppressMessage(
-        "AOT",
-        "IL3050",
-        Justification = "AnsiConsole.WriteException's ExceptionFormatter needs runtime IL generation, but this is the dev-time db-assert command path — never reached in an AOT-published consumer. weasel#265.")]
     public override async Task<bool> Execute(WeaselInput input)
     {
         AnsiConsole.Write(
@@ -41,25 +17,75 @@ public class AssertCommand: JasperFxAsyncCommand<WeaselInput>
 
         var databases = await input.FilterDatabases(host).ConfigureAwait(false);
 
-        var success = true;
-        foreach (var database in databases)
+        // AnsiConsole is not safe for concurrent writers, so every write from inside the batch takes
+        // this lock and a database's failure story (headline plus exception) lands as one unit.
+        var console = new object();
+
+        // db-assert has the identical many-database loop -- and the identical sequential pain at fleet
+        // scale -- as db-apply, which is why the parallelism knob lives on WeaselInput and the shared
+        // batch runner is used here too (weasel#431). Assertion failures were already collected rather
+        // than fatal; the runner preserves exactly that: every database is checked, the command fails
+        // if any database failed.
+        var failures = await DatabaseBatch.RunAsync(databases, input.ParallelFlag, async (database, token) =>
         {
             try
             {
-                await database.AssertDatabaseMatchesConfigurationAsync().ConfigureAwait(false);
-                AnsiConsole.MarkupLine(
-                    $"[green]No database differences detected for '{Markup.Escape(database.Identifier)}'.[/]");
+                await database.AssertDatabaseMatchesConfigurationAsync(token).ConfigureAwait(false);
+                lock (console)
+                {
+                    AnsiConsole.MarkupLine(
+                        $"[green]No database differences detected for '{Markup.Escape(database.Identifier)}'.[/]");
+                }
             }
-            catch (DatabaseValidationException e)
+            catch (OperationCanceledException) when (token.IsCancellationRequested)
             {
-                success = false;
-
-                AnsiConsole.MarkupLine(
-                    $"[red]Database '{Markup.Escape(database.Identifier)}' does not match the configuration![/]");
-                AnsiConsole.WriteException(e);
+                throw;
             }
-        }
+            catch (Exception e)
+            {
+                writeFailure(console, database, e);
+                throw;
+            }
+        }).ConfigureAwait(false);
 
-        return success;
+        return !failures.Any();
+    }
+
+    /// <summary>
+    ///     Uses <see cref="AnsiConsole.WriteException(Exception, ExceptionFormats)" /> to
+    ///     pretty-print database validation failures. Spectre.Console's exception
+    ///     formatter uses runtime IL generation that isn't available under
+    ///     <c>PublishAot</c>, which surfaced as IL3050 with <c>IsAotCompatible=true</c>
+    ///     on Weasel.Core.
+    ///     <para>
+    ///     This is a dev-time CLI tool (the <c>db-assert</c> command), not on any
+    ///     hot path. Earlier passes tried <c>[RequiresDynamicCode]</c> to propagate the
+    ///     diagnostic; the analyzer rejected that with IL3051 when the annotation sat on
+    ///     the <c>Execute</c> override, because the base member
+    ///     (<c>JasperFx.CommandLine.JasperFxAsyncCommand&lt;T&gt;.Execute</c>)
+    ///     doesn't carry the same annotation. The
+    ///     <see cref="UnconditionalSuppressMessageAttribute" /> below silences the
+    ///     underlying IL3050 with a Justification — end users targeting AOT can
+    ///     either avoid this command or substitute a non-Spectre exception
+    ///     formatter in their own host. Surfaced by Weasel.Core.AotSmoke
+    ///     (weasel#263 / JasperFx/jasperfx#213). Lives on this helper rather than on
+    ///     <c>Execute</c> because the call moved into a lambda for weasel#431's parallel
+    ///     batch, and the suppression does not flow into a lambda's generated method.
+    ///     </para>
+    /// </summary>
+    [UnconditionalSuppressMessage(
+        "AOT",
+        "IL3050",
+        Justification = "AnsiConsole.WriteException's ExceptionFormatter needs runtime IL generation, but this is the dev-time db-assert command path — never reached in an AOT-published consumer. weasel#265.")]
+    private static void writeFailure(object console, IDatabase database, Exception exception)
+    {
+        lock (console)
+        {
+            AnsiConsole.MarkupLine(
+                exception is DatabaseValidationException
+                    ? $"[red]Database '{Markup.Escape(database.Identifier)}' does not match the configuration![/]"
+                    : $"[red]Failed to assert database '{Markup.Escape(database.Identifier)}'![/]");
+            AnsiConsole.WriteException(exception);
+        }
     }
 }

--- a/src/Weasel.Core/CommandLine/DatabaseBatch.cs
+++ b/src/Weasel.Core/CommandLine/DatabaseBatch.cs
@@ -1,0 +1,86 @@
+using System.Collections.Concurrent;
+using Weasel.Core.Migrations;
+
+namespace Weasel.Core.CommandLine;
+
+/// <summary>
+///     One database that failed during a batch run, with the exception that felled it.
+/// </summary>
+internal sealed record DatabaseFailure(IDatabase Database, Exception Exception);
+
+/// <summary>
+///     Runs an operation across many databases with bounded parallelism (weasel#431). At 1,037 target
+///     databases a strictly sequential walk cost a field deployment 8m41s of dead time for a no-op
+///     apply; both <c>db-apply</c> and <c>db-assert</c> have this loop and this pain, which is why the
+///     scheduler is shared rather than living in either command.
+///     <para>
+///     Targets are grouped by <c>Describe().DatabaseUri()</c> and the parallelism is applied *across*
+///     groups while each group runs sequentially *within* itself. Parallel DDL against the same
+///     physical database only contends on locks — nothing corrupts, but the speedup goes sublinear —
+///     so <c>--parallel N</c> means "N physical databases in flight", which is also the right unit for
+///     reasoning about a server's <c>max_connections</c> ceiling.
+///     </para>
+/// </summary>
+internal static class DatabaseBatch
+{
+    /// <summary>
+    ///     Runs <paramref name="operation" /> once for every database. A throwing operation never stops
+    ///     the rest of the batch: <see cref="Parallel.ForEachAsync{TSource}(IEnumerable{TSource},ParallelOptions,Func{TSource,CancellationToken,ValueTask})" />
+    ///     cancels its remaining iterations when a body throws, so keep-going-and-aggregate has to be
+    ///     built by catching inside the body — which is done here, once, instead of in every caller.
+    ///     Failures come back with their database so the caller can report them together and decide the
+    ///     exit semantics. Only cancellation stops the run early, and it propagates as
+    ///     <see cref="OperationCanceledException" />.
+    /// </summary>
+    /// <param name="databases">Every database the batch should touch.</param>
+    /// <param name="maxParallel">
+    ///     Maximum number of physical databases in flight at once. Values below 1 are treated as 1,
+    ///     which preserves the strictly sequential behavior.
+    /// </param>
+    /// <param name="operation">
+    ///     The per-database work. Exceptions it throws are collected, not fatal — except an
+    ///     <see cref="OperationCanceledException" /> for the supplied token, which cancels the batch.
+    /// </param>
+    /// <param name="ct">Cancellation token, propagated into both the scheduler and the operation.</param>
+    public static async Task<IReadOnlyList<DatabaseFailure>> RunAsync(
+        IEnumerable<IDatabase> databases,
+        int maxParallel,
+        Func<IDatabase, CancellationToken, Task> operation,
+        CancellationToken ct = default)
+    {
+        var groups = databases
+            .GroupBy(x => x.Describe().DatabaseUri())
+            .Select(x => x.ToArray())
+            .ToArray();
+
+        var options = new ParallelOptions
+        {
+            MaxDegreeOfParallelism = Math.Max(1, maxParallel), CancellationToken = ct
+        };
+
+        var failures = new ConcurrentQueue<DatabaseFailure>();
+
+        await Parallel.ForEachAsync(groups, options, async (group, token) =>
+        {
+            foreach (var database in group)
+            {
+                token.ThrowIfCancellationRequested();
+
+                try
+                {
+                    await operation(database, token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (token.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (Exception e)
+                {
+                    failures.Enqueue(new DatabaseFailure(database, e));
+                }
+            }
+        }).ConfigureAwait(false);
+
+        return failures.ToList();
+    }
+}

--- a/src/Weasel.Core/CommandLine/WeaselInput.cs
+++ b/src/Weasel.Core/CommandLine/WeaselInput.cs
@@ -16,6 +16,16 @@ public class WeaselInput: NetCoreInput
     public string? DatabaseFlag { get; set; }
 
     /// <summary>
+    ///     Maximum degree of parallelism for the commands that walk every database (db-apply,
+    ///     db-assert). Counted in *physical* databases: targets are grouped by their DatabaseUri and a
+    ///     group is always processed sequentially within itself, since parallel DDL against one
+    ///     physical database only contends on its locks. Defaults to 1 — strictly sequential, exactly
+    ///     the pre-weasel#431 behavior — so nothing changes for anyone who does not opt in.
+    /// </summary>
+    [Description("Maximum number of physical databases to process in parallel for db-apply/db-assert. Targets sharing a DatabaseUri are always processed sequentially. Default is 1 (sequential)")]
+    public int ParallelFlag { get; set; } = 1;
+
+    /// <summary>
     ///     Where discovery progress is written. Resolved lazily so that a host which replaces
     ///     <see cref="AnsiConsole.Console" /> after this input is constructed is still respected.
     /// </summary>

--- a/src/Weasel.Core/Migrations/IDatabase.cs
+++ b/src/Weasel.Core/Migrations/IDatabase.cs
@@ -289,6 +289,13 @@ public class DefaultMigrationLogger: IMigrationLogger
         _writer = writer ?? throw new ArgumentNullException(nameof(writer));
     }
 
+    /// <summary>
+    ///     Where this logger writes, or null when it writes to the console. Lets tooling that wants to
+    ///     buffer per-database output (parallel db-apply, weasel#431) distinguish a console-bound logger
+    ///     it may safely redirect from one a host already pointed somewhere deliberate.
+    /// </summary>
+    internal TextWriter? Writer => _writer;
+
     public void SchemaChange(string sql)
     {
         // Resolved per call rather than captured in the constructor: Console.Out is reassignable, and a


### PR DESCRIPTION
Fixes #431 — `db-apply` walked 1,037 databases strictly sequentially: 8m41s of dead deploy time for a no-op. Implements the direction from the issue thread.

## Design (per the thread)

- **`--parallel` / `-p` lives on `WeaselInput`, default 1** — nothing changes for anyone who doesn't set it, and `db-assert` gets the same knob (identical loop, identical pain).
- **Grouped by `descriptor.DatabaseUri()`**: N *physical* databases in flight, strict sequencing within a group.
- **Failure semantics identical at every parallelism**: failures are caught inside the `Parallel.ForEachAsync` body (a body throw would otherwise cancel remaining iterations), printed as they happen, and the command terminates with an `AggregateException` of new `DatabaseApplyException` wrappers (database identity in message, original as inner). Non-zero exit if any failed.
- **Progress is a completion counter** (positional `(i+1)/total` is meaningless in parallel), console writes under a lock, and per-database migration DDL is **buffered and flushed as a unit** above its completion line when `--parallel > 1` — at 1 the logger streams live, preserving liveness for the >90-minute single-database case. Rides the redirectable-logger seam from `98aecb1` (#437); a host's deliberately redirected logger is left alone.
- **Summary block**: `N unchanged / M migrated / K failed`, failures listed.

## Behavior changes (called out per the thread)

- An apply failure no longer aborts the walk at the first bad database — every database is attempted, at any parallelism.
- `db-assert` now reports unexpected (non-validation) exceptions as failed assertions instead of crashing the command.

## Tests

`Weasel.CommandLine.Tests` **56/56 on net9.0 and net10.0**. New coverage: runner unit tests (every DB exactly once; bounded concurrency with no overlap within a physical DB, using the field's two-targets-per-physical-DB topology in miniature; failures collected, not fatal; cancellation propagates; `<= 1` runs sequentially) and integration tests against real Postgres (cross-physical-DB parallel apply; aggregate-and-continue at `--parallel 4` and at 1; DDL attribution/counter/summary via captured console; no-op reapply; `db-assert` parallel pass and keep-going-on-failure). Docs updated for both commands.

Merging this also flushes the 11 commits pending on master since 9.23.2 (discovery progress, SQLite generated-columns fix, per-fingerprint stamp keying, SQL Server CREATE DATABASE postcondition, redirectable migration logger) into the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)