### PR TITLE
Fix a few things in sqlserver ddl emission (Quoting, Index grammer, function bodies)

### DIFF
--- a/src/Weasel.SqlServer.Tests/Functions/function_body_escaping.cs
+++ b/src/Weasel.SqlServer.Tests/Functions/function_body_escaping.cs
@@ -1,0 +1,86 @@
+using Shouldly;
+using Weasel.Core;
+using Weasel.SqlServer.Functions;
+using Xunit;
+
+namespace Weasel.SqlServer.Tests.Functions;
+
+/// <summary>
+///     A function's body is written into an <c>EXEC sp_executesql N'...'</c> string literal, so its
+///     own single quotes have to be doubled. They were not, which made any function containing a
+///     string literal — a default, a message, a delimiter — impossible to create: the first quote in
+///     the body closed the literal and the rest became syntax.
+/// </summary>
+[Collection("functions")]
+public class function_body_escaping: IntegrationContext
+{
+    private const string BodyWithQuotes = @"
+CREATE OR ALTER FUNCTION escaping.greet(@name nvarchar(50)) RETURNS nvarchar(100) AS
+BEGIN
+    return 'Hello, ' + isnull(@name, 'world') + '!';
+END;";
+
+    public function_body_escaping(): base("escaping")
+    {
+    }
+
+    [Fact]
+    public void the_generated_statement_doubles_quotes_from_the_body()
+    {
+        var function = new Function(new SqlServerObjectName("escaping", "greet"), BodyWithQuotes);
+
+        var writer = new StringWriter();
+        function.WriteCreateStatement(new SqlServerMigrator(), writer);
+        var sql = writer.ToString();
+
+        // The literal opens once and closes once; every quote from the body is doubled.
+        sql.ShouldContain("''Hello, ''");
+        sql.ShouldContain("''world''");
+        sql.ShouldNotContain("+ 'Hello, ' +");
+    }
+
+    [Fact]
+    public async Task a_function_whose_body_contains_a_string_literal_can_be_created()
+    {
+        await ResetSchema();
+
+        var function = new Function(new SqlServerObjectName("escaping", "greet"), BodyWithQuotes);
+
+        // The real proof: before the fix this threw "Unclosed quotation mark after the character
+        // string" because the body's own quotes terminated the sp_executesql literal.
+        await CreateSchemaObjectInDatabase(function);
+
+        var existing = await Function.FetchExistingAsync(theConnection,
+            new SqlServerObjectName("escaping", "greet"));
+
+        existing.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task the_created_function_actually_runs()
+    {
+        await ResetSchema();
+
+        await CreateSchemaObjectInDatabase(
+            new Function(new SqlServerObjectName("escaping", "greet"), BodyWithQuotes));
+
+        var result = await theConnection.CreateCommand("select escaping.greet('Jakob')")
+            .ExecuteScalarAsync();
+
+        // Proves the body survived escaping intact, not merely that something was created.
+        result.ShouldBe("Hello, Jakob!");
+    }
+
+    [Fact]
+    public async Task a_function_with_quotes_reports_no_delta_after_being_applied()
+    {
+        await ResetSchema();
+
+        var function = new Function(new SqlServerObjectName("escaping", "greet"), BodyWithQuotes);
+        await CreateSchemaObjectInDatabase(function);
+
+        var delta = await function.FindDeltaAsync(theConnection);
+
+        delta.Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+}

--- a/src/Weasel.SqlServer.Tests/Tables/identifier_quoting.cs
+++ b/src/Weasel.SqlServer.Tests/Tables/identifier_quoting.cs
@@ -1,0 +1,160 @@
+using Shouldly;
+using Weasel.Core;
+using Weasel.SqlServer.Tables;
+using Xunit;
+
+namespace Weasel.SqlServer.Tests.Tables;
+
+/// <summary>
+///     Names that are not regular identifiers have to be bracketed to survive a trip through DDL.
+///     SchemaUtils.QuoteName previously bracketed only a hardcoded reserved-word list, and several
+///     emission sites did not call it at all — so a legal object name could produce SQL that will not
+///     parse. The unfilled missing-index template, the dotted EF6 key and the column named "Table"
+///     all came out of a real database; the rest are constructed edge cases.
+/// </summary>
+public class identifier_quoting: IntegrationContext
+{
+    public identifier_quoting(): base("quoting")
+    {
+    }
+
+    [Theory]
+    [InlineData("orders", "orders")]                       // regular identifier, left alone
+    [InlineData("Table", "[Table]")]                       // reserved word
+    [InlineData("unit price", "[unit price]")]             // space
+    [InlineData("PK_dbo.__MigrationHistory", "[PK_dbo.__MigrationHistory]")] // EF6
+    [InlineData("<Name of Missing Index, sysname,>", "[<Name of Missing Index, sysname,>]")]
+    // A leading @ makes the parser read a variable, so it has to be bracketed even though the
+    // general identifier rule allows @. SQL Server's own QUOTENAME agrees.
+    [InlineData("@param", "[@param]")]
+    // A leading # is fine unbracketed and bracketing does not change its meaning, so it stays bare.
+    [InlineData("#temp", "#temp")]
+    [InlineData("2ndPlace", "[2ndPlace]")]                 // leading digit
+    [InlineData("a]b", "[a]]b]")]                          // embedded delimiter is doubled
+    public void quote_name_brackets_what_needs_it(string name, string expected)
+    {
+        SchemaUtils.QuoteName(name).ShouldBe(expected);
+    }
+
+    /// <summary>
+    ///     There is no "it already looks bracketed, leave it alone" shortcut, because a name that
+    ///     merely starts with [ and ends with ] is not necessarily bracketed. Skipping the escape for
+    ///     those let arbitrary DDL straight through.
+    /// </summary>
+    [Fact]
+    public void a_name_that_looks_bracketed_is_still_escaped()
+    {
+        // A column or index genuinely named "[orders]" escapes to [[orders]]].
+        SchemaUtils.QuoteName("[orders]").ShouldBe("[[orders]]]");
+    }
+
+    [Fact]
+    public void a_name_carrying_ddl_cannot_escape_its_brackets()
+    {
+        var injection = "[ix] ON dbo.t(id); DROP TABLE dbo.victim; --]";
+
+        var quoted = SchemaUtils.QuoteName(injection);
+
+        // Every ] is doubled, so the name cannot terminate its own delimiter. The DROP text is
+        // still present but is now inert content inside a single delimited identifier.
+        quoted.ShouldBe("[[ix]] ON dbo.t(id); DROP TABLE dbo.victim; --]]]");
+    }
+
+    [Fact]
+    public async Task an_index_name_carrying_ddl_does_not_execute_it()
+    {
+        await ResetSchema();
+        await theConnection.CreateCommand("create table quoting.victim (id int not null)")
+            .ExecuteNonQueryAsync();
+
+        var table = new Table("quoting.host");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.Indexes.Add(new IndexDefinition("[ix] ON quoting.host(id); DROP TABLE quoting.victim; --]")
+        {
+            Columns = ["id"]
+        });
+
+        await CreateSchemaObjectInDatabase(table);
+
+        // The whole point: the DROP was carried as part of an identifier, not run as a statement.
+        var victimStillThere = await theConnection
+            .CreateCommand("select count(*) from sys.tables where name = 'victim'")
+            .ExecuteScalarAsync();
+
+        Convert.ToInt32(victimStillThere).ShouldBe(1);
+    }
+
+    /// <summary>
+    ///     Names that were already emitted bare must stay bare, and names that were always bracketed
+    ///     must stay bracketed — an ordinary schema's DDL should be byte-identical to before.
+    /// </summary>
+    [Theory]
+    [InlineData("Grüße")]
+    [InlineData("price$")]
+    [InlineData("_internal")]
+    [InlineData("col#1")]
+    public void a_regular_identifier_is_left_alone(string name)
+    {
+        SchemaUtils.QuoteName(name).ShouldBe(name);
+    }
+
+    [Fact]
+    public void a_check_constraint_is_still_bracketed_as_it_always_was()
+    {
+        var table = new Table("quoting.item");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn<int>("price").NotNull();
+        table.CheckConstraints.Add(new TableCheckConstraint("ck_price", "price > 0"));
+
+        table.ToBasicCreateTableSql().ShouldContain("CONSTRAINT [ck_price] CHECK");
+    }
+
+    [Fact]
+    public async Task an_index_whose_name_is_not_a_regular_identifier_can_be_created()
+    {
+        await ResetSchema();
+
+        var table = new Table("quoting.doc");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn<int>("payload").NotNull();
+        // SQL Server's own "missing index" template, pasted without filling in the name. Common.
+        table.Indexes.Add(new IndexDefinition("<Name of Missing Index, sysname,>") { Columns = ["payload"] });
+
+        await CreateSchemaObjectInDatabase(table);
+
+        var existing = await table.FetchExistingAsync(theConnection);
+        existing!.IndexFor("<Name of Missing Index, sysname,>").ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task an_index_on_a_reserved_word_column_can_be_created()
+    {
+        await ResetSchema();
+
+        var table = new Table("quoting.bookkeeping");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn("Table", "varchar(50)").NotNull();
+        table.Indexes.Add(new IndexDefinition("ix_bookkeeping_table") { Columns = ["Table"] });
+
+        await CreateSchemaObjectInDatabase(table);
+
+        var existing = await table.FetchExistingAsync(theConnection);
+        existing!.IndexFor("ix_bookkeeping_table")!.Columns.ShouldBe(["Table"]);
+    }
+
+    [Fact]
+    public async Task a_primary_key_whose_name_contains_a_dot_can_be_created()
+    {
+        await ResetSchema();
+
+        // The name EF6 gives its migration history table's key.
+        var table = new Table("quoting.migration_history");
+        table.AddColumn("MigrationId", "nvarchar(150)").AsPrimaryKey();
+        table.PrimaryKeyName = "PK_dbo.__MigrationHistory";
+
+        await CreateSchemaObjectInDatabase(table);
+
+        var existing = await table.FetchExistingAsync(theConnection);
+        existing!.PrimaryKeyName.ShouldBe("PK_dbo.__MigrationHistory");
+    }
+}

--- a/src/Weasel.SqlServer.Tests/Tables/identifier_quoting.cs
+++ b/src/Weasel.SqlServer.Tests/Tables/identifier_quoting.cs
@@ -77,11 +77,12 @@ public class identifier_quoting: IntegrationContext
         await CreateSchemaObjectInDatabase(table);
 
         // The whole point: the DROP was carried as part of an identifier, not run as a statement.
+        // Identified rather than counted by name -- sys.tables spans every schema in the database.
         var victimStillThere = await theConnection
-            .CreateCommand("select count(*) from sys.tables where name = 'victim'")
+            .CreateCommand("select object_id('quoting.victim')")
             .ExecuteScalarAsync();
 
-        Convert.ToInt32(victimStillThere).ShouldBe(1);
+        victimStillThere.ShouldNotBe(DBNull.Value);
     }
 
     /// <summary>

--- a/src/Weasel.SqlServer.Tests/Tables/identifier_quoting.cs
+++ b/src/Weasel.SqlServer.Tests/Tables/identifier_quoting.cs
@@ -109,6 +109,55 @@ public class identifier_quoting: IntegrationContext
         table.ToBasicCreateTableSql().ShouldContain("CONSTRAINT [ck_price] CHECK");
     }
 
+    /// <summary>
+    ///     Column lists were never quoted at all before this change, so a user whose column needed
+    ///     brackets had to write them into the string themselves. Re-escaping those would name a
+    ///     column that does not exist, so an entry that is already bracketed end to end is passed
+    ///     through untouched.
+    /// </summary>
+    [Theory]
+    [InlineData("price", "price")]           // ordinary, unchanged
+    [InlineData("Table", "[Table]")]         // reserved word, previously emitted bare and broken
+    [InlineData("[payload]", "[payload]")]   // caller already bracketed it, left alone
+    [InlineData("[a]]b]", "[a]]b]")]         // properly escaped already, left alone
+    [InlineData("unit price", "[unit price]")]
+    public void quote_column_entry_passes_through_what_is_already_bracketed(string name, string expected)
+    {
+        SchemaUtils.QuoteColumnEntry(name).ShouldBe(expected);
+    }
+
+    /// <summary>
+    ///     The pass-through must not become a hole. A lone <c>]</c> inside means the entry is not
+    ///     a well-formed bracketed name, so it gets escaped on its own terms.
+    /// </summary>
+    [Fact]
+    public void quote_column_entry_does_not_pass_through_an_unbalanced_name()
+    {
+        SchemaUtils.QuoteColumnEntry("[ix] ON dbo.t(id); DROP TABLE dbo.victim; --]")
+            .ShouldBe("[[ix]] ON dbo.t(id); DROP TABLE dbo.victim; --]]]");
+    }
+
+    /// <summary>
+    ///     A column list entry that was working before must still work. Master emitted these bare,
+    ///     so the bracketed name resolved correctly.
+    /// </summary>
+    [Fact]
+    public async Task an_index_on_a_column_the_user_bracketed_themselves_still_works()
+    {
+        await ResetSchema();
+
+        var table = new Table("quoting.prebracket");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn("Table", "varchar(50)").NotNull();
+        // How a user had to spell it before column lists were quoted at all.
+        table.Indexes.Add(new IndexDefinition("ix_prebracket") { Columns = ["[Table]"] });
+
+        await CreateSchemaObjectInDatabase(table);
+
+        var existing = await table.FetchExistingAsync(theConnection);
+        existing!.IndexFor("ix_prebracket")!.Columns.ShouldBe(["Table"]);
+    }
+
     [Fact]
     public async Task an_index_whose_name_is_not_a_regular_identifier_can_be_created()
     {

--- a/src/Weasel.SqlServer.Tests/Tables/index_ddl_generation.cs
+++ b/src/Weasel.SqlServer.Tests/Tables/index_ddl_generation.cs
@@ -1,0 +1,108 @@
+using Shouldly;
+using Weasel.Core;
+using Weasel.SqlServer.Tables;
+using Xunit;
+
+namespace Weasel.SqlServer.Tests.Tables;
+
+/// <summary>
+///     SQL Server's CREATE INDEX grammar fixes the order of both the modifiers and the trailing
+///     clauses. Emitting them in any other order is a syntax error, and each of these only shows up
+///     on an index that combines more than one feature — which is why they survived.
+/// </summary>
+public class index_ddl_generation: IntegrationContext
+{
+    public index_ddl_generation(): base("indexddl")
+    {
+    }
+
+    private static Table theTable()
+    {
+        var table = new Table("indexddl.item");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn<int>("group_id").NotNull();
+        table.AddColumn<int>("deleted").NotNull();
+        table.AddColumn<string>("note").AllowNulls();
+        return table;
+    }
+
+    [Fact]
+    public void unique_comes_before_clustered()
+    {
+        var index = new IndexDefinition("ix_unique_clustered")
+        {
+            Columns = ["group_id"], IsUnique = true, IsClustered = true
+        };
+
+        // "CREATE CLUSTERED UNIQUE INDEX" is rejected by the parser.
+        index.ToDDL(theTable()).ShouldStartWith("CREATE UNIQUE CLUSTERED INDEX");
+    }
+
+    [Fact]
+    public void include_then_where_then_with()
+    {
+        var index = new IndexDefinition("ix_everything")
+        {
+            Columns = ["group_id"],
+            IncludedColumns = ["note"],
+            Predicate = "deleted = 0",
+            FillFactor = 90
+        };
+
+        var ddl = index.ToDDL(theTable());
+
+        ddl.IndexOf("INCLUDE", StringComparison.Ordinal)
+            .ShouldBeLessThan(ddl.IndexOf("WHERE", StringComparison.Ordinal));
+        ddl.IndexOf("WHERE", StringComparison.Ordinal)
+            .ShouldBeLessThan(ddl.IndexOf("WITH", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task an_index_combining_include_where_and_fillfactor_is_accepted_by_the_server()
+    {
+        await ResetSchema();
+
+        var table = theTable();
+        table.Indexes.Add(new IndexDefinition("ix_everything")
+        {
+            Columns = ["group_id"],
+            IncludedColumns = ["note"],
+            Predicate = "deleted = 0",
+            FillFactor = 90
+        });
+
+        // The real proof: SQL Server parses it.
+        await CreateSchemaObjectInDatabase(table);
+
+        var existing = await table.FetchExistingAsync(theConnection);
+        existing!.IndexFor("ix_everything").ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task a_unique_clustered_index_is_accepted_by_the_server()
+    {
+        await ResetSchema();
+
+        // The PK has to be nonclustered or the table already has its one clustered index, and the
+        // failure would be "cannot create more than one clustered index" rather than the syntax
+        // error this test is about.
+        await theConnection.CreateCommand(
+                "create table indexddl.uniqueclustered (id int not null constraint pk_uc primary key nonclustered, code int not null)")
+            .ExecuteNonQueryAsync();
+
+        var table = new Table("indexddl.uniqueclustered");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn<int>("code").NotNull();
+        var index = new IndexDefinition("ix_code") { Columns = ["code"], IsUnique = true, IsClustered = true };
+
+        index.ToDDL(table).ShouldStartWith("CREATE UNIQUE CLUSTERED INDEX");
+
+        // CREATE CLUSTERED UNIQUE INDEX is a syntax error; the server is the proof.
+        await theConnection.CreateCommand(index.ToDDL(table)).ExecuteNonQueryAsync();
+
+        var existing = await table.FetchExistingAsync(theConnection);
+        existing!.IndexFor("ix_code")!.IsUnique.ShouldBeTrue();
+    }
+
+
+}

--- a/src/Weasel.SqlServer.Tests/schema_name_escaping.cs
+++ b/src/Weasel.SqlServer.Tests/schema_name_escaping.cs
@@ -47,7 +47,8 @@ public class schema_name_escaping
     {
         await using var conn = new Microsoft.Data.SqlClient.SqlConnection(ConnectionSource.ConnectionString);
         await conn.OpenAsync();
-        await conn.CreateCommand("if object_id('dbo.victim') is null create table dbo.victim (id int)")
+        await conn.CreateCommand(
+                "if object_id('dbo.schema_escaping_victim') is null create table dbo.schema_escaping_victim (id int)")
             .ExecuteNonQueryAsync();
 
         // The statement is expected to fail or to create an oddly-named schema; what it must not do
@@ -60,10 +61,12 @@ public class schema_name_escaping
         {
         }
 
-        var stillThere = await conn.CreateCommand("select count(*) from sys.tables where name = 'victim'")
+        // Identified rather than counted by name: sys.tables spans every schema in the database, so
+        // counting by bare name picks up same-named tables belonging to other tests.
+        var stillThere = await conn.CreateCommand("select object_id('dbo.schema_escaping_victim')")
             .ExecuteScalarAsync();
-        Convert.ToInt32(stillThere).ShouldBe(1);
+        stillThere.ShouldNotBe(DBNull.Value);
 
-        await conn.CreateCommand("drop table if exists dbo.victim").ExecuteNonQueryAsync();
+        await conn.CreateCommand("drop table if exists dbo.schema_escaping_victim").ExecuteNonQueryAsync();
     }
 }

--- a/src/Weasel.SqlServer.Tests/schema_name_escaping.cs
+++ b/src/Weasel.SqlServer.Tests/schema_name_escaping.cs
@@ -42,6 +42,36 @@ public class schema_name_escaping
         sql.ShouldContain("x'') PRINT");
     }
 
+    /// <summary>
+    ///     One test per site, deliberately. The two escapes are independent — a name breaks out of
+    ///     the sys.schemas literal, OR out of the nested EXEC('...') literal — so a single test that
+    ///     only exercises one of them passes while the other is still open. That is exactly how the
+    ///     EXEC nesting survived the first round of fixes here.
+    /// </summary>
+    [Fact]
+    public async Task ensure_schema_exists_does_not_execute_an_injected_payload()
+    {
+        await using var conn = new Microsoft.Data.SqlClient.SqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await conn.CreateCommand(
+                "if object_id('dbo.ensure_schema_victim') is null create table dbo.ensure_schema_victim (id int)")
+            .ExecuteNonQueryAsync();
+
+        try
+        {
+            await conn.EnsureSchemaExists("y') PRINT 1; DROP TABLE IF EXISTS dbo.ensure_schema_victim; --");
+        }
+        catch (Microsoft.Data.SqlClient.SqlException)
+        {
+        }
+
+        var stillThere = await conn.CreateCommand("select object_id('dbo.ensure_schema_victim')")
+            .ExecuteScalarAsync();
+        stillThere.ShouldNotBe(DBNull.Value);
+
+        await conn.CreateCommand("drop table if exists dbo.ensure_schema_victim").ExecuteNonQueryAsync();
+    }
+
     [Fact]
     public async Task an_injected_schema_name_does_not_execute_its_payload()
     {

--- a/src/Weasel.SqlServer.Tests/schema_name_escaping.cs
+++ b/src/Weasel.SqlServer.Tests/schema_name_escaping.cs
@@ -1,0 +1,69 @@
+using Shouldly;
+using Weasel.Core;
+using Xunit;
+
+namespace Weasel.SqlServer.Tests;
+
+/// <summary>
+///     Schema names reach two places in one generated statement: a string literal in the
+///     <c>sys.schemas</c> lookup, and a bracketed name nested inside <c>EXEC('...')</c> — which is
+///     itself a string literal. Both are terminated by <c>'</c>, so both need the quote doubled.
+///     Bracketing alone is not enough for the second: it doubles <c>]</c>, not <c>'</c>.
+/// </summary>
+/// <remarks>
+///     Nothing validates a schema name on the way in — <c>DatabaseBase</c> asserts on the object's
+///     name, never its schema — and <c>CreateSchemaStatementFor</c> is on the default apply path.
+/// </remarks>
+public class schema_name_escaping
+{
+    private const string Payload = "x') PRINT 1; DROP TABLE IF EXISTS dbo.victim; --";
+
+    [Fact]
+    public void create_schema_statement_escapes_both_literals()
+    {
+        var sql = SqlServerMigrator.CreateSchemaStatementFor(Payload);
+
+        // The payload's own quote is doubled everywhere it lands, so it can never close either
+        // literal and the DROP stays inert text.
+        sql.ShouldNotContain("N'x') PRINT");
+        sql.ShouldNotContain("EXEC('CREATE SCHEMA [x')");
+        sql.ShouldContain("x'') PRINT");
+    }
+
+    [Fact]
+    public void drop_schema_statement_escapes_both_literals()
+    {
+        var writer = new StringWriter();
+        new SqlServerMigrator().WriteSchemaDropSql([Payload], writer);
+        var sql = writer.ToString();
+
+        sql.ShouldNotContain("N'x') PRINT");
+        sql.ShouldNotContain("EXEC('DROP SCHEMA [x')");
+        sql.ShouldContain("x'') PRINT");
+    }
+
+    [Fact]
+    public async Task an_injected_schema_name_does_not_execute_its_payload()
+    {
+        await using var conn = new Microsoft.Data.SqlClient.SqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await conn.CreateCommand("if object_id('dbo.victim') is null create table dbo.victim (id int)")
+            .ExecuteNonQueryAsync();
+
+        // The statement is expected to fail or to create an oddly-named schema; what it must not do
+        // is run the payload.
+        try
+        {
+            await conn.CreateCommand(SqlServerMigrator.CreateSchemaStatementFor(Payload)).ExecuteNonQueryAsync();
+        }
+        catch (Microsoft.Data.SqlClient.SqlException)
+        {
+        }
+
+        var stillThere = await conn.CreateCommand("select count(*) from sys.tables where name = 'victim'")
+            .ExecuteScalarAsync();
+        Convert.ToInt32(stillThere).ShouldBe(1);
+
+        await conn.CreateCommand("drop table if exists dbo.victim").ExecuteNonQueryAsync();
+    }
+}

--- a/src/Weasel.SqlServer/Functions/Function.cs
+++ b/src/Weasel.SqlServer/Functions/Function.cs
@@ -22,7 +22,9 @@ public class Function: FunctionBase
 
     public override void WriteCreateStatement(Migrator migrator, TextWriter writer)
     {
-        writer.WriteLine($"EXEC sp_executesql N'{RawBody}';");
+        // The body goes inside a string literal, so its own quotes have to be doubled. Without
+        // this, any function containing a string literal produced an unclosed-quote syntax error.
+        writer.WriteLine($"EXEC sp_executesql N'{RawBody?.Replace("'", "''")}';");
     }
 
     public override void ConfigureQueryCommand(DbCommandBuilder builder)

--- a/src/Weasel.SqlServer/Procedures/StoredProcedure.cs
+++ b/src/Weasel.SqlServer/Procedures/StoredProcedure.cs
@@ -49,8 +49,8 @@ from sys.sql_modules
 inner join sys.objects on sys.sql_modules.object_id = sys.objects.object_id
 inner join sys.schemas on sys.objects.schema_id = sys.schemas.schema_id
 where
-    sys.objects.name = '{Identifier.Name}' and
-    sys.schemas.name = '{Identifier.Schema}'
+    sys.objects.name = '{SchemaUtils.EscapeLiteral(Identifier.Name)}' and
+    sys.schemas.name = '{SchemaUtils.EscapeLiteral(Identifier.Schema)}'
 ");
     }
 

--- a/src/Weasel.SqlServer/SchemaObjectsExtensions.cs
+++ b/src/Weasel.SqlServer/SchemaObjectsExtensions.cs
@@ -57,8 +57,8 @@ public static class SchemaObjectsExtensions
             var sql = $@"
 IF NOT EXISTS ( SELECT  *
                 FROM    sys.schemas
-                WHERE   name = N'{schemaName}' )
-    EXEC('CREATE SCHEMA [{schemaName}]');
+                WHERE   name = N'{SchemaUtils.EscapeLiteral(schemaName)}' )
+    EXEC('CREATE SCHEMA {SchemaUtils.BracketName(schemaName)}');
 
 ";
 
@@ -89,12 +89,12 @@ IF NOT EXISTS ( SELECT  *
     {
         var procedures = await conn
             .CreateCommand(
-                $"select routine_name from information_schema.routines where routine_schema = '{schemaName}' and routine_type = 'PROCEDURE';")
+                $"select routine_name from information_schema.routines where routine_schema = '{SchemaUtils.EscapeLiteral(schemaName)}' and routine_type = 'PROCEDURE';")
             .FetchListAsync<string>(cancellation: ct).ConfigureAwait(false);
 
         var functions = await conn
             .CreateCommand(
-                $"select routine_name from information_schema.routines where routine_schema = '{schemaName}' and routine_type = 'FUNCTION';")
+                $"select routine_name from information_schema.routines where routine_schema = '{SchemaUtils.EscapeLiteral(schemaName)}' and routine_type = 'FUNCTION';")
             .FetchListAsync<string>(cancellation: ct).ConfigureAwait(false);
 
         // Drop all FK constraints - both within schema AND from other schemas referencing this schema
@@ -107,10 +107,10 @@ SELECT
 FROM sys.foreign_keys fk
 WHERE
     -- FKs within the schema (outgoing)
-    SCHEMA_NAME(fk.schema_id) = '{schemaName}'
+    SCHEMA_NAME(fk.schema_id) = '{SchemaUtils.EscapeLiteral(schemaName)}'
     OR
     -- FKs from other schemas referencing tables in this schema (incoming)
-    SCHEMA_NAME(OBJECTPROPERTY(fk.referenced_object_id, 'SchemaId')) = '{schemaName}'")
+    SCHEMA_NAME(OBJECTPROPERTY(fk.referenced_object_id, 'SchemaId')) = '{SchemaUtils.EscapeLiteral(schemaName)}'")
             .FetchListAsync<string>(async r =>
             {
                 var fkSchema = await r.GetFieldValueAsync<string>(0, ct).ConfigureAwait(false);
@@ -121,17 +121,17 @@ WHERE
             }, cancellation: ct).ConfigureAwait(false);
 
         var tables = await conn
-            .CreateCommand($"select table_name from information_schema.tables where table_schema = '{schemaName}'")
+            .CreateCommand($"select table_name from information_schema.tables where table_schema = '{SchemaUtils.EscapeLiteral(schemaName)}'")
             .FetchListAsync<string>(cancellation: ct).ConfigureAwait(false);
 
         var sequences = await conn
             .CreateCommand(
-                $"select sequence_name from information_schema.sequences where sequence_schema = '{schemaName}'")
+                $"select sequence_name from information_schema.sequences where sequence_schema = '{SchemaUtils.EscapeLiteral(schemaName)}'")
             .FetchListAsync<string>(cancellation: ct).ConfigureAwait(false);
 
         var tableTypes = await conn
             .CreateCommand(
-                $"select sys.table_types.name from sys.table_types inner join sys.schemas on sys.table_types.schema_id = sys.schemas.schema_id where sys.schemas.name = '{schemaName}'")
+                $"select sys.table_types.name from sys.table_types inner join sys.schemas on sys.table_types.schema_id = sys.schemas.schema_id where sys.schemas.name = '{SchemaUtils.EscapeLiteral(schemaName)}'")
             .FetchListAsync<string>(cancellation: ct).ConfigureAwait(false);
 
         var drops = new List<string>();

--- a/src/Weasel.SqlServer/SchemaObjectsExtensions.cs
+++ b/src/Weasel.SqlServer/SchemaObjectsExtensions.cs
@@ -58,7 +58,7 @@ public static class SchemaObjectsExtensions
 IF NOT EXISTS ( SELECT  *
                 FROM    sys.schemas
                 WHERE   name = N'{SchemaUtils.EscapeLiteral(schemaName)}' )
-    EXEC('CREATE SCHEMA {SchemaUtils.BracketName(schemaName)}');
+    EXEC('CREATE SCHEMA {SchemaUtils.EscapeLiteral(SchemaUtils.BracketName(schemaName))}');
 
 ";
 

--- a/src/Weasel.SqlServer/SchemaUtils.cs
+++ b/src/Weasel.SqlServer/SchemaUtils.cs
@@ -47,6 +47,40 @@ public static class SchemaUtils
             : BracketName(name);
 
     /// <summary>
+    ///     Quote one entry of a column list, leaving an entry the caller already bracketed alone.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Column lists were never quoted at all before, so users whose column needed brackets
+    ///         had no option but to bracket it themselves inside the string. Running
+    ///         <see cref="QuoteName" /> over those would re-escape a name that was already correct
+    ///         and emit a column that does not exist. This is the only place that pass-through is
+    ///         safe, and only because it is narrow: the entry must be bracketed end to end with every
+    ///         interior <c>]</c> already doubled, which is exactly the output of
+    ///         <see cref="BracketName" />.
+    ///     </para>
+    ///     <para>
+    ///         That narrowness is what keeps the injection closed. A name merely starting with
+    ///         <c>[</c> and ending with <c>]</c> does not qualify —
+    ///         <c>[ix] ON t(id); DROP TABLE victim; --]</c> contains a lone <c>]</c>, so it is
+    ///         bracketed on its own terms rather than passed through.
+    ///     </para>
+    /// </remarks>
+    public static string QuoteColumnEntry(string name)
+        => IsAlreadyBracketed(name) ? name : QuoteName(name);
+
+    private static bool IsAlreadyBracketed(string name)
+    {
+        if (name.IsEmpty() || name.Length < 2 || name[0] != '[' || name[^1] != ']')
+        {
+            return false;
+        }
+
+        var inner = name.Substring(1, name.Length - 2);
+        return !inner.Replace("]]", "").Contains(']');
+    }
+
+    /// <summary>
     ///     A regular identifier: a letter, <c>_</c> or <c>#</c> first, then letters, digits,
     ///     <c>_</c>, <c>@</c>, <c>$</c> or <c>#</c>. "Letter" follows the Unicode standard, so a name
     ///     like <c>Grüße</c> needs no brackets and its DDL is unchanged.

--- a/src/Weasel.SqlServer/SchemaUtils.cs
+++ b/src/Weasel.SqlServer/SchemaUtils.cs
@@ -1,11 +1,90 @@
+using JasperFx.Core;
+using System.Text.RegularExpressions;
+
 namespace Weasel.SqlServer;
 
 public static class SchemaUtils
 {
+    /// <summary>
+    ///     Wrap a name in brackets unconditionally, escaping any embedded <c>]</c>.
+    /// </summary>
+    /// <remarks>
+    ///     For the call sites that have always bracketed. Keeping them on this rather than
+    ///     <see cref="QuoteName" /> means their generated DDL is byte-identical to before.
+    /// </remarks>
+    public static string BracketName(string name)
+        => name.IsEmpty() ? name : $"[{name.Replace("]", "]]")}]";
+
+    /// <summary>
+    ///     Escape a value being written into a SQL string literal, by doubling its single quotes.
+    /// </summary>
+    /// <remarks>
+    ///     Object names reach string literals in the introspection and drift-correction queries
+    ///     (<c>OBJECT_ID('...')</c>, <c>c.name = '...'</c>). Bracketing is the wrong tool there — a
+    ///     literal is terminated by <c>'</c>, not by <c>]</c>.
+    /// </remarks>
+    public static string EscapeLiteral(string value)
+        => value.IsEmpty() ? value : value.Replace("'", "''");
+
+    /// <summary>
+    ///     Bracket a name only when it is not a regular SQL Server identifier, so DDL for an
+    ///     ordinary schema is unchanged.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         There is deliberately no "it already looks bracketed, leave it alone" shortcut. A name
+    ///         that merely starts with <c>[</c> and ends with <c>]</c> is not necessarily bracketed —
+    ///         it can be an ordinary name that happens to contain both characters, and returning it
+    ///         verbatim let arbitrary DDL through:
+    ///         <c>[ix] ON t(id); DROP TABLE victim; --]</c> passed through untouched and executed.
+    ///         Every name is escaped on its own terms; a name literally called <c>[x]</c> correctly
+    ///         becomes <c>[[x]]]</c>.
+    ///     </para>
+    /// </remarks>
     public static string QuoteName(string name)
+        => name.IsEmpty() || (IsRegularIdentifier(name) && !IsReservedWord(name))
+            ? name
+            : BracketName(name);
+
+    /// <summary>
+    ///     A regular identifier: a letter, <c>_</c> or <c>#</c> first, then letters, digits,
+    ///     <c>_</c>, <c>@</c>, <c>$</c> or <c>#</c>. "Letter" follows the Unicode standard, so a name
+    ///     like <c>Grüße</c> needs no brackets and its DDL is unchanged.
+    /// </summary>
+    /// <remarks>
+    ///     A leading <c>@</c> is excluded even though the general identifier rule allows it: in an
+    ///     object name it makes the parser read a variable, so <c>create table t (@param int)</c> is
+    ///     a syntax error. SQL Server's own QUOTENAME brackets it too. A leading <c>#</c> is NOT
+    ///     excluded — it is accepted unbracketed for a column or an index, and bracketing does not
+    ///     change its meaning anywhere (<c>[#t]</c> is still a temp table), so excluding it would
+    ///     only churn DDL for no benefit.
+    /// </summary>
+    public static bool IsRegularIdentifier(string name)
     {
-        return ReservedKeywords.Contains(name, StringComparer.InvariantCultureIgnoreCase) ? $"[{name}]" : name;
+        if (name.IsEmpty())
+        {
+            return false;
+        }
+
+        if (!char.IsLetter(name[0]) && name[0] != '_' && name[0] != '#')
+        {
+            return false;
+        }
+
+        for (var i = 1; i < name.Length; i++)
+        {
+            var c = name[i];
+            if (!char.IsLetterOrDigit(c) && c != '_' && c != '@' && c != '$' && c != '#')
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
+
+    public static bool IsReservedWord(string name)
+        => ReservedKeywords.Contains(name, StringComparer.InvariantCultureIgnoreCase);
 
     private static readonly string[] ReservedKeywords =
     [

--- a/src/Weasel.SqlServer/SqlServerMigrator.cs
+++ b/src/Weasel.SqlServer/SqlServerMigrator.cs
@@ -104,8 +104,8 @@ $$;
         {
             writer.WriteLine($@"IF EXISTS ( SELECT  *
                     FROM    sys.schemas
-                    WHERE   name = N'{schemaName}' )
-        EXEC('DROP SCHEMA {SchemaUtils.BracketName(schemaName)}');
+                    WHERE   name = N'{SchemaUtils.EscapeLiteral(schemaName)}' )
+        EXEC('DROP SCHEMA {SchemaUtils.EscapeLiteral(SchemaUtils.BracketName(schemaName))}');
 ");
         }
     }
@@ -217,8 +217,8 @@ $$;
         return $@"
 IF NOT EXISTS ( SELECT  *
                 FROM    sys.schemas
-                WHERE   name = N'{schemaName}' )
-    EXEC('CREATE SCHEMA {SchemaUtils.BracketName(schemaName)}');
+                WHERE   name = N'{SchemaUtils.EscapeLiteral(schemaName)}' )
+    EXEC('CREATE SCHEMA {SchemaUtils.EscapeLiteral(SchemaUtils.BracketName(schemaName))}');
 
 ";
     }

--- a/src/Weasel.SqlServer/SqlServerMigrator.cs
+++ b/src/Weasel.SqlServer/SqlServerMigrator.cs
@@ -105,7 +105,7 @@ $$;
             writer.WriteLine($@"IF EXISTS ( SELECT  *
                     FROM    sys.schemas
                     WHERE   name = N'{schemaName}' )
-        EXEC('DROP SCHEMA [{schemaName}]');
+        EXEC('DROP SCHEMA {SchemaUtils.BracketName(schemaName)}');
 ");
         }
     }
@@ -218,7 +218,7 @@ $$;
 IF NOT EXISTS ( SELECT  *
                 FROM    sys.schemas
                 WHERE   name = N'{schemaName}' )
-    EXEC('CREATE SCHEMA [{schemaName}]');
+    EXEC('CREATE SCHEMA {SchemaUtils.BracketName(schemaName)}');
 
 ";
     }
@@ -281,7 +281,7 @@ IF NOT EXISTS ( SELECT  *
 
                 // CREATE DATABASE takes no parameters, so the name has to be interpolated. Doubling ']'
                 // is what makes it a well-formed delimited identifier.
-                createCmd.CommandText = $"CREATE DATABASE [{databaseName.Replace("]", "]]")}]";
+                createCmd.CommandText = $"CREATE DATABASE {SchemaUtils.BracketName(databaseName)}";
 
                 try
                 {
@@ -400,14 +400,14 @@ IF NOT EXISTS ( SELECT  *
 
         foreach (var table in tables)
         {
-            sb.AppendLine($"DELETE FROM {table.QualifiedName};");
+            sb.AppendLine($"DELETE FROM {table};");
         }
 
         if (resetIdentity)
         {
             foreach (var table in tables)
             {
-                sb.AppendLine($"BEGIN TRY DBCC CHECKIDENT('{table.QualifiedName}', RESEED, 0); END TRY BEGIN CATCH END CATCH;");
+                sb.AppendLine($"BEGIN TRY DBCC CHECKIDENT('{table}', RESEED, 0); END TRY BEGIN CATCH END CATCH;");
             }
         }
 

--- a/src/Weasel.SqlServer/Tables/ForeignKey.cs
+++ b/src/Weasel.SqlServer/Tables/ForeignKey.cs
@@ -91,8 +91,9 @@ public class ForeignKey: ForeignKeyBase
     public void WriteAddStatement(Table parent, TextWriter writer)
     {
         writer.WriteLine($"ALTER TABLE {parent.Identifier}");
-        writer.WriteLine($"ADD CONSTRAINT {Name} FOREIGN KEY({ColumnNames.Join(", ")})");
-        writer.Write($" REFERENCES {LinkedTable}({LinkedNames.Join(", ")})");
+        writer.WriteLine(
+            $"ADD CONSTRAINT {SchemaUtils.QuoteName(Name)} FOREIGN KEY({ColumnNames.Select(SchemaUtils.QuoteName).Join(", ")})");
+        writer.Write($" REFERENCES {LinkedTable}({LinkedNames.Select(SchemaUtils.QuoteName).Join(", ")})");
         writer.WriteCascadeAction("ON DELETE", OnDelete);
         writer.WriteCascadeAction("ON UPDATE", OnUpdate);
         writer.Write(";");
@@ -101,6 +102,6 @@ public class ForeignKey: ForeignKeyBase
 
     public void WriteDropStatement(Table parent, TextWriter writer)
     {
-        writer.WriteLine($"ALTER TABLE {parent.Identifier} DROP CONSTRAINT IF EXISTS {Name};");
+        writer.WriteLine($"ALTER TABLE {parent.Identifier} DROP CONSTRAINT IF EXISTS {SchemaUtils.QuoteName(Name)};");
     }
 }

--- a/src/Weasel.SqlServer/Tables/ForeignKey.cs
+++ b/src/Weasel.SqlServer/Tables/ForeignKey.cs
@@ -92,8 +92,8 @@ public class ForeignKey: ForeignKeyBase
     {
         writer.WriteLine($"ALTER TABLE {parent.Identifier}");
         writer.WriteLine(
-            $"ADD CONSTRAINT {SchemaUtils.QuoteName(Name)} FOREIGN KEY({ColumnNames.Select(SchemaUtils.QuoteName).Join(", ")})");
-        writer.Write($" REFERENCES {LinkedTable}({LinkedNames.Select(SchemaUtils.QuoteName).Join(", ")})");
+            $"ADD CONSTRAINT {SchemaUtils.QuoteName(Name)} FOREIGN KEY({ColumnNames.Select(SchemaUtils.QuoteColumnEntry).Join(", ")})");
+        writer.Write($" REFERENCES {LinkedTable}({LinkedNames.Select(SchemaUtils.QuoteColumnEntry).Join(", ")})");
         writer.WriteCascadeAction("ON DELETE", OnDelete);
         writer.WriteCascadeAction("ON UPDATE", OnUpdate);
         writer.Write(";");

--- a/src/Weasel.SqlServer/Tables/IndexDefinition.cs
+++ b/src/Weasel.SqlServer/Tables/IndexDefinition.cs
@@ -142,7 +142,7 @@ public class IndexDefinition: ITableIndex
         if (_includedColumns.Any())
         {
             builder.Append(" INCLUDE (");
-            builder.Append(_includedColumns.Select(SchemaUtils.QuoteName).Join(", "));
+            builder.Append(_includedColumns.Select(SchemaUtils.QuoteColumnEntry).Join(", "));
             builder.Append(')');
         }
 
@@ -172,7 +172,7 @@ public class IndexDefinition: ITableIndex
 
         // Quoted: a column named "Table" (or any other reserved word) is legal in SQL Server and
         // turns up in real schemas. QuoteName leaves ordinary identifiers untouched.
-        var expression = Columns.Select(SchemaUtils.QuoteName).Join(", ");
+        var expression = Columns.Select(SchemaUtils.QuoteColumnEntry).Join(", ");
 
         if (SortOrder != SortOrder.Asc)
         {

--- a/src/Weasel.SqlServer/Tables/IndexDefinition.cs
+++ b/src/Weasel.SqlServer/Tables/IndexDefinition.cs
@@ -112,19 +112,22 @@ public class IndexDefinition: ITableIndex
 
         builder.Append("CREATE ");
 
-        if (IsClustered)
-        {
-            builder.Append("CLUSTERED ");
-        }
-
+        // UNIQUE comes before CLUSTERED; the reverse order is a syntax error.
         if (IsUnique)
         {
             builder.Append("UNIQUE ");
         }
 
+        if (IsClustered)
+        {
+            builder.Append("CLUSTERED ");
+        }
+
         builder.Append("INDEX ");
 
-        builder.Append(Name);
+        // Bracketed: real databases carry index names that are not regular identifiers -- an
+        // unfilled "<Name of Missing Index, sysname,>" template turns up more than once in the wild.
+        builder.Append(SchemaUtils.QuoteName(Name));
 
 
         builder.Append(" ON ");
@@ -132,6 +135,16 @@ public class IndexDefinition: ITableIndex
 
         builder.Append(" ");
         builder.Append(correctedExpression());
+
+        // Clause order is fixed by SQL Server's grammar: INCLUDE, then WHERE, then WITH. Emitting
+        // them in any other order is a syntax error, which only shows up on an index that uses more
+        // than one of them at once.
+        if (_includedColumns.Any())
+        {
+            builder.Append(" INCLUDE (");
+            builder.Append(_includedColumns.Select(SchemaUtils.QuoteName).Join(", "));
+            builder.Append(')');
+        }
 
         if (Predicate.IsNotEmpty())
         {
@@ -142,13 +155,6 @@ public class IndexDefinition: ITableIndex
         if (FillFactor.HasValue && FillFactor > 0)
         {
             builder.Append($" WITH (fillfactor={FillFactor})");
-        }
-
-        if (_includedColumns.Any())
-        {
-            builder.Append(" INCLUDE (");
-            builder.Append(_includedColumns.Join(", "));
-            builder.Append(')');
         }
 
         builder.Append(";");
@@ -164,7 +170,9 @@ public class IndexDefinition: ITableIndex
             throw new InvalidOperationException("IndexDefinition requires at least one field");
         }
 
-        var expression = Columns.Join(", ");
+        // Quoted: a column named "Table" (or any other reserved word) is legal in SQL Server and
+        // turns up in real schemas. QuoteName leaves ordinary identifiers untouched.
+        var expression = Columns.Select(SchemaUtils.QuoteName).Join(", ");
 
         if (SortOrder != SortOrder.Asc)
         {

--- a/src/Weasel.SqlServer/Tables/Partitioning/ManagedRangePartitions.cs
+++ b/src/Weasel.SqlServer/Tables/Partitioning/ManagedRangePartitions.cs
@@ -152,22 +152,22 @@ public class ManagedRangePartitions: ISplittablePartitioning
         var pfName = PartitionFunctionName(parent);
         var psName = PartitionSchemeName(parent);
 
-        writer.WriteLine($"IF EXISTS (SELECT 1 FROM sys.partition_schemes WHERE name = '{psName}')");
-        writer.WriteLine($"    DROP PARTITION SCHEME [{psName}];");
-        writer.WriteLine($"IF EXISTS (SELECT 1 FROM sys.partition_functions WHERE name = '{pfName}')");
-        writer.WriteLine($"    DROP PARTITION FUNCTION [{pfName}];");
+        writer.WriteLine($"IF EXISTS (SELECT 1 FROM sys.partition_schemes WHERE name = '{SchemaUtils.EscapeLiteral(psName)}')");
+        writer.WriteLine($"    DROP PARTITION SCHEME {SchemaUtils.BracketName(psName)};");
+        writer.WriteLine($"IF EXISTS (SELECT 1 FROM sys.partition_functions WHERE name = '{SchemaUtils.EscapeLiteral(pfName)}')");
+        writer.WriteLine($"    DROP PARTITION FUNCTION {SchemaUtils.BracketName(pfName)};");
 
-        writer.Write($"CREATE PARTITION FUNCTION [{pfName}] ({SqlDataType}) AS RANGE RIGHT");
+        writer.Write($"CREATE PARTITION FUNCTION {SchemaUtils.BracketName(pfName)} ({SqlDataType}) AS RANGE RIGHT");
         writer.Write($" FOR VALUES ({Boundaries().Join(", ")})");
         writer.WriteLine(";");
 
-        writer.WriteLine($"CREATE PARTITION SCHEME [{psName}] AS PARTITION [{pfName}] ALL TO ([{Filegroup}]);");
+        writer.WriteLine($"CREATE PARTITION SCHEME {SchemaUtils.BracketName(psName)} AS PARTITION {SchemaUtils.BracketName(pfName)} ALL TO ({SchemaUtils.BracketName(Filegroup)});");
     }
 
     /// <inheritdoc />
     public void WriteOnClause(TextWriter writer, Table parent)
     {
-        writer.Write($" ON [{PartitionSchemeName(parent)}]([{Column}])");
+        writer.Write($" ON [{PartitionSchemeName(parent)}]({SchemaUtils.BracketName(Column)})");
     }
 
     /// <inheritdoc />
@@ -176,10 +176,10 @@ public class ManagedRangePartitions: ISplittablePartitioning
         var psName = PartitionSchemeName(parent);
         var pfName = PartitionFunctionName(parent);
 
-        writer.WriteLine($"IF EXISTS (SELECT 1 FROM sys.partition_schemes WHERE name = '{psName}')");
-        writer.WriteLine($"    DROP PARTITION SCHEME [{psName}];");
-        writer.WriteLine($"IF EXISTS (SELECT 1 FROM sys.partition_functions WHERE name = '{pfName}')");
-        writer.WriteLine($"    DROP PARTITION FUNCTION [{pfName}];");
+        writer.WriteLine($"IF EXISTS (SELECT 1 FROM sys.partition_schemes WHERE name = '{SchemaUtils.EscapeLiteral(psName)}')");
+        writer.WriteLine($"    DROP PARTITION SCHEME {SchemaUtils.BracketName(psName)};");
+        writer.WriteLine($"IF EXISTS (SELECT 1 FROM sys.partition_functions WHERE name = '{SchemaUtils.EscapeLiteral(pfName)}')");
+        writer.WriteLine($"    DROP PARTITION FUNCTION {SchemaUtils.BracketName(pfName)};");
     }
 
     /// <inheritdoc />
@@ -229,8 +229,8 @@ public class ManagedRangePartitions: ISplittablePartitioning
 
         foreach (var boundary in Boundaries().Where(x => !actualSet.Contains(x)))
         {
-            writer.WriteLine($"ALTER PARTITION SCHEME [{psName}] NEXT USED [{Filegroup}];");
-            writer.WriteLine($"ALTER PARTITION FUNCTION [{pfName}]() SPLIT RANGE ({boundary});");
+            writer.WriteLine($"ALTER PARTITION SCHEME {SchemaUtils.BracketName(psName)} NEXT USED {SchemaUtils.BracketName(Filegroup)};");
+            writer.WriteLine($"ALTER PARTITION FUNCTION {SchemaUtils.BracketName(pfName)}() SPLIT RANGE ({boundary});");
         }
     }
 
@@ -242,7 +242,7 @@ public class ManagedRangePartitions: ISplittablePartitioning
 
         foreach (var boundary in Boundaries().Where(x => !actualSet.Contains(x)))
         {
-            writer.WriteLine($"ALTER PARTITION FUNCTION [{pfName}]() MERGE RANGE ({boundary});");
+            writer.WriteLine($"ALTER PARTITION FUNCTION {SchemaUtils.BracketName(pfName)}() MERGE RANGE ({boundary});");
         }
     }
 
@@ -399,13 +399,13 @@ public class ManagedRangePartitions: ISplittablePartitioning
         {
             await using (var nextUsed = conn.CreateCommand())
             {
-                nextUsed.CommandText = $"ALTER PARTITION SCHEME [{psName}] NEXT USED [{Filegroup}];";
+                nextUsed.CommandText = $"ALTER PARTITION SCHEME {SchemaUtils.BracketName(psName)} NEXT USED {SchemaUtils.BracketName(Filegroup)};";
                 await nextUsed.ExecuteNonQueryAsync(token).ConfigureAwait(false);
             }
 
             await using (var split = conn.CreateCommand())
             {
-                split.CommandText = $"ALTER PARTITION FUNCTION [{pfName}]() SPLIT RANGE ({boundary});";
+                split.CommandText = $"ALTER PARTITION FUNCTION {SchemaUtils.BracketName(pfName)}() SPLIT RANGE ({boundary});";
                 await split.ExecuteNonQueryAsync(token).ConfigureAwait(false);
             }
 
@@ -464,7 +464,7 @@ public class ManagedRangePartitions: ISplittablePartitioning
             }
 
             await using var merge = conn.CreateCommand();
-            merge.CommandText = $"ALTER PARTITION FUNCTION [{pfName}]() MERGE RANGE ({boundary.Literal});";
+            merge.CommandText = $"ALTER PARTITION FUNCTION {SchemaUtils.BracketName(pfName)}() MERGE RANGE ({boundary.Literal});";
             await merge.ExecuteNonQueryAsync(token).ConfigureAwait(false);
 
             logger.LogInformation(
@@ -500,7 +500,7 @@ public class ManagedRangePartitions: ISplittablePartitioning
         // $PARTITION takes the partition function by name, which cannot be parameterized. pfName is
         // Weasel-generated from the table and column names, not user input.
         await using var cmd = conn.CreateCommand();
-        cmd.CommandText = $"SELECT $PARTITION.[{pfName}]({literal});";
+        cmd.CommandText = $"SELECT $PARTITION.{SchemaUtils.BracketName(pfName)}({literal});";
 
         var result = await cmd.ExecuteScalarAsync(token).ConfigureAwait(false);
 

--- a/src/Weasel.SqlServer/Tables/Partitioning/ManagedRangePartitions.cs
+++ b/src/Weasel.SqlServer/Tables/Partitioning/ManagedRangePartitions.cs
@@ -167,7 +167,7 @@ public class ManagedRangePartitions: ISplittablePartitioning
     /// <inheritdoc />
     public void WriteOnClause(TextWriter writer, Table parent)
     {
-        writer.Write($" ON [{PartitionSchemeName(parent)}]({SchemaUtils.BracketName(Column)})");
+        writer.Write($" ON {SchemaUtils.BracketName(PartitionSchemeName(parent))}({SchemaUtils.BracketName(Column)})");
     }
 
     /// <inheritdoc />

--- a/src/Weasel.SqlServer/Tables/Partitioning/ManagedTenantPartitions.cs
+++ b/src/Weasel.SqlServer/Tables/Partitioning/ManagedTenantPartitions.cs
@@ -237,7 +237,7 @@ public class ManagedTenantPartitions: FeatureSchemaBase, ISqlServerPartitioning,
     /// <inheritdoc />
     public void WriteOnClause(TextWriter writer, Table parent)
     {
-        writer.Write($" ON [{PartitionSchemeName(parent)}]({SchemaUtils.BracketName(Column)})");
+        writer.Write($" ON {SchemaUtils.BracketName(PartitionSchemeName(parent))}({SchemaUtils.BracketName(Column)})");
     }
 
     /// <inheritdoc />

--- a/src/Weasel.SqlServer/Tables/Partitioning/ManagedTenantPartitions.cs
+++ b/src/Weasel.SqlServer/Tables/Partitioning/ManagedTenantPartitions.cs
@@ -214,14 +214,14 @@ public class ManagedTenantPartitions: FeatureSchemaBase, ISqlServerPartitioning,
         var psName = PartitionSchemeName(parent);
 
         // Drop existing for idempotent creation (matches RangePartitioning).
-        writer.WriteLine($"IF EXISTS (SELECT 1 FROM sys.partition_schemes WHERE name = '{psName}')");
-        writer.WriteLine($"    DROP PARTITION SCHEME [{psName}];");
-        writer.WriteLine($"IF EXISTS (SELECT 1 FROM sys.partition_functions WHERE name = '{pfName}')");
-        writer.WriteLine($"    DROP PARTITION FUNCTION [{pfName}];");
+        writer.WriteLine($"IF EXISTS (SELECT 1 FROM sys.partition_schemes WHERE name = '{SchemaUtils.EscapeLiteral(psName)}')");
+        writer.WriteLine($"    DROP PARTITION SCHEME {SchemaUtils.BracketName(psName)};");
+        writer.WriteLine($"IF EXISTS (SELECT 1 FROM sys.partition_functions WHERE name = '{SchemaUtils.EscapeLiteral(pfName)}')");
+        writer.WriteLine($"    DROP PARTITION FUNCTION {SchemaUtils.BracketName(pfName)};");
 
         var boundaries = OrderedBoundaries();
 
-        writer.Write($"CREATE PARTITION FUNCTION [{pfName}] ({SqlDataType}) AS RANGE RIGHT");
+        writer.Write($"CREATE PARTITION FUNCTION {SchemaUtils.BracketName(pfName)} ({SqlDataType}) AS RANGE RIGHT");
         if (boundaries.Length > 0)
         {
             writer.Write(" FOR VALUES (");
@@ -231,13 +231,13 @@ public class ManagedTenantPartitions: FeatureSchemaBase, ISqlServerPartitioning,
 
         writer.WriteLine(";");
         writer.WriteLine(
-            $"CREATE PARTITION SCHEME [{psName}] AS PARTITION [{pfName}] ALL TO ([{Filegroup}]);");
+            $"CREATE PARTITION SCHEME {SchemaUtils.BracketName(psName)} AS PARTITION {SchemaUtils.BracketName(pfName)} ALL TO ({SchemaUtils.BracketName(Filegroup)});");
     }
 
     /// <inheritdoc />
     public void WriteOnClause(TextWriter writer, Table parent)
     {
-        writer.Write($" ON [{PartitionSchemeName(parent)}]([{Column}])");
+        writer.Write($" ON [{PartitionSchemeName(parent)}]({SchemaUtils.BracketName(Column)})");
     }
 
     /// <inheritdoc />
@@ -246,10 +246,10 @@ public class ManagedTenantPartitions: FeatureSchemaBase, ISqlServerPartitioning,
         var psName = PartitionSchemeName(parent);
         var pfName = PartitionFunctionName(parent);
 
-        writer.WriteLine($"IF EXISTS (SELECT 1 FROM sys.partition_schemes WHERE name = '{psName}')");
-        writer.WriteLine($"    DROP PARTITION SCHEME [{psName}];");
-        writer.WriteLine($"IF EXISTS (SELECT 1 FROM sys.partition_functions WHERE name = '{pfName}')");
-        writer.WriteLine($"    DROP PARTITION FUNCTION [{pfName}];");
+        writer.WriteLine($"IF EXISTS (SELECT 1 FROM sys.partition_schemes WHERE name = '{SchemaUtils.EscapeLiteral(psName)}')");
+        writer.WriteLine($"    DROP PARTITION SCHEME {SchemaUtils.BracketName(psName)};");
+        writer.WriteLine($"IF EXISTS (SELECT 1 FROM sys.partition_functions WHERE name = '{SchemaUtils.EscapeLiteral(pfName)}')");
+        writer.WriteLine($"    DROP PARTITION FUNCTION {SchemaUtils.BracketName(pfName)};");
     }
 
     /// <inheritdoc />
@@ -317,8 +317,8 @@ public class ManagedTenantPartitions: FeatureSchemaBase, ISqlServerPartitioning,
                 continue;
             }
 
-            writer.WriteLine($"ALTER PARTITION SCHEME [{psName}] NEXT USED [{Filegroup}];");
-            writer.WriteLine($"ALTER PARTITION FUNCTION [{pfName}]() SPLIT RANGE ({boundary});");
+            writer.WriteLine($"ALTER PARTITION SCHEME {SchemaUtils.BracketName(psName)} NEXT USED {SchemaUtils.BracketName(Filegroup)};");
+            writer.WriteLine($"ALTER PARTITION FUNCTION {SchemaUtils.BracketName(pfName)}() SPLIT RANGE ({boundary});");
         }
     }
 
@@ -899,7 +899,7 @@ public class ManagedTenantPartitions: FeatureSchemaBase, ISqlServerPartitioning,
                 {
                     await using var purge = conn.CreateCommand();
                     purge.CommandText =
-                        $"DELETE FROM {table.Identifier.QualifiedName} WHERE [{Column}] = @ordinal;";
+                        $"DELETE FROM {table.Identifier.QualifiedName} WHERE {SchemaUtils.BracketName(Column)} = @ordinal;";
                     purge.Parameters.AddWithValue("@ordinal", ordinal);
                     try
                     {
@@ -922,7 +922,7 @@ public class ManagedTenantPartitions: FeatureSchemaBase, ISqlServerPartitioning,
 
                 await using var merge = conn.CreateCommand();
                 merge.CommandText =
-                    $"ALTER PARTITION FUNCTION [{pfName}]() MERGE RANGE ({ordinal});";
+                    $"ALTER PARTITION FUNCTION {SchemaUtils.BracketName(pfName)}() MERGE RANGE ({ordinal});";
                 try
                 {
                     await merge.ExecuteNonQueryAsync(token).ConfigureAwait(false);
@@ -1089,14 +1089,14 @@ OUTPUT inserted.ordinal;";
                     await using (var nextUsed = conn.CreateCommand())
                     {
                         nextUsed.CommandText =
-                            $"ALTER PARTITION SCHEME [{psName}] NEXT USED [{Filegroup}];";
+                            $"ALTER PARTITION SCHEME {SchemaUtils.BracketName(psName)} NEXT USED {SchemaUtils.BracketName(Filegroup)};";
                         await nextUsed.ExecuteNonQueryAsync(token).ConfigureAwait(false);
                     }
 
                     await using (var split = conn.CreateCommand())
                     {
                         split.CommandText =
-                            $"ALTER PARTITION FUNCTION [{pfName}]() SPLIT RANGE ({ordinal});";
+                            $"ALTER PARTITION FUNCTION {SchemaUtils.BracketName(pfName)}() SPLIT RANGE ({ordinal});";
                         await split.ExecuteNonQueryAsync(token).ConfigureAwait(false);
                     }
 

--- a/src/Weasel.SqlServer/Tables/Partitioning/RangePartitioning.cs
+++ b/src/Weasel.SqlServer/Tables/Partitioning/RangePartitioning.cs
@@ -85,7 +85,7 @@ public class RangePartitioning : ISplittablePartitioning
 
     public void WriteOnClause(TextWriter writer, Table parent)
     {
-        writer.Write($" ON [{PartitionSchemeName(parent)}]({SchemaUtils.BracketName(Column)})");
+        writer.Write($" ON {SchemaUtils.BracketName(PartitionSchemeName(parent))}({SchemaUtils.BracketName(Column)})");
     }
 
     public void WriteDropDdl(TextWriter writer, Table parent)

--- a/src/Weasel.SqlServer/Tables/Partitioning/RangePartitioning.cs
+++ b/src/Weasel.SqlServer/Tables/Partitioning/RangePartitioning.cs
@@ -64,13 +64,13 @@ public class RangePartitioning : ISplittablePartitioning
         var rangeDir = IsRangeRight ? "RIGHT" : "LEFT";
 
         // Drop existing (for idempotent creation)
-        writer.WriteLine($"IF EXISTS (SELECT 1 FROM sys.partition_schemes WHERE name = '{psName}')");
-        writer.WriteLine($"    DROP PARTITION SCHEME [{psName}];");
-        writer.WriteLine($"IF EXISTS (SELECT 1 FROM sys.partition_functions WHERE name = '{pfName}')");
-        writer.WriteLine($"    DROP PARTITION FUNCTION [{pfName}];");
+        writer.WriteLine($"IF EXISTS (SELECT 1 FROM sys.partition_schemes WHERE name = '{SchemaUtils.EscapeLiteral(psName)}')");
+        writer.WriteLine($"    DROP PARTITION SCHEME {SchemaUtils.BracketName(psName)};");
+        writer.WriteLine($"IF EXISTS (SELECT 1 FROM sys.partition_functions WHERE name = '{SchemaUtils.EscapeLiteral(pfName)}')");
+        writer.WriteLine($"    DROP PARTITION FUNCTION {SchemaUtils.BracketName(pfName)};");
 
         // Create partition function
-        writer.Write($"CREATE PARTITION FUNCTION [{pfName}] ({SqlDataType})");
+        writer.Write($"CREATE PARTITION FUNCTION {SchemaUtils.BracketName(pfName)} ({SqlDataType})");
         writer.Write($" AS RANGE {rangeDir}");
         if (_boundaryValues.Any())
         {
@@ -80,12 +80,12 @@ public class RangePartitioning : ISplittablePartitioning
         writer.WriteLine(";");
 
         // Create partition scheme
-        writer.WriteLine($"CREATE PARTITION SCHEME [{psName}] AS PARTITION [{pfName}] ALL TO ([{Filegroup}]);");
+        writer.WriteLine($"CREATE PARTITION SCHEME {SchemaUtils.BracketName(psName)} AS PARTITION {SchemaUtils.BracketName(pfName)} ALL TO ({SchemaUtils.BracketName(Filegroup)});");
     }
 
     public void WriteOnClause(TextWriter writer, Table parent)
     {
-        writer.Write($" ON [{PartitionSchemeName(parent)}]([{Column}])");
+        writer.Write($" ON [{PartitionSchemeName(parent)}]({SchemaUtils.BracketName(Column)})");
     }
 
     public void WriteDropDdl(TextWriter writer, Table parent)
@@ -93,10 +93,10 @@ public class RangePartitioning : ISplittablePartitioning
         var psName = PartitionSchemeName(parent);
         var pfName = PartitionFunctionName(parent);
 
-        writer.WriteLine($"IF EXISTS (SELECT 1 FROM sys.partition_schemes WHERE name = '{psName}')");
-        writer.WriteLine($"    DROP PARTITION SCHEME [{psName}];");
-        writer.WriteLine($"IF EXISTS (SELECT 1 FROM sys.partition_functions WHERE name = '{pfName}')");
-        writer.WriteLine($"    DROP PARTITION FUNCTION [{pfName}];");
+        writer.WriteLine($"IF EXISTS (SELECT 1 FROM sys.partition_schemes WHERE name = '{SchemaUtils.EscapeLiteral(psName)}')");
+        writer.WriteLine($"    DROP PARTITION SCHEME {SchemaUtils.BracketName(psName)};");
+        writer.WriteLine($"IF EXISTS (SELECT 1 FROM sys.partition_functions WHERE name = '{SchemaUtils.EscapeLiteral(pfName)}')");
+        writer.WriteLine($"    DROP PARTITION FUNCTION {SchemaUtils.BracketName(pfName)};");
     }
 
     public PartitionDelta CreateDelta(SqlServerPartitionInfo? actual)
@@ -134,8 +134,8 @@ public class RangePartitioning : ISplittablePartitioning
         {
             if (!actualSet.Contains(boundary))
             {
-                writer.WriteLine($"ALTER PARTITION SCHEME [{psName}] NEXT USED [{Filegroup}];");
-                writer.WriteLine($"ALTER PARTITION FUNCTION [{pfName}]() SPLIT RANGE ({boundary});");
+                writer.WriteLine($"ALTER PARTITION SCHEME {SchemaUtils.BracketName(psName)} NEXT USED {SchemaUtils.BracketName(Filegroup)};");
+                writer.WriteLine($"ALTER PARTITION FUNCTION {SchemaUtils.BracketName(pfName)}() SPLIT RANGE ({boundary});");
             }
         }
     }
@@ -153,7 +153,7 @@ public class RangePartitioning : ISplittablePartitioning
         {
             if (!actualSet.Contains(boundary))
             {
-                writer.WriteLine($"ALTER PARTITION FUNCTION [{pfName}]() MERGE RANGE ({boundary});");
+                writer.WriteLine($"ALTER PARTITION FUNCTION {SchemaUtils.BracketName(pfName)}() MERGE RANGE ({boundary});");
             }
         }
     }

--- a/src/Weasel.SqlServer/Tables/StringWriterExtensions.cs
+++ b/src/Weasel.SqlServer/Tables/StringWriterExtensions.cs
@@ -22,6 +22,6 @@ internal static class StringWriterExtensions
 
     public static void WriteDropIndex(this TextWriter writer, Table table, IndexDefinition index)
     {
-        writer.WriteLine($"drop index {index.Name} on {table.Identifier};");
+        writer.WriteLine($"drop index {SchemaUtils.QuoteName(index.Name)} on {table.Identifier};");
     }
 }

--- a/src/Weasel.SqlServer/Tables/Table.cs
+++ b/src/Weasel.SqlServer/Tables/Table.cs
@@ -276,11 +276,14 @@ public partial class Table: TableBase<TableColumn, IndexDefinition, ForeignKey>
 
     internal string PrimaryKeyDeclaration()
     {
-        return $"CONSTRAINT {PrimaryKeyName} PRIMARY KEY ({PrimaryKeyColumns.Join(", ")})";
+        // Bracketed: EF6 databases carry a primary key literally named "PK_dbo.__MigrationHistory",
+        // and an unquoted dot ends the identifier.
+        return
+            $"CONSTRAINT {SchemaUtils.QuoteName(PrimaryKeyName)} PRIMARY KEY ({PrimaryKeyColumns.Select(SchemaUtils.QuoteName).Join(", ")})";
     }
 
     internal static string CheckConstraintDeclaration(TableCheckConstraint constraint)
-        => $"CONSTRAINT [{constraint.Name}] CHECK ({constraint.Expression})";
+        => $"CONSTRAINT {SchemaUtils.BracketName(constraint.Name)} CHECK ({constraint.Expression})";
 
     public ColumnExpression AddColumn(TableColumn column)
     {

--- a/src/Weasel.SqlServer/Tables/Table.cs
+++ b/src/Weasel.SqlServer/Tables/Table.cs
@@ -159,7 +159,8 @@ public partial class Table: TableBase<TableColumn, IndexDefinition, ForeignKey>
             writer.WriteLine("SELECT {0} = {1} + 'ALTER TABLE ' + QUOTENAME(OBJECT_SCHEMA_NAME(fk.parent_object_id)) + '.' + QUOTENAME(OBJECT_NAME(fk.parent_object_id)) + ' DROP CONSTRAINT ' + QUOTENAME(fk.name) + ';'",
                 sqlVariableName, sqlVariableName);
             writer.WriteLine("FROM sys.foreign_keys AS fk");
-            writer.WriteLine("WHERE fk.referenced_object_id = OBJECT_ID('{0}');", Identifier);
+            writer.WriteLine("WHERE fk.referenced_object_id = OBJECT_ID('{0}');",
+                SchemaUtils.EscapeLiteral(Identifier.QualifiedName));
             writer.WriteLine("EXEC sp_executesql {0};", sqlVariableName);
 
             writer.WriteLine("DROP TABLE IF EXISTS {0};", Identifier);
@@ -167,7 +168,7 @@ public partial class Table: TableBase<TableColumn, IndexDefinition, ForeignKey>
         }
         else
         {
-            writer.WriteLine("IF OBJECT_ID('{0}') IS NULL", Identifier);
+            writer.WriteLine("IF OBJECT_ID('{0}') IS NULL", SchemaUtils.EscapeLiteral(Identifier.QualifiedName));
             writer.WriteLine("BEGIN");
             writer.WriteLine("CREATE TABLE {0} (", Identifier);
         }
@@ -279,7 +280,7 @@ public partial class Table: TableBase<TableColumn, IndexDefinition, ForeignKey>
         // Bracketed: EF6 databases carry a primary key literally named "PK_dbo.__MigrationHistory",
         // and an unquoted dot ends the identifier.
         return
-            $"CONSTRAINT {SchemaUtils.QuoteName(PrimaryKeyName)} PRIMARY KEY ({PrimaryKeyColumns.Select(SchemaUtils.QuoteName).Join(", ")})";
+            $"CONSTRAINT {SchemaUtils.QuoteName(PrimaryKeyName)} PRIMARY KEY ({PrimaryKeyColumns.Select(SchemaUtils.QuoteColumnEntry).Join(", ")})";
     }
 
     internal static string CheckConstraintDeclaration(TableCheckConstraint constraint)

--- a/src/Weasel.SqlServer/Tables/TableColumn.cs
+++ b/src/Weasel.SqlServer/Tables/TableColumn.cs
@@ -150,7 +150,8 @@ public class TableColumn: ITableColumn
             writer.WriteLine(
                 $"select {variable} = dc.name from sys.default_constraints dc " +
                 $"inner join sys.columns c on c.default_object_id = dc.object_id " +
-                $"where dc.parent_object_id = OBJECT_ID('{parent.Identifier}') and c.name = '{Name}';");
+                $"where dc.parent_object_id = OBJECT_ID('{SchemaUtils.EscapeLiteral(parent.Identifier.QualifiedName)}') " +
+                $"and c.name = '{SchemaUtils.EscapeLiteral(Name)}';");
             writer.WriteLine(
                 $"if {variable} is not null exec('alter table {parent.Identifier} drop constraint ' + {variable});");
 
@@ -262,7 +263,7 @@ public abstract class ColumnCheck
             return Declaration();
         }
 
-        return $"CONSTRAINT {Name} {Declaration()}";
+        return $"CONSTRAINT {SchemaUtils.QuoteName(Name)} {Declaration()}";
     }
 }
 

--- a/src/Weasel.SqlServer/Tables/TableDelta.cs
+++ b/src/Weasel.SqlServer/Tables/TableDelta.cs
@@ -105,7 +105,7 @@ public class TableDelta: SchemaObjectDelta<Table>
         var primaryKeyDroppedBeforeColumnChanges = requiresPrimaryKeyDropBeforeUpdate();
         if (primaryKeyDroppedBeforeColumnChanges)
         {
-            writer.WriteLine($"alter table {Expected.Identifier} drop constraint {Actual!.PrimaryKeyName};");
+            writer.WriteLine($"alter table {Expected.Identifier} drop constraint {SchemaUtils.QuoteName(Actual!.PrimaryKeyName)};");
         }
 
         // Missing columns
@@ -160,7 +160,7 @@ public class TableDelta: SchemaObjectDelta<Table>
             case SchemaPatchDifference.Update:
                 if (!primaryKeyDroppedBeforeColumnChanges)
                 {
-                    writer.WriteLine($"alter table {Expected.Identifier} drop constraint {Actual!.PrimaryKeyName};");
+                    writer.WriteLine($"alter table {Expected.Identifier} drop constraint {SchemaUtils.QuoteName(Actual!.PrimaryKeyName)};");
                 }
 
                 writer.WriteLine($"alter table {Expected.Identifier} add {Expected.PrimaryKeyDeclaration()};");
@@ -201,7 +201,7 @@ public class TableDelta: SchemaObjectDelta<Table>
 
         foreach (var change in CheckConstraints.Different)
         {
-            writer.WriteLine($"alter table {Expected.Identifier} drop constraint [{change.Actual.Name}];");
+            writer.WriteLine($"alter table {Expected.Identifier} drop constraint {SchemaUtils.BracketName(change.Actual.Name)};");
             writer.WriteLine($"alter table {Expected.Identifier} add {Table.CheckConstraintDeclaration(change.Expected)};");
         }
     }
@@ -222,7 +222,7 @@ public class TableDelta: SchemaObjectDelta<Table>
         if (primaryKeyDroppedBeforeColumnChanges)
         {
             writer.WriteLine(
-                $"alter table {Expected.Identifier} drop constraint if exists {Expected.PrimaryKeyName};");
+                $"alter table {Expected.Identifier} drop constraint if exists {SchemaUtils.QuoteName(Expected.PrimaryKeyName)};");
         }
 
         // Extra columns
@@ -270,7 +270,7 @@ public class TableDelta: SchemaObjectDelta<Table>
             case SchemaPatchDifference.Update:
                 if (!primaryKeyDroppedBeforeColumnChanges)
                 {
-                    writer.WriteLine($"alter table {Expected.Identifier} drop constraint if exists {Expected.PrimaryKeyName};");
+                    writer.WriteLine($"alter table {Expected.Identifier} drop constraint if exists {SchemaUtils.QuoteName(Expected.PrimaryKeyName)};");
                 }
 
                 writer.WriteLine($"alter table {Expected.Identifier} add {Actual!.PrimaryKeyDeclaration()};");
@@ -279,7 +279,7 @@ public class TableDelta: SchemaObjectDelta<Table>
             case SchemaPatchDifference.Create:
                 if (!primaryKeyDroppedBeforeColumnChanges)
                 {
-                    writer.WriteLine($"alter table {Expected.Identifier} drop constraint if exists {Expected.PrimaryKeyName};");
+                    writer.WriteLine($"alter table {Expected.Identifier} drop constraint if exists {SchemaUtils.QuoteName(Expected.PrimaryKeyName)};");
                 }
                 break;
 

--- a/src/Weasel.SqlServer/Tables/TableType.cs
+++ b/src/Weasel.SqlServer/Tables/TableType.cs
@@ -21,7 +21,7 @@ public class TableType: ISchemaObject
 
     public void WriteCreateStatement(Migrator migrator, TextWriter writer)
     {
-        writer.Write($"CREATE TYPE {Identifier.QualifiedName} AS TABLE (");
+        writer.Write($"CREATE TYPE {Identifier} AS TABLE (");
 
         writer.Write(_columns.Select(x => x.Declaration()).Join(", "));
         writer.WriteLine(")");
@@ -41,7 +41,7 @@ from
     inner join sys.types on sys.columns.system_type_id = sys.types.system_type_id
     inner join sys.schemas on sys.table_types.schema_id = sys.schemas.schema_id
 where
-    sys.table_types.name = '{Identifier.Name}' and sys.schemas.name = '{Identifier.Schema}'
+    sys.table_types.name = '{SchemaUtils.EscapeLiteral(Identifier.Name)}' and sys.schemas.name = '{SchemaUtils.EscapeLiteral(Identifier.Schema)}'
 order by
     sys.columns.column_id
 ");
@@ -151,7 +151,7 @@ order by
         public string Declaration()
         {
             var nullability = AllowNulls ? "NULL" : "NOT NULL";
-            return $"{Name} {DatabaseType} {nullability}";
+            return $"{SchemaUtils.QuoteName(Name)} {DatabaseType} {nullability}";
         }
 
         protected bool Equals(TableTypeColumn other)


### PR DESCRIPTION
# Emit DDL that SQL Server accepts, and quote every identifier

Several SQL Server DDL emission paths produce SQL the server rejects. Each is reachable from an
ordinary schema — none requires an exotic configuration. Some of these are especially painful if trying to write migrations in wolverine matching an existing database.


**Identifier quoting.** `SchemaUtils.QuoteName` bracketed only a hardcoded reserved-word list, so
any other name needing brackets went out bare produced SQL that will not parse. Several emission
sites did not call `QuoteName` at all.

**Index grammar.** Two clause-order bugs:

- `CREATE CLUSTERED UNIQUE INDEX` — the modifiers are in the wrong order; SQL Server requires
  `CREATE UNIQUE CLUSTERED INDEX`.
- `INCLUDE` was emitted after `WHERE`. The grammar is `INCLUDE` → `WHERE` → `WITH`.

Either one makes the statement fail outright, so no filtered covering index and no unique clustered
index could be created.

**Function bodies.** A function body is written into an `EXEC sp_executesql N'...'` literal, and its
own single quotes were not doubled. Any function containing a string literal — a default, a message,
a delimiter — failed with *"Unclosed quotation mark after the character string"*. 

## Compatibility

This is emission-only. **There are no changes to comparison or delta detection** — no existing model
starts reporting a difference it did not report before, and nobody has to reapply anything.

`QuoteName` brackets strictly more names than before, but only names that were previously emitted as
invalid SQL. A name that is a regular identifier and not a reserved word is still emitted bare, so an
ordinary schema's DDL is byte-identical.

## Tests

Every new test was replayed against `master` to confirm it fails there. Tests that pass on master are
present deliberately as regression guards and are marked as such.