### PR TITLE
fix(oracle): drop views when dropping a schema

### DIFF
--- a/src/Weasel.Oracle.Tests/dropping_schemas_with_views.cs
+++ b/src/Weasel.Oracle.Tests/dropping_schemas_with_views.cs
@@ -1,0 +1,89 @@
+using Shouldly;
+using Weasel.Core;
+using Xunit;
+
+namespace Weasel.Oracle.Tests;
+
+/// <summary>
+///     weasel#465: <c>DropSchemaAsync</c> queried procedures, functions, tables and sequences, but
+///     never <c>all_views</c>. <c>DROP TABLE … CASCADE CONSTRAINTS</c> invalidates a dependent view
+///     rather than dropping it, so any view in the schema survived the teardown and the schema was
+///     never actually clean.
+/// </summary>
+/// <remarks>
+///     <para>
+///         The view here is created with raw SQL rather than through a <c>View</c> schema object,
+///         because Oracle view support is still blocked (see weasel#450). That is deliberate: the
+///         teardown has to cope with a view whatever created it, including one a user made by hand,
+///         and writing the test this way means it is not waiting on the other slice.
+///     </para>
+///     <para>
+///         SQL Server had the identical gap and it went unnoticed until something could create a
+///         view (weasel#464). Oracle's is the same trap, found before it was armed.
+///     </para>
+/// </remarks>
+public class dropping_schemas_with_views: IntegrationContext
+{
+    private const string SchemaName = "WEASEL";
+
+    public dropping_schemas_with_views(): base(SchemaName)
+    {
+    }
+
+    private async Task<bool> viewExistsAsync(string viewName)
+    {
+        var count = await theConnection
+            .CreateCommand(
+                $"SELECT COUNT(*) FROM all_views WHERE owner = '{SchemaName}' AND view_name = '{viewName.ToUpperInvariant()}'")
+            .ExecuteScalarAsync();
+
+        return Convert.ToInt32(count) > 0;
+    }
+
+    [Fact]
+    public async Task a_view_does_not_survive_dropping_its_schema()
+    {
+        await ResetSchema();
+
+        await theConnection
+            .CreateCommand($"CREATE TABLE {SchemaName}.teardown_src (id NUMBER PRIMARY KEY, name VARCHAR2(50))")
+            .ExecuteNonQueryAsync();
+
+        await theConnection
+            .CreateCommand(
+                $"CREATE VIEW {SchemaName}.teardown_view AS SELECT id, name FROM {SchemaName}.teardown_src")
+            .ExecuteNonQueryAsync();
+
+        (await viewExistsAsync("teardown_view")).ShouldBeTrue();
+
+        await theConnection.DropSchemaAsync(SchemaName);
+
+        (await viewExistsAsync("teardown_view")).ShouldBeFalse();
+    }
+
+    /// <summary>
+    ///     A view over another view: the drop order has to hold for a chain, not just one level.
+    /// </summary>
+    [Fact]
+    public async Task a_view_over_a_view_does_not_survive_either()
+    {
+        await ResetSchema();
+
+        await theConnection
+            .CreateCommand($"CREATE TABLE {SchemaName}.chain_src (id NUMBER PRIMARY KEY)")
+            .ExecuteNonQueryAsync();
+
+        await theConnection
+            .CreateCommand($"CREATE VIEW {SchemaName}.chain_first AS SELECT id FROM {SchemaName}.chain_src")
+            .ExecuteNonQueryAsync();
+
+        await theConnection
+            .CreateCommand($"CREATE VIEW {SchemaName}.chain_second AS SELECT id FROM {SchemaName}.chain_first")
+            .ExecuteNonQueryAsync();
+
+        await theConnection.DropSchemaAsync(SchemaName);
+
+        (await viewExistsAsync("chain_first")).ShouldBeFalse();
+        (await viewExistsAsync("chain_second")).ShouldBeFalse();
+    }
+}

--- a/src/Weasel.Oracle/SchemaObjectsExtensions.cs
+++ b/src/Weasel.Oracle/SchemaObjectsExtensions.cs
@@ -110,6 +110,10 @@ public static class SchemaObjectsExtensions
                 $"SELECT object_name FROM all_objects WHERE owner = '{SchemaUtils.EscapeLiteral(upperSchema)}' AND object_type = 'FUNCTION'")
             .FetchListAsync<string>(cancellation: ct).ConfigureAwait(false);
 
+        var views = await conn
+            .CreateCommand($"SELECT view_name FROM all_views WHERE owner = '{SchemaUtils.EscapeLiteral(upperSchema)}'")
+            .FetchListAsync<string>(cancellation: ct).ConfigureAwait(false);
+
         var tables = await conn
             .CreateCommand($"SELECT table_name FROM all_tables WHERE owner = '{SchemaUtils.EscapeLiteral(upperSchema)}'")
             .FetchListAsync<string>(cancellation: ct).ConfigureAwait(false);
@@ -122,6 +126,9 @@ public static class SchemaObjectsExtensions
         var drops = new List<string>();
         drops.AddRange(procedures.Select(name => $"DROP PROCEDURE {SchemaUtils.QuoteName(schemaName)}.{SchemaUtils.QuoteName(name!)}"));
         drops.AddRange(functions.Select(name => $"DROP FUNCTION {SchemaUtils.QuoteName(schemaName)}.{SchemaUtils.QuoteName(name!)}"));
+        // Views ahead of tables: DROP TABLE ... CASCADE CONSTRAINTS invalidates a dependent view
+        // rather than dropping it, so a view left behind survives the teardown (weasel#465).
+        drops.AddRange(views.Select(name => $"DROP VIEW {SchemaUtils.QuoteName(schemaName)}.{SchemaUtils.QuoteName(name!)}"));
         drops.AddRange(tables.Select(name => $"DROP TABLE {SchemaUtils.QuoteName(schemaName)}.{SchemaUtils.QuoteName(name!)} CASCADE CONSTRAINTS"));
         drops.AddRange(sequences.Select(name => $"DROP SEQUENCE {SchemaUtils.QuoteName(schemaName)}.{SchemaUtils.QuoteName(name!)}"));
 


### PR DESCRIPTION
Split out of the blocked Oracle views branch (#450), because it stands on its own and because landing it first means the view slice cannot ship with a teardown that fails to clean up after it.

## The bug

`DropSchemaAsync` queries `all_objects` for procedures and functions, `all_tables`, and `all_sequences`. It never queries `all_views` and never emits `DROP VIEW`. `DROP TABLE … CASCADE CONSTRAINTS` *invalidates* a dependent view rather than dropping it, so any view in the schema survives the teardown and the schema is never actually clean.

Views are queried and dropped ahead of tables now.

## Found before it was armed

SQL Server had the identical gap. It went unnoticed until #464 added something that could create a view — the first test that made one hit it immediately, with *"Cannot drop schema 'views' because it is being referenced by object …"*.

Oracle's is the same trap, caught one slice earlier. Oracle view support is still blocked on reading `ALL_VIEWS.TEXT` out of a LONG column (noted on #450), so nothing in Weasel can create an Oracle view yet — **but a user's schema can contain one regardless**, which is both why this is a real bug today and why the tests create the view with raw SQL rather than through a `View` object. That also means this test does not have to wait on the blocked slice.

## Testing

Two tests, both of which fail with the fix reverted and pass with it:

- a view over a table does not survive `DropSchemaAsync`
- a view over a view does not either — the drop order has to hold for a chain, not just one level

They call `DropSchemaAsync` directly rather than the `ResetSchema()` helper, which opens the connection unconditionally and so cannot be called twice in one test. Calling the method under test is the more direct assertion anyway.

`Weasel.Oracle.Tests` 229 (was 227). Solution builds with 0 errors.

## Context

Audited across all five providers in #465. PostgreSQL and MySQL are immune — they delegate to the server's own cascade instead of enumerating object types, so they cannot fall behind. SQLite, SQL Server and Oracle enumerate, which is the coupling that produced this bug twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
