### PR TITLE
fix(sqlserver): treat a name the caller bracketed as the name they meant

### DIFF
--- a/src/Weasel.Core/TableBase.cs
+++ b/src/Weasel.Core/TableBase.cs
@@ -116,8 +116,17 @@ public abstract class TableBase<TColumn, TIndex, TForeignKey>: SchemaObjectBase,
     public string PrimaryKeyName
     {
         get => _primaryKeyName.IsNotEmpty() ? _primaryKeyName : DefaultPrimaryKeyName();
-        set => _primaryKeyName = value;
+        set => _primaryKeyName = NormalizeIdentifier(value);
     }
+
+    /// <summary>
+    ///     Hook for a provider that accepts identifiers the caller has already delimited.
+    ///     The model has to hold the name the database will report back, or the two never
+    ///     compare equal and the table reports drift on every check. Default is a no-op;
+    ///     only SQL Server overrides it today, because only its callers had to bracket
+    ///     names themselves to get valid DDL.
+    /// </summary>
+    protected virtual string NormalizeIdentifier(string name) => name;
 
     /// <inheritdoc cref="ITable.PreserveIdentifierCase" />
     public bool PreserveIdentifierCase { get; set; }

--- a/src/Weasel.SqlServer.Tests/Tables/identifier_quoting.cs
+++ b/src/Weasel.SqlServer.Tests/Tables/identifier_quoting.cs
@@ -37,15 +37,31 @@ public class identifier_quoting: IntegrationContext
     }
 
     /// <summary>
-    ///     There is no "it already looks bracketed, leave it alone" shortcut, because a name that
-    ///     merely starts with [ and ends with ] is not necessarily bracketed. Skipping the escape for
-    ///     those let arbitrary DDL straight through.
+    ///     Weasel emitted most identifiers bare until 9.25, so bracketing the name yourself was the
+    ///     only way to use one that needed delimiting. Re-escaping those would silently rename the
+    ///     object, so a properly bracketed name is passed through.
     /// </summary>
-    [Fact]
-    public void a_name_that_looks_bracketed_is_still_escaped()
+    [Theory]
+    [InlineData("[orders]", "[orders]")]     // caller bracketed an ordinary name
+    [InlineData("[Table]", "[Table]")]       // caller bracketed a reserved word
+    [InlineData("[unit price]", "[unit price]")]
+    [InlineData("[a]]b]", "[a]]b]")]         // interior delimiter already doubled
+    public void a_name_the_caller_already_bracketed_is_left_alone(string name, string expected)
     {
-        // A column or index genuinely named "[orders]" escapes to [[orders]]].
-        SchemaUtils.QuoteName("[orders]").ShouldBe("[[orders]]]");
+        SchemaUtils.QuoteName(name).ShouldBe(expected);
+    }
+
+    /// <summary>
+    ///     The pass-through must not become a hole. A lone <c>]</c> inside means the name is not a
+    ///     well-formed bracketed identifier, so it is escaped on its own terms.
+    /// </summary>
+    [Theory]
+    [InlineData("[a]b]", "[[a]]b]]]")]
+    [InlineData("[unbalanced", "[[unbalanced]")]
+    [InlineData("unbalanced]", "[unbalanced]]]")]
+    public void a_name_that_is_not_properly_bracketed_is_still_escaped(string name, string expected)
+    {
+        SchemaUtils.QuoteName(name).ShouldBe(expected);
     }
 
     [Fact]
@@ -111,31 +127,43 @@ public class identifier_quoting: IntegrationContext
     }
 
     /// <summary>
-    ///     Column lists were never quoted at all before this change, so a user whose column needed
-    ///     brackets had to write them into the string themselves. Re-escaping those would name a
-    ///     column that does not exist, so an entry that is already bracketed end to end is passed
-    ///     through untouched.
+    ///     The pass-through used to apply to column list entries only, which left the workaround
+    ///     working in one half of a statement and renaming the object in the other: an index
+    ///     declared over <c>[Table]</c> resolved, while the index's own pre-bracketed name did not.
+    ///     One rule now covers every name Weasel writes.
     /// </summary>
-    [Theory]
-    [InlineData("price", "price")]           // ordinary, unchanged
-    [InlineData("Table", "[Table]")]         // reserved word, previously emitted bare and broken
-    [InlineData("[payload]", "[payload]")]   // caller already bracketed it, left alone
-    [InlineData("[a]]b]", "[a]]b]")]         // properly escaped already, left alone
-    [InlineData("unit price", "[unit price]")]
-    public void quote_column_entry_passes_through_what_is_already_bracketed(string name, string expected)
+    [Fact]
+    public void the_pass_through_covers_names_and_column_lists_alike()
     {
-        SchemaUtils.QuoteColumnEntry(name).ShouldBe(expected);
+        var table = new Table("quoting.consistent");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn("[Table]", "varchar(50)");
+
+        var index = new IndexDefinition("[ix consistent]") { Columns = ["[Table]"] };
+        index.AddIncludedColumn("[Table]");
+
+        var ddl = index.ToDDL(table);
+
+        // The column list honoured the caller's brackets before; the index's own name did not.
+        ddl.ShouldContain("INDEX [ix consistent] ON");
+        ddl.ShouldContain("([Table])");
+        ddl.ShouldContain("INCLUDE ([Table])");
+        table.ToBasicCreateTableSql().ShouldContain("[Table] varchar(50)");
     }
 
     /// <summary>
-    ///     The pass-through must not become a hole. A lone <c>]</c> inside means the entry is not
-    ///     a well-formed bracketed name, so it gets escaped on its own terms.
+    ///     A check constraint name was always bracketed and still is, so ordinary DDL is unchanged
+    ///     — but it honours the same pass-through as everything else now.
     /// </summary>
     [Fact]
-    public void quote_column_entry_does_not_pass_through_an_unbalanced_name()
+    public void a_check_constraint_name_the_caller_bracketed_is_not_double_bracketed()
     {
-        SchemaUtils.QuoteColumnEntry("[ix] ON dbo.t(id); DROP TABLE dbo.victim; --]")
-            .ShouldBe("[[ix]] ON dbo.t(id); DROP TABLE dbo.victim; --]]]");
+        var table = new Table("quoting.checked_item");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn<int>("price").NotNull();
+        table.CheckConstraints.Add(new TableCheckConstraint("[ck price]", "price > 0"));
+
+        table.ToBasicCreateTableSql().ShouldContain("CONSTRAINT [ck price] CHECK");
     }
 
     /// <summary>
@@ -157,6 +185,72 @@ public class identifier_quoting: IntegrationContext
 
         var existing = await table.FetchExistingAsync(theConnection);
         existing!.IndexFor("ix_prebracket")!.Columns.ShouldBe(["Table"]);
+    }
+
+    [Fact]
+    public async Task an_index_whose_name_the_user_bracketed_themselves_still_works()
+    {
+        await ResetSchema();
+
+        var table = new Table("quoting.prebracket_name");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn<int>("payload").NotNull();
+        // The other half of the workaround: bracketing the index's own name. Escaping this one
+        // created an index called "[ix prebracket]", brackets and all, and it drifted forever.
+        table.Indexes.Add(new IndexDefinition("[ix prebracket]") { Columns = ["payload"] });
+
+        await CreateSchemaObjectInDatabase(table);
+
+        // Created under the name the caller meant, rather than one called "[ix prebracket]".
+        var existing = await table.FetchExistingAsync(theConnection);
+        existing!.IndexFor("ix prebracket").ShouldNotBeNull();
+        existing.IndexFor("[ix prebracket]").ShouldBeNull();
+
+        (await table.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    /// <summary>
+    ///     Emitting the caller's brackets is only half of it. The database reports the bare name
+    ///     back, so a model still holding the bracketed spelling never pairs with it and the table
+    ///     drifts on every check — which is what happened before names were normalized on the way
+    ///     in. Every kind of name a caller can bracket is covered here at once.
+    /// </summary>
+    [Fact]
+    public async Task a_table_named_entirely_in_brackets_round_trips_without_drift()
+    {
+        await ResetSchema();
+
+        var parent = new Table("quoting.bracket_parent");
+        parent.AddColumn<int>("id").AsPrimaryKey();
+        await CreateSchemaObjectInDatabase(parent);
+
+        var table = new Table("quoting.bracket_child");
+        table.AddColumn("[id]", "int").AsPrimaryKey();
+        table.AddColumn("[Table]", "varchar(50)").NotNull();
+        table.AddColumn("[parent_id]", "int");
+        table.PrimaryKeyName = "[pk bracket child]";
+        table.CheckConstraints.Add(new TableCheckConstraint("[ck not empty]", "[Table] <> ''"));
+
+        var index = new IndexDefinition("[ix bracket child]") { Columns = ["[Table]"] };
+        index.AddIncludedColumn("[parent_id]");
+        table.Indexes.Add(index);
+
+        table.ForeignKeys.Add(new ForeignKey("[fk bracket child parent]")
+        {
+            ColumnNames = ["[parent_id]"],
+            LinkedNames = ["[id]"],
+            LinkedTable = parent.Identifier
+        });
+
+        await CreateSchemaObjectInDatabase(table);
+
+        (await table.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+
+        // And the model holds what the database reports, not the spelling it was handed.
+        var existing = await table.FetchExistingAsync(theConnection);
+        existing!.PrimaryKeyName.ShouldBe("pk bracket child");
+        existing.IndexFor("ix bracket child")!.Columns.ShouldBe(["Table"]);
+        existing.ForeignKeys.Single().Name.ShouldBe("fk bracket child parent");
     }
 
     [Fact]

--- a/src/Weasel.SqlServer/SchemaUtils.cs
+++ b/src/Weasel.SqlServer/SchemaUtils.cs
@@ -6,14 +6,16 @@ namespace Weasel.SqlServer;
 public static class SchemaUtils
 {
     /// <summary>
-    ///     Wrap a name in brackets unconditionally, escaping any embedded <c>]</c>.
+    ///     Wrap a name in delimiters, escaping any embedded <c>]</c>, unless the caller has
+    ///     already bracketed it themselves.
     /// </summary>
     /// <remarks>
-    ///     For the call sites that have always bracketed. Keeping them on this rather than
-    ///     <see cref="QuoteName" /> means their generated DDL is byte-identical to before.
+    ///     For the call sites that have always bracketed. Ordinary names come out exactly as
+    ///     they did before, so their generated DDL is byte-identical; see <see cref="QuoteName" />
+    ///     for the pass-through rule the two share.
     /// </remarks>
     public static string BracketName(string name)
-        => name.IsEmpty() ? name : $"[{name.Replace("]", "]]")}]";
+        => name.IsEmpty() || IsAlreadyBracketed(name) ? name : Bracket(name);
 
     /// <summary>
     ///     Escape a value being written into a SQL string literal, by doubling its single quotes.
@@ -32,42 +34,49 @@ public static class SchemaUtils
     /// </summary>
     /// <remarks>
     ///     <para>
-    ///         There is deliberately no "it already looks bracketed, leave it alone" shortcut. A name
-    ///         that merely starts with <c>[</c> and ends with <c>]</c> is not necessarily bracketed —
-    ///         it can be an ordinary name that happens to contain both characters, and returning it
-    ///         verbatim let arbitrary DDL through:
-    ///         <c>[ix] ON t(id); DROP TABLE victim; --]</c> passed through untouched and executed.
-    ///         Every name is escaped on its own terms; a name literally called <c>[x]</c> correctly
-    ///         becomes <c>[[x]]]</c>.
+    ///         A name the caller has already bracketed is passed through untouched. Weasel emitted
+    ///         most identifiers bare until 9.25, so bracketing the name yourself was the only way to
+    ///         use one that needed delimiting; re-escaping those now would silently rename the
+    ///         object — a column declared as <c>[Order Date]</c> would be created under the literal
+    ///         name <c>[Order Date]</c>, brackets and all. The cost is that a name genuinely
+    ///         containing its own brackets cannot be expressed, which is the rarer case by far.
+    ///     </para>
+    ///     <para>
+    ///         The pass-through is narrow enough not to be a hole: the name has to be bracketed end
+    ///         to end with every interior <c>]</c> already doubled, which is exactly what
+    ///         <see cref="Bracket" /> produces. A name that merely starts with <c>[</c> and ends
+    ///         with <c>]</c> does not qualify — <c>[ix] ON t(id); DROP TABLE victim; --]</c> carries
+    ///         a lone <c>]</c>, so it is escaped on its own terms and the DDL it is carrying stays
+    ///         inert inside a single delimited identifier.
     ///     </para>
     /// </remarks>
     public static string QuoteName(string name)
-        => name.IsEmpty() || (IsRegularIdentifier(name) && !IsReservedWord(name))
+        => name.IsEmpty() || (IsRegularIdentifier(name) && !IsReservedWord(name)) || IsAlreadyBracketed(name)
             ? name
-            : BracketName(name);
+            : Bracket(name);
 
     /// <summary>
-    ///     Quote one entry of a column list, leaving an entry the caller already bracketed alone.
+    ///     Strip the delimiters off a name the caller bracketed themselves, undoubling any
+    ///     interior <c>]]</c>. A name that is not properly bracketed is returned as it is.
     /// </summary>
     /// <remarks>
-    ///     <para>
-    ///         Column lists were never quoted at all before, so users whose column needed brackets
-    ///         had no option but to bracket it themselves inside the string. Running
-    ///         <see cref="QuoteName" /> over those would re-escape a name that was already correct
-    ///         and emit a column that does not exist. This is the only place that pass-through is
-    ///         safe, and only because it is narrow: the entry must be bracketed end to end with every
-    ///         interior <c>]</c> already doubled, which is exactly the output of
-    ///         <see cref="BracketName" />.
-    ///     </para>
-    ///     <para>
-    ///         That narrowness is what keeps the injection closed. A name merely starting with
-    ///         <c>[</c> and ending with <c>]</c> does not qualify —
-    ///         <c>[ix] ON t(id); DROP TABLE victim; --]</c> contains a lone <c>]</c>, so it is
-    ///         bracketed on its own terms rather than passed through.
-    ///     </para>
+    ///     The inverse of <see cref="Bracket" />, and the counterpart to the pass-through in
+    ///     <see cref="QuoteName" />. Emitting the caller's brackets untouched is only half the
+    ///     job: the database reports the bare name back, and a model still holding the bracketed
+    ///     spelling never compares equal to it, so the table reported drift on every check. The
+    ///     SQL Server model normalizes names through this as they arrive, so what it holds is
+    ///     always the name the database will report.
     /// </remarks>
-    public static string QuoteColumnEntry(string name)
-        => IsAlreadyBracketed(name) ? name : QuoteName(name);
+    public static string Unbracket(string name)
+        => IsAlreadyBracketed(name) ? name.Substring(1, name.Length - 2).Replace("]]", "]") : name;
+
+    /// <summary>
+    ///     Delimit a name unconditionally, with no pass-through. Only for a value that is the
+    ///     object's literal name and cannot have been pre-bracketed by a caller — a database name
+    ///     read out of a connection string, where <c>[</c> and <c>]</c> are part of the name.
+    /// </summary>
+    internal static string Bracket(string name)
+        => $"[{name.Replace("]", "]]")}]";
 
     private static bool IsAlreadyBracketed(string name)
     {

--- a/src/Weasel.SqlServer/SqlServerMigrator.cs
+++ b/src/Weasel.SqlServer/SqlServerMigrator.cs
@@ -280,8 +280,10 @@ IF NOT EXISTS ( SELECT  *
                 var createCmd = adminConn.CreateCommand();
 
                 // CREATE DATABASE takes no parameters, so the name has to be interpolated. Doubling ']'
-                // is what makes it a well-formed delimited identifier.
-                createCmd.CommandText = $"CREATE DATABASE {SchemaUtils.BracketName(databaseName)}";
+                // is what makes it a well-formed delimited identifier. Bracket rather than
+                // BracketName: this name comes off a connection string, where a leading '[' is part
+                // of the name and not a delimiter the caller added.
+                createCmd.CommandText = $"CREATE DATABASE {SchemaUtils.Bracket(databaseName)}";
 
                 try
                 {

--- a/src/Weasel.SqlServer/Tables/ForeignKey.cs
+++ b/src/Weasel.SqlServer/Tables/ForeignKey.cs
@@ -8,20 +8,20 @@ public class ForeignKey: ForeignKeyBase
     private string[] _columnNames = null!;
     private string[] _linkedNames = null!;
 
-    public ForeignKey(string name) : base(name)
+    public ForeignKey(string name) : base(SchemaUtils.Unbracket(name))
     {
     }
 
     public override string[] ColumnNames
     {
         get => _columnNames;
-        set => _columnNames = value.OrderBy(x => x).ToArray();
+        set => _columnNames = value.Select(SchemaUtils.Unbracket).OrderBy(x => x).ToArray();
     }
 
     public override string[] LinkedNames
     {
         get => _linkedNames;
-        set => _linkedNames = value.OrderBy(x => x).ToArray();
+        set => _linkedNames = value.Select(SchemaUtils.Unbracket).OrderBy(x => x).ToArray();
     }
 
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -92,8 +92,8 @@ public class ForeignKey: ForeignKeyBase
     {
         writer.WriteLine($"ALTER TABLE {parent.Identifier}");
         writer.WriteLine(
-            $"ADD CONSTRAINT {SchemaUtils.QuoteName(Name)} FOREIGN KEY({ColumnNames.Select(SchemaUtils.QuoteColumnEntry).Join(", ")})");
-        writer.Write($" REFERENCES {LinkedTable}({LinkedNames.Select(SchemaUtils.QuoteColumnEntry).Join(", ")})");
+            $"ADD CONSTRAINT {SchemaUtils.QuoteName(Name)} FOREIGN KEY({ColumnNames.Select(SchemaUtils.QuoteName).Join(", ")})");
+        writer.Write($" REFERENCES {LinkedTable}({LinkedNames.Select(SchemaUtils.QuoteName).Join(", ")})");
         writer.WriteCascadeAction("ON DELETE", OnDelete);
         writer.WriteCascadeAction("ON UPDATE", OnUpdate);
         writer.Write(";");

--- a/src/Weasel.SqlServer/Tables/IndexDefinition.cs
+++ b/src/Weasel.SqlServer/Tables/IndexDefinition.cs
@@ -13,7 +13,7 @@ public class IndexDefinition: ITableIndex
 
     public IndexDefinition(string indexName)
     {
-        _indexName = indexName;
+        _indexName = SchemaUtils.Unbracket(indexName);
     }
 
     protected IndexDefinition()
@@ -30,7 +30,7 @@ public class IndexDefinition: ITableIndex
         set
         {
             _columns.Clear();
-            _columns.AddRange(value);
+            _columns.AddRange(value.Select(SchemaUtils.Unbracket));
         }
     }
 
@@ -40,7 +40,7 @@ public class IndexDefinition: ITableIndex
         set
         {
             _includedColumns.Clear();
-            _includedColumns.AddRange(value);
+            _includedColumns.AddRange(value.Select(SchemaUtils.Unbracket));
         }
     }
 
@@ -86,7 +86,7 @@ public class IndexDefinition: ITableIndex
 
             return deriveIndexName();
         }
-        set => _indexName = value;
+        set => _indexName = SchemaUtils.Unbracket(value);
     }
 
     protected virtual string deriveIndexName()
@@ -102,7 +102,7 @@ public class IndexDefinition: ITableIndex
     public IndexDefinition AgainstColumns(params string[] columns)
     {
         _columns.Clear();
-        _columns.AddRange(columns);
+        _columns.AddRange(columns.Select(SchemaUtils.Unbracket));
         return this;
     }
 
@@ -142,7 +142,7 @@ public class IndexDefinition: ITableIndex
         if (_includedColumns.Any())
         {
             builder.Append(" INCLUDE (");
-            builder.Append(_includedColumns.Select(SchemaUtils.QuoteColumnEntry).Join(", "));
+            builder.Append(_includedColumns.Select(SchemaUtils.QuoteName).Join(", "));
             builder.Append(')');
         }
 
@@ -172,7 +172,7 @@ public class IndexDefinition: ITableIndex
 
         // Quoted: a column named "Table" (or any other reserved word) is legal in SQL Server and
         // turns up in real schemas. QuoteName leaves ordinary identifiers untouched.
-        var expression = Columns.Select(SchemaUtils.QuoteColumnEntry).Join(", ");
+        var expression = Columns.Select(SchemaUtils.QuoteName).Join(", ");
 
         if (SortOrder != SortOrder.Asc)
         {
@@ -224,11 +224,11 @@ public class IndexDefinition: ITableIndex
 
     public void AddColumn(string columnName)
     {
-        _columns.Add(columnName);
+        _columns.Add(SchemaUtils.Unbracket(columnName));
     }
 
     public void AddIncludedColumn(string columnName)
     {
-        _includedColumns.Add(columnName);
+        _includedColumns.Add(SchemaUtils.Unbracket(columnName));
     }
 }

--- a/src/Weasel.SqlServer/Tables/ItemDelta.cs
+++ b/src/Weasel.SqlServer/Tables/ItemDelta.cs
@@ -13,11 +13,11 @@ internal class ItemDelta<T> where T : INamed
     {
         comparison ??= (expected, actual) => expected.Equals(actual);
         // SQL Server identifiers are case-insensitive under the default collation
-        var expecteds = expectedItems.ToDictionary(x => x.Name, StringComparer.OrdinalIgnoreCase);
+        var expecteds = expectedItems.ToDictionary(NameKey, StringComparer.OrdinalIgnoreCase);
 
         foreach (var actual in actualItems)
         {
-            if (expecteds.TryGetValue(actual.Name, out var expected))
+            if (expecteds.TryGetValue(NameKey(actual), out var expected))
             {
                 if (comparison(expected, actual))
                 {
@@ -34,9 +34,17 @@ internal class ItemDelta<T> where T : INamed
             }
         }
 
-        var actuals = actualItems.ToDictionary(x => x.Name, StringComparer.OrdinalIgnoreCase);
-        _missing.AddRange(expectedItems.Where(x => !actuals.ContainsKey(x.Name)));
+        var actuals = actualItems.ToDictionary(NameKey, StringComparer.OrdinalIgnoreCase);
+        _missing.AddRange(expectedItems.Where(x => !actuals.ContainsKey(NameKey(x))));
     }
+
+    /// <summary>
+    ///     Pair on the undelimited name. The provider's own types normalize as names arrive,
+    ///     but <see cref="TableCheckConstraint" /> is a shared Weasel.Core type the caller
+    ///     constructs directly, so a name they bracketed themselves reaches the comparison
+    ///     as-is and would never match the bare name the database reports.
+    /// </summary>
+    private static string NameKey(T item) => SchemaUtils.Unbracket(item.Name);
 
     public IReadOnlyList<Change<T>> Different => _different;
 

--- a/src/Weasel.SqlServer/Tables/Table.cs
+++ b/src/Weasel.SqlServer/Tables/Table.cs
@@ -44,6 +44,9 @@ public partial class Table: TableBase<TableColumn, IndexDefinition, ForeignKey>
         _columns.Where(x => x.IsPrimaryKey).Select(x => x.Name).ToList();
 
     /// <inheritdoc />
+    /// <inheritdoc />
+    protected override string NormalizeIdentifier(string name) => SchemaUtils.Unbracket(name);
+
     protected override string DefaultPrimaryKeyName()
         => $"pkey_{Identifier.Name}_{PrimaryKeyColumns.Join("_")}";
 
@@ -280,7 +283,7 @@ public partial class Table: TableBase<TableColumn, IndexDefinition, ForeignKey>
         // Bracketed: EF6 databases carry a primary key literally named "PK_dbo.__MigrationHistory",
         // and an unquoted dot ends the identifier.
         return
-            $"CONSTRAINT {SchemaUtils.QuoteName(PrimaryKeyName)} PRIMARY KEY ({PrimaryKeyColumns.Select(SchemaUtils.QuoteColumnEntry).Join(", ")})";
+            $"CONSTRAINT {SchemaUtils.QuoteName(PrimaryKeyName)} PRIMARY KEY ({PrimaryKeyColumns.Select(SchemaUtils.QuoteName).Join(", ")})";
     }
 
     internal static string CheckConstraintDeclaration(TableCheckConstraint constraint)

--- a/src/Weasel.SqlServer/Tables/TableColumn.cs
+++ b/src/Weasel.SqlServer/Tables/TableColumn.cs
@@ -22,7 +22,9 @@ public class TableColumn: ITableColumn
         // by default but legacy schemas often use PascalCase. Lowercasing here
         // produced duplicate-column DDL when callers added the same logical column
         // with different casings (issue: JasperFx/polecat#45).
-        Name = name.Trim().Replace(' ', '_');
+        // Unbracketed first: a caller who wrote "[Order Date]" means the column Order Date,
+        // and the database will report it back that way.
+        Name = SchemaUtils.Unbracket(name.Trim()).Replace(' ', '_');
         Type = type.ToLowerInvariant();
     }
 

--- a/src/Weasel.SqlServer/Tables/TableDelta.cs
+++ b/src/Weasel.SqlServer/Tables/TableDelta.cs
@@ -44,9 +44,10 @@ public class TableDelta: SchemaObjectDelta<Table>
         // table declares participate, and actual constraints the expected table
         // doesn't know about are never treated as extras to drop.
         var relevantActualChecks = actual.CheckConstraints
-            .Where(a => expected.CheckConstraints.Any(e => e.Name.Equals(a.Name, StringComparison.OrdinalIgnoreCase)));
+            .Where(a => expected.CheckConstraints.Any(e =>
+                SchemaUtils.Unbracket(e.Name).Equals(SchemaUtils.Unbracket(a.Name), StringComparison.OrdinalIgnoreCase)));
         CheckConstraints = new ItemDelta<TableCheckConstraint>(expected.CheckConstraints, relevantActualChecks,
-            (e, a) => e.Matches(a));
+            checkConstraintsMatch);
 
         PrimaryKeyDifference = SchemaPatchDifference.None;
         if (expected.PrimaryKeyName.IsEmpty())
@@ -82,6 +83,16 @@ public class TableDelta: SchemaObjectDelta<Table>
 
         return determinePatchDifference();
     }
+
+    /// <summary>
+    ///     <see cref="TableCheckConstraint.Matches" /> compares names verbatim, and a name the
+    ///     caller bracketed themselves never equals the bare name the catalog reports back.
+    ///     Pairing has already matched the two on the undelimited name by this point, so all
+    ///     that is left to decide is whether the expression changed.
+    /// </summary>
+    private static bool checkConstraintsMatch(TableCheckConstraint expected, TableCheckConstraint actual)
+        => TableCheckConstraint.Canonicalize(expected.Expression)
+           == TableCheckConstraint.Canonicalize(actual.Expression);
 
     public override void WriteUpdate(Migrator rules, TextWriter writer)
     {


### PR DESCRIPTION
Follow-up to #443, which started quoting SQL Server identifiers. That change re-escaped names callers had already bracketed themselves — and it applied the pass-through that would have prevented it to column list entries only.

## The workaround it broke

Weasel emitted most identifiers bare until #443, so bracketing the name yourself was the only way to use one that needed delimiting. After #443:

```csharp
table.AddColumn("[Order Date]", "datetime2");          // column created as "[Order Date]", brackets and all
table.Indexes.Add(new IndexDefinition("[my index]"));  // CREATE INDEX [[my index]]] — a different index
```

`QuoteColumnEntry` passed a properly bracketed entry through, but only in index and foreign key **column lists**. `QuoteName` — index names, constraint names, primary key names — and `TableColumn.QuotedName` had no pass-through at all. So the same workaround survived in one half of a statement and renamed the object in the other: an index declared over `[Table]` resolved correctly, while the index's own bracketed name did not.

## One rule, everywhere

`QuoteName` now passes through a name that is already properly bracketed, and `QuoteColumnEntry` is gone — its four call sites use `QuoteName` like everything else. `BracketName`, for the sites that have always bracketed, honours the same rule while still bracketing ordinary names byte-identically, so check-constraint and schema DDL is unchanged.

The pass-through stays narrow enough not to reopen what #443 guarded against: the name has to be bracketed end to end with every interior `]` already doubled. `[ix] ON t(id); DROP TABLE victim; --]` carries a lone `]`, so it is escaped on its own terms and #443's injection test still passes. `[a]b]`, `[unbalanced` and `unbalanced]` are covered explicitly.

`CREATE DATABASE` moves to a raw `Bracket` with no pass-through. That name comes off a connection string, where a leading `[` is part of the name rather than a delimiter a caller added.

## The half that emission does not fix

Emitting the caller's brackets is only half the job. The database reports the bare name back, so a model still holding the bracketed spelling never pairs with it and the table reports drift on **every** check. That predates #443 — the name was emitted raw and drifted the same way; #443 made it worse by creating a literally-bracketed object.

Names are normalized as they arrive now:

- `IndexDefinition`, `TableColumn` and `ForeignKey` unbracket their own names and column lists.
- `TableBase` gains a `NormalizeIdentifier` hook, called from the `PrimaryKeyName` setter. **Only SQL Server overrides it** — every other provider gets the identity function and no behaviour change.
- `TableCheckConstraint` is a Weasel.Core type callers construct directly, with no setter to intercept, so SQL Server's `ItemDelta` pairs on the undelimited name.

That last one surfaced a second leak the pairing fix alone did not close: `TableCheckConstraint.Matches` compares names verbatim, so a paired constraint still came back `Different` and generated a drop-and-re-add on every migration. Pairing has already matched the two by name at that point, so SQL Server's `TableDelta` now decides on the canonicalized expression alone.

## Compatibility

A name that genuinely contains its own brackets can no longer be expressed — `[x]` names the object `x`, not `[x]`. That is the trade for making the workaround work, and it is the rarer case by far. Ordinary schemas are unaffected: a regular identifier is still emitted bare and an always-bracketed site still brackets, so their DDL is byte-identical.

## Testing

Eight new or rewritten tests in `identifier_quoting`, all of which fail on `master`. The broadest is a round trip where the table's primary key, column, index, included column, foreign key and check constraint names are *every one* bracketed by the caller: it asserts no drift, and that introspection reports the bare names back.

`Weasel.SqlServer.Tests` is green at 420 (8 skipped). Because `TableBase` is shared, the other suites were run too: Postgres 855, SQLite 401, MySql 246, Core 75 — all green. `Weasel.slnx` builds with 0 errors.

Oracle was not run locally; CI covers it. The Core change is a default no-op Oracle never overrides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
