### PR TITLE
fix(mysql): stop the schema diff from reporting permanent drift on foreign keys

### DIFF
--- a/src/Weasel.MySql.Tests/Tables/foreign_key_backing_indexes.cs
+++ b/src/Weasel.MySql.Tests/Tables/foreign_key_backing_indexes.cs
@@ -138,4 +138,154 @@ public class foreign_key_backing_indexes: IntegrationContext
         delta!.Indexes!.Extras.ShouldBeEmpty();
         delta.Difference.ShouldBe(SchemaPatchDifference.None);
     }
+
+    [Fact]
+    public async Task a_redundant_index_is_dropped_once_a_declared_index_covers_the_constraint()
+    {
+        await DropTableAsync("`weasel_testing`.`fkidx_child_6`");
+        await createParentAsync("fkidx_parent_6");
+
+        // Two indexes, either of which can back the constraint. This is what a caller is left
+        // with after they add a wider index and stop declaring the narrow one.
+        await CreateTableAsync(
+            """
+            CREATE TABLE `weasel_testing`.`fkidx_child_6` (
+                `id` INT NOT NULL,
+                `parent_id` INT NULL,
+                `name` VARCHAR(100) NULL,
+                PRIMARY KEY (`id`),
+                INDEX `idx_fkidx_child_6_parent_id` (`parent_id`),
+                INDEX `idx_fkidx_child_6_parent_id_name` (`parent_id`, `name`),
+                CONSTRAINT `fk_fkidx_child_6_parent_id` FOREIGN KEY (`parent_id`)
+                    REFERENCES `weasel_testing`.`fkidx_parent_6` (`id`)
+            ) ENGINE=InnoDB
+            """);
+
+        var expected = new Table("weasel_testing.fkidx_child_6");
+        expected.AddColumn<int>("id").AsPrimaryKey();
+        expected.AddColumn<int>("parent_id").ForeignKeyTo(
+            new MySqlObjectName("weasel_testing", "fkidx_parent_6"), "id");
+        expected.AddColumn<string>("name");
+        expected.Indexes.Add(new IndexDefinition("idx_fkidx_child_6_parent_id_name")
+            .AgainstColumns("parent_id", "name"));
+
+        var delta = await expected.FindDeltaAsync(theConnection) as TableDelta;
+
+        // The declared index is covering the constraint, so the other one is only an extra.
+        delta!.Indexes!.Extras.Single().Name.ShouldBe("idx_fkidx_child_6_parent_id");
+
+        await expected.ApplyChangesAsync(theConnection);
+
+        (await expected.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+
+        var existing = await expected.FetchExistingAsync(theConnection);
+        existing!.Indexes.Single().Name.ShouldBe("idx_fkidx_child_6_parent_id_name");
+        existing.ForeignKeys.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task declaring_an_index_over_the_implicit_one_settles_in_a_single_pass()
+    {
+        await DropTableAsync("`weasel_testing`.`fkidx_child_7`");
+        var parent = await createParentAsync("fkidx_parent_7");
+
+        var actual = new Table("weasel_testing.fkidx_child_7");
+        actual.AddColumn<int>("id").AsPrimaryKey();
+        actual.AddColumn<int>("parent_id").ForeignKeyTo(parent.Identifier, "id");
+        await actual.CreateAsync(theConnection);
+
+        // The declared index does not exist yet, so it cannot be leaned on and the implicit
+        // index is still protected -- no DROP INDEX is emitted for it. InnoDB retires it on
+        // its own the moment the declared index appears, so one pass is still enough.
+        var expected = new Table("weasel_testing.fkidx_child_7");
+        expected.AddColumn<int>("id").AsPrimaryKey();
+        expected.AddColumn<int>("parent_id").ForeignKeyTo(parent.Identifier, "id").AddIndex();
+
+        var delta = await expected.FindDeltaAsync(theConnection) as TableDelta;
+        delta!.Indexes!.Extras.ShouldBeEmpty();
+
+        await expected.ApplyChangesAsync(theConnection);
+
+        (await expected.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+
+        var existing = await expected.FetchExistingAsync(theConnection);
+        existing!.Indexes.Single().Name.ShouldBe("idx_fkidx_child_7_parent_id");
+        existing.ForeignKeys.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task the_primary_key_backing_a_constraint_leaves_nothing_to_protect()
+    {
+        await DropTableAsync("`weasel_testing`.`fkidx_child_8`");
+        var parent = await createParentAsync("fkidx_parent_8");
+
+        // The constrained column is the primary key, so MySQL backs the constraint with the
+        // primary key index and never creates one of its own. A secondary index on the same
+        // column is pure redundancy and has to stay droppable.
+        await CreateTableAsync(
+            """
+            CREATE TABLE `weasel_testing`.`fkidx_child_8` (
+                `id` INT NOT NULL,
+                PRIMARY KEY (`id`),
+                CONSTRAINT `fk_fkidx_child_8_id` FOREIGN KEY (`id`)
+                    REFERENCES `weasel_testing`.`fkidx_parent_8` (`id`)
+            ) ENGINE=InnoDB
+            """);
+        await CreateTableAsync(
+            "CREATE INDEX `idx_fkidx_child_8_id` ON `weasel_testing`.`fkidx_child_8` (`id`)");
+
+        var expected = new Table("weasel_testing.fkidx_child_8");
+        expected.AddColumn<int>("id").AsPrimaryKey().ForeignKeyTo(parent.Identifier, "id");
+
+        var delta = await expected.FindDeltaAsync(theConnection) as TableDelta;
+
+        delta!.Indexes!.Extras.Single().Name.ShouldBe("idx_fkidx_child_8_id");
+
+        await expected.ApplyChangesAsync(theConnection);
+
+        (await expected.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+        (await expected.FetchExistingAsync(theConnection))!.ForeignKeys.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task exactly_one_backing_index_is_kept_when_two_cover_the_same_constraint()
+    {
+        await DropTableAsync("`weasel_testing`.`fkidx_child_9`");
+        await createParentAsync("fkidx_parent_9");
+
+        // Same two covering indexes as above, but now the expected table declares neither.
+        // One of them still has to survive to keep InnoDB happy -- but only one.
+        await CreateTableAsync(
+            """
+            CREATE TABLE `weasel_testing`.`fkidx_child_9` (
+                `id` INT NOT NULL,
+                `parent_id` INT NULL,
+                `name` VARCHAR(100) NULL,
+                PRIMARY KEY (`id`),
+                INDEX `idx_fkidx_child_9_parent_id` (`parent_id`),
+                INDEX `idx_fkidx_child_9_parent_id_name` (`parent_id`, `name`),
+                CONSTRAINT `fk_fkidx_child_9_parent_id` FOREIGN KEY (`parent_id`)
+                    REFERENCES `weasel_testing`.`fkidx_parent_9` (`id`)
+            ) ENGINE=InnoDB
+            """);
+
+        var expected = new Table("weasel_testing.fkidx_child_9");
+        expected.AddColumn<int>("id").AsPrimaryKey();
+        expected.AddColumn<int>("parent_id").ForeignKeyTo(
+            new MySqlObjectName("weasel_testing", "fkidx_parent_9"), "id");
+        expected.AddColumn<string>("name");
+
+        var delta = await expected.FindDeltaAsync(theConnection) as TableDelta;
+
+        // The narrow one is the one worth keeping: it is the least use for anything else.
+        delta!.Indexes!.Extras.Single().Name.ShouldBe("idx_fkidx_child_9_parent_id_name");
+
+        await expected.ApplyChangesAsync(theConnection);
+
+        (await expected.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+
+        var existing = await expected.FetchExistingAsync(theConnection);
+        existing!.Indexes.Single().Name.ShouldBe("idx_fkidx_child_9_parent_id");
+        existing.ForeignKeys.Count.ShouldBe(1);
+    }
 }

--- a/src/Weasel.MySql.Tests/Tables/foreign_key_backing_indexes.cs
+++ b/src/Weasel.MySql.Tests/Tables/foreign_key_backing_indexes.cs
@@ -1,0 +1,141 @@
+using Shouldly;
+using Weasel.Core;
+using Weasel.MySql.Tables;
+using Xunit;
+
+namespace Weasel.MySql.Tests.Tables;
+
+/// <summary>
+///     MySQL implicitly creates a backing index for every FOREIGN KEY constraint and
+///     names it after the constraint. information_schema.STATISTICS reports that index
+///     like any other, so a table that declares only a foreign key used to diff as
+///     "one extra index" forever, and InnoDB refuses the DROP INDEX that follows
+///     (error 1553). See wolverine#3983.
+/// </summary>
+public class foreign_key_backing_indexes: IntegrationContext
+{
+    private async Task<Table> createParentAsync(string name)
+    {
+        await DropTableAsync($"`weasel_testing`.`{name}`");
+        var parent = new Table($"weasel_testing.{name}");
+        parent.AddColumn<int>("id").AsPrimaryKey();
+        await parent.CreateAsync(theConnection);
+        return parent;
+    }
+
+    [Fact]
+    public async Task a_table_declaring_only_a_foreign_key_round_trips_with_no_delta()
+    {
+        await DropTableAsync("`weasel_testing`.`fkidx_child_1`");
+        var parent = await createParentAsync("fkidx_parent_1");
+
+        var expected = new Table("weasel_testing.fkidx_child_1");
+        expected.AddColumn<int>("id").AsPrimaryKey();
+        expected.AddColumn<int>("parent_id")
+            .ForeignKeyTo(parent.Identifier, "id", onDelete: CascadeAction.Cascade);
+
+        await expected.CreateAsync(theConnection);
+
+        var delta = await expected.FindDeltaAsync(theConnection) as TableDelta;
+
+        delta!.Indexes!.Extras.ShouldBeEmpty();
+        delta.Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task applying_changes_twice_against_a_foreign_key_is_a_no_op()
+    {
+        await DropTableAsync("`weasel_testing`.`fkidx_child_2`");
+        var parent = await createParentAsync("fkidx_parent_2");
+
+        var expected = new Table("weasel_testing.fkidx_child_2");
+        expected.AddColumn<int>("id").AsPrimaryKey();
+        expected.AddColumn<int>("parent_id")
+            .ForeignKeyTo(parent.Identifier, "id", onDelete: CascadeAction.Cascade);
+
+        // First pass creates the table; the second used to emit an unrunnable DROP INDEX.
+        await expected.ApplyChangesAsync(theConnection);
+        await expected.ApplyChangesAsync(theConnection);
+
+        (await expected.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task dropping_a_foreign_key_also_clears_its_backing_index()
+    {
+        await DropTableAsync("`weasel_testing`.`fkidx_child_3`");
+        var parent = await createParentAsync("fkidx_parent_3");
+
+        var withKey = new Table("weasel_testing.fkidx_child_3");
+        withKey.AddColumn<int>("id").AsPrimaryKey();
+        withKey.AddColumn<int>("parent_id").ForeignKeyTo(parent.Identifier, "id");
+        await withKey.CreateAsync(theConnection);
+
+        // Same table, minus the constraint. The DROP FOREIGN KEY has to be emitted before
+        // the DROP INDEX or InnoDB rejects the batch.
+        var withoutKey = new Table("weasel_testing.fkidx_child_3");
+        withoutKey.AddColumn<int>("id").AsPrimaryKey();
+        withoutKey.AddColumn<int>("parent_id");
+
+        await withoutKey.ApplyChangesAsync(theConnection);
+
+        (await withoutKey.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task an_index_unrelated_to_a_foreign_key_is_still_reported_as_extra()
+    {
+        await DropTableAsync("`weasel_testing`.`fkidx_child_4`");
+        var parent = await createParentAsync("fkidx_parent_4");
+
+        var actual = new Table("weasel_testing.fkidx_child_4");
+        actual.AddColumn<int>("id").AsPrimaryKey();
+        actual.AddColumn<int>("parent_id").ForeignKeyTo(parent.Identifier, "id");
+        actual.AddColumn<string>("name").AddIndex();
+        await actual.CreateAsync(theConnection);
+
+        var expected = new Table("weasel_testing.fkidx_child_4");
+        expected.AddColumn<int>("id").AsPrimaryKey();
+        expected.AddColumn<int>("parent_id").ForeignKeyTo(parent.Identifier, "id");
+        expected.AddColumn<string>("name");
+
+        var delta = await expected.FindDeltaAsync(theConnection) as TableDelta;
+
+        // The backing index is protected; the deliberately declared one is not.
+        delta!.Indexes!.Extras.Count.ShouldBe(1);
+        delta.Indexes.Extras.Single().Columns.ShouldBe(["name"]);
+
+        await expected.ApplyChangesAsync(theConnection);
+        (await expected.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task a_pre_existing_index_that_backs_a_foreign_key_under_another_name_is_protected()
+    {
+        await DropTableAsync("`weasel_testing`.`fkidx_child_5`");
+        var parent = await createParentAsync("fkidx_parent_5");
+
+        // MySQL reuses an existing covering index rather than creating its own, so the
+        // backing index here is named idx_..., nothing like the constraint.
+        await CreateTableAsync(
+            """
+            CREATE TABLE `weasel_testing`.`fkidx_child_5` (
+                `id` INT NOT NULL,
+                `parent_id` INT NULL,
+                PRIMARY KEY (`id`),
+                INDEX `idx_fkidx_child_5_parent_id` (`parent_id`),
+                CONSTRAINT `fk_fkidx_child_5_parent_id` FOREIGN KEY (`parent_id`)
+                    REFERENCES `weasel_testing`.`fkidx_parent_5` (`id`)
+            ) ENGINE=InnoDB
+            """);
+
+        var expected = new Table("weasel_testing.fkidx_child_5");
+        expected.AddColumn<int>("id").AsPrimaryKey();
+        expected.AddColumn<int>("parent_id").ForeignKeyTo(parent.Identifier, "id");
+
+        var delta = await expected.FindDeltaAsync(theConnection) as TableDelta;
+
+        delta!.Indexes!.Extras.ShouldBeEmpty();
+        delta.Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+}

--- a/src/Weasel.MySql.Tests/Tables/table_identifier_normalization.cs
+++ b/src/Weasel.MySql.Tests/Tables/table_identifier_normalization.cs
@@ -1,0 +1,67 @@
+using Shouldly;
+using Weasel.Core;
+using Weasel.MySql.Tables;
+using Xunit;
+
+namespace Weasel.MySql.Tests.Tables;
+
+/// <summary>
+///     A Table built from a plain <see cref="DbObjectName" /> used to keep it, so its
+///     qualified name rendered unquoted while everything read back out of the catalog
+///     came back as a backtick-quoted <see cref="MySqlObjectName" />. DbObjectName
+///     equality compares those qualified names, so the two never matched and a foreign
+///     key built that way reported drift forever. See wolverine#3983.
+/// </summary>
+public class table_identifier_normalization: IntegrationContext
+{
+    [Fact]
+    public void identifier_is_normalized_from_a_plain_db_object_name()
+    {
+        var table = new Table(new DbObjectName("weasel_testing", "normalize_1"));
+
+        table.Identifier.ShouldBeOfType<MySqlObjectName>();
+        table.Identifier.QualifiedName.ShouldBe("`weasel_testing`.`normalize_1`");
+    }
+
+    [Fact]
+    public void a_plain_db_object_name_equals_the_parsed_form()
+    {
+        new Table(new DbObjectName("weasel_testing", "normalize_2")).Identifier
+            .ShouldBe(new Table("weasel_testing.normalize_2").Identifier);
+    }
+
+    [Fact]
+    public void foreign_key_linked_table_is_normalized()
+    {
+        var table = new Table(new DbObjectName("weasel_testing", "normalize_3"));
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn<int>("parent_id")
+            .ForeignKeyTo(new DbObjectName("weasel_testing", "normalize_parent"), "id");
+
+        table.ForeignKeys.Single().LinkedTable.ShouldBeOfType<MySqlObjectName>();
+    }
+
+    [Fact]
+    public async Task a_foreign_key_declared_with_a_plain_db_object_name_reports_no_drift()
+    {
+        await DropTableAsync("`weasel_testing`.`normalize_child`");
+        await DropTableAsync("`weasel_testing`.`normalize_parent`");
+
+        var parent = new Table(new DbObjectName("weasel_testing", "normalize_parent"));
+        parent.AddColumn<int>("id").AsPrimaryKey();
+        await parent.CreateAsync(theConnection);
+
+        var child = new Table(new DbObjectName("weasel_testing", "normalize_child"));
+        child.AddColumn<int>("id").AsPrimaryKey();
+        child.AddColumn<int>("parent_id")
+            .ForeignKeyTo(new DbObjectName("weasel_testing", "normalize_parent"), "id",
+                onDelete: CascadeAction.Cascade);
+
+        await child.CreateAsync(theConnection);
+
+        var delta = await child.FindDeltaAsync(theConnection) as TableDelta;
+
+        delta!.ForeignKeys!.Different.ShouldBeEmpty();
+        delta.Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+}

--- a/src/Weasel.MySql/Tables/Table.cs
+++ b/src/Weasel.MySql/Tables/Table.cs
@@ -16,14 +16,25 @@ public enum PartitionStrategy
 
 public partial class Table: TableBase<TableColumn, IndexDefinition, ForeignKey>
 {
+    /// <summary>
+    ///     The identifier is always normalized to a <see cref="MySqlObjectName" />. A plain
+    ///     <see cref="DbObjectName" /> renders its qualified name unquoted, which both breaks
+    ///     DDL for any identifier that needs escaping and — because DbObjectName equality is
+    ///     a comparison of those qualified names — makes a hand-built identifier compare
+    ///     unequal to the same table read back out of the catalog. That mismatch showed up as
+    ///     a foreign key that reported drift on every single schema check (wolverine#3983).
+    /// </summary>
     public Table(DbObjectName name)
-        : base(name ?? throw new ArgumentNullException(nameof(name)))
+        : base(Normalize(name ?? throw new ArgumentNullException(nameof(name))))
     {
     }
 
     public Table(string tableName): this(DbObjectName.Parse(MySqlProvider.Instance, tableName))
     {
     }
+
+    internal static MySqlObjectName Normalize(DbObjectName name) =>
+        name as MySqlObjectName ?? MySqlObjectName.From(name);
 
     /// <inheritdoc />
     public override IReadOnlyList<string> PrimaryKeyColumns =>
@@ -391,10 +402,12 @@ public partial class Table: TableBase<TableColumn, IndexDefinition, ForeignKey>
             string? fkName = null, CascadeAction onDelete = CascadeAction.NoAction,
             CascadeAction onUpdate = CascadeAction.NoAction)
         {
-            var identifier = _parent.Identifier as MySqlObjectName ?? MySqlObjectName.From(_parent.Identifier);
+            var identifier = Normalize(_parent.Identifier);
             var fk = new ForeignKey(fkName ?? identifier.ToIndexName("fk", Column.Name))
             {
-                LinkedTable = referencedIdentifier,
+                // Normalized for the same reason the table's own identifier is: the catalog
+                // hands back a MySqlObjectName, and an unquoted one never compares equal to it.
+                LinkedTable = Normalize(referencedIdentifier),
                 ColumnNames = new[] { Column.Name },
                 LinkedNames = new[] { referencedColumnName },
                 OnDelete = onDelete,

--- a/src/Weasel.MySql/Tables/TableDelta.cs
+++ b/src/Weasel.MySql/Tables/TableDelta.cs
@@ -35,15 +35,15 @@ public class TableDelta: SchemaObjectDelta<Table>
             actual.Columns,
             (e, a) => e.IsEquivalentTo(a));
 
-        Indexes = new ItemDelta<IndexDefinition>(
-            expected.Indexes,
-            actual.Indexes,
-            (e, a) => e.Matches(a, expected));
-
         ForeignKeys = new ItemDelta<ForeignKey>(
             expected.ForeignKeys,
             actual.ForeignKeys,
             (e, a) => e.IsEquivalentTo(a));
+
+        Indexes = new ItemDelta<IndexDefinition>(
+            expected.Indexes,
+            comparableIndexes(expected, actual, ForeignKeys),
+            (e, a) => e.Matches(a, expected));
 
         // Check primary key differences
         var expectedPks = expected.PrimaryKeyColumns.OrderBy(x => x).ToList();
@@ -79,6 +79,63 @@ public class TableDelta: SchemaObjectDelta<Table>
         if (PrimaryKeyDifference != SchemaPatchDifference.None) return true;
 
         return false;
+    }
+
+    /// <summary>
+    ///     MySQL creates a backing index for every FOREIGN KEY constraint — normally one
+    ///     named after the constraint, or an existing index that already covers the
+    ///     constrained columns — and <c>information_schema.STATISTICS</c> reports it like
+    ///     any other index. InnoDB then refuses to drop it while the constraint still
+    ///     needs it (error 1553), so an index that exists only to back a surviving foreign
+    ///     key is not an "extra" and must be kept out of the comparison entirely.
+    ///     Indexes the expected table declares by name are always compared, so real drift
+    ///     on a deliberately declared index is still detected.
+    /// </summary>
+    private static IEnumerable<IndexDefinition> comparableIndexes(
+        Table expected,
+        Table actual,
+        ItemDelta<ForeignKey> foreignKeys)
+    {
+        var dropped = foreignKeys.Extras.Select(x => x.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        // A foreign key that is itself being dropped stops protecting its index in the
+        // same migration, because the DROP FOREIGN KEY is emitted first.
+        var surviving = actual.ForeignKeys.Where(fk => !dropped.Contains(fk.Name)).ToArray();
+        if (surviving.Length == 0)
+        {
+            return actual.Indexes;
+        }
+
+        return actual.Indexes.Where(index =>
+            expected.Indexes.Any(e => e.Name.Equals(index.Name, StringComparison.OrdinalIgnoreCase))
+            || !surviving.Any(fk => backs(index, fk)));
+    }
+
+    /// <summary>
+    ///     True when MySQL could be using <paramref name="index" /> as the backing index for
+    ///     <paramref name="foreignKey" /> — that is, the constrained columns are the leftmost
+    ///     prefix of the index. More than one index can qualify; protecting all of them only
+    ///     risks leaving a redundant index in place, while protecting none breaks the migration.
+    /// </summary>
+    private static bool backs(IndexDefinition index, ForeignKey foreignKey)
+    {
+        var indexColumns = index.Columns;
+        var keyColumns = foreignKey.ColumnNames;
+
+        if (keyColumns.Length == 0 || indexColumns.Length < keyColumns.Length)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < keyColumns.Length; i++)
+        {
+            if (!indexColumns[i].Equals(keyColumns[i], StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     public override void WriteUpdate(Migrator migrator, TextWriter writer)
@@ -117,7 +174,25 @@ public class TableDelta: SchemaObjectDelta<Table>
             }
         }
 
-        // Handle index changes - drop extras first, then add missing
+        // Ordering matters, and it is not symmetric: InnoDB refuses to drop an index that a
+        // foreign key still needs (error 1553), and refuses to add a foreign key that has no
+        // covering index. So every constraint comes off first, then indexes are reshaped, then
+        // the constraints go back on against the indexes they need.
+        if (ForeignKeys != null)
+        {
+            foreach (var fk in ForeignKeys.Extras)
+            {
+                writer.WriteLine(
+                    $"ALTER TABLE {Expected.Identifier.QualifiedName} DROP FOREIGN KEY `{fk.Name}`;");
+            }
+
+            foreach (var change in ForeignKeys.Different)
+            {
+                writer.WriteLine(
+                    $"ALTER TABLE {Expected.Identifier.QualifiedName} DROP FOREIGN KEY `{change.Actual.Name}`;");
+            }
+        }
+
         if (Indexes != null)
         {
             foreach (var index in Indexes.Extras)
@@ -137,19 +212,10 @@ public class TableDelta: SchemaObjectDelta<Table>
             }
         }
 
-        // Handle foreign key changes - drop extras first, then add missing
         if (ForeignKeys != null)
         {
-            foreach (var fk in ForeignKeys.Extras)
-            {
-                writer.WriteLine(
-                    $"ALTER TABLE {Expected.Identifier.QualifiedName} DROP FOREIGN KEY `{fk.Name}`;");
-            }
-
             foreach (var change in ForeignKeys.Different)
             {
-                writer.WriteLine(
-                    $"ALTER TABLE {Expected.Identifier.QualifiedName} DROP FOREIGN KEY `{change.Actual.Name}`;");
                 writer.WriteLine(change.Expected.ToDDL(Expected));
             }
 

--- a/src/Weasel.MySql/Tables/TableDelta.cs
+++ b/src/Weasel.MySql/Tables/TableDelta.cs
@@ -40,12 +40,8 @@ public class TableDelta: SchemaObjectDelta<Table>
             actual.ForeignKeys,
             (e, a) => e.IsEquivalentTo(a));
 
-        Indexes = new ItemDelta<IndexDefinition>(
-            expected.Indexes,
-            comparableIndexes(expected, actual, ForeignKeys),
-            (e, a) => e.Matches(a, expected));
-
-        // Check primary key differences
+        // Ahead of the index comparison, which needs to know whether the primary key is
+        // staying put: MySQL is happy to back a foreign key with the primary key index.
         var expectedPks = expected.PrimaryKeyColumns.OrderBy(x => x).ToList();
         var actualPks = actual.PrimaryKeyColumns.OrderBy(x => x).ToList();
 
@@ -53,6 +49,12 @@ public class TableDelta: SchemaObjectDelta<Table>
         {
             PrimaryKeyDifference = SchemaPatchDifference.Update;
         }
+
+        Indexes = new ItemDelta<IndexDefinition>(
+            expected.Indexes,
+            comparableIndexes(expected, actual, ForeignKeys,
+                PrimaryKeyDifference == SchemaPatchDifference.None),
+            (e, a) => e.Matches(a, expected));
 
         // Partition strategy can't be altered in place — flag as needing manual intervention
         if (expected.PartitionStrategy != actual.PartitionStrategy)
@@ -86,15 +88,37 @@ public class TableDelta: SchemaObjectDelta<Table>
     ///     named after the constraint, or an existing index that already covers the
     ///     constrained columns — and <c>information_schema.STATISTICS</c> reports it like
     ///     any other index. InnoDB then refuses to drop it while the constraint still
-    ///     needs it (error 1553), so an index that exists only to back a surviving foreign
-    ///     key is not an "extra" and must be kept out of the comparison entirely.
-    ///     Indexes the expected table declares by name are always compared, so real drift
-    ///     on a deliberately declared index is still detected.
+    ///     needs it (error 1553).
     /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         What InnoDB actually requires is that <em>some</em> index cover the constrained
+    ///         columns, not that any particular one survive. So only the last remaining cover is
+    ///         held back from the comparison: as soon as another index will still be there once
+    ///         the migration finishes, every other backing index is an ordinary extra and gets
+    ///         dropped like one. That is what keeps a redundant index — the implicit one left
+    ///         behind after the caller declares their own, say — from being protected forever.
+    ///     </para>
+    ///     <para>
+    ///         A cover has to be one the DROP INDEX statements can rely on already being in
+    ///         place: an index the expected table declares and that the database already has
+    ///         unchanged, or the primary key when it is not being rebuilt. An index that is
+    ///         about to be created, or dropped and recreated, is not there when it would be
+    ///         needed and does not count. That costs nothing when a declared index is replacing
+    ///         an implicit one, because InnoDB retires its own backing index by itself the
+    ///         moment another index can serve the constraint — so the CREATE INDEX alone
+    ///         settles it, and the next comparison sees no extra at all.
+    ///     </para>
+    ///     <para>
+    ///         Indexes the expected table declares by name are always compared, so real drift on
+    ///         a deliberately declared index is still detected.
+    ///     </para>
+    /// </remarks>
     private static IEnumerable<IndexDefinition> comparableIndexes(
         Table expected,
         Table actual,
-        ItemDelta<ForeignKey> foreignKeys)
+        ItemDelta<ForeignKey> foreignKeys,
+        bool primaryKeyIsStable)
     {
         var dropped = foreignKeys.Extras.Select(x => x.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
 
@@ -106,23 +130,87 @@ public class TableDelta: SchemaObjectDelta<Table>
             return actual.Indexes;
         }
 
-        return actual.Indexes.Where(index =>
-            expected.Indexes.Any(e => e.Name.Equals(index.Name, StringComparison.OrdinalIgnoreCase))
-            || !surviving.Any(fk => backs(index, fk)));
+        var declared = expected.Indexes.Select(x => x.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var kept = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var fk in surviving)
+        {
+            if (isCovered(expected, actual, fk, kept, primaryKeyIsStable))
+            {
+                continue;
+            }
+
+            // Nothing is guaranteed to be there for this constraint, so exactly one of the
+            // indexes that could be backing it has to stay. Prefer the one MySQL creates
+            // itself, then the narrowest — the least useful for anything but the constraint.
+            var keeper = actual.Indexes
+                .Where(index => backs(index, fk))
+                .OrderBy(index => index.Name.Equals(fk.Name, StringComparison.OrdinalIgnoreCase) ? 0 : 1)
+                .ThenBy(index => index.Columns.Length)
+                .ThenBy(index => index.Name, StringComparer.OrdinalIgnoreCase)
+                .FirstOrDefault();
+
+            if (keeper != null)
+            {
+                kept.Add(keeper.Name);
+            }
+        }
+
+        return actual.Indexes.Where(index => declared.Contains(index.Name) || !kept.Contains(index.Name));
+    }
+
+    /// <summary>
+    ///     True when <paramref name="foreignKey" /> is certain to still have a backing index
+    ///     after the migration runs, without holding anything else back.
+    /// </summary>
+    private static bool isCovered(
+        Table expected,
+        Table actual,
+        ForeignKey foreignKey,
+        IReadOnlyCollection<string> kept,
+        bool primaryKeyIsStable)
+    {
+        if (primaryKeyIsStable && covers(actual.PrimaryKeyColumns, foreignKey))
+        {
+            return true;
+        }
+
+        if (actual.Indexes.Any(index => kept.Contains(index.Name) && backs(index, foreignKey)))
+        {
+            return true;
+        }
+
+        // Only an index that is already in place and staying that way. One the expected table
+        // declares but the database does not have yet is created after the drops, and one that
+        // is being altered is dropped and recreated — neither is there when it would be needed.
+        return expected.Indexes.Any(index =>
+        {
+            if (!backs(index, foreignKey))
+            {
+                return false;
+            }
+
+            var current = actual.Indexes.FirstOrDefault(x =>
+                x.Name.Equals(index.Name, StringComparison.OrdinalIgnoreCase));
+
+            return current != null && index.Matches(current, expected);
+        });
     }
 
     /// <summary>
     ///     True when MySQL could be using <paramref name="index" /> as the backing index for
     ///     <paramref name="foreignKey" /> — that is, the constrained columns are the leftmost
-    ///     prefix of the index. More than one index can qualify; protecting all of them only
-    ///     risks leaving a redundant index in place, while protecting none breaks the migration.
+    ///     prefix of the index. More than one index can qualify, which is exactly why
+    ///     <see cref="isCovered" /> exists: only the last of them is worth protecting.
     /// </summary>
     private static bool backs(IndexDefinition index, ForeignKey foreignKey)
+        => covers(index.Columns, foreignKey);
+
+    private static bool covers(IReadOnlyList<string> indexColumns, ForeignKey foreignKey)
     {
-        var indexColumns = index.Columns;
         var keyColumns = foreignKey.ColumnNames;
 
-        if (keyColumns.Length == 0 || indexColumns.Length < keyColumns.Length)
+        if (keyColumns.Length == 0 || indexColumns.Count < keyColumns.Length)
         {
             return false;
         }


### PR DESCRIPTION
Fixes the upstream half of [wolverine#3983](https://github.com/JasperFx/wolverine/issues/3983), where every Wolverine node on MySQL logged an error on **every** startup:

```
DROP INDEX `fk_wolverine_node_assignments_node_id` ON <schema>.wolverine_node_assignments
MySqlException (0x80004005): Cannot drop index 'fk_wolverine_node_assignments_node_id':
    needed in a foreign key constraint
```

The reporter had it right that the index and the constraint are the same object. Digging in, there turned out to be **three** independent defects, all in `Weasel.MySql`, and any MySQL table that declares a foreign key hits them. The first migration against an empty database is a pure `CREATE`, so none of it is reachable until the second run — which is why it reproduces against a brand-new database and then repeats forever.

Credit to **@cyclr-adrian**, who hit the same failure and diagnosed defect 1 independently in #444 — including the detail that MySQL only names the index after the constraint when it creates that index itself. This PR supersedes that one, and takes defects 2 and 3 with it.

## 1. A foreign key's backing index was diffed as an extra index

MySQL implicitly creates a backing index for every `FOREIGN KEY` constraint, normally named after the constraint, and `information_schema.STATISTICS` reports it like any other index. `Table.FetchExisting` read it back, `TableDelta` found no counterpart in the expected table, and emitted a `DROP INDEX` that InnoDB refuses (error 1553).

An index that exists only to back a *surviving* foreign key is now kept out of the comparison. Three details worth calling out:

- Indexes the expected table declares **by name** are still compared, so real drift on a deliberately declared index is unaffected.
- The match is on the index's **leading columns**, not its name. MySQL reuses an existing covering index instead of creating its own when one is available, so the backing index is not always named after the constraint.
- Only the **last remaining** cover is held back. What InnoDB requires is that *some* index cover the constrained columns, not that any particular one survive, so protecting every index that matches would strand a redundant one — a narrow index the caller has stopped declaring in favour of a wider one — as undroppable forever. Each surviving constraint is checked for a cover that will still be there when the `DROP INDEX` statements run: the primary key when it is not being rebuilt, an index the expected table declares that the database already has unchanged, or an index already held back for another constraint. Only when none of those hold is one index kept, preferring the constraint-named one and then the narrowest. Everything else is an ordinary extra again.

An index that is *about* to be created does not count as a cover, because it is created after the drops. That costs nothing in the case it looks like it should — a declared index replacing the implicit one — because InnoDB retires its own backing index by itself the moment another index can serve the constraint. The `CREATE INDEX` alone settles it and the next comparison sees no extra at all, so that case is still a single pass. (Creating the new indexes *before* dropping the old ones, to widen what counts as a cover, is exactly what does not work: the `DROP INDEX` that follows hits a key MySQL has already removed.)

## 2. `WriteUpdate` emitted index changes before foreign key changes

So *removing* a foreign key failed for the same reason: the `DROP INDEX` for its backing index went out ahead of the `DROP FOREIGN KEY`. Constraints now come off first, then indexes are reshaped, then the constraints go back on — which is also the order `ADD CONSTRAINT` needs, since MySQL will not add a foreign key that has no covering index.

## 3. `Table(DbObjectName)` did not normalize its identifier

`MySqlObjectName` renders ``​`schema`.`name`​`` and a plain `DbObjectName` renders `schema.name`. `DbObjectName` equality compares exactly those strings, so a hand-built identifier never compared equal to the same table read back out of the catalog, and the foreign key reported as `Different` on every check — a `DROP FOREIGN KEY` + re-`ADD` on every migration.

The identifier and a foreign key's `LinkedTable` are both normalized now. This also fixes DDL for any identifier that actually needs escaping — the unquoted form was being emitted into `REFERENCES` clauses.

Only MySQL is affected by #3: PostgreSQL, SQL Server and Oracle all render qualified names unquoted, so their plain and provider-specific object names already compare equal.

## Testing

Two new test classes, both of which fail on `master`:

- `foreign_key_backing_indexes` — round-trip with no delta; apply-twice is a no-op; dropping a foreign key also clears its backing index; an unrelated index is *still* reported as extra; a pre-existing index backing a constraint under a different name is protected.
- `table_identifier_normalization` — identifier and `LinkedTable` normalization, and a no-drift round trip for a foreign key declared with a plain `DbObjectName`.

Four more in `foreign_key_backing_indexes` cover the last-cover rule specifically — a redundant index is dropped once a declared index covers the constraint; the primary key backing a constraint leaves nothing to protect; exactly one index is kept when two cover the same constraint and neither is declared; and, as a guard, declaring an index over the implicit one still settles in a single pass. The first three fail against the earlier protect-everything rule.

`Weasel.MySql.Tests` is green at 246 tests against `mysql:8.0`, and the full `Weasel.slnx` builds clean (0 errors).

Verified end-to-end against Wolverine with a local project reference: with this change plus [JasperFx/wolverine#3984](https://github.com/JasperFx/wolverine/pull/3984), `MigrateAsync()` three times over followed by `AssertDatabaseMatchesConfigurationAsync()` passes, where today it reports four separate drift items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HxbBpN6PmRB5CMSSTdGNr3
