### PR TITLE
fix(sqlite): quote for shape, not for a hand-written list of characters

### DIFF
--- a/src/Weasel.Core.Tests/Weasel.Core.Tests.csproj
+++ b/src/Weasel.Core.Tests/Weasel.Core.Tests.csproj
@@ -16,6 +16,7 @@
            no database, no containers. -->
       <ProjectReference Include="..\Weasel.MySql\Weasel.MySql.csproj" />
       <ProjectReference Include="..\Weasel.SqlServer\Weasel.SqlServer.csproj" />
+      <ProjectReference Include="..\Weasel.Sqlite\Weasel.Sqlite.csproj" />
     </ItemGroup>
 
     <Import Project="../../Tests.Build.props" />

--- a/src/Weasel.Core.Tests/identifier_rules_conformance.cs
+++ b/src/Weasel.Core.Tests/identifier_rules_conformance.cs
@@ -2,6 +2,7 @@ using Shouldly;
 using Weasel.Core;
 using Weasel.MySql;
 using Weasel.SqlServer;
+using Weasel.Sqlite;
 using Xunit;
 
 namespace Weasel.Core.Tests;
@@ -18,8 +19,8 @@ namespace Weasel.Core.Tests;
 ///     <para>
 ///         Providers join the suite as their fixes land (weasel#447). SQL Server is here because
 ///         it is the reference implementation the contract was lifted from, and MySQL joined with
-///         its own fix. SQLite, PostgreSQL and Oracle each join in the PR that fixes them — adding
-///         a provider is one entry in <see cref="Providers" />.
+///         its own fix, as did SQLite. PostgreSQL and Oracle each join in the PR that fixes them —
+///         adding a provider is one entry in <see cref="Providers" />.
 ///     </para>
 ///     <para>
 ///         Deliberately pure string logic: no connection, no container, so it runs everywhere and
@@ -32,7 +33,8 @@ public class identifier_rules_conformance
         new()
         {
             { "SqlServer", SqlServerIdentifierRules.Instance },
-            { "MySql", MySqlIdentifierRules.Instance }
+            { "MySql", MySqlIdentifierRules.Instance },
+            { "Sqlite", SqliteIdentifierRules.Instance }
         };
 
     /// <summary>

--- a/src/Weasel.Sqlite.Tests/SchemaUtilsTests.cs
+++ b/src/Weasel.Sqlite.Tests/SchemaUtilsTests.cs
@@ -70,15 +70,33 @@ public class SchemaUtilsTests
         quoted.ShouldBe(expected);
     }
 
+    /// <summary>
+    ///     This test used to assert the opposite — that a name containing a double quote was left
+    ///     bare, because it had no space, was not a keyword and did not start with a digit. Those
+    ///     were the only four things the old rule looked at, so the escaping below it, which was
+    ///     written and correct, was never reached for the one character that most needs it. The
+    ///     name went out raw and closed whatever it was written into (weasel#447).
+    /// </summary>
     [Fact]
-    public void quote_name_with_embedded_quotes_no_quoting_needed()
+    public void quote_name_escapes_an_embedded_quote_rather_than_emitting_it_raw()
     {
-        // If the name doesn't meet any criteria for quoting, embedded quotes are left as-is
         var name = "my\"column";
+
         var quoted = SchemaUtils.QuoteName(name);
 
-        // Since "my\"column" doesn't have spaces, isn't a keyword, doesn't start with digit, it's not quoted
-        quoted.ShouldBe("my\"column");
+        quoted.ShouldBe("\"my\"\"column\"");
+        SchemaUtils.Unquote(quoted).ShouldBe(name);
+    }
+
+    /// <summary>
+    ///     <c>char.IsDigit(name[0])</c> threw <c>IndexOutOfRangeException</c> on an empty name,
+    ///     where every other provider returned it unchanged.
+    /// </summary>
+    [Fact]
+    public void an_empty_name_is_returned_rather_than_throwing()
+    {
+        SchemaUtils.QuoteName("").ShouldBe("");
+        SchemaUtils.Unquote("").ShouldBe("");
     }
 
     [Theory]

--- a/src/Weasel.Sqlite/SchemaUtils.cs
+++ b/src/Weasel.Sqlite/SchemaUtils.cs
@@ -1,26 +1,47 @@
+using JasperFx.Core;
+using Weasel.Core;
+
 namespace Weasel.Sqlite;
 
-public static class SchemaUtils
+/// <summary>
+///     SQLite's identifier rules. Everything that is not dialect-specific lives in
+///     <see cref="IdentifierRules" />; what stays here is the double-quote delimiter, SQLite's
+///     regular-identifier rule, and its keyword list.
+/// </summary>
+public sealed class SqliteIdentifierRules: IdentifierRules
 {
+    public static readonly SqliteIdentifierRules Instance = new();
+
+    protected override char Open => '"';
+    protected override char Close => '"';
+
     /// <summary>
-    /// Quotes an identifier name using double quotes for SQLite.
-    /// SQLite uses double quotes for identifiers per SQL standard.
+    ///     A regular identifier: a letter or <c>_</c> first, then letters, digits, <c>_</c> or
+    ///     <c>$</c>.
     /// </summary>
-    public static string QuoteName(string name)
+    /// <remarks>
+    ///     This replaces a hand-written list — the old rule quoted only for a reserved keyword, a
+    ///     space, a hyphen or a leading digit, so a name containing anything else (a dot, a
+    ///     parenthesis, or a double quote itself) went out bare. The double-quote case was the sharp
+    ///     one: the escaping was written and correct, but the name never reached it.
+    /// </remarks>
+    public override bool IsRegularIdentifier(string name)
     {
-        // SQLite is case-insensitive by default, but we quote reserved keywords
-        // and any identifier that needs escaping
-        if (ReservedKeywords.Contains(name, StringComparer.OrdinalIgnoreCase) ||
-            name.Contains(' ') ||
-            name.Contains('-') ||
-            char.IsDigit(name[0]))
+        if (name.IsEmpty())
         {
-            // Escape any double quotes in the name by doubling them
-            return $"\"{name.Replace("\"", "\"\"")}\"";
+            return false;
         }
 
-        return name;
+        if (!char.IsLetter(name[0]) && name[0] != '_')
+        {
+            return false;
+        }
+
+        return name.Skip(1).All(c => char.IsLetterOrDigit(c) || c == '_' || c == '$');
     }
+
+    public override bool IsReservedWord(string name)
+        => ReservedKeywords.Contains(name, StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// SQLite reserved keywords that should be quoted when used as identifiers.
@@ -176,4 +197,22 @@ public static class SchemaUtils
         "WITH",
         "WITHOUT"
     ];
+}
+
+/// <summary>
+///     The static facade the SQLite DDL writers call. Delegates to
+///     <see cref="SqliteIdentifierRules" />.
+/// </summary>
+public static class SchemaUtils
+{
+    /// <inheritdoc cref="IdentifierRules.Quote" />
+    public static string QuoteName(string name) => SqliteIdentifierRules.Instance.Quote(name);
+
+    /// <inheritdoc cref="IdentifierRules.Undelimit" />
+    public static string Unquote(string name) => SqliteIdentifierRules.Instance.Undelimit(name);
+
+    /// <inheritdoc cref="IdentifierRules.EscapeLiteral" />
+    public static string EscapeLiteral(string value) => IdentifierRules.EscapeLiteral(value);
+
+    public static bool IsReservedKeyword(string name) => SqliteIdentifierRules.Instance.IsReservedWord(name);
 }

--- a/src/Weasel.Sqlite/SqliteMigrator.cs
+++ b/src/Weasel.Sqlite/SqliteMigrator.cs
@@ -162,12 +162,12 @@ public class SqliteMigrator: Migrator
 
         foreach (var table in tables)
         {
-            sb.AppendLine($"DELETE FROM \"{table.Name}\";");
+            sb.AppendLine($"DELETE FROM {SchemaUtils.QuoteName(table.Name)};");
         }
 
         if (resetIdentity)
         {
-            var names = string.Join(", ", tables.Select(t => $"'{t.Name}'"));
+            var names = string.Join(", ", tables.Select(t => $"'{SchemaUtils.EscapeLiteral(t.Name)}'"));
             sb.AppendLine($"DELETE FROM sqlite_sequence WHERE name IN ({names});");
         }
 

--- a/src/Weasel.Sqlite/Tables/ForeignKey.cs
+++ b/src/Weasel.Sqlite/Tables/ForeignKey.cs
@@ -8,7 +8,7 @@ public class ForeignKey: ForeignKeyBase
     private string[] _columnNames = null!;
     private string[] _linkedNames = null!;
 
-    public ForeignKey(string name) : base(name)
+    public ForeignKey(string name) : base(SchemaUtils.Unquote(name))
     {
     }
 

--- a/src/Weasel.Sqlite/Tables/IndexDefinition.cs
+++ b/src/Weasel.Sqlite/Tables/IndexDefinition.cs
@@ -14,7 +14,7 @@ public class IndexDefinition: ITableIndex
 
     public IndexDefinition(string indexName)
     {
-        _indexName = indexName;
+        _indexName = SchemaUtils.Unquote(indexName);
     }
 
     protected IndexDefinition()
@@ -81,7 +81,7 @@ public class IndexDefinition: ITableIndex
 
             return deriveIndexName();
         }
-        set => _indexName = value;
+        set => _indexName = SchemaUtils.Unquote(value);
     }
 
     /// <summary>

--- a/src/Weasel.Sqlite/Tables/Table.cs
+++ b/src/Weasel.Sqlite/Tables/Table.cs
@@ -9,6 +9,9 @@ namespace Weasel.Sqlite.Tables;
 /// </summary>
 public partial class Table: TableBase<TableColumn, IndexDefinition, ForeignKey>
 {
+    /// <inheritdoc />
+    protected override string NormalizeIdentifier(string name) => SchemaUtils.Unquote(name);
+
     internal readonly List<string> _primaryKeyColumns = new();
 
     public Table(DbObjectName name)

--- a/src/Weasel.Sqlite/Tables/TableColumn.cs
+++ b/src/Weasel.Sqlite/Tables/TableColumn.cs
@@ -19,7 +19,10 @@ public class TableColumn: ITableColumn
         }
 
         // SQLite is case-insensitive, normalize names to lowercase
-        Name = name.ToLowerInvariant().Trim().Replace(' ', '_');
+        // Undelimited first: a caller who wrote "order date" means that column, and the
+        // catalog reports it back bare. The lowercasing and space handling that follow are
+        // long-standing SQLite behaviour, untouched here (see weasel#458).
+        Name = SchemaUtils.Unquote(name.Trim()).ToLowerInvariant().Trim().Replace(' ', '_');
         // Normalize type using provider
         Type = SqliteProvider.Instance.ConvertSynonyms(type);
     }


### PR DESCRIPTION
Third slice of #447. Based on master — #459 and #460 are already merged.

## The bug

SQLite's `QuoteName` escaped an embedded double quote correctly, but only decided to quote *at all* for a reserved keyword, a space, a hyphen, or a leading digit:

```csharp
if (ReservedKeywords.Contains(name, ...) || name.Contains(' ') || name.Contains('-') || char.IsDigit(name[0]))
{
    return $"\"{name.Replace("\"", "\"\"")}\"";   // correct, and unreachable for a name that is only a quote
}
return name;
```

A name containing a `"` and nothing else matches none of those conditions, so it went out raw — the one character that most needs escaping was the one that never reached the escaping. Anything else outside the list (a dot, a parenthesis) went out bare too.

`char.IsDigit(name[0])` also threw `IndexOutOfRangeException` on an empty name, where every other provider returns it unchanged.

`SqliteIdentifierRules` replaces the list with a regular-identifier rule, so the question becomes "can this be written bare" rather than "is it one of four things".

## String literals

`GenerateDeleteAllSql` interpolated table names into a `sqlite_sequence WHERE name IN (...)` literal list with no escaping, and the `DELETE` above it interpolated a name straight into double quotes. Both go through the helpers now.

## Identity

Names are undelimited as they enter `TableColumn`, `IndexDefinition` and `ForeignKey`, and `Table` overrides the `NormalizeIdentifier` hook for `PrimaryKeyName` — same as SQL Server (#446) and MySQL (#460).

The lowercasing and space-to-underscore handling that `TableColumn` has always done is **untouched**; undelimiting runs ahead of it. That behaviour is tracked separately in #458.

## An existing test asserted the bug

`quote_name_with_embedded_quotes_no_quoting_needed` pinned `my"column` coming back raw, with a comment explaining that it has no space, is not a keyword and does not start with a digit — an accurate description of the defect, written as though it were the specification. It now asserts the escaped form, under a name that says what it checks, and its doc comment records why it changed rather than quietly flipping the expectation.

Added alongside it: an empty-name test for the crash.

## Testing

SQLite joins the conformance suite. `Weasel.Core.Tests` 103, `Weasel.Sqlite.Tests` 402, `Weasel.SqlServer.Tests` 420 with 8 skipped, `Weasel.MySql.Tests` 251. Solution builds with 0 errors.

## Remaining in #447

PostgreSQL, then Oracle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
