### PR TITLE
MySQL: stop treating a foreign key's implicit backing index as a table index

### DIFF
--- a/src/Weasel.MySql.Tests/Tables/detecting_table_deltas.cs
+++ b/src/Weasel.MySql.Tests/Tables/detecting_table_deltas.cs
@@ -244,4 +244,80 @@ public class detecting_table_deltas: IntegrationContext
         existing.Indexes.Count.ShouldBeGreaterThanOrEqualTo(1);
         existing.Indexes.Any(i => i.IsUnique).ShouldBeTrue();
     }
+
+    [Fact]
+    public async Task foreign_key_backing_index_does_not_produce_a_delta()
+    {
+        await DropTableAsync("`weasel_testing`.`fk_index_orders`");
+        await DropTableAsync("`weasel_testing`.`fk_index_customers`");
+
+        var customers = new Table("weasel_testing.fk_index_customers");
+        customers.AddColumn<int>("id").AsPrimaryKey();
+        await customers.CreateAsync(theConnection);
+
+        var orders = new Table("weasel_testing.fk_index_orders");
+        orders.AddColumn<int>("id").AsPrimaryKey();
+        orders.AddColumn<int>("customer_id").ForeignKeyTo(customers, "id");
+        await orders.CreateAsync(theConnection);
+
+        // MySQL silently creates an index to back the foreign key and names it after the
+        // constraint. Reading that back as an ordinary index made the table look like it had
+        // an index nobody declared, so every delta wanted to drop it -- and InnoDB refuses
+        // while the constraint still needs it, so the migration failed on every single run.
+        var delta = await orders.FindDeltaAsync(theConnection);
+
+        delta.Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task foreign_key_backing_index_is_not_read_back_as_an_index()
+    {
+        await DropTableAsync("`weasel_testing`.`fk_index_only_orders`");
+        await DropTableAsync("`weasel_testing`.`fk_index_only_customers`");
+
+        var customers = new Table("weasel_testing.fk_index_only_customers");
+        customers.AddColumn<int>("id").AsPrimaryKey();
+        await customers.CreateAsync(theConnection);
+
+        var orders = new Table("weasel_testing.fk_index_only_orders");
+        orders.AddColumn<int>("id").AsPrimaryKey();
+        orders.AddColumn<int>("customer_id").ForeignKeyTo(customers, "id");
+        await orders.CreateAsync(theConnection);
+
+        var existing = await orders.FetchExistingAsync(theConnection);
+
+        existing.ShouldNotBeNull();
+        existing.ForeignKeys.Count.ShouldBe(1);
+        existing.Indexes.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task an_explicit_index_on_a_foreign_key_column_is_still_tracked()
+    {
+        await DropTableAsync("`weasel_testing`.`fk_explicit_idx_orders`");
+        await DropTableAsync("`weasel_testing`.`fk_explicit_idx_customers`");
+
+        var customers = new Table("weasel_testing.fk_explicit_idx_customers");
+        customers.AddColumn<int>("id").AsPrimaryKey();
+        await customers.CreateAsync(theConnection);
+
+        // An index the caller declares is created first, so the constraint reuses it rather
+        // than making its own. It therefore keeps its own name and must stay under Weasel's
+        // management -- the exclusion above must not swallow it.
+        var orders = new Table("weasel_testing.fk_explicit_idx_orders");
+        orders.AddColumn<int>("id").AsPrimaryKey();
+        orders.AddColumn<int>("customer_id")
+            .ForeignKeyTo(customers, "id")
+            .AddIndex();
+        await orders.CreateAsync(theConnection);
+
+        var existing = await orders.FetchExistingAsync(theConnection);
+
+        existing.ShouldNotBeNull();
+        existing.ForeignKeys.Count.ShouldBe(1);
+        existing.Indexes.Count.ShouldBe(1);
+        existing.Indexes.Single().Name.ShouldBe("idx_fk_explicit_idx_orders_customer_id");
+
+        (await orders.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
 }

--- a/src/Weasel.MySql/Tables/Table.FetchExisting.cs
+++ b/src/Weasel.MySql/Tables/Table.FetchExisting.cs
@@ -60,7 +60,13 @@ WHERE tc.TABLE_SCHEMA = @{schemaParam}
     AND tc.CONSTRAINT_TYPE = 'FOREIGN KEY'
 ORDER BY tc.CONSTRAINT_NAME, kcu.ORDINAL_POSITION;
 
--- Indexes (excluding primary key)
+-- Indexes, excluding the primary key and any index MySQL created implicitly to back a
+-- foreign key. MySQL requires an index on the referencing column and silently creates one
+-- when none exists, naming it after the constraint. Such an index is not part of the table
+-- as declared, so reading it back as an ordinary index makes every delta want to drop it,
+-- and InnoDB refuses while the constraint still needs it. An index the caller declared
+-- explicitly is reused by the constraint and keeps its own name, so it is still returned
+-- here and stays under Weasel's management.
 SELECT
     s.INDEX_NAME,
     s.COLUMN_NAME,
@@ -71,6 +77,14 @@ FROM information_schema.STATISTICS s
 WHERE s.TABLE_SCHEMA = @{schemaParam}
     AND s.TABLE_NAME = @{nameParam}
     AND s.INDEX_NAME != 'PRIMARY'
+    AND NOT EXISTS (
+        SELECT 1
+        FROM information_schema.TABLE_CONSTRAINTS tc
+        WHERE tc.TABLE_SCHEMA = s.TABLE_SCHEMA
+            AND tc.TABLE_NAME = s.TABLE_NAME
+            AND tc.CONSTRAINT_TYPE = 'FOREIGN KEY'
+            AND tc.CONSTRAINT_NAME = s.INDEX_NAME
+    )
 ORDER BY s.INDEX_NAME, s.SEQ_IN_INDEX;
 ");
     }


### PR DESCRIPTION
Fixes the MySQL schema migration failing on every run with:

```
Cannot drop index 'fk_...': needed in a foreign key constraint
```

## The problem

MySQL requires an index on a foreign key's referencing column, and silently creates one when none exists, naming it after the constraint.

`Table.FetchExisting` reads every non-primary index out of `information_schema.STATISTICS`:

```sql
WHERE s.TABLE_SCHEMA = @schema
    AND s.TABLE_NAME = @name
    AND s.INDEX_NAME != 'PRIMARY'
```

So that implicit index comes back as an ordinary index on a table whose declaration never mentioned one. The delta reports it as an index to remove, and the generated `DROP INDEX` is rejected by InnoDB while the constraint still needs it.

The table is therefore left permanently out of step with its declaration — the migration fails on *every* run rather than once, and `FindDeltaAsync` never returns `None`.

PostgreSQL is unaffected because it does not create an index for a foreign key, which is why this only shows up on MySQL.

## The fix

Exclude indexes whose name matches a `FOREIGN KEY` constraint on the same table:

```sql
    AND NOT EXISTS (
        SELECT 1
        FROM information_schema.TABLE_CONSTRAINTS tc
        WHERE tc.TABLE_SCHEMA = s.TABLE_SCHEMA
            AND tc.TABLE_NAME = s.TABLE_NAME
            AND tc.CONSTRAINT_TYPE = 'FOREIGN KEY'
            AND tc.CONSTRAINT_NAME = s.INDEX_NAME
    )
```

## Why matching on the constraint name is precise rather than a heuristic

MySQL only names an index after the constraint when it creates that index itself. If an index on the column already exists, the constraint **reuses** it and creates nothing — so an index the caller declared keeps its own name and never matches the exclusion.

Verified both ways:

| Index | Created by | Before | After |
|---|---|---|---|
| `fk_child_node_id` | MySQL, implicitly | returned → `DROP INDEX` | excluded |
| `idx_my_own_index` | declared, also backs an FK | returned | still returned |

Only the implicit index disappears from the model. Anything explicitly declared stays under Weasel's management.

## Tests

Three tests added to `Weasel.MySql.Tests/Tables/detecting_table_deltas.cs`:

| Test | Without the fix | With the fix |
|---|---|---|
| `foreign_key_backing_index_does_not_produce_a_delta` | fails | passes |
| `foreign_key_backing_index_is_not_read_back_as_an_index` | fails | passes |
| `an_explicit_index_on_a_foreign_key_column_is_still_tracked` | passes | passes |

The third is a guard rather than a regression test — it has to pass in **both** states, since its job is to prove the exclusion does not swallow indexes the caller declared.

`detecting_table_deltas` is 15/15 including the 12 pre-existing tests. The full `Weasel.MySql.Tests` suite on net10.0 is 235/236; the one failure, `MySqlMigratorTests.can_ensure_database_that_does_not_exist`, fails identically on a clean checkout in my environment (a MySqlConnector connection error — that test uses its own connection details rather than `weasel_mysql_testing_database`) and is unrelated to this change.

## How it was found

Via WolverineFx. `wolverine_node_assignments` declares a foreign key and no index — the same shape as the PostgreSQL definition — so every Wolverine node on MySQL logged a failed envelope-storage migration on every startup. Reported as JasperFx/wolverine#3983.

## Verified against the downstream symptom

Ran a minimal WolverineFx 6.29.0 host (`PersistMessagesWithMySql` + `AddResourceSetupOnStartup`)
against MySQL 8.4, with a `ProjectReference` substituting this branch for the Weasel.MySql 9.24.0
package that WolverineFx.MySql 6.29.0 depends on.

Before: `Error executing Wolverine Envelope Storage database migration: DROP INDEX
`fk_wolverine_node_assignments_node_id`` on both a fresh database and on every subsequent start.

After: no migration errors on either run, with the foreign key and its backing index still
present and all eight `wolverine_*` tables created as before.