### PR TITLE
feat(sqlserver): views

### DIFF
--- a/src/Weasel.SqlServer.Tests/Views/ViewTests.cs
+++ b/src/Weasel.SqlServer.Tests/Views/ViewTests.cs
@@ -1,0 +1,163 @@
+using Shouldly;
+using Weasel.Core;
+using Weasel.SqlServer.Views;
+using SqlServerTable = Weasel.SqlServer.Tables.Table;
+using Xunit;
+
+namespace Weasel.SqlServer.Tests.Views;
+
+/// <summary>
+///     SQL Server had no view support at all, despite <c>ViewBase</c> existing in Weasel.Core with
+///     two working implementations. See weasel#450.
+/// </summary>
+public class ViewTests: IntegrationContext
+{
+    public ViewTests(): base("views")
+    {
+    }
+
+    private async Task createSourceTableAsync(string name)
+    {
+        var table = new SqlServerTable($"views.{name}");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn<string>("name");
+        table.AddColumn<int>("quantity");
+        await CreateSchemaObjectInDatabase(table);
+    }
+
+    [Fact]
+    public void write_create_statement_wraps_the_create_for_the_batch_rule()
+    {
+        var view = new View("views.simple", "select id, name from views.source");
+
+        var sql = view.ToBasicCreateViewSql();
+
+        // CREATE VIEW has to be the only statement in its batch, so it goes through sp_executesql.
+        sql.ShouldContain("DROP VIEW IF EXISTS views.simple;");
+        sql.ShouldContain("EXEC sp_executesql N'CREATE VIEW views.simple AS select id, name from views.source';");
+    }
+
+    [Fact]
+    public void a_body_containing_a_string_literal_is_escaped_for_the_wrapper()
+    {
+        var view = new View("views.filtered", "select id from views.source where name = 'active'");
+
+        var sql = view.ToBasicCreateViewSql();
+
+        // Doubled, or the wrapper's own literal closes early — the defect weasel#443 fixed for functions.
+        sql.ShouldContain("where name = ''active''");
+    }
+
+    [Fact]
+    public async Task create_a_view_and_read_it_back()
+    {
+        await ResetSchema();
+        await createSourceTableAsync("source");
+
+        var view = new View("views.active_items", "select id, name from views.source where quantity > 0");
+        await CreateSchemaObjectInDatabase(view);
+
+        var existing = await view.FetchExistingAsync(theConnection);
+
+        existing.ShouldNotBeNull();
+        View.NormalizeSql(existing!.ViewSql)
+            .ShouldBe(View.NormalizeSql("select id, name from views.source where quantity > 0"));
+    }
+
+    [Fact]
+    public async Task a_view_that_matches_reports_no_delta()
+    {
+        await ResetSchema();
+        await createSourceTableAsync("source");
+
+        var view = new View("views.no_delta", "select id, name from views.source");
+        await CreateSchemaObjectInDatabase(view);
+
+        var delta = await view.FindDeltaAsync(theConnection);
+
+        delta.Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task a_missing_view_reports_create()
+    {
+        await ResetSchema();
+        await createSourceTableAsync("source");
+
+        var view = new View("views.not_there_yet", "select id from views.source");
+
+        (await view.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.Create);
+    }
+
+    [Fact]
+    public async Task a_changed_body_reports_update_and_applying_it_converges()
+    {
+        await ResetSchema();
+        await createSourceTableAsync("source");
+
+        await CreateSchemaObjectInDatabase(new View("views.changing", "select id from views.source"));
+
+        var changed = new View("views.changing", "select id, name from views.source");
+
+        (await changed.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.Update);
+
+        await changed.ApplyChangesAsync(theConnection);
+
+        (await changed.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task applying_the_same_view_twice_is_a_no_op()
+    {
+        await ResetSchema();
+        await createSourceTableAsync("source");
+
+        var view = new View("views.idempotent", "select id, name from views.source");
+
+        await view.ApplyChangesAsync(theConnection);
+        await view.ApplyChangesAsync(theConnection);
+
+        (await view.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task whitespace_and_case_differences_are_not_drift()
+    {
+        await ResetSchema();
+        await createSourceTableAsync("source");
+
+        await CreateSchemaObjectInDatabase(new View("views.reformatted", "select id, name from views.source"));
+
+        var reformatted = new View("views.reformatted", @"SELECT   id,
+    name
+FROM views.source");
+
+        (await reformatted.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task a_view_over_a_join_round_trips()
+    {
+        await ResetSchema();
+        await createSourceTableAsync("source");
+        await createSourceTableAsync("other");
+
+        var view = new View("views.joined", @"select s.id, s.name, o.quantity
+from views.source s inner join views.other o on o.id = s.id");
+
+        await CreateSchemaObjectInDatabase(view);
+
+        (await view.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public void move_to_schema_rewraps_the_identifier()
+    {
+        var view = new View("views.movable", "select 1 as one");
+
+        view.MoveToSchema("other");
+
+        view.Identifier.Schema.ShouldBe("other");
+        view.Identifier.ShouldBeOfType<SqlServerObjectName>();
+    }
+}

--- a/src/Weasel.SqlServer/SchemaObjectsExtensions.cs
+++ b/src/Weasel.SqlServer/SchemaObjectsExtensions.cs
@@ -120,8 +120,14 @@ WHERE
                 return $"ALTER TABLE {SchemaUtils.QuoteName(fkSchema)}.{SchemaUtils.QuoteName(tableName)} DROP CONSTRAINT {SchemaUtils.QuoteName(constraintName)};";
             }, cancellation: ct).ConfigureAwait(false);
 
+        // BASE TABLE only: information_schema.tables lists views too, and "drop table" does not
+        // drop a view -- it silently does nothing under IF EXISTS, leaving the schema undroppable.
         var tables = await conn
-            .CreateCommand($"select table_name from information_schema.tables where table_schema = '{SchemaUtils.EscapeLiteral(schemaName)}'")
+            .CreateCommand($"select table_name from information_schema.tables where table_schema = '{SchemaUtils.EscapeLiteral(schemaName)}' and table_type = 'BASE TABLE'")
+            .FetchListAsync<string>(cancellation: ct).ConfigureAwait(false);
+
+        var views = await conn
+            .CreateCommand($"select table_name from information_schema.views where table_schema = '{SchemaUtils.EscapeLiteral(schemaName)}'")
             .FetchListAsync<string>(cancellation: ct).ConfigureAwait(false);
 
         var sequences = await conn
@@ -138,6 +144,9 @@ WHERE
         drops.AddRange(procedures.Select(name => $"drop procedure if exists {SchemaUtils.QuoteName(schemaName)}.{SchemaUtils.QuoteName(name)};"));
         drops.AddRange(functions.Select(name => $"drop function if exists {SchemaUtils.QuoteName(schemaName)}.{SchemaUtils.QuoteName(name)};"));
         drops.AddRange(fkConstraints);
+        // Views before tables: a view outlives the table it selects from, and either one left
+        // behind blocks the DROP SCHEMA.
+        drops.AddRange(views.Select(name => $"drop view if exists {SchemaUtils.QuoteName(schemaName)}.{SchemaUtils.QuoteName(name)};"));
         drops.AddRange(tables.Select(name => $"drop table if exists {SchemaUtils.QuoteName(schemaName)}.{SchemaUtils.QuoteName(name)};"));
         drops.AddRange(sequences.Select(name => $"drop sequence if exists {SchemaUtils.QuoteName(schemaName)}.{SchemaUtils.QuoteName(name)};"));
         drops.AddRange(tableTypes.Select(x => $"DROP TYPE IF EXISTS {SchemaUtils.QuoteName(schemaName)}.{SchemaUtils.QuoteName(x)};"));

--- a/src/Weasel.SqlServer/Views/View.cs
+++ b/src/Weasel.SqlServer/Views/View.cs
@@ -1,0 +1,139 @@
+using System.Data.Common;
+using Microsoft.Data.SqlClient;
+using Weasel.Core;
+using DbCommandBuilder = Weasel.Core.DbCommandBuilder;
+
+namespace Weasel.SqlServer.Views;
+
+/// <summary>
+///     A SQL Server view. Changes are applied by dropping and recreating, because
+///     <c>ALTER VIEW</c> replaces the whole definition anyway and the drop keeps the path
+///     identical whether or not the view is already there.
+/// </summary>
+/// <remarks>
+///     SQL Server requires <c>CREATE VIEW</c> to be the only statement in its batch, so the
+///     create goes inside <c>EXEC sp_executesql</c> — the same reason
+///     <see cref="Functions.Function" /> does it. That puts the body inside a string literal,
+///     so its own single quotes have to be doubled.
+/// </remarks>
+public class View: ViewBase
+{
+    public View(string viewName, string viewSql)
+        : this(
+            viewName != null
+                ? DbObjectName.Parse(SqlServerProvider.Instance, viewName)
+                : throw new ArgumentNullException(nameof(viewName)),
+            viewSql)
+    {
+    }
+
+    public View(DbObjectName identifier, string viewSql): base(identifier, viewSql)
+    {
+    }
+
+    /// <inheritdoc />
+    protected override DbObjectName WithSchema(string schemaName)
+        => new SqlServerObjectName(schemaName, Identifier.Name);
+
+    /// <inheritdoc />
+    protected override Migrator GetDefaultMigratorForBasicSql()
+        => new SqlServerMigrator { Formatting = SqlFormatting.Concise };
+
+    public override void WriteCreateStatement(Migrator migrator, TextWriter writer)
+    {
+        WriteDropStatement(migrator, writer);
+
+        var body = ViewSql.TrimEnd().TrimEnd(';');
+        var create = $"CREATE VIEW {Identifier} AS {body}";
+
+        writer.WriteLine($"EXEC sp_executesql N'{SchemaUtils.EscapeLiteral(create)}';");
+    }
+
+    public override void WriteDropStatement(Migrator migrator, TextWriter writer)
+    {
+        writer.WriteLine($"DROP VIEW IF EXISTS {Identifier};");
+    }
+
+    public override void ConfigureQueryCommand(DbCommandBuilder builder)
+    {
+        var nameParam = builder.AddParameter(Identifier.ToString()).ParameterName;
+        builder.Append(
+            $"SELECT sm.definition FROM sys.sql_modules AS sm INNER JOIN sys.views AS v ON v.object_id = sm.object_id WHERE sm.object_id = OBJECT_ID(@{nameParam})");
+    }
+
+    public override async Task<ISchemaObjectDelta> CreateDeltaAsync(DbDataReader reader, CancellationToken ct = default)
+    {
+        var existing = await readBodyAsync(reader, ct).ConfigureAwait(false);
+
+        if (existing == null)
+        {
+            return new SchemaObjectDelta(this, SchemaPatchDifference.Create);
+        }
+
+        return NormalizeSql(existing) == NormalizeSql(ViewSql)
+            ? new SchemaObjectDelta(this, SchemaPatchDifference.None)
+            : new SchemaObjectDelta(this, SchemaPatchDifference.Update);
+    }
+
+    public async Task<View?> FetchExistingAsync(SqlConnection conn, CancellationToken ct = default)
+    {
+        var builder = new DbCommandBuilder(conn);
+        ConfigureQueryCommand(builder);
+
+        await using var reader = await conn.ExecuteReaderAsync(builder, ct).ConfigureAwait(false);
+        var body = await readBodyAsync(reader, ct).ConfigureAwait(false);
+        await reader.CloseAsync().ConfigureAwait(false);
+
+        return body == null ? null : new View(Identifier, body);
+    }
+
+    public static Task<View?> FetchExistingAsync(SqlConnection conn, DbObjectName identifier,
+        CancellationToken ct = default)
+        => new View(identifier, "select 1 as one").FetchExistingAsync(conn, ct);
+
+    public async Task<bool> ExistsInDatabaseAsync(SqlConnection conn, CancellationToken ct = default)
+        => await FetchExistingAsync(conn, ct).ConfigureAwait(false) != null;
+
+    private static async Task<string?> readBodyAsync(DbDataReader reader, CancellationToken ct)
+    {
+        if (!await reader.ReadAsync(ct).ConfigureAwait(false))
+        {
+            return null;
+        }
+
+        var definition = await reader.GetFieldValueAsync<string>(0, ct).ConfigureAwait(false);
+
+        return string.IsNullOrEmpty(definition) ? null : ExtractViewBody(definition);
+    }
+
+    /// <summary>
+    ///     Whitespace-insensitive and case-insensitive, because <c>sys.sql_modules</c> hands back
+    ///     the text as it was submitted and callers reformat freely.
+    /// </summary>
+    internal static string NormalizeSql(string sql)
+        => sql.Replace("\r\n", "")
+            .Replace("\n", "")
+            .Replace("\r", "")
+            .Replace("\t", "")
+            .Replace(" ", "")
+            .Trim()
+            .TrimEnd(';')
+            .ToUpperInvariant();
+
+    /// <summary>
+    ///     <c>sys.sql_modules</c> stores the whole <c>CREATE VIEW … AS …</c> text, so the body is
+    ///     what follows the first <c>AS</c> that stands on its own.
+    /// </summary>
+    private static string ExtractViewBody(string definition)
+    {
+        var asIndex = definition.IndexOf(" AS ", StringComparison.OrdinalIgnoreCase);
+        if (asIndex < 0)
+        {
+            // The create may have been written with a newline instead of a space before AS.
+            asIndex = definition.IndexOf("\nAS", StringComparison.OrdinalIgnoreCase);
+            return asIndex < 0 ? definition : definition.Substring(asIndex + 3).Trim();
+        }
+
+        return definition.Substring(asIndex + 4).Trim();
+    }
+}


### PR DESCRIPTION
First slice of #450. Views for SQL Server; MySQL and Oracle views, then functions for MySQL and Oracle, follow as separate PRs.

## Mostly wiring, as the survey predicted

`ViewBase` has been in Weasel.Core all along with two working implementations — PostgreSQL and SQLite — and SQL Server had none. Introspection reads `sys.sql_modules` joined to `sys.views`; changes are applied by dropping and recreating, since `ALTER VIEW` replaces the whole definition anyway and the drop makes the path identical whether or not the view already exists.

## Two SQL Server specifics

**`CREATE VIEW` must be the only statement in its batch.** So the create goes inside `EXEC sp_executesql` — the same reason `Function` does it. Following the existing house pattern rather than inventing a second one.

**That puts the body inside a string literal**, so its own single quotes have to be doubled. A view whose body contains `where name = 'active'` would otherwise fail with an unclosed quotation mark — exactly the defect #443 fixed for functions. `SchemaUtils.EscapeLiteral` handles it, and there is a test pinning it.

## A latent bug the tests flushed out

`DropSchemaAsync` could not drop a schema containing a view. `information_schema.tables` lists views as well as base tables, and `drop table if exists` against a view silently does nothing under `IF EXISTS` — so the view survived and `DROP SCHEMA` failed with *"Cannot drop schema 'views' because it is being referenced by object..."*.

The table query is restricted to `BASE TABLE` now, and views are dropped in their own pass ahead of tables. This was latent only because nothing in Weasel could create a SQL Server view; the first test that made one hit it immediately.

## Testing

Ten new tests: DDL shape including the `sp_executesql` wrapper and the literal escaping, create-and-read-back, no-delta, missing-reports-Create, changed-body-reports-Update-and-converges, apply-twice-is-a-no-op, whitespace/case insensitivity, a view over a join, and `MoveToSchema`.

`Weasel.SqlServer.Tests` 430 (was 420), 8 skipped. Solution builds with 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
