### PR TITLE
fix(postgresql): quote for shape as well as for case and keywords

### DIFF
--- a/src/Weasel.Core.Tests/Weasel.Core.Tests.csproj
+++ b/src/Weasel.Core.Tests/Weasel.Core.Tests.csproj
@@ -17,6 +17,7 @@
       <ProjectReference Include="..\Weasel.MySql\Weasel.MySql.csproj" />
       <ProjectReference Include="..\Weasel.SqlServer\Weasel.SqlServer.csproj" />
       <ProjectReference Include="..\Weasel.Sqlite\Weasel.Sqlite.csproj" />
+      <ProjectReference Include="..\Weasel.Postgresql\Weasel.Postgresql.csproj" />
     </ItemGroup>
 
     <Import Project="../../Tests.Build.props" />

--- a/src/Weasel.Core.Tests/identifier_rules_conformance.cs
+++ b/src/Weasel.Core.Tests/identifier_rules_conformance.cs
@@ -1,6 +1,7 @@
 using Shouldly;
 using Weasel.Core;
 using Weasel.MySql;
+using Weasel.Postgresql;
 using Weasel.SqlServer;
 using Weasel.Sqlite;
 using Xunit;
@@ -19,8 +20,9 @@ namespace Weasel.Core.Tests;
 ///     <para>
 ///         Providers join the suite as their fixes land (weasel#447). SQL Server is here because
 ///         it is the reference implementation the contract was lifted from, and MySQL joined with
-///         its own fix, as did SQLite. PostgreSQL and Oracle each join in the PR that fixes them —
-///         adding a provider is one entry in <see cref="Providers" />.
+///         its own fix, as did SQLite and PostgreSQL — the last in both its general and its
+///         function-name usage. Oracle joins in the PR that fixes it; adding a provider is one
+///         entry in <see cref="Providers" />.
 ///     </para>
 ///     <para>
 ///         Deliberately pure string logic: no connection, no container, so it runs everywhere and
@@ -34,7 +36,9 @@ public class identifier_rules_conformance
         {
             { "SqlServer", SqlServerIdentifierRules.Instance },
             { "MySql", MySqlIdentifierRules.Instance },
-            { "Sqlite", SqliteIdentifierRules.Instance }
+            { "Sqlite", SqliteIdentifierRules.Instance },
+            { "Postgresql", PostgresqlIdentifierRules.General },
+            { "Postgresql/function", PostgresqlIdentifierRules.Function }
         };
 
     /// <summary>

--- a/src/Weasel.Postgresql.Tests/identifier_quoting.cs
+++ b/src/Weasel.Postgresql.Tests/identifier_quoting.cs
@@ -1,0 +1,88 @@
+using Shouldly;
+using Weasel.Postgresql.Tables;
+using Xunit;
+
+namespace Weasel.Postgresql.Tests;
+
+/// <summary>
+///     PostgreSQL's <c>QuoteName</c> quoted for keywords and for case, but not for shape — a
+///     lowercase name containing a hyphen, a dot or a leading digit went out bare and produced DDL
+///     that will not parse. It also never doubled an embedded double quote. See weasel#447.
+/// </summary>
+public class identifier_quoting
+{
+    [Theory]
+    [InlineData("orders", "orders")]                                 // ordinary, still bare
+    [InlineData("_internal", "_internal")]
+    [InlineData("MiXeD", "\"MiXeD\"")]                               // case preserved, as before
+    [InlineData("select", "\"select\"")]                             // reserved keyword, as before
+    [InlineData("order-date", "\"order-date\"")]                     // hyphen: went out bare before
+    [InlineData("unit price", "\"unit price\"")]                     // space: went out bare before
+    [InlineData("2ndplace", "\"2ndplace\"")]                         // leading digit: bare before
+    [InlineData("pk_dbo.__migrationhistory", "\"pk_dbo.__migrationhistory\"")] // dot: bare before
+    public void quotes_for_shape_as_well_as_for_case_and_keywords(string name, string expected)
+    {
+        SchemaUtils.QuoteName(name, SchemaUtils.IdentifierUsage.General).ShouldBe(expected);
+    }
+
+    [Fact]
+    public void an_embedded_double_quote_is_doubled_rather_than_closing_the_quoting()
+    {
+        var quoted = SchemaUtils.QuoteName("we\"ird", SchemaUtils.IdentifierUsage.General);
+
+        quoted.ShouldBe("\"we\"\"ird\"");
+        SchemaUtils.Unquote(quoted).ShouldBe("we\"ird");
+    }
+
+    [Fact]
+    public void a_name_carrying_ddl_stays_inside_its_delimiters()
+    {
+        var injection = "ix\" ON t(id); DROP TABLE victim; --";
+
+        var quoted = SchemaUtils.QuoteName(injection, SchemaUtils.IdentifierUsage.General);
+
+        quoted.ShouldBe("\"ix\"\" ON t(id); DROP TABLE victim; --\"");
+        SchemaUtils.Unquote(quoted).ShouldBe(injection);
+    }
+
+    /// <summary>
+    ///     The usage distinction has to survive the refactoring: a type/function name keyword is
+    ///     quoted in general use but not as a function name, and a column name keyword the reverse.
+    /// </summary>
+    [Fact]
+    public void the_usage_distinction_still_decides_the_keyword_categories()
+    {
+        // "left" is a type/function name keyword (catcode T)
+        SchemaUtils.QuoteName("left", SchemaUtils.IdentifierUsage.General).ShouldBe("\"left\"");
+        SchemaUtils.QuoteName("left", SchemaUtils.IdentifierUsage.Function).ShouldBe("left");
+
+        // "between" is a column name keyword (catcode C)
+        SchemaUtils.QuoteName("between", SchemaUtils.IdentifierUsage.Function).ShouldBe("\"between\"");
+        SchemaUtils.QuoteName("between", SchemaUtils.IdentifierUsage.General).ShouldBe("between");
+    }
+
+    [Fact]
+    public void a_name_the_caller_already_quoted_is_left_alone()
+    {
+        SchemaUtils.QuoteName("\"orders\"", SchemaUtils.IdentifierUsage.General).ShouldBe("\"orders\"");
+        SchemaUtils.QuoteName("\"we\"\"ird\"", SchemaUtils.IdentifierUsage.General).ShouldBe("\"we\"\"ird\"");
+    }
+
+    /// <summary>
+    ///     The identity half: the catalog reports the bare name, so a model holding the quoted
+    ///     spelling never compares equal to it and the table drifts on every check.
+    /// </summary>
+    [Fact]
+    public void names_the_caller_quoted_are_normalized_on_the_way_into_the_model()
+    {
+        var table = new Table("quoting.normalized");
+        table.AddColumn("\"id\"", "int").AsPrimaryKey();
+        table.PrimaryKeyName = "\"pk normalized\"";
+
+        table.Columns[0].Name.ShouldBe("id");
+        table.PrimaryKeyName.ShouldBe("pk normalized");
+
+        new IndexDefinition("\"ix normalized\"").Name.ShouldBe("ix normalized");
+        new ForeignKey("\"fk normalized\"").Name.ShouldBe("fk normalized");
+    }
+}

--- a/src/Weasel.Postgresql/SchemaUtils.cs
+++ b/src/Weasel.Postgresql/SchemaUtils.cs
@@ -1,7 +1,132 @@
 using System.Collections.Frozen;
+using JasperFx.Core;
 using Npgsql;
+using Weasel.Core;
 
 namespace Weasel.Postgresql;
+
+/// <summary>
+///     PostgreSQL's identifier rules. Everything that is not dialect-specific lives in
+///     <see cref="IdentifierRules" />; what stays here is the double-quote delimiter, PostgreSQL's
+///     regular-identifier rule, and its three keyword categories.
+/// </summary>
+/// <remarks>
+///     The usage distinction is modelled as two instances rather than a parameter, because it only
+///     ever changes which keyword categories force quoting: a type/function name keyword must be
+///     quoted in general use but not as a function name, and a column name keyword the other way
+///     round.
+/// </remarks>
+public sealed class PostgresqlIdentifierRules: IdentifierRules
+{
+    public static readonly PostgresqlIdentifierRules General = new(SchemaUtils.IdentifierUsage.General);
+    public static readonly PostgresqlIdentifierRules Function = new(SchemaUtils.IdentifierUsage.Function);
+
+    private readonly SchemaUtils.IdentifierUsage _usage;
+
+    private PostgresqlIdentifierRules(SchemaUtils.IdentifierUsage usage) => _usage = usage;
+
+    public static PostgresqlIdentifierRules For(SchemaUtils.IdentifierUsage usage)
+        => usage == SchemaUtils.IdentifierUsage.Function ? Function : General;
+
+    protected override char Open => '"';
+    protected override char Close => '"';
+
+    /// <summary>
+    ///     A regular identifier: a letter or <c>_</c> first, then letters, digits, <c>_</c> or
+    ///     <c>$</c>. Case is handled separately in <see cref="RequiresDelimiting" />, because an
+    ///     uppercase name is syntactically fine bare — PostgreSQL just folds it, which silently
+    ///     changes which object the name refers to.
+    /// </summary>
+    public override bool IsRegularIdentifier(string name)
+    {
+        if (name.IsEmpty())
+        {
+            return false;
+        }
+
+        if (!char.IsLetter(name[0]) && name[0] != '_')
+        {
+            return false;
+        }
+
+        return name.Skip(1).All(c => char.IsLetterOrDigit(c) || c == '_' || c == '$');
+    }
+
+    /// <summary>
+    ///     Quoted when it is a keyword in a category that applies to this usage, when it carries an
+    ///     uppercase character that would otherwise be folded away, or — the part that was missing —
+    ///     when it simply cannot be written bare. The old rule looked only at keywords and case, so
+    ///     a lowercase name with a hyphen, a dot or a leading digit went out unquoted and produced
+    ///     DDL that will not parse.
+    /// </summary>
+    public override bool RequiresDelimiting(string name)
+    {
+        if (name.IsEmpty())
+        {
+            return false;
+        }
+
+        return !IsRegularIdentifier(name)
+               || name.Any(char.IsUpper)
+               || IsReservedWord(name)
+               || (_usage == SchemaUtils.IdentifierUsage.Function && CategoryCKeywords.Contains(name))
+               || (_usage == SchemaUtils.IdentifierUsage.General && CategoryTKeywords.Contains(name));
+    }
+
+    public override bool IsReservedWord(string name) => ReservedKeywords.Contains(name);
+
+    /// <summary>
+    /// PostgreSQL reserved keywords (catcode 'R').
+    /// These keywords are always reserved and must be quoted when used as identifiers.
+    /// Source: pg_get_keywords() from PostgreSQL 10-17
+    /// </summary>
+    private static readonly FrozenSet<string> ReservedKeywords = new[]
+    {
+        "ALL", "ANALYSE", "ANALYZE", "AND", "ANY", "ARRAY", "AS", "ASC", "ASYMMETRIC", "BOTH",
+        "CASE", "CAST", "CHECK", "COLLATE", "COLUMN", "CONSTRAINT", "CREATE", "CURRENT_CATALOG",
+        "CURRENT_DATE", "CURRENT_ROLE", "CURRENT_TIME", "CURRENT_TIMESTAMP", "CURRENT_USER",
+        "DEFAULT", "DEFERRABLE", "DESC", "DISTINCT", "DO", "ELSE", "END", "EXCEPT", "FALSE",
+        "FETCH", "FOR", "FOREIGN", "FROM", "GRANT", "GROUP", "HAVING", "IN", "INITIALLY",
+        "INTERSECT", "INTO", "LATERAL", "LEADING", "LIMIT", "LOCALTIME", "LOCALTIMESTAMP",
+        "NOT", "NULL", "OFFSET", "ON", "ONLY", "OR", "ORDER", "PLACING", "PRIMARY",
+        "REFERENCES", "RETURNING", "SELECT", "SESSION_USER", "SOME", "SYMMETRIC", "SYSTEM_USER",
+        "TABLE", "THEN", "TO", "TRAILING", "TRUE", "UNION", "UNIQUE", "USER", "USING",
+        "VARIADIC", "WHEN", "WHERE", "WINDOW", "WITH"
+    }.ToFrozenSet(StringComparer.InvariantCultureIgnoreCase);
+
+    /// <summary>
+    /// PostgreSQL column name keywords (catcode 'C').
+    /// These keywords can be used without quotes except for function or type names.
+    /// Source: pg_get_keywords() from PostgreSQL 10-17
+    /// </summary>
+    private static readonly FrozenSet<string> CategoryCKeywords = new[]
+    {
+        "BETWEEN", "BIGINT", "BIT", "BOOLEAN", "CHAR", "CHARACTER", "COALESCE", "DEC",
+        "DECIMAL", "EXISTS", "EXTRACT", "FLOAT", "GREATEST", "GROUPING", "INOUT", "INT",
+        "INTEGER", "INTERVAL", "JSON", "JSON_ARRAY", "JSON_ARRAYAGG", "JSON_EXISTS",
+        "JSON_OBJECT", "JSON_OBJECTAGG", "JSON_QUERY", "JSON_SCALAR", "JSON_SERIALIZE",
+        "JSON_TABLE", "JSON_VALUE", "LEAST", "MERGE_ACTION", "NATIONAL", "NCHAR", "NONE",
+        "NORMALIZE", "NULLIF", "NUMERIC", "OUT", "OVERLAY", "POSITION", "PRECISION",
+        "REAL", "ROW", "SETOF", "SMALLINT", "SUBSTRING", "TIME", "TIMESTAMP", "TREAT",
+        "TRIM", "VALUES", "VARCHAR", "XMLATTRIBUTES", "XMLCONCAT", "XMLELEMENT",
+        "XMLEXISTS", "XMLFOREST", "XMLNAMESPACES", "XMLPARSE", "XMLPI", "XMLROOT",
+        "XMLSERIALIZE", "XMLTABLE"
+    }.ToFrozenSet(StringComparer.InvariantCultureIgnoreCase);
+
+    /// <summary>
+    /// PostgreSQL type/function name keywords (catcode 'T').
+    /// These keywords can only be used for function or type names without quotes.
+    /// Anywhere else will need to be quoted.
+    /// Source: pg_get_keywords() from PostgreSQL 10-17
+    /// </summary>
+    private static readonly FrozenSet<string> CategoryTKeywords = new[]
+    {
+        "AUTHORIZATION", "BINARY", "COLLATION", "CONCURRENTLY", "CROSS",
+        "CURRENT_SCHEMA", "FREEZE", "FULL", "ILIKE", "INNER", "IS", "ISNULL", "JOIN",
+        "LEFT", "LIKE", "NATURAL", "NOTNULL", "OUTER", "OVERLAPS", "RIGHT", "SIMILAR",
+        "TABLESAMPLE", "VERBOSE"
+    }.ToFrozenSet(StringComparer.InvariantCultureIgnoreCase);
+}
 
 public static class SchemaUtils
 {
@@ -59,84 +184,25 @@ public static class SchemaUtils
     public static string QuoteName(string name) => QuoteName(name, IdentifierUsage.General);
 
     /// <summary>
-    /// Quotes a PostgreSQL identifier if it is a keyword or contains uppercase characters.
-    /// Keywords are checked according to their PostgreSQL category:
+    /// Quotes a PostgreSQL identifier if it is a keyword, contains uppercase characters, or cannot
+    /// be written bare. Keywords are checked according to their PostgreSQL category:
     /// - Reserved (catcode 'R'): always quoted
     /// - Type/function name (catcode 'T'): quoted in General usage, not in Function usage
     /// - Column name (catcode 'C'): quoted only in Function usage
     /// Mixed-case identifiers are always quoted to preserve case.
     /// </summary>
     public static string QuoteName(string name, IdentifierUsage usage)
-    {
-        if (string.IsNullOrEmpty(name))
-            return name;
+        => PostgresqlIdentifierRules.For(usage).Quote(name);
 
-        if (ReservedKeywords.Contains(name) ||
-            (usage == IdentifierUsage.Function && CategoryCKeywords.Contains(name)) ||
-            (usage == IdentifierUsage.General && CategoryTKeywords.Contains(name)) ||
-            name.Any(char.IsUpper))
-        {
-            return $"\"{name}\"";
-        }
+    /// <inheritdoc cref="IdentifierRules.Undelimit" />
+    public static string Unquote(string name) => PostgresqlIdentifierRules.General.Undelimit(name);
 
-        return name;
-    }
+    /// <inheritdoc cref="IdentifierRules.EscapeLiteral" />
+    public static string EscapeLiteral(string value) => IdentifierRules.EscapeLiteral(value);
 
     /// <summary>
     /// Returns true if the given identifier is a PostgreSQL reserved keyword (catcode 'R')
     /// that must always be quoted when used as an identifier.
     /// </summary>
-    public static bool IsReservedKeyword(string name) => ReservedKeywords.Contains(name);
-
-    /// <summary>
-    /// PostgreSQL reserved keywords (catcode 'R').
-    /// These keywords are always reserved and must be quoted when used as identifiers.
-    /// Source: pg_get_keywords() from PostgreSQL 10-17
-    /// </summary>
-    private static readonly FrozenSet<string> ReservedKeywords = new[]
-    {
-        "ALL", "ANALYSE", "ANALYZE", "AND", "ANY", "ARRAY", "AS", "ASC", "ASYMMETRIC", "BOTH",
-        "CASE", "CAST", "CHECK", "COLLATE", "COLUMN", "CONSTRAINT", "CREATE", "CURRENT_CATALOG",
-        "CURRENT_DATE", "CURRENT_ROLE", "CURRENT_TIME", "CURRENT_TIMESTAMP", "CURRENT_USER",
-        "DEFAULT", "DEFERRABLE", "DESC", "DISTINCT", "DO", "ELSE", "END", "EXCEPT", "FALSE",
-        "FETCH", "FOR", "FOREIGN", "FROM", "GRANT", "GROUP", "HAVING", "IN", "INITIALLY",
-        "INTERSECT", "INTO", "LATERAL", "LEADING", "LIMIT", "LOCALTIME", "LOCALTIMESTAMP",
-        "NOT", "NULL", "OFFSET", "ON", "ONLY", "OR", "ORDER", "PLACING", "PRIMARY",
-        "REFERENCES", "RETURNING", "SELECT", "SESSION_USER", "SOME", "SYMMETRIC", "SYSTEM_USER",
-        "TABLE", "THEN", "TO", "TRAILING", "TRUE", "UNION", "UNIQUE", "USER", "USING",
-        "VARIADIC", "WHEN", "WHERE", "WINDOW", "WITH"
-    }.ToFrozenSet(StringComparer.InvariantCultureIgnoreCase);
-
-    /// <summary>
-    /// PostgreSQL column name keywords (catcode 'C').
-    /// These keywords can be used without quotes except for function or type names.
-    /// Source: pg_get_keywords() from PostgreSQL 10-17
-    /// </summary>
-    private static readonly FrozenSet<string> CategoryCKeywords = new[]
-    {
-        "BETWEEN", "BIGINT", "BIT", "BOOLEAN", "CHAR", "CHARACTER", "COALESCE", "DEC",
-        "DECIMAL", "EXISTS", "EXTRACT", "FLOAT", "GREATEST", "GROUPING", "INOUT", "INT",
-        "INTEGER", "INTERVAL", "JSON", "JSON_ARRAY", "JSON_ARRAYAGG", "JSON_EXISTS",
-        "JSON_OBJECT", "JSON_OBJECTAGG", "JSON_QUERY", "JSON_SCALAR", "JSON_SERIALIZE",
-        "JSON_TABLE", "JSON_VALUE", "LEAST", "MERGE_ACTION", "NATIONAL", "NCHAR", "NONE",
-        "NORMALIZE", "NULLIF", "NUMERIC", "OUT", "OVERLAY", "POSITION", "PRECISION",
-        "REAL", "ROW", "SETOF", "SMALLINT", "SUBSTRING", "TIME", "TIMESTAMP", "TREAT",
-        "TRIM", "VALUES", "VARCHAR", "XMLATTRIBUTES", "XMLCONCAT", "XMLELEMENT",
-        "XMLEXISTS", "XMLFOREST", "XMLNAMESPACES", "XMLPARSE", "XMLPI", "XMLROOT",
-        "XMLSERIALIZE", "XMLTABLE"
-    }.ToFrozenSet(StringComparer.InvariantCultureIgnoreCase);
-
-    /// <summary>
-    /// PostgreSQL type/function name keywords (catcode 'T').
-    /// These keywords can only be used for function or type names without quotes.
-    /// Anywhere else will need to be quoted.
-    /// Source: pg_get_keywords() from PostgreSQL 10-17
-    /// </summary>
-    private static readonly FrozenSet<string> CategoryTKeywords = new[]
-    {
-        "AUTHORIZATION", "BINARY", "COLLATION", "CONCURRENTLY", "CROSS",
-        "CURRENT_SCHEMA", "FREEZE", "FULL", "ILIKE", "INNER", "IS", "ISNULL", "JOIN",
-        "LEFT", "LIKE", "NATURAL", "NOTNULL", "OUTER", "OVERLAPS", "RIGHT", "SIMILAR",
-        "TABLESAMPLE", "VERBOSE"
-    }.ToFrozenSet(StringComparer.InvariantCultureIgnoreCase);
+    public static bool IsReservedKeyword(string name) => PostgresqlIdentifierRules.General.IsReservedWord(name);
 }

--- a/src/Weasel.Postgresql/Tables/ForeignKey.cs
+++ b/src/Weasel.Postgresql/Tables/ForeignKey.cs
@@ -8,7 +8,7 @@ public class ForeignKey: ForeignKeyBase
     private string[] _columnNames = null!;
     private string[] _linkedNames = null!;
 
-    public ForeignKey(string name) : base(name)
+    public ForeignKey(string name) : base(SchemaUtils.Unquote(name))
     {
     }
 

--- a/src/Weasel.Postgresql/Tables/IndexDefinition.cs
+++ b/src/Weasel.Postgresql/Tables/IndexDefinition.cs
@@ -27,7 +27,7 @@ public class IndexDefinition: ITableIndex
 
     public IndexDefinition(string indexName)
     {
-        _indexName = indexName;
+        _indexName = SchemaUtils.Unquote(indexName);
     }
 
     protected IndexDefinition()
@@ -177,7 +177,7 @@ public class IndexDefinition: ITableIndex
 
             return deriveIndexName();
         }
-        set => _indexName = value;
+        set => _indexName = SchemaUtils.Unquote(value);
     }
 
     public string QuotedName => SchemaUtils.QuoteName(Name);

--- a/src/Weasel.Postgresql/Tables/Table.cs
+++ b/src/Weasel.Postgresql/Tables/Table.cs
@@ -157,6 +157,9 @@ public partial class Table: TableBase<TableColumn, IndexDefinition, ForeignKey>,
         Syntax.WriteDropTable(writer, Identifier);
     }
 
+    /// <inheritdoc />
+    protected override string NormalizeIdentifier(string name) => SchemaUtils.Unquote(name);
+
     public override IEnumerable<DbObjectName> AllNames()
     {
         yield return Identifier;

--- a/src/Weasel.Postgresql/Tables/TableColumn.cs
+++ b/src/Weasel.Postgresql/Tables/TableColumn.cs
@@ -30,9 +30,14 @@ public class TableColumn: ITableColumn
             throw new ArgumentOutOfRangeException(nameof(type));
         }
 
+        // Unquoted first: a caller who wrote "Order Date" means that column, and the catalog
+        // reports it back bare. The casing and space handling that follow are long-standing
+        // behaviour, untouched here (see weasel#458).
+        var unquoted = SchemaUtils.Unquote(name.Trim());
+
         Name = preserveCase
-            ? name.Trim()
-            : name.ToLowerInvariant().Trim().Replace(' ', '_');
+            ? unquoted.Trim()
+            : unquoted.ToLowerInvariant().Trim().Replace(' ', '_');
         Type = type.ToLowerInvariant();
     }
 


### PR DESCRIPTION
Fourth slice of #447. Based on master — #459, #460 and #461 are merged.

## The bug

`QuoteName` asked two questions: is this a keyword in a category that applies to this usage, and does it carry an uppercase character that would otherwise be folded away. It never asked the third — **can this be written bare at all**. So a lowercase name containing a hyphen, a dot or a leading digit went out unquoted and produced DDL that will not parse.

It also emitted `$"\"{name}\""` with no doubling, so a name carrying a double quote closed its own quoting.

`PostgresqlIdentifierRules` adds the missing question and inherits correct escaping from the contract.

## The usage distinction

`IdentifierUsage` is the genuinely PostgreSQL-specific part, and it survives intact — modelled as **two instances** rather than a parameter, since it only ever selects which keyword categories apply:

- a type/function name keyword (catcode T) is quoted in general use, not as a function name
- a column name keyword (catcode C) is quoted as a function name, not in general use

Both instances are in the conformance suite, and `the_usage_distinction_still_decides_the_keyword_categories` pins the behaviour directly with `left` and `between`, so the refactoring cannot quietly drop it.

## Identity

Names are undelimited entering `TableColumn`, `IndexDefinition` and `ForeignKey`, and `Table` overrides `NormalizeIdentifier` for `PrimaryKeyName` — same as SQL Server (#446), MySQL (#460) and SQLite (#461). The casing and space-to-underscore handling `TableColumn` has always done is untouched; undelimiting runs ahead of it. That is #458's business.

## Testing

Thirteen new tests. Verified by restoring **only** the old quoting decision — keeping `Unquote` so the tests still compile — which fails six: the four shape cases (hyphen, space, leading digit, dot), the embedded double quote, and the name carrying DDL.

The existing suite is the more important evidence here, since PostgreSQL is the most heavily exercised provider: `Weasel.Postgresql.Tests` 868 (855 existing + 13), no regressions. `Weasel.Core.Tests` 121, `Weasel.Sqlite.Tests` 402, `Weasel.MySql.Tests` 251. Solution builds with 0 errors.

## Remaining in #447

Oracle — case-folding split from quoting, literal escaping in six places, and the mixed-case identity mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
