### PR TITLE
feat(core): an identifier rules contract, and a conformance suite to hold it

### DIFF
--- a/.github/workflows/ci-build-core.yml
+++ b/.github/workflows/ci-build-core.yml
@@ -1,0 +1,48 @@
+name: Core CI Build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  config: Release
+  DOTNET_CLI_TELEMETRY_OPTOUT: 1
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    strategy:
+      matrix:
+        framework:
+          - net9.0
+          - net10.0
+
+    name: Core ${{ matrix.framework }}
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Install .NET
+      uses: actions/setup-dotnet@v5
+      with:
+          dotnet-version: |
+              9.0.x
+              10.0.x
+
+    - name: Restore dependencies
+      run: dotnet restore
+
+    - name: Build
+      run: dotnet build --no-restore --configuration ${{ env.config }}
+
+    # Weasel.Core.Tests was not run by any workflow before this one. No services needed:
+    # these are unit tests, including the cross-provider identifier conformance suite,
+    # which is pure string logic against each provider's IdentifierRules.
+    - name: Test
+      run: dotnet test src/Weasel.Core.Tests/Weasel.Core.Tests.csproj --no-build --verbosity normal --configuration ${{ env.config }} --framework ${{ matrix.framework }}

--- a/src/Weasel.Core.Tests/Weasel.Core.Tests.csproj
+++ b/src/Weasel.Core.Tests/Weasel.Core.Tests.csproj
@@ -12,6 +12,9 @@
 
     <ItemGroup>
       <ProjectReference Include="..\Weasel.Core\Weasel.Core.csproj" />
+      <!-- Referenced for the cross-provider identifier conformance suite. Pure string logic;
+           no database, no containers. -->
+      <ProjectReference Include="..\Weasel.SqlServer\Weasel.SqlServer.csproj" />
     </ItemGroup>
 
     <Import Project="../../Tests.Build.props" />

--- a/src/Weasel.Core.Tests/identifier_rules_conformance.cs
+++ b/src/Weasel.Core.Tests/identifier_rules_conformance.cs
@@ -1,0 +1,189 @@
+using Shouldly;
+using Weasel.Core;
+using Weasel.SqlServer;
+using Xunit;
+
+namespace Weasel.Core.Tests;
+
+/// <summary>
+///     One suite of hostile names, run against every provider's <see cref="IdentifierRules" />.
+///     The five providers each grew their quoting in isolation and diverged sharply — one could not
+///     escape its own delimiter, one conflated quoting with case folding, one quoted for a
+///     hand-written list of characters and crashed on an empty string. This is the shared floor:
+///     for any name, a provider either quotes it correctly or leaves it correctly bare, and never
+///     emits something that changes which object the name refers to.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Providers join the suite as their fixes land (weasel#447). SQL Server is here because
+///         it is the reference implementation the contract was lifted from. MySQL, SQLite,
+///         PostgreSQL and Oracle each join in the PR that fixes them — adding a provider is one
+///         entry in <see cref="Providers" />.
+///     </para>
+///     <para>
+///         Deliberately pure string logic: no connection, no container, so it runs everywhere and
+///         costs nothing.
+///     </para>
+/// </remarks>
+public class identifier_rules_conformance
+{
+    public static TheoryData<string, IdentifierRules> Providers =>
+        new() { { "SqlServer", SqlServerIdentifierRules.Instance } };
+
+    /// <summary>
+    ///     Names that have to survive a round trip through the dialect. Each one either broke a
+    ///     provider in the wild or is the shape that broke one.
+    /// </summary>
+    public static readonly string[] HostileNames =
+    [
+        "orders",                                   // ordinary
+        "Table",                                    // reserved word
+        "unit price",                               // space
+        "order-date",                               // hyphen
+        "PK_dbo.__MigrationHistory",                // dot: the key EF6 gives its history table
+        "<Name of Missing Index, sysname,>",        // SQL Server's own unfilled template
+        "2ndPlace",                                 // leading digit
+        "Grüße",                                    // non-ASCII letters
+        "MiXeDcAsE",                                // case that must not be folded away
+        "price$",
+        "col#1",
+        "_internal"
+    ];
+
+    [Theory]
+    [MemberData(nameof(Providers))]
+    public void delimiting_round_trips_every_hostile_name(string provider, IdentifierRules rules)
+    {
+        foreach (var name in HostileNames)
+        {
+            rules.Undelimit(rules.Delimit(name))
+                .ShouldBe(name, $"{provider} lost '{name}' delimiting and undelimiting it");
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(Providers))]
+    public void a_delimited_name_is_recognized_as_delimited(string provider, IdentifierRules rules)
+    {
+        foreach (var name in HostileNames)
+        {
+            rules.IsDelimited(rules.Delimit(name))
+                .ShouldBeTrue($"{provider} did not recognize its own output for '{name}'");
+        }
+    }
+
+    /// <summary>
+    ///     A name carrying the close delimiter is where the naive implementations broke: MySQL's
+    ///     <c>$"`{name}`"</c> let it close its own quoting. Doubling has to survive a round trip.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(Providers))]
+    public void an_embedded_close_delimiter_is_escaped_and_round_trips(string provider, IdentifierRules rules)
+    {
+        var delimited = rules.Delimit("a]b\"c`d");
+
+        rules.IsDelimited(delimited).ShouldBeTrue($"{provider} produced output it cannot parse back");
+        rules.Undelimit(delimited).ShouldBe("a]b\"c`d", $"{provider} mangled an embedded delimiter");
+    }
+
+    /// <summary>
+    ///     The pass-through must not become a hole. A name that merely starts and ends with the
+    ///     delimiters is not delimited — an unbalanced interior close character means the DDL it is
+    ///     carrying would escape the identifier.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(Providers))]
+    public void a_name_carrying_ddl_cannot_escape_its_delimiters(string provider, IdentifierRules rules)
+    {
+        foreach (var injection in new[]
+                 {
+                     "[ix] ON t(id); DROP TABLE victim; --]",
+                     "\"ix\" ON t(id); DROP TABLE victim; --\"",
+                     "`ix` ON t(id); DROP TABLE victim; --`"
+                 })
+        {
+            var quoted = rules.Quote(injection);
+
+            // Either it was delimited on its own terms, or it was already delimited end to end
+            // with everything interior escaped. Never passed through with a loose close character.
+            rules.IsDelimited(quoted).ShouldBeTrue($"{provider} left '{injection}' able to escape");
+            rules.Undelimit(quoted).ShouldBe(injection, $"{provider} altered '{injection}'");
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(Providers))]
+    public void quoting_never_changes_which_object_a_name_refers_to(string provider, IdentifierRules rules)
+    {
+        foreach (var name in HostileNames)
+        {
+            var quoted = rules.Quote(name);
+            var resolved = rules.IsDelimited(quoted) ? rules.Undelimit(quoted) : quoted;
+
+            resolved.ShouldBe(name, $"{provider} renamed '{name}' by quoting it");
+        }
+    }
+
+    /// <summary>
+    ///     Weasel emitted most identifiers bare until 9.25, so delimiting the name yourself was the
+    ///     only way to use one that needed it. Re-escaping those would silently rename the object.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(Providers))]
+    public void a_name_the_caller_already_delimited_is_left_alone(string provider, IdentifierRules rules)
+    {
+        foreach (var name in HostileNames)
+        {
+            var alreadyDelimited = rules.Delimit(name);
+
+            rules.Quote(alreadyDelimited)
+                .ShouldBe(alreadyDelimited, $"{provider} re-escaped an already delimited '{name}'");
+        }
+    }
+
+    /// <summary>
+    ///     SQLite's <c>QuoteName</c> indexed <c>name[0]</c> without checking, so an empty name threw
+    ///     <c>IndexOutOfRangeException</c> where every other provider returned it unchanged.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(Providers))]
+    public void an_empty_name_is_returned_rather_than_throwing(string provider, IdentifierRules rules)
+    {
+        rules.Quote("").ShouldBe("", $"{provider} did not pass an empty name through");
+        rules.Delimit("").ShouldBe("", $"{provider} did not pass an empty name through");
+        rules.Undelimit("").ShouldBe("", $"{provider} did not pass an empty name through");
+        rules.IsDelimited("").ShouldBeFalse($"{provider} called an empty name delimited");
+    }
+
+    [Theory]
+    [MemberData(nameof(Providers))]
+    public void an_ordinary_name_is_left_bare(string provider, IdentifierRules rules)
+    {
+        foreach (var name in new[] { "orders", "_internal", "price$" })
+        {
+            rules.Quote(name).ShouldBe(name, $"{provider} needlessly delimited '{name}'");
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(Providers))]
+    public void a_reserved_word_is_delimited(string provider, IdentifierRules rules)
+    {
+        rules.IsReservedWord("Table").ShouldBeTrue($"{provider} does not know 'Table' is reserved");
+        rules.IsDelimited(rules.Quote("Table")).ShouldBeTrue($"{provider} left a reserved word bare");
+    }
+
+    /// <summary>
+    ///     Object names reach string literals on every provider — existence checks, introspection
+    ///     queries, and PostgreSQL's <c>DEFAULT nextval('...')</c>. This is dialect-independent, so
+    ///     it is asserted once rather than per provider.
+    /// </summary>
+    [Fact]
+    public void a_single_quote_is_doubled_for_a_string_literal()
+    {
+        IdentifierRules.EscapeLiteral("O'Brien").ShouldBe("O''Brien");
+        IdentifierRules.EscapeLiteral("'; drop table victim; --").ShouldBe("''; drop table victim; --");
+        IdentifierRules.EscapeLiteral("").ShouldBe("");
+        IdentifierRules.EscapeLiteral("plain").ShouldBe("plain");
+    }
+}

--- a/src/Weasel.Core/IdentifierRules.cs
+++ b/src/Weasel.Core/IdentifierRules.cs
@@ -1,0 +1,140 @@
+using JasperFx.Core;
+
+namespace Weasel.Core;
+
+/// <summary>
+///     How one dialect delimits, escapes and normalizes identifiers. The five providers each grew
+///     their own <c>SchemaUtils.QuoteName</c> in isolation and diverged sharply — one could not
+///     escape its own delimiter, one conflated quoting with case folding, one quoted for a
+///     hand-written list of characters. This is the shared behaviour, so only what is genuinely
+///     dialect-specific stays per provider: the delimiter pair, what counts as a regular
+///     identifier, and the keyword list.
+/// </summary>
+/// <remarks>
+///     <para>
+///         SQL Server's implementation is the reference — it is the one that has been worked over
+///         (weasel#443, weasel#446) until it handled embedded delimiters, pre-delimited names and
+///         string literals correctly, and this class is that behaviour lifted out.
+///     </para>
+///     <para>
+///         Call sites stay on their provider's static <c>SchemaUtils</c> facade; that facade
+///         delegates here. Nothing in the DDL writers has to change to adopt this.
+///     </para>
+/// </remarks>
+public abstract class IdentifierRules
+{
+    /// <summary>The character that opens a delimited identifier — <c>[</c>, <c>"</c> or a backtick.</summary>
+    protected abstract char Open { get; }
+
+    /// <summary>
+    ///     The character that closes a delimited identifier. Doubling this character is what escapes
+    ///     it, in every dialect Weasel supports.
+    /// </summary>
+    protected abstract char Close { get; }
+
+    /// <summary>Whether the name is one of this dialect's reserved words, and so needs delimiting.</summary>
+    public abstract bool IsReservedWord(string name);
+
+    /// <summary>
+    ///     Whether the name can be written into DDL bare. The rule differs per dialect — which
+    ///     characters may lead, which may follow — so each provider supplies its own.
+    /// </summary>
+    public abstract bool IsRegularIdentifier(string name);
+
+    /// <summary>
+    ///     Whether <see cref="Quote" /> should delimit this name. The default — anything that is not
+    ///     a plain regular identifier, plus reserved words — suits most dialects. A provider
+    ///     overrides it when it needs more: MySQL delimits unconditionally, and PostgreSQL also
+    ///     delimits anything containing an uppercase character, because leaving it bare would let
+    ///     the server fold the case and change which object the name refers to.
+    /// </summary>
+    public virtual bool RequiresDelimiting(string name)
+        => !IsRegularIdentifier(name) || IsReservedWord(name);
+
+    /// <summary>
+    ///     Whether a name the caller has already delimited is passed through untouched rather than
+    ///     escaped again. On by default, because Weasel emitted most identifiers bare until 9.25 and
+    ///     delimiting the name yourself was the only way to use one that needed it — re-escaping
+    ///     those would silently rename the object.
+    /// </summary>
+    /// <remarks>
+    ///     The cost is that a name genuinely containing its own delimiters cannot be expressed:
+    ///     <c>[x]</c> names the object <c>x</c>. That is the rarer case by a wide margin, but a
+    ///     provider with no such legacy can turn the pass-through off and get the stricter reading.
+    /// </remarks>
+    protected virtual bool PassThroughDelimitedNames => true;
+
+    /// <summary>
+    ///     Delimit unconditionally, escaping any embedded close character. No pass-through — use
+    ///     this only for a value that is the object's literal name and cannot have been delimited by
+    ///     a caller, such as a database name read out of a connection string.
+    /// </summary>
+    public string Delimit(string name)
+        => name.IsEmpty() ? name : $"{Open}{name.Replace(Close.ToString(), $"{Close}{Close}")}{Close}";
+
+    /// <summary>
+    ///     Delimit, unless the caller already did. Ordinary names come out exactly as
+    ///     <see cref="Delimit" /> would leave them, so DDL for a site that has always delimited is
+    ///     byte-identical.
+    /// </summary>
+    public string DelimitIfNeeded(string name)
+        => name.IsEmpty() || (PassThroughDelimitedNames && IsDelimited(name)) ? name : Delimit(name);
+
+    /// <summary>
+    ///     Delimit only when the name cannot be written bare, so DDL for an ordinary schema is
+    ///     unchanged. A name the caller already delimited is passed through.
+    /// </summary>
+    public string Quote(string name)
+        => name.IsEmpty() || !RequiresDelimiting(name) || (PassThroughDelimitedNames && IsDelimited(name))
+            ? name
+            : Delimit(name);
+
+    /// <summary>
+    ///     True when the name is delimited end to end with every interior close character already
+    ///     doubled — exactly what <see cref="Delimit" /> produces, and nothing looser.
+    /// </summary>
+    /// <remarks>
+    ///     The narrowness is what keeps the pass-through from being a hole. A name that merely
+    ///     starts and ends with the delimiters does not qualify:
+    ///     <c>[ix] ON t(id); DROP TABLE victim; --]</c> carries a lone <c>]</c>, so it is escaped on
+    ///     its own terms and the DDL it is carrying stays inert inside one delimited identifier.
+    /// </remarks>
+    public bool IsDelimited(string name)
+    {
+        if (name.IsEmpty() || name.Length < 2 || name[0] != Open || name[^1] != Close)
+        {
+            return false;
+        }
+
+        var inner = name.Substring(1, name.Length - 2);
+        return !inner.Replace($"{Close}{Close}", "").Contains(Close);
+    }
+
+    /// <summary>
+    ///     Strip the delimiters off a name the caller delimited, undoubling any interior close
+    ///     character. A name that is not properly delimited is returned as it is.
+    /// </summary>
+    /// <remarks>
+    ///     The counterpart to the pass-through in <see cref="Quote" />, and the half that is easy to
+    ///     miss. Emitting the caller's delimiters untouched still leaves the model holding the
+    ///     delimited spelling, while the database reports the bare name — so the two never compare
+    ///     equal and the object reports drift on every check. A provider normalizes names through
+    ///     this as they arrive so that what the model holds is what the database will report.
+    /// </remarks>
+    public string Undelimit(string name)
+        => IsDelimited(name)
+            ? name.Substring(1, name.Length - 2).Replace($"{Close}{Close}", Close.ToString())
+            : name;
+
+    /// <summary>
+    ///     Escape a value being written into a SQL string literal, by doubling its single quotes.
+    /// </summary>
+    /// <remarks>
+    ///     Object names reach string literals on every provider — existence checks and introspection
+    ///     queries interpolate them, and PostgreSQL writes a sequence's name into one for a column
+    ///     default. Delimiting is the wrong tool there: a literal is terminated by <c>'</c>, not by
+    ///     the identifier delimiter.
+    /// </remarks>
+    public static string EscapeLiteral(string value)
+        => value.IsEmpty() ? value : value.Replace("'", "''");
+}

--- a/src/Weasel.SqlServer/SchemaUtils.cs
+++ b/src/Weasel.SqlServer/SchemaUtils.cs
@@ -1,93 +1,20 @@
 using JasperFx.Core;
-using System.Text.RegularExpressions;
+using Weasel.Core;
 
 namespace Weasel.SqlServer;
 
-public static class SchemaUtils
+/// <summary>
+///     SQL Server's identifier rules. Everything that is not dialect-specific — delimiting,
+///     escaping, the already-delimited pass-through, undelimiting, string literal escaping —
+///     lives in <see cref="IdentifierRules" />; what stays here is the delimiter pair, SQL
+///     Server's regular-identifier rule, and its keyword list.
+/// </summary>
+public sealed class SqlServerIdentifierRules: IdentifierRules
 {
-    /// <summary>
-    ///     Wrap a name in delimiters, escaping any embedded <c>]</c>, unless the caller has
-    ///     already bracketed it themselves.
-    /// </summary>
-    /// <remarks>
-    ///     For the call sites that have always bracketed. Ordinary names come out exactly as
-    ///     they did before, so their generated DDL is byte-identical; see <see cref="QuoteName" />
-    ///     for the pass-through rule the two share.
-    /// </remarks>
-    public static string BracketName(string name)
-        => name.IsEmpty() || IsAlreadyBracketed(name) ? name : Bracket(name);
+    public static readonly SqlServerIdentifierRules Instance = new();
 
-    /// <summary>
-    ///     Escape a value being written into a SQL string literal, by doubling its single quotes.
-    /// </summary>
-    /// <remarks>
-    ///     Object names reach string literals in the introspection and drift-correction queries
-    ///     (<c>OBJECT_ID('...')</c>, <c>c.name = '...'</c>). Bracketing is the wrong tool there — a
-    ///     literal is terminated by <c>'</c>, not by <c>]</c>.
-    /// </remarks>
-    public static string EscapeLiteral(string value)
-        => value.IsEmpty() ? value : value.Replace("'", "''");
-
-    /// <summary>
-    ///     Bracket a name only when it is not a regular SQL Server identifier, so DDL for an
-    ///     ordinary schema is unchanged.
-    /// </summary>
-    /// <remarks>
-    ///     <para>
-    ///         A name the caller has already bracketed is passed through untouched. Weasel emitted
-    ///         most identifiers bare until 9.25, so bracketing the name yourself was the only way to
-    ///         use one that needed delimiting; re-escaping those now would silently rename the
-    ///         object — a column declared as <c>[Order Date]</c> would be created under the literal
-    ///         name <c>[Order Date]</c>, brackets and all. The cost is that a name genuinely
-    ///         containing its own brackets cannot be expressed, which is the rarer case by far.
-    ///     </para>
-    ///     <para>
-    ///         The pass-through is narrow enough not to be a hole: the name has to be bracketed end
-    ///         to end with every interior <c>]</c> already doubled, which is exactly what
-    ///         <see cref="Bracket" /> produces. A name that merely starts with <c>[</c> and ends
-    ///         with <c>]</c> does not qualify — <c>[ix] ON t(id); DROP TABLE victim; --]</c> carries
-    ///         a lone <c>]</c>, so it is escaped on its own terms and the DDL it is carrying stays
-    ///         inert inside a single delimited identifier.
-    ///     </para>
-    /// </remarks>
-    public static string QuoteName(string name)
-        => name.IsEmpty() || (IsRegularIdentifier(name) && !IsReservedWord(name)) || IsAlreadyBracketed(name)
-            ? name
-            : Bracket(name);
-
-    /// <summary>
-    ///     Strip the delimiters off a name the caller bracketed themselves, undoubling any
-    ///     interior <c>]]</c>. A name that is not properly bracketed is returned as it is.
-    /// </summary>
-    /// <remarks>
-    ///     The inverse of <see cref="Bracket" />, and the counterpart to the pass-through in
-    ///     <see cref="QuoteName" />. Emitting the caller's brackets untouched is only half the
-    ///     job: the database reports the bare name back, and a model still holding the bracketed
-    ///     spelling never compares equal to it, so the table reported drift on every check. The
-    ///     SQL Server model normalizes names through this as they arrive, so what it holds is
-    ///     always the name the database will report.
-    /// </remarks>
-    public static string Unbracket(string name)
-        => IsAlreadyBracketed(name) ? name.Substring(1, name.Length - 2).Replace("]]", "]") : name;
-
-    /// <summary>
-    ///     Delimit a name unconditionally, with no pass-through. Only for a value that is the
-    ///     object's literal name and cannot have been pre-bracketed by a caller — a database name
-    ///     read out of a connection string, where <c>[</c> and <c>]</c> are part of the name.
-    /// </summary>
-    internal static string Bracket(string name)
-        => $"[{name.Replace("]", "]]")}]";
-
-    private static bool IsAlreadyBracketed(string name)
-    {
-        if (name.IsEmpty() || name.Length < 2 || name[0] != '[' || name[^1] != ']')
-        {
-            return false;
-        }
-
-        var inner = name.Substring(1, name.Length - 2);
-        return !inner.Replace("]]", "").Contains(']');
-    }
+    protected override char Open => '[';
+    protected override char Close => ']';
 
     /// <summary>
     ///     A regular identifier: a letter, <c>_</c> or <c>#</c> first, then letters, digits,
@@ -101,8 +28,8 @@ public static class SchemaUtils
     ///     excluded — it is accepted unbracketed for a column or an index, and bracketing does not
     ///     change its meaning anywhere (<c>[#t]</c> is still a temp table), so excluding it would
     ///     only churn DDL for no benefit.
-    /// </summary>
-    public static bool IsRegularIdentifier(string name)
+    /// </remarks>
+    public override bool IsRegularIdentifier(string name)
     {
         if (name.IsEmpty())
         {
@@ -126,7 +53,7 @@ public static class SchemaUtils
         return true;
     }
 
-    public static bool IsReservedWord(string name)
+    public override bool IsReservedWord(string name)
         => ReservedKeywords.Contains(name, StringComparer.InvariantCultureIgnoreCase);
 
     private static readonly string[] ReservedKeywords =
@@ -318,4 +245,33 @@ public static class SchemaUtils
         "PROC",
         "RANK"
     ];
+}
+
+/// <summary>
+///     The static facade the SQL Server DDL writers call. Delegates to
+///     <see cref="SqlServerIdentifierRules" />; the behaviour and the doc comments for each
+///     operation live there and in <see cref="IdentifierRules" />.
+/// </summary>
+public static class SchemaUtils
+{
+    /// <inheritdoc cref="IdentifierRules.DelimitIfNeeded" />
+    public static string BracketName(string name) => SqlServerIdentifierRules.Instance.DelimitIfNeeded(name);
+
+    /// <inheritdoc cref="IdentifierRules.EscapeLiteral" />
+    public static string EscapeLiteral(string value) => IdentifierRules.EscapeLiteral(value);
+
+    /// <inheritdoc cref="IdentifierRules.Quote" />
+    public static string QuoteName(string name) => SqlServerIdentifierRules.Instance.Quote(name);
+
+    /// <inheritdoc cref="IdentifierRules.Undelimit" />
+    public static string Unbracket(string name) => SqlServerIdentifierRules.Instance.Undelimit(name);
+
+    /// <inheritdoc cref="IdentifierRules.Delimit" />
+    internal static string Bracket(string name) => SqlServerIdentifierRules.Instance.Delimit(name);
+
+    /// <inheritdoc cref="IdentifierRules.IsRegularIdentifier" />
+    public static bool IsRegularIdentifier(string name) => SqlServerIdentifierRules.Instance.IsRegularIdentifier(name);
+
+    /// <inheritdoc cref="IdentifierRules.IsReservedWord" />
+    public static bool IsReservedWord(string name) => SqlServerIdentifierRules.Instance.IsReservedWord(name);
 }


### PR DESCRIPTION
First slice of #447. This is the contract and the test harness; the four provider fixes follow as separate PRs, each joining the conformance suite as it lands.

## What this does

**`IdentifierRules` in Weasel.Core.** The five providers each grew their own `SchemaUtils.QuoteName` in isolation, and the divergence is severe — MySQL cannot escape its own delimiter, Oracle conflates quoting with case folding, PostgreSQL quotes for case but not for shape, SQLite quotes for a hand-written list of characters and throws on an empty name. SQL Server is the only one that has been worked over until it was right, across #443 and #446.

`IdentifierRules` is that behaviour lifted out. Written once: delimiting, escaping an embedded close character, the already-delimited pass-through, undelimiting, and string literal escaping. Left per provider: the delimiter pair, the regular-identifier rule, and the keyword list.

**Nothing in the DDL writers changes.** Each provider keeps its static `SchemaUtils` facade and the facade delegates. That is what makes the remaining four fixes small.

**SQL Server is refitted onto it, with no behaviour change.** Its 420 tests are the evidence the abstraction holds — they pin the exact output of the implementation the contract was lifted from, so if the generalization were lossy they would say so.

**The conformance suite** runs one set of hostile names against every participating provider: reserved word, space, hyphen, dot, leading digit, non-ASCII, mixed case, embedded delimiter, a name carrying trailing DDL, and the empty string. The invariant each provider has to hold is that a name either quotes correctly or stays correctly bare, and never comes back naming a different object.

Providers join as their fixes land — one entry in the `Providers` table. Today that is SQL Server alone, deliberately: adding a provider before fixing it would just be a red build.

## A gap this turned up

**`Weasel.Core.Tests` was not run by any CI workflow.** Not by the postgres, mssql, mysql, oracle, sqlite or efcore build — 75 existing unit tests that never executed. `ci-build-core.yml` runs it now, on both TFMs, with no services since these are unit tests.

That is also why the conformance suite lives in `Weasel.Core.Tests` rather than being split across the provider test projects: one place, no containers, and it runs on every PR.

## Testing

`Weasel.Core.Tests` 85 (75 existing + 10 new), `Weasel.SqlServer.Tests` 420 with 8 skipped, solution builds with 0 errors.

## Next in #447

MySQL, SQLite, PostgreSQL and Oracle, one PR each, each adding its provider to the `Providers` table as its fix lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
