### PR TITLE
fix(mysql): escape the delimiter, and normalize names on the way into the model

### DIFF
--- a/src/Weasel.Core.Tests/Weasel.Core.Tests.csproj
+++ b/src/Weasel.Core.Tests/Weasel.Core.Tests.csproj
@@ -14,6 +14,7 @@
       <ProjectReference Include="..\Weasel.Core\Weasel.Core.csproj" />
       <!-- Referenced for the cross-provider identifier conformance suite. Pure string logic;
            no database, no containers. -->
+      <ProjectReference Include="..\Weasel.MySql\Weasel.MySql.csproj" />
       <ProjectReference Include="..\Weasel.SqlServer\Weasel.SqlServer.csproj" />
     </ItemGroup>
 

--- a/src/Weasel.Core.Tests/identifier_rules_conformance.cs
+++ b/src/Weasel.Core.Tests/identifier_rules_conformance.cs
@@ -1,5 +1,6 @@
 using Shouldly;
 using Weasel.Core;
+using Weasel.MySql;
 using Weasel.SqlServer;
 using Xunit;
 
@@ -16,9 +17,9 @@ namespace Weasel.Core.Tests;
 /// <remarks>
 ///     <para>
 ///         Providers join the suite as their fixes land (weasel#447). SQL Server is here because
-///         it is the reference implementation the contract was lifted from. MySQL, SQLite,
-///         PostgreSQL and Oracle each join in the PR that fixes them — adding a provider is one
-///         entry in <see cref="Providers" />.
+///         it is the reference implementation the contract was lifted from, and MySQL joined with
+///         its own fix. SQLite, PostgreSQL and Oracle each join in the PR that fixes them — adding
+///         a provider is one entry in <see cref="Providers" />.
 ///     </para>
 ///     <para>
 ///         Deliberately pure string logic: no connection, no container, so it runs everywhere and
@@ -28,7 +29,11 @@ namespace Weasel.Core.Tests;
 public class identifier_rules_conformance
 {
     public static TheoryData<string, IdentifierRules> Providers =>
-        new() { { "SqlServer", SqlServerIdentifierRules.Instance } };
+        new()
+        {
+            { "SqlServer", SqlServerIdentifierRules.Instance },
+            { "MySql", MySqlIdentifierRules.Instance }
+        };
 
     /// <summary>
     ///     Names that have to survive a round trip through the dialect. Each one either broke a
@@ -155,13 +160,24 @@ public class identifier_rules_conformance
         rules.IsDelimited("").ShouldBeFalse($"{provider} called an empty name delimited");
     }
 
+    /// <summary>
+    ///     Not every dialect quotes conditionally — MySQL delimits every identifier, which is what
+    ///     keeps its generated DDL byte-identical to what it emitted before it could escape its own
+    ///     delimiter. So the invariant is keyed off the provider's own answer: whatever it says does
+    ///     not need delimiting, it has to leave alone.
+    /// </summary>
     [Theory]
     [MemberData(nameof(Providers))]
-    public void an_ordinary_name_is_left_bare(string provider, IdentifierRules rules)
+    public void a_name_that_needs_no_delimiting_is_left_bare(string provider, IdentifierRules rules)
     {
         foreach (var name in new[] { "orders", "_internal", "price$" })
         {
-            rules.Quote(name).ShouldBe(name, $"{provider} needlessly delimited '{name}'");
+            if (rules.RequiresDelimiting(name))
+            {
+                continue;
+            }
+
+            rules.Quote(name).ShouldBe(name, $"{provider} delimited '{name}' after saying it need not be");
         }
     }
 

--- a/src/Weasel.MySql.Tests/Tables/identifier_quoting.cs
+++ b/src/Weasel.MySql.Tests/Tables/identifier_quoting.cs
@@ -1,0 +1,89 @@
+using Shouldly;
+using Weasel.Core;
+using Weasel.MySql.Tables;
+using Xunit;
+
+namespace Weasel.MySql.Tests.Tables;
+
+/// <summary>
+///     MySQL's <c>QuoteName</c> was <c>$"`{name}`"</c> with no doubling, so a name carrying a
+///     backtick closed its own quoting, and 27 further sites interpolated backticks inline without
+///     going through the helper at all. See weasel#447.
+/// </summary>
+public class identifier_quoting: IntegrationContext
+{
+    [Fact]
+    public void an_embedded_backtick_is_doubled_rather_than_closing_the_quoting()
+    {
+        SchemaUtils.QuoteName("we`ird").ShouldBe("`we``ird`");
+        SchemaUtils.Unquote("`we``ird`").ShouldBe("we`ird");
+    }
+
+    [Fact]
+    public void a_name_carrying_ddl_stays_inside_its_delimiters()
+    {
+        var injection = "ix` ON t(id); DROP TABLE victim; --";
+
+        var quoted = SchemaUtils.QuoteName(injection);
+
+        // The backtick is doubled, so the name cannot terminate its own delimiter. The DROP text
+        // survives as inert content inside one identifier.
+        quoted.ShouldBe("`ix`` ON t(id); DROP TABLE victim; --`");
+        SchemaUtils.Unquote(quoted).ShouldBe(injection);
+    }
+
+    [Fact]
+    public void a_name_the_caller_already_quoted_is_left_alone()
+    {
+        SchemaUtils.QuoteName("`orders`").ShouldBe("`orders`");
+        SchemaUtils.QuoteName("`we``ird`").ShouldBe("`we``ird`");
+    }
+
+    /// <summary>
+    ///     The identity half. Emitting the caller's backticks untouched still leaves the model
+    ///     holding the quoted spelling while the catalog reports the bare name, so the two never
+    ///     compare equal and the table drifts on every check — the same defect weasel#446 fixed for
+    ///     SQL Server.
+    /// </summary>
+    [Fact]
+    public void names_the_caller_quoted_are_normalized_on_the_way_into_the_model()
+    {
+        var table = new Table("weasel_testing.quoting_normalized");
+        table.AddColumn("`id`", "int").AsPrimaryKey();
+        table.AddColumn("`order date`", "datetime");
+
+        table.Columns[0].Name.ShouldBe("id");
+        table.Columns[1].Name.ShouldBe("order date");
+
+        var index = new IndexDefinition("`ix quoting`");
+        index.AgainstColumns("`order date`");
+
+        index.Name.ShouldBe("ix quoting");
+        index.Columns.ShouldBe(["order date"]);
+
+        new ForeignKey("`fk quoting`").Name.ShouldBe("fk quoting");
+    }
+
+    [Fact]
+    public async Task a_table_named_entirely_in_backticks_round_trips_without_drift()
+    {
+        await DropTableAsync("`weasel_testing`.`quoting_round_trip`");
+
+        var table = new Table("weasel_testing.quoting_round_trip");
+        table.AddColumn("`id`", "int").AsPrimaryKey();
+        table.AddColumn("`Table`", "varchar(50)");     // reserved word, quoted by the caller
+
+        var index = new IndexDefinition("`ix_quoting_round_trip`");
+        index.AgainstColumns("`Table`");
+        table.Indexes.Add(index);
+
+        await table.CreateAsync(theConnection);
+
+        (await table.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+
+        // And the model holds what the database reports, not the spelling it was handed.
+        var existing = await table.FetchExistingAsync(theConnection);
+        existing!.Columns.Select(x => x.Name).ShouldContain("Table");
+        existing.Indexes.Single().Name.ShouldBe("ix_quoting_round_trip");
+    }
+}

--- a/src/Weasel.MySql/MySqlMigrator.cs
+++ b/src/Weasel.MySql/MySqlMigrator.cs
@@ -77,7 +77,7 @@ public class MySqlMigrator: Migrator
     {
         foreach (var schemaName in schemaNames)
         {
-            writer.WriteLine($"DROP DATABASE IF EXISTS `{schemaName}`;");
+            writer.WriteLine($"DROP DATABASE IF EXISTS {SchemaUtils.QuoteName(schemaName)};");
         }
     }
 
@@ -195,7 +195,7 @@ public class MySqlMigrator: Migrator
 
     public static string CreateDatabaseStatementFor(string databaseName)
     {
-        return $"CREATE DATABASE IF NOT EXISTS `{databaseName}`;";
+        return $"CREATE DATABASE IF NOT EXISTS {SchemaUtils.QuoteName(databaseName)};";
     }
 
     public override async Task EnsureDatabaseExistsAsync(DbConnection connection, CancellationToken ct = default)
@@ -213,7 +213,7 @@ public class MySqlMigrator: Migrator
         await adminConn.OpenAsync(ct).ConfigureAwait(false);
 
         var cmd = adminConn.CreateCommand();
-        cmd.CommandText = $"CREATE DATABASE IF NOT EXISTS `{databaseName}`";
+        cmd.CommandText = $"CREATE DATABASE IF NOT EXISTS {SchemaUtils.QuoteName(databaseName)}";
         await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
     }
 

--- a/src/Weasel.MySql/MySqlObjectName.cs
+++ b/src/Weasel.MySql/MySqlObjectName.cs
@@ -7,8 +7,8 @@ namespace Weasel.MySql;
 public class MySqlObjectName: DbObjectName
 {
     protected override string QuotedQualifiedName => Schema.IsEmpty()
-        ? $"`{Name}`"
-        : $"`{Schema}`.`{Name}`";
+        ? SchemaUtils.QuoteName(Name)
+        : $"{SchemaUtils.QuoteName(Schema)}.{SchemaUtils.QuoteName(Name)}";
 
     public MySqlObjectName(string schema, string name)
         : base(schema, name, ComputeQualifiedName(schema, name))
@@ -18,8 +18,8 @@ public class MySqlObjectName: DbObjectName
     private static string ComputeQualifiedName(string schema, string name)
     {
         return schema.IsEmpty()
-            ? $"`{name}`"
-            : $"`{schema}`.`{name}`";
+            ? SchemaUtils.QuoteName(name)
+            : $"{SchemaUtils.QuoteName(schema)}.{SchemaUtils.QuoteName(name)}";
     }
 
     private MySqlObjectName(DbObjectName dbObjectName): this(dbObjectName.Schema, dbObjectName.Name)

--- a/src/Weasel.MySql/MySqlProvider.cs
+++ b/src/Weasel.MySql/MySqlProvider.cs
@@ -52,7 +52,7 @@ public class MySqlProvider: DatabaseProvider<MySqlCommand, MySqlParameter, MySql
     }
 
     public override string ToQualifiedName(string objectName) =>
-        string.IsNullOrEmpty(objectName) ? objectName : $"`{objectName}`";
+        string.IsNullOrEmpty(objectName) ? objectName : $"{SchemaUtils.QuoteName(objectName)}";
 
     public override DbObjectName Parse(string schemaName, string objectName) =>
         new MySqlObjectName(schemaName, objectName);

--- a/src/Weasel.MySql/SchemaUtils.cs
+++ b/src/Weasel.MySql/SchemaUtils.cs
@@ -1,23 +1,44 @@
+using JasperFx.Core;
+using Weasel.Core;
+
 namespace Weasel.MySql;
 
-public static class SchemaUtils
+/// <summary>
+///     MySQL's identifier rules. Everything that is not dialect-specific lives in
+///     <see cref="IdentifierRules" />; what stays here is the backtick delimiter, MySQL's
+///     regular-identifier rule, and its keyword list.
+/// </summary>
+public sealed class MySqlIdentifierRules: IdentifierRules
 {
-    public static string QuoteName(string name)
+    public static readonly MySqlIdentifierRules Instance = new();
+
+    protected override char Open => '`';
+    protected override char Close => '`';
+
+    /// <summary>
+    ///     MySQL delimits every identifier, which is what it has always done here — keeping it
+    ///     means the generated DDL for an ordinary schema is byte-identical to before. What
+    ///     changes is that an embedded backtick is now doubled instead of closing the quoting.
+    /// </summary>
+    public override bool RequiresDelimiting(string name) => true;
+
+    /// <summary>
+    ///     Unquoted MySQL identifiers permit ASCII letters, digits, <c>_</c> and <c>$</c>, plus
+    ///     extended characters, and may not consist solely of digits. Since
+    ///     <see cref="RequiresDelimiting" /> is always true this only informs callers; it does not
+    ///     gate the quoting.
+    /// </summary>
+    public override bool IsRegularIdentifier(string name)
     {
-        return $"`{name}`";
+        if (name.IsEmpty() || name.All(char.IsDigit))
+        {
+            return false;
+        }
+
+        return name.All(c => char.IsLetterOrDigit(c) || c == '_' || c == '$');
     }
 
-    public static string QuoteQualifiedName(string schema, string name)
-    {
-        return string.IsNullOrEmpty(schema)
-            ? QuoteName(name)
-            : $"{QuoteName(schema)}.{QuoteName(name)}";
-    }
-
-    public static bool IsReservedKeyword(string name)
-    {
-        return ReservedKeywords.Contains(name, StringComparer.OrdinalIgnoreCase);
-    }
+    public override bool IsReservedWord(string name) => ReservedKeywords.Contains(name);
 
     private static readonly HashSet<string> ReservedKeywords = new(StringComparer.OrdinalIgnoreCase)
     {
@@ -43,4 +64,27 @@ public static class SchemaUtils
         "UNLOCK", "UNSIGNED", "UPDATE", "USAGE", "USE", "USING", "VALUES",
         "VARBINARY", "VARCHAR", "WHEN", "WHERE", "WHILE", "WITH", "WRITE", "XOR"
     };
+}
+
+/// <summary>
+///     The static facade the MySQL DDL writers call. Delegates to
+///     <see cref="MySqlIdentifierRules" />.
+/// </summary>
+public static class SchemaUtils
+{
+    /// <inheritdoc cref="IdentifierRules.Quote" />
+    public static string QuoteName(string name) => MySqlIdentifierRules.Instance.Quote(name);
+
+    public static string QuoteQualifiedName(string schema, string name)
+        => string.IsNullOrEmpty(schema)
+            ? QuoteName(name)
+            : $"{QuoteName(schema)}.{QuoteName(name)}";
+
+    /// <inheritdoc cref="IdentifierRules.Undelimit" />
+    public static string Unquote(string name) => MySqlIdentifierRules.Instance.Undelimit(name);
+
+    /// <inheritdoc cref="IdentifierRules.EscapeLiteral" />
+    public static string EscapeLiteral(string value) => IdentifierRules.EscapeLiteral(value);
+
+    public static bool IsReservedKeyword(string name) => MySqlIdentifierRules.Instance.IsReservedWord(name);
 }

--- a/src/Weasel.MySql/Tables/ForeignKey.cs
+++ b/src/Weasel.MySql/Tables/ForeignKey.cs
@@ -9,7 +9,7 @@ public class ForeignKey: ForeignKeyBase
     private readonly List<string> _columnNames = new();
     private readonly List<string> _linkedNames = new();
 
-    public ForeignKey(string name) : base(name)
+    public ForeignKey(string name) : base(SchemaUtils.Unquote(name))
     {
     }
 
@@ -102,9 +102,9 @@ public class ForeignKey: ForeignKeyBase
         }
 
         var builder = new StringBuilder();
-        builder.Append($"ALTER TABLE {parent.Identifier.QualifiedName} ADD CONSTRAINT `{Name}` ");
-        builder.Append($"FOREIGN KEY ({_columnNames.Select(c => $"`{c}`").Join(", ")}) ");
-        builder.Append($"REFERENCES {LinkedTable.QualifiedName} ({_linkedNames.Select(c => $"`{c}`").Join(", ")})");
+        builder.Append($"ALTER TABLE {parent.Identifier.QualifiedName} ADD CONSTRAINT {SchemaUtils.QuoteName(Name)} ");
+        builder.Append($"FOREIGN KEY ({_columnNames.Select(c => $"{SchemaUtils.QuoteName(c)}").Join(", ")}) ");
+        builder.Append($"REFERENCES {LinkedTable.QualifiedName} ({_linkedNames.Select(c => $"{SchemaUtils.QuoteName(c)}").Join(", ")})");
 
         if (OnDelete != CascadeAction.NoAction)
         {

--- a/src/Weasel.MySql/Tables/IndexDefinition.cs
+++ b/src/Weasel.MySql/Tables/IndexDefinition.cs
@@ -11,7 +11,7 @@ public class IndexDefinition: ITableIndex
 
     public IndexDefinition(string indexName)
     {
-        _indexName = indexName;
+        _indexName = SchemaUtils.Unquote(indexName);
     }
 
     protected IndexDefinition()
@@ -28,7 +28,7 @@ public class IndexDefinition: ITableIndex
         set
         {
             _columns.Clear();
-            _columns.AddRange(value);
+            _columns.AddRange(value.Select(SchemaUtils.Unquote));
         }
     }
 
@@ -85,7 +85,7 @@ public class IndexDefinition: ITableIndex
 
             return deriveIndexName();
         }
-        set => _indexName = value;
+        set => _indexName = SchemaUtils.Unquote(value);
     }
 
     protected virtual string deriveIndexName()
@@ -99,7 +99,7 @@ public class IndexDefinition: ITableIndex
     public IndexDefinition AgainstColumns(params string[] columns)
     {
         _columns.Clear();
-        _columns.AddRange(columns);
+        _columns.AddRange(columns.Select(SchemaUtils.Unquote));
         return this;
     }
 
@@ -126,7 +126,7 @@ public class IndexDefinition: ITableIndex
         }
 
         builder.Append("INDEX ");
-        builder.Append($"`{Name}`");
+        builder.Append($"{SchemaUtils.QuoteName(Name)}");
         builder.Append(" ON ");
         builder.Append(parent.Identifier.QualifiedName);
         builder.Append(" ");
@@ -161,7 +161,7 @@ public class IndexDefinition: ITableIndex
 
         var columns = Columns.Select(c =>
         {
-            var col = $"`{c}`";
+            var col = $"{SchemaUtils.QuoteName(c)}";
             if (PrefixLength.HasValue)
             {
                 col += $"({PrefixLength.Value})";
@@ -213,6 +213,6 @@ public class IndexDefinition: ITableIndex
 
     public void AddColumn(string columnName)
     {
-        _columns.Add(columnName);
+        _columns.Add(SchemaUtils.Unquote(columnName));
     }
 }

--- a/src/Weasel.MySql/Tables/Table.cs
+++ b/src/Weasel.MySql/Tables/Table.cs
@@ -37,6 +37,9 @@ public partial class Table: TableBase<TableColumn, IndexDefinition, ForeignKey>
         name as MySqlObjectName ?? MySqlObjectName.From(name);
 
     /// <inheritdoc />
+    protected override string NormalizeIdentifier(string name) => SchemaUtils.Unquote(name);
+
+    /// <inheritdoc />
     public override IReadOnlyList<string> PrimaryKeyColumns =>
         _columns.Where(x => x.IsPrimaryKey).Select(x => x.Name).ToList();
 
@@ -135,7 +138,7 @@ public partial class Table: TableBase<TableColumn, IndexDefinition, ForeignKey>
             // Add inline UNIQUE KEY declarations for AUTO_INCREMENT columns
             foreach (var index in autoIncrementUniqueIndexes)
             {
-                lines.Add($"    UNIQUE KEY `{index.Name}` (`{index.Columns[0]}`)");
+                lines.Add($"    UNIQUE KEY {SchemaUtils.QuoteName(index.Name)} ({SchemaUtils.QuoteName(index.Columns[0])})");
             }
 
             for (var i = 0; i < lines.Count - 1; i++)
@@ -159,7 +162,7 @@ public partial class Table: TableBase<TableColumn, IndexDefinition, ForeignKey>
             // Add inline UNIQUE KEY declarations for AUTO_INCREMENT columns
             foreach (var index in autoIncrementUniqueIndexes)
             {
-                lines.Add($"UNIQUE KEY `{index.Name}` (`{index.Columns[0]}`)");
+                lines.Add($"UNIQUE KEY {SchemaUtils.QuoteName(index.Name)} ({SchemaUtils.QuoteName(index.Columns[0])})");
             }
 
             for (var i = 0; i < lines.Count - 1; i++)
@@ -269,7 +272,7 @@ public partial class Table: TableBase<TableColumn, IndexDefinition, ForeignKey>
 
     internal string PrimaryKeyDeclaration()
     {
-        var columns = PrimaryKeyColumns.Select(c => $"`{c}`").Join(", ");
+        var columns = PrimaryKeyColumns.Select(c => $"{SchemaUtils.QuoteName(c)}").Join(", ");
         return $"    PRIMARY KEY ({columns})";
     }
 

--- a/src/Weasel.MySql/Tables/TableColumn.cs
+++ b/src/Weasel.MySql/Tables/TableColumn.cs
@@ -7,7 +7,10 @@ public class TableColumn: ITableColumn
 {
     public TableColumn(string name, string type)
     {
-        Name = name;
+        // Undelimited on the way in: a caller who wrote `Order Date` means the column
+        // Order Date, and that is the name the catalog will report back. A model holding the
+        // delimited spelling never compares equal to it and drifts on every check.
+        Name = SchemaUtils.Unquote(name);
         Type = type;
     }
 
@@ -19,7 +22,7 @@ public class TableColumn: ITableColumn
     public string? DefaultExpression { get; set; }
     public Table? Parent { get; set; }
 
-    public string QuotedName => $"`{Name}`";
+    public string QuotedName => $"{SchemaUtils.QuoteName(Name)}";
 
     public string RawType()
     {

--- a/src/Weasel.MySql/Tables/TableDelta.cs
+++ b/src/Weasel.MySql/Tables/TableDelta.cs
@@ -252,7 +252,7 @@ public class TableDelta: SchemaObjectDelta<Table>
 
             foreach (var column in Columns.Extras)
             {
-                writer.WriteLine($"ALTER TABLE {Expected.Identifier.QualifiedName} DROP COLUMN `{column.Name}`;");
+                writer.WriteLine($"ALTER TABLE {Expected.Identifier.QualifiedName} DROP COLUMN {SchemaUtils.QuoteName(column.Name)};");
             }
 
             foreach (var change in Columns.Different)
@@ -271,13 +271,13 @@ public class TableDelta: SchemaObjectDelta<Table>
             foreach (var fk in ForeignKeys.Extras)
             {
                 writer.WriteLine(
-                    $"ALTER TABLE {Expected.Identifier.QualifiedName} DROP FOREIGN KEY `{fk.Name}`;");
+                    $"ALTER TABLE {Expected.Identifier.QualifiedName} DROP FOREIGN KEY {SchemaUtils.QuoteName(fk.Name)};");
             }
 
             foreach (var change in ForeignKeys.Different)
             {
                 writer.WriteLine(
-                    $"ALTER TABLE {Expected.Identifier.QualifiedName} DROP FOREIGN KEY `{change.Actual.Name}`;");
+                    $"ALTER TABLE {Expected.Identifier.QualifiedName} DROP FOREIGN KEY {SchemaUtils.QuoteName(change.Actual.Name)};");
             }
         }
 
@@ -285,12 +285,12 @@ public class TableDelta: SchemaObjectDelta<Table>
         {
             foreach (var index in Indexes.Extras)
             {
-                writer.WriteLine($"DROP INDEX `{index.Name}` ON {Expected.Identifier.QualifiedName};");
+                writer.WriteLine($"DROP INDEX {SchemaUtils.QuoteName(index.Name)} ON {Expected.Identifier.QualifiedName};");
             }
 
             foreach (var change in Indexes.Different)
             {
-                writer.WriteLine($"DROP INDEX `{change.Actual.Name}` ON {Expected.Identifier.QualifiedName};");
+                writer.WriteLine($"DROP INDEX {SchemaUtils.QuoteName(change.Actual.Name)} ON {Expected.Identifier.QualifiedName};");
                 writer.WriteLine(change.Expected.ToDDL(Expected));
             }
 
@@ -323,7 +323,7 @@ public class TableDelta: SchemaObjectDelta<Table>
 
             if (Expected.PrimaryKeyColumns.Any())
             {
-                var pkColumns = Expected.PrimaryKeyColumns.Select(c => $"`{c}`").Join(", ");
+                var pkColumns = Expected.PrimaryKeyColumns.Select(c => $"{SchemaUtils.QuoteName(c)}").Join(", ");
                 writer.WriteLine($"ALTER TABLE {Expected.Identifier.QualifiedName} ADD PRIMARY KEY ({pkColumns});");
             }
         }
@@ -342,7 +342,7 @@ public class TableDelta: SchemaObjectDelta<Table>
         {
             foreach (var column in Columns.Missing)
             {
-                writer.WriteLine($"ALTER TABLE {Expected.Identifier.QualifiedName} DROP COLUMN `{column.Name}`;");
+                writer.WriteLine($"ALTER TABLE {Expected.Identifier.QualifiedName} DROP COLUMN {SchemaUtils.QuoteName(column.Name)};");
             }
 
             foreach (var column in Columns.Extras)
@@ -363,7 +363,7 @@ public class TableDelta: SchemaObjectDelta<Table>
         {
             foreach (var index in Indexes.Missing)
             {
-                writer.WriteLine($"DROP INDEX `{index.Name}` ON {Expected.Identifier.QualifiedName};");
+                writer.WriteLine($"DROP INDEX {SchemaUtils.QuoteName(index.Name)} ON {Expected.Identifier.QualifiedName};");
             }
 
             foreach (var index in Indexes.Extras)
@@ -378,7 +378,7 @@ public class TableDelta: SchemaObjectDelta<Table>
             foreach (var fk in ForeignKeys.Missing)
             {
                 writer.WriteLine(
-                    $"ALTER TABLE {Expected.Identifier.QualifiedName} DROP FOREIGN KEY `{fk.Name}`;");
+                    $"ALTER TABLE {Expected.Identifier.QualifiedName} DROP FOREIGN KEY {SchemaUtils.QuoteName(fk.Name)};");
             }
 
             foreach (var fk in ForeignKeys.Extras)


### PR DESCRIPTION
Second slice of #447, stacked on #459 — **review that one first**; this PR's base is its branch, so the diff here is MySQL only.

## The quoting bug

`SchemaUtils.QuoteName` was `$"`{name}`"` with no doubling, so a name carrying a backtick closed its own quoting. Twenty-seven further sites interpolated backticks inline without going through the helper at all — `MySqlMigrator`, `MySqlObjectName`, `MySqlProvider`, `Table`, `TableColumn`, `TableDelta`, `IndexDefinition`, `ForeignKey`.

`MySqlIdentifierRules` supplies the backtick pair, the regular-identifier rule and the keyword list; everything else comes from `IdentifierRules`. All 27 inline sites now route through the facade.

**MySQL keeps delimiting every identifier**, which is what it has always done, so generated DDL for an ordinary schema is byte-identical. What changes is that an embedded backtick is doubled instead of terminating the name.

## The identity half

Emitting correctly is only half the job — the half #446 had to come back for. The catalog reports the bare name, so a model still holding the quoted spelling never compares equal to it and the table drifts on every check.

`TableColumn`, `IndexDefinition` and `ForeignKey` undelimit as names arrive, and `Table` overrides the `NormalizeIdentifier` hook added in #446 for `PrimaryKeyName`. So `AddColumn("`order date`")` names the column `order date`, and a round trip reports no drift.

## A conformance assertion that was wrong

`an_ordinary_name_is_left_bare` failed for MySQL, and MySQL was right. That invariant holds only for a dialect that quotes *conditionally*; MySQL delimits everything by design. It now keys off the provider's own `RequiresDelimiting` — whatever a provider says needs no delimiting, it must leave alone — so it holds for both kinds without weakening. Better to find that on the second provider than the fifth.

## Testing

Five new tests in `Weasel.MySql.Tests/Tables/identifier_quoting.cs`. Verified by restoring **only** the old `QuoteName` body — stashing the whole file does not work, since the tests need `Unquote` to compile — which fails three of the five: embedded backtick, name carrying DDL, and already-quoted pass-through.

MySQL joins the conformance suite: `Weasel.Core.Tests` 94, `Weasel.MySql.Tests` 251, `Weasel.SqlServer.Tests` 420 with 8 skipped, solution builds with 0 errors.

## Remaining in #447

SQLite, PostgreSQL, Oracle — one PR each, each adding its entry to the `Providers` table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
