### PR TITLE
test(postgresql): serialize every fixture that mutates the public schema

### DIFF
--- a/src/Weasel.Postgresql.Tests/Migrations/schema_fingerprint_colocated_tests.cs
+++ b/src/Weasel.Postgresql.Tests/Migrations/schema_fingerprint_colocated_tests.cs
@@ -13,9 +13,10 @@ namespace Weasel.Postgresql.Tests.Migrations;
 /// its own, every apply ran in full, and each one paid an extra SELECT and upsert for the privilege:
 /// measurably slower than leaving fingerprinting off. Exactly the topology it was meant to help.
 /// </summary>
-// Same collection as schema_fingerprint_tests: both fixtures share public.weasel_schema_fingerprints
-// and drop it on setup, so they must not run in parallel.
-[Collection("fingerprint")]
+// The stamp table lives in the migrator's default schema, which PostgresqlMigrator hardcodes to
+// "public" -- so every fixture that mutates the public schema has to be serialized against this one,
+// not just the fixtures that read the stamps. That is the whole "public schema" collection.
+[Collection("public schema")]
 public class schema_fingerprint_colocated_tests: IntegrationContext, IAsyncLifetime
 {
     private const string OtherSchema = "fingerprint_colocated_other";

--- a/src/Weasel.Postgresql.Tests/Migrations/schema_fingerprint_tests.cs
+++ b/src/Weasel.Postgresql.Tests/Migrations/schema_fingerprint_tests.cs
@@ -14,7 +14,7 @@ namespace Weasel.Postgresql.Tests.Migrations;
 /// verification route. Any configuration change (new table/column/partition) changes the hash and
 /// re-enables the full apply.
 /// </summary>
-[Collection("fingerprint")]
+[Collection("public schema")]
 public class schema_fingerprint_tests: IntegrationContext, IAsyncLifetime
 {
     private readonly TestDatabaseWithTables theDatabase;

--- a/src/Weasel.Postgresql.Tests/create_and_teardown_schemas.cs
+++ b/src/Weasel.Postgresql.Tests/create_and_teardown_schemas.cs
@@ -6,7 +6,11 @@ using Xunit;
 
 namespace Weasel.Postgresql.Tests;
 
-[Collection("schemas")]
+// Shares a collection with the schema fingerprint fixtures. The [InlineData("public")] case below
+// calls ResetSchemaAsync("public"), which is a DROP SCHEMA ... CASCADE followed by a CREATE -- it
+// takes public.weasel_schema_fingerprints with it. Run in parallel with a fingerprint test, that
+// surfaces over there as "relation public.weasel_schema_fingerprints does not exist" (weasel#440).
+[Collection("public schema")]
 public class create_and_teardown_schemas: IntegrationContext
 {
     public create_and_teardown_schemas(): base("schemas")


### PR DESCRIPTION
Follow-up to the intermittent Postgres CI failure that interrupted #445 and #446. Both times the schema fingerprint fixtures failed with

```
Npgsql.PostgresException : 42P01: relation "public.weasel_schema_fingerprints" does not exist
```

on a different test method and a different matrix leg each time — `co_located_databases_each_keep_their_own_stamp` on net9.0/case-sensitive-true, then `interleaved_applies_do_not_invalidate_each_other` on net10.0/case-sensitive-false. A flake does not usually move around inside one class like that.

## What was actually racing

The stamp table lives in the migrator's default schema, and `PostgresqlMigrator` hardcodes that to `public`. `schema_fingerprint_tests` and `schema_fingerprint_colocated_tests` already shared `[Collection("fingerprint")]`, so they could not race each other — that part of the original comment was right, and it is why the obvious explanation is the wrong one.

What they *could* race is `create_and_teardown_schemas`, sitting in `[Collection("schemas")]` and therefore running in parallel. Its `[InlineData("public")]` case calls `ResetSchemaAsync("public")`, which is `drop schema if exists public cascade` followed by a `create` ([SchemaObjectsExtensions.cs:114](https://github.com/JasperFx/weasel/blob/master/src/Weasel.Postgresql/SchemaObjectsExtensions.cs#L114)). Landing mid-flight, it takes `public.weasel_schema_fingerprints` with it, and the fingerprint test reports it missing.

## The change

All three fixtures share one collection, named for the resource it guards — `public schema` — rather than for one of its users. The next fixture that mutates the public schema now has an obvious place to go, instead of the current situation where the constraint is invisible until CI trips over it.

`schemas` had exactly one member, so nothing else loses parallelism.

## Verification

By construction, not by reproduction, and worth being explicit about: the race needs a narrow window and did **not** surface in five local runs of the two fixtures together against `2e159f5`. A collection is xUnit's serialization guarantee, so the overlap that caused this can no longer occur — but I cannot show you a red-to-green reproduction, and I would rather say so than imply I proved more than I did.

`Weasel.Postgresql.Tests` is green at 855 (3 skipped), and the two fixtures pass three consecutive runs together.

## Not fixed here

The underlying sharpness is that the fingerprint stamp table has no way to live anywhere but the migrator's default schema, so tests cannot isolate it by configuration. Making `PostgresqlMigrator`'s default schema constructible would remove the need for the collection entirely — worth considering, but it is a product change and does not belong in a test-isolation fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
