### PR TITLE
feat(core): allow an interior space in an identifier, keep rejecting the rest

### DIFF
--- a/src/Weasel.Core.Tests/IdentifierValidationTests.cs
+++ b/src/Weasel.Core.Tests/IdentifierValidationTests.cs
@@ -14,14 +14,41 @@ public class IdentifierValidationTests
         IdentifierValidation.FindProblem(name, "\"").ShouldBe("it is null, empty, or entirely whitespace");
     }
 
+    /// <summary>
+    ///     A line break or a tab can introduce a <c>--</c> comment into an unquoted name, so those stay
+    ///     rejected. A plain interior space cannot, and every provider quotes for shape as of weasel#447,
+    ///     so <c>unit price</c> — somebody's real legacy column — is now allowed through (weasel#448).
+    /// </summary>
     [Theory]
-    [InlineData("us ers")]
     [InlineData("us\ters")]
     [InlineData("us\ners")]
     [InlineData("us\rers")]
-    public void all_whitespace_characters_are_rejected_not_just_the_space(string name)
+    public void a_line_break_or_tab_is_still_rejected(string name)
     {
-        IdentifierValidation.FindProblem(name, "\"").ShouldBe("it contains whitespace");
+        IdentifierValidation.FindProblem(name, "\"").ShouldBe("it contains a line break or tab");
+    }
+
+    [Theory]
+    [InlineData("us ers")]
+    [InlineData("unit price")]
+    [InlineData("PK_dbo.__MigrationHistory")]
+    public void an_interior_space_is_allowed_now_that_every_provider_quotes_for_shape(string name)
+    {
+        IdentifierValidation.FindProblem(name, "\"").ShouldBeNull();
+    }
+
+    /// <summary>
+    ///     Leading or trailing whitespace is a typo every time. Allowing it would silently create an
+    ///     object under a name nobody meant, which then drifts forever — so it stays rejected even
+    ///     though the interior case is now permitted.
+    /// </summary>
+    [Theory]
+    [InlineData(" users")]
+    [InlineData("users ")]
+    [InlineData("\tusers")]
+    public void leading_or_trailing_whitespace_is_still_rejected(string name)
+    {
+        IdentifierValidation.FindProblem(name, "\"").ShouldBe("it starts or ends with whitespace");
     }
 
     /// <summary>

--- a/src/Weasel.Core/IdentifierValidation.cs
+++ b/src/Weasel.Core/IdentifierValidation.cs
@@ -53,11 +53,21 @@ public static class IdentifierValidation
             return "it is null, empty, or entirely whitespace";
         }
 
+        // Leading and trailing whitespace is always a typo, and allowing it would silently create
+        // an object under a name nobody meant, which then drifts forever. Interior whitespace is a
+        // different thing entirely -- "unit price" is somebody's real legacy column.
+        if (name![0] == ' ' || char.IsWhiteSpace(name[0]) || char.IsWhiteSpace(name[^1]))
+        {
+            return "it starts or ends with whitespace";
+        }
+
         foreach (var c in name)
         {
-            if (char.IsWhiteSpace(c))
+            if (char.IsWhiteSpace(c) && c != ' ')
             {
-                return "it contains whitespace";
+                // A newline or a tab can introduce a -- comment into an unquoted name; a plain
+                // space cannot.
+                return "it contains a line break or tab";
             }
 
             if (c is ';' or '\'' || unsafeCharacters.Contains(c))

--- a/src/Weasel.MySql.Tests/MySqlMigratorTests.cs
+++ b/src/Weasel.MySql.Tests/MySqlMigratorTests.cs
@@ -58,11 +58,15 @@ public class MySqlMigratorTests
     [InlineData(null)]
     [InlineData("")]
     [InlineData("   ")]
-    [InlineData("us ers")]
     [InlineData("us\ters")]
     [InlineData("us\ners")]
     [InlineData("us\rers")]
     [InlineData("users\n-- the rest of this statement is now a comment")]
+    /// <remarks>
+    ///     An interior space is deliberately absent from this list as of weasel#448: every provider
+    ///     quotes for shape now (weasel#447), so "unit price" is safe and is somebody's real legacy
+    ///     column. A line break or tab still is not — it can smuggle a '--' comment into the statement.
+    /// </remarks>
     public void assert_identifier_rejects_null_empty_and_whitespace(string? name)
     {
         var migrator = new MySqlMigrator();

--- a/src/Weasel.Oracle.Tests/OracleMigratorTests.cs
+++ b/src/Weasel.Oracle.Tests/OracleMigratorTests.cs
@@ -59,11 +59,15 @@ public class OracleMigratorTests
     [InlineData(null)]
     [InlineData("")]
     [InlineData("   ")]
-    [InlineData("US ERS")]
     [InlineData("US\tERS")]
     [InlineData("US\nERS")]
     [InlineData("US\rERS")]
     [InlineData("USERS\n-- the rest of this statement is now a comment")]
+    /// <remarks>
+    ///     An interior space is deliberately absent from this list as of weasel#448: every provider
+    ///     quotes for shape now (weasel#447), so "UNIT PRICE" is safe and is somebody's real legacy
+    ///     column. A line break or tab still is not — it can smuggle a '--' comment into the statement.
+    /// </remarks>
     public void assert_identifier_rejects_null_empty_and_whitespace(string? name)
     {
         var migrator = new OracleMigrator();

--- a/src/Weasel.Postgresql/Tables/Table.cs
+++ b/src/Weasel.Postgresql/Tables/Table.cs
@@ -584,7 +584,7 @@ public partial class Table: TableBase<TableColumn, IndexDefinition, ForeignKey>,
 
         public ColumnExpression DefaultValueFromSequence(DbObjectName sequenceName)
         {
-            return DefaultValueByExpression($"nextval('{sequenceName}')");
+            return DefaultValueByExpression($"nextval('{IdentifierRules.EscapeLiteral(sequenceName.QualifiedName)}')");
         }
 
         public ColumnExpression DefaultValueByExpression(string expression)

--- a/src/Weasel.SqlServer.Tests/SqlServerMigratorTests.cs
+++ b/src/Weasel.SqlServer.Tests/SqlServerMigratorTests.cs
@@ -64,11 +64,15 @@ public class SqlServerMigratorTests
     [InlineData(null)]
     [InlineData("")]
     [InlineData("   ")]
-    [InlineData("us ers")]
     [InlineData("us\ters")]
     [InlineData("us\ners")]
     [InlineData("us\rers")]
     [InlineData("users\n-- the rest of this statement is now a comment")]
+    /// <remarks>
+    ///     An interior space is deliberately absent from this list as of weasel#448: every provider
+    ///     quotes for shape now (weasel#447), so "unit price" is safe and is somebody's real legacy
+    ///     column. A line break or tab still is not — it can smuggle a '--' comment into the statement.
+    /// </remarks>
     public void assert_identifier_rejects_null_empty_and_whitespace(string? name)
     {
         var migrator = new SqlServerMigrator();

--- a/src/Weasel.Sqlite.Tests/SqliteMigratorTests.cs
+++ b/src/Weasel.Sqlite.Tests/SqliteMigratorTests.cs
@@ -139,11 +139,15 @@ public class SqliteMigratorTests
     /// </summary>
     [Theory]
     [InlineData(null)]
-    [InlineData("us ers")]
     [InlineData("us\ters")]
     [InlineData("us\ners")]
     [InlineData("us\rers")]
     [InlineData("users\n-- the rest of this statement is now a comment")]
+    /// <remarks>
+    ///     An interior space is deliberately absent from this list as of weasel#448: every provider
+    ///     quotes for shape now (weasel#447), so "unit price" is safe and is somebody's real legacy
+    ///     column. A line break or tab still is not — it can smuggle a '--' comment into the statement.
+    /// </remarks>
     public void assert_identifier_rejects_null_and_interior_whitespace(string? name)
     {
         var migrator = new SqliteMigrator();


### PR DESCRIPTION
First slice of #448, settling the whitespace half of the policy recorded there.

## Why the rule could change

`AssertValidIdentifier` rejected **any** name containing whitespace. That rule was written when the quoting helpers could not delimit such a name safely — #416's own doc comment says exactly that: *"Weasel's quoting helpers do not double an embedded delimiter."*

Every provider quotes for shape as of #447, so the premise is gone. Worse, the rule was actively blocking the capability #443 and #446 added: `unit price` is somebody's real legacy column, and the audience for that work is precisely the people pointing Weasel at a database they did not design. The ordering constraint recorded on this issue — *do not touch validation until #447 is green per provider* — is now satisfied for all five.

## The three-way split

- **Interior space: allowed.** Safe to quote on every provider, and safe in a string literal.
- **Line break or tab: still rejected.** Either can smuggle a `--` comment into an unquoted name, and no legitimate identifier needs one.
- **Leading or trailing whitespace: still rejected.** That is a typo every time. Permitting it would silently create an object under a name nobody meant, which then drifts forever — the failure mode this whole run of work has been about.

`;` and `'` stay rejected. See below for why `'` in particular is not ready to relax.

## The last unescaped literal site

PostgreSQL writes a sequence's name into a string literal for a column default — `nextval('...')` — and never escaped it. That is the final one from the #447 survey, and it is fixed here, because the `'` character stays rejected partly on its account.

## Six tests asserted the old rule

Across five projects, including one named `all_whitespace_characters_are_rejected_not_just_the_space`. They are rewritten to pin the three-way split rather than quietly deleted, and each carries a remark saying why the space case left the list — so the next reader does not restore it.

## Not in this slice

Extending validation to **column, primary key and check constraint names** — the other half of this issue. `AllNames()` feeds schema discovery in `SchemaMigration` as well as validation, so those names cannot simply be added to it without polluting the schema list. That needs a contract decision (a separate `AllIdentifiers()` hook, or validating where the names are set) rather than a patch, so it stays open here.

## Testing

Every provider suite green: Core 135, PostgreSQL 868, SQL Server 429, MySQL 250, SQLite 401, Oracle 226. Solution builds with 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
