### PR TITLE
feat(core): validate every identifier a table writes, not just the ones that name objects

### DIFF
--- a/src/Weasel.Core.Tests/table_identifier_coverage_conformance.cs
+++ b/src/Weasel.Core.Tests/table_identifier_coverage_conformance.cs
@@ -1,0 +1,156 @@
+using Shouldly;
+using Weasel.Core;
+using Xunit;
+
+namespace Weasel.Core.Tests;
+
+/// <summary>
+///     Every identifier a table writes into its DDL has to be reachable by the migration path's
+///     validation, and there are only two ways to reach one: <see cref="ISchemaObject.AllNames" />
+///     for the named objects the table creates, and
+///     <see cref="ISchemaObjectWithLocalIdentifiers.LocalIdentifiers" /> for the names that are not
+///     objects of their own. This suite holds the floor that the union of the two covers
+///     everything (weasel#448).
+/// </summary>
+/// <remarks>
+///     <para>
+///         Before this, four of the five providers yielded the table, its indexes and its foreign
+///         keys, SQLite omitted foreign keys, and <em>no</em> provider yielded a column name, the
+///         primary key constraint name, or a check constraint name. Those went into DDL unexamined.
+///     </para>
+///     <para>
+///         The suite is built entirely through <see cref="ITable" />, so a provider joins with one
+///         entry in <see cref="Providers" /> and nothing else. Pure model construction — no
+///         connection, no container.
+///     </para>
+///     <para>
+///         Names are compared case-insensitively throughout: Oracle folds an unquoted identifier to
+///         uppercase on the way into the model, and that is correct behaviour rather than a
+///         coverage gap.
+///     </para>
+/// </remarks>
+public class table_identifier_coverage_conformance
+{
+    public static TheoryData<string, Func<ITable>> Providers =>
+        new()
+        {
+            { "SqlServer", () => new SqlServer.Tables.Table("dbo.people") },
+            { "MySql", () => new MySql.Tables.Table("weasel_testing.people") },
+            { "Sqlite", () => new Sqlite.Tables.Table("people") },
+            { "Postgresql", () => new Postgresql.Tables.Table("public.people") },
+            { "Oracle", () => new Oracle.Tables.Table("WEASEL.PEOPLE") }
+        };
+
+    /// <summary>
+    ///     One table carrying every kind of name a table can write: an identifier, a primary key
+    ///     over a named column, an ordinary column, an index, a foreign key, and a check
+    ///     constraint. Built through <see cref="ITable" /> so it is the same table on all five.
+    /// </summary>
+    private static ITable BuildFullyDressedTable(Func<ITable> factory, out string[] expected)
+    {
+        var table = factory();
+
+        table.AddPrimaryKeyColumn("id", typeof(int));
+        table.AddColumn("email", typeof(string));
+        table.AddColumn("state_id", typeof(int));
+
+        table.PrimaryKeyName = "pk_people_id";
+        table.AddIndex("idx_people_email", ["email"]);
+        table.AddForeignKey("fk_people_state", table.Identifier, ["state_id"], ["id"]);
+        table.AddCheckConstraint("ck_people_email_present", "email is not null");
+
+        expected =
+        [
+            table.Identifier.Name,
+            "id",
+            "email",
+            "state_id",
+            "pk_people_id",
+            "idx_people_email",
+            "fk_people_state",
+            "ck_people_email_present"
+        ];
+
+        return table;
+    }
+
+    private static IEnumerable<string> EveryValidatedName(ITable table)
+    {
+        foreach (var name in table.AllNames()) yield return name.Name;
+
+        if (table is ISchemaObjectWithLocalIdentifiers withLocals)
+        {
+            foreach (var name in withLocals.LocalIdentifiers()) yield return name;
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(Providers))]
+    public void every_name_the_table_writes_is_reachable_by_validation(string provider, Func<ITable> factory)
+    {
+        var table = BuildFullyDressedTable(factory, out var expected);
+        var validated = EveryValidatedName(table).ToArray();
+
+        foreach (var name in expected)
+        {
+            validated.ShouldContain(
+                x => string.Equals(x, name, StringComparison.OrdinalIgnoreCase),
+                $"{provider} never offers '{name}' for validation, so it reaches DDL unchecked");
+        }
+    }
+
+    /// <summary>
+    ///     Index and foreign key names are real named objects, so they belong in
+    ///     <see cref="ISchemaObject.AllNames" /> rather than in the local names. SQLite writes its
+    ///     foreign keys inline in CREATE TABLE and had left them out entirely.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(Providers))]
+    public void all_names_carries_the_table_its_indexes_and_its_foreign_keys(string provider, Func<ITable> factory)
+    {
+        var table = BuildFullyDressedTable(factory, out _);
+        var names = table.AllNames().Select(x => x.Name).ToArray();
+
+        names.ShouldContain(x => string.Equals(x, table.Identifier.Name, StringComparison.OrdinalIgnoreCase),
+            $"{provider} omits the table itself");
+        names.ShouldContain(x => string.Equals(x, "idx_people_email", StringComparison.OrdinalIgnoreCase),
+            $"{provider} omits the index name");
+        names.ShouldContain(x => string.Equals(x, "fk_people_state", StringComparison.OrdinalIgnoreCase),
+            $"{provider} omits the foreign key name");
+    }
+
+    [Theory]
+    [MemberData(nameof(Providers))]
+    public void local_identifiers_carry_the_names_that_are_not_objects(string provider, Func<ITable> factory)
+    {
+        var table = BuildFullyDressedTable(factory, out _);
+        var locals = ((ISchemaObjectWithLocalIdentifiers)table).LocalIdentifiers().ToArray();
+
+        locals.ShouldContain(x => string.Equals(x, "email", StringComparison.OrdinalIgnoreCase),
+            $"{provider} omits a column name");
+        locals.ShouldContain(x => string.Equals(x, "pk_people_id", StringComparison.OrdinalIgnoreCase),
+            $"{provider} omits the primary key constraint name");
+        locals.ShouldContain(x => string.Equals(x, "ck_people_email_present", StringComparison.OrdinalIgnoreCase),
+            $"{provider} omits a check constraint name");
+    }
+
+    /// <summary>
+    ///     A table with no primary key never emits a primary key constraint, so validating the
+    ///     name <see cref="ITable.PrimaryKeyName" /> falls back to would be checking a string that
+    ///     is never written. Every provider derives that fallback from the table name, which has
+    ///     already been validated.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(Providers))]
+    public void a_table_without_a_primary_key_offers_no_primary_key_name(string provider, Func<ITable> factory)
+    {
+        var table = factory();
+        table.AddColumn("email", typeof(string));
+
+        var locals = ((ISchemaObjectWithLocalIdentifiers)table).LocalIdentifiers().ToArray();
+
+        locals.ShouldNotContain(
+            x => string.Equals(x, table.PrimaryKeyName, StringComparison.OrdinalIgnoreCase),
+            $"{provider} offers a primary key name for a table that has no primary key");
+    }
+}

--- a/src/Weasel.Core/ISchemaObject.cs
+++ b/src/Weasel.Core/ISchemaObject.cs
@@ -30,6 +30,28 @@ public interface ISchemaObjectWithPostProcessing : ISchemaObject
 }
 
 /// <summary>
+///     Schema objects that write identifiers into their DDL which are not themselves named
+///     database objects — a table's column names, its primary key constraint name, its check
+///     constraint names. <see cref="ISchemaObject.AllNames" /> cannot carry these: it yields
+///     <see cref="DbObjectName" />, and callers read the schema off every name it returns
+///     (<c>SchemaMigration.Schemas</c>, <c>DatabaseBase.ApplyAllConfiguredChangesToDatabaseAsync</c>),
+///     so a column name would arrive there claiming to be an object in a schema.
+/// </summary>
+/// <remarks>
+///     The migration path validates these alongside <see cref="ISchemaObject.AllNames" />
+///     (weasel#448). Before that, a table's identifier, index names and foreign key names were
+///     checked and everything else went straight into the DDL unexamined.
+/// </remarks>
+public interface ISchemaObjectWithLocalIdentifiers : ISchemaObject
+{
+    /// <summary>
+    ///     Every identifier this object writes into DDL that is not one of its
+    ///     <see cref="ISchemaObject.AllNames" />. Duplicates are fine; the caller only validates.
+    /// </summary>
+    IEnumerable<string> LocalIdentifiers();
+}
+
+/// <summary>
 ///     Responsible for the desired configuration of a single database object like
 ///     a table, sequence, of function.
 /// </summary>

--- a/src/Weasel.Core/IdentifierValidation.cs
+++ b/src/Weasel.Core/IdentifierValidation.cs
@@ -21,9 +21,24 @@ namespace Weasel.Core;
 ///         the existence checks and introspection queries interpolate them (SQL Server's
 ///         <c>IF OBJECT_ID('...')</c>, Oracle's <c>WHERE table_name = '...'</c> inside an anonymous PL/SQL
 ///         block, SQLite's <c>pragma_table_info('...')</c>), and PostgreSQL writes a sequence's name into
-///         one when a column defaults from it (<c>DEFAULT nextval('...')</c>). Whitespace is rejected in
-///         full rather than just the literal space character, so that a newline cannot introduce a
-///         <c>--</c> comment into an unquoted name.
+///         one when a column defaults from it (<c>DEFAULT nextval('...')</c>). Whitespace is rejected
+///         selectively: a line break or a tab can introduce a <c>--</c> comment into an unquoted
+///         name and stays rejected, and leading or trailing whitespace is a typo every time, but a
+///         plain interior space is somebody's real legacy column and is allowed through
+///         (weasel#448).
+///     </para>
+///     <para>
+///         <strong>This runs on the migration path only.</strong>
+///         <c>DatabaseBase.ApplyAllConfiguredChangesToDatabaseAsync</c> and
+///         <c>DatabaseBase.generateOrUpdateFeature</c> check every name a schema object will write
+///         -- the objects it creates (<c>ISchemaObject.AllNames</c>) and the names that are not
+///         objects of their own, columns, primary key and check constraints
+///         (<c>ISchemaObjectWithLocalIdentifiers.LocalIdentifiers</c>). Calling a schema object's
+///         <c>WriteCreateStatement</c> or <c>ApplyChangesAsync</c> directly does not go through
+///         here at all. That split is deliberate: the direct API is how you drive a schema Weasel
+///         did not author, and there the provider's quoting is what keeps a hostile name safe
+///         (weasel#447). The migration path is where Weasel is choosing the names, and it is strict
+///         about what it will bring into existence.
 ///     </para>
 ///     <para>
 ///         The rest is per-provider, because the character that closes an identifier is not: SQL Server

--- a/src/Weasel.Core/Migrations/DatabaseBase.cs
+++ b/src/Weasel.Core/Migrations/DatabaseBase.cs
@@ -336,10 +336,7 @@ public abstract class DatabaseBase<TConnection>: IDatabase<TConnection>, IDataba
 
         var objects = AllObjects().ToArray();
 
-        foreach (var objectName in objects.SelectMany(x => x.AllNames()))
-        {
-            Migrator.AssertValidIdentifier(objectName.Name);
-        }
+        assertValidIdentifiers(objects);
 
         foreach (var postProcessing in objects.OfType<ISchemaObjectWithPostProcessing>().ToArray())
         {
@@ -539,6 +536,39 @@ public abstract class DatabaseBase<TConnection>: IDatabase<TConnection>, IDataba
         await generateOrUpdateFeature(featureType, feature, token, false).ConfigureAwait(false);
     }
 
+    /// <summary>
+    ///     Run every identifier these objects will write into DDL through the provider's
+    ///     <see cref="Migrator.AssertValidIdentifier" />: the named objects they create
+    ///     (<see cref="ISchemaObject.AllNames" />) and, for those that declare them, the names
+    ///     that are not objects of their own — columns, primary key, check constraints
+    ///     (<see cref="ISchemaObjectWithLocalIdentifiers" />, weasel#448).
+    /// </summary>
+    /// <remarks>
+    ///     This is the migration path only, and deliberately so. Calling a schema object's
+    ///     <c>WriteCreateStatement</c> or <c>ApplyChangesAsync</c> directly bypasses it — those
+    ///     callers get correct quoting rather than a rejection, which is what makes a legacy name
+    ///     like <c>unit price</c> usable through the direct API while the migration path stays
+    ///     strict about what it will create.
+    /// </remarks>
+    private void assertValidIdentifiers(IEnumerable<ISchemaObject> objects)
+    {
+        foreach (var schemaObject in objects)
+        {
+            foreach (var objectName in schemaObject.AllNames())
+            {
+                Migrator.AssertValidIdentifier(objectName.Name);
+            }
+
+            if (schemaObject is ISchemaObjectWithLocalIdentifiers withLocals)
+            {
+                foreach (var name in withLocals.LocalIdentifiers())
+                {
+                    Migrator.AssertValidIdentifier(name);
+                }
+            }
+        }
+    }
+
     protected async ValueTask generateOrUpdateFeature(Type featureType, IFeatureSchema feature, CancellationToken token,
         bool skipPostProcessing)
     {
@@ -550,10 +580,7 @@ public abstract class DatabaseBase<TConnection>: IDatabase<TConnection>, IDataba
 
         var schemaObjects = feature.Objects;
 
-        foreach (var objectName in schemaObjects.SelectMany(x => x.AllNames()))
-        {
-            Migrator.AssertValidIdentifier(objectName.Name);
-        }
+        assertValidIdentifiers(schemaObjects);
 
         if (!skipPostProcessing)
         {

--- a/src/Weasel.Core/TableBase.cs
+++ b/src/Weasel.Core/TableBase.cs
@@ -59,7 +59,8 @@ namespace Weasel.Core;
 ///     <see cref="ForeignKeyBase" /> so the <see cref="ITable.ForeignKeys" />
 ///     contravariance works.
 /// </typeparam>
-public abstract class TableBase<TColumn, TIndex, TForeignKey>: SchemaObjectBase, ITable
+public abstract class TableBase<TColumn, TIndex, TForeignKey>: SchemaObjectBase, ITable,
+    ISchemaObjectWithLocalIdentifiers
     where TColumn : ITableColumn
     where TIndex : ITableIndex
     where TForeignKey : ForeignKeyBase
@@ -117,6 +118,34 @@ public abstract class TableBase<TColumn, TIndex, TForeignKey>: SchemaObjectBase,
     {
         get => _primaryKeyName.IsNotEmpty() ? _primaryKeyName : DefaultPrimaryKeyName();
         set => _primaryKeyName = NormalizeIdentifier(value);
+    }
+
+    /// <summary>
+    ///     The names this table writes into its DDL that are not database objects in their own
+    ///     right, and so cannot travel through <see cref="SchemaObjectBase.AllNames" />: every
+    ///     column, the primary key constraint name, and every check constraint name.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         The primary key name only appears when the table actually declares a primary key.
+    ///         <see cref="PrimaryKeyName" /> falls back to <see cref="DefaultPrimaryKeyName" />
+    ///         whenever it has not been set, so reading it unconditionally would validate a name
+    ///         that is never emitted — and every provider derives that default from the table name,
+    ///         which has already been checked.
+    ///     </para>
+    ///     <para>
+    ///         Index and foreign key names are deliberately absent: they are real named objects and
+    ///         belong in <see cref="SchemaObjectBase.AllNames" />, where every provider already
+    ///         yields them.
+    ///     </para>
+    /// </remarks>
+    public virtual IEnumerable<string> LocalIdentifiers()
+    {
+        foreach (var column in Columns) yield return column.Name;
+
+        if (PrimaryKeyColumns.Any()) yield return PrimaryKeyName;
+
+        foreach (var constraint in CheckConstraints) yield return constraint.Name;
     }
 
     /// <summary>

--- a/src/Weasel.Sqlite.Tests/migration_path_identifier_validation.cs
+++ b/src/Weasel.Sqlite.Tests/migration_path_identifier_validation.cs
@@ -1,0 +1,121 @@
+using Microsoft.Data.Sqlite;
+using Shouldly;
+using Weasel.Core;
+using Xunit;
+
+namespace Weasel.Sqlite.Tests;
+
+/// <summary>
+///     End-to-end cover for weasel#448: the migration path validates every identifier a table
+///     writes, not only the ones that name a database object. Before this, a column name, the
+///     primary key constraint name and a check constraint name all went into DDL unexamined —
+///     <c>DatabaseBase</c> only walked <see cref="ISchemaObject.AllNames" />, and none of the five
+///     providers put those names there.
+/// </summary>
+/// <remarks>
+///     SQLite is the provider these live on because it needs no container. The coverage itself is
+///     cross-provider and structural, and is held by
+///     <c>Weasel.Core.Tests.table_identifier_coverage_conformance</c>; this suite proves the
+///     structural coverage actually reaches <c>Migrator.AssertValidIdentifier</c> on a real
+///     migration.
+/// </remarks>
+public class migration_path_identifier_validation
+{
+    private static DatabaseWithTables NewDatabase()
+        => new("test", $"Data Source={Path.GetTempFileName()};");
+
+    [Fact]
+    public async Task a_column_name_carrying_the_delimiter_is_rejected()
+    {
+        var db = NewDatabase();
+        var table = db.AddTable(new DbObjectName("main", "mpiv_people"));
+        table.AddPrimaryKeyColumn("id", typeof(int));
+        table.AddColumn("na\"me", typeof(string));
+
+        var ex = await Should.ThrowAsync<InvalidOperationException>(
+            () => db.ApplyAllConfiguredChangesToDatabaseAsync());
+
+        ex.Message.ShouldContain("na\"me");
+        ex.Message.ShouldContain("a double quote");
+    }
+
+    [Fact]
+    public async Task a_column_name_carrying_a_semicolon_is_rejected()
+    {
+        var db = NewDatabase();
+        var table = db.AddTable(new DbObjectName("main", "mpiv_semicolon"));
+        table.AddPrimaryKeyColumn("id", typeof(int));
+        table.AddColumn("name; drop table students", typeof(string));
+
+        var ex = await Should.ThrowAsync<InvalidOperationException>(
+            () => db.ApplyAllConfiguredChangesToDatabaseAsync());
+
+        ex.Message.ShouldContain("a semicolon");
+    }
+
+    [Fact]
+    public async Task a_primary_key_constraint_name_is_rejected()
+    {
+        var db = NewDatabase();
+        var table = db.AddTable(new DbObjectName("main", "mpiv_pk"));
+        table.AddPrimaryKeyColumn("id", typeof(int));
+        table.PrimaryKeyName = "pk\"broken";
+
+        var ex = await Should.ThrowAsync<InvalidOperationException>(
+            () => db.ApplyAllConfiguredChangesToDatabaseAsync());
+
+        ex.Message.ShouldContain("pk\"broken");
+    }
+
+    [Fact]
+    public async Task a_check_constraint_name_is_rejected()
+    {
+        var db = NewDatabase();
+        var table = db.AddTable(new DbObjectName("main", "mpiv_check"));
+        table.AddPrimaryKeyColumn("id", typeof(int));
+        table.AddColumn("qty", typeof(int));
+        table.AddCheckConstraint("ck\"broken", "qty > 0");
+
+        var ex = await Should.ThrowAsync<InvalidOperationException>(
+            () => db.ApplyAllConfiguredChangesToDatabaseAsync());
+
+        ex.Message.ShouldContain("ck\"broken");
+    }
+
+    /// <summary>
+    ///     A foreign key name reaches validation now that SQLite's <c>AllNames()</c> yields it.
+    ///     SQLite writes its foreign keys inline in CREATE TABLE, which is why they had been left
+    ///     out — but the name is still written, so it still has to be checked.
+    /// </summary>
+    [Fact]
+    public async Task a_foreign_key_constraint_name_is_rejected()
+    {
+        var db = NewDatabase();
+        var table = db.AddTable(new DbObjectName("main", "mpiv_fk"));
+        table.AddPrimaryKeyColumn("id", typeof(int));
+        table.AddColumn("state_id", typeof(int));
+        table.AddForeignKey("fk\"broken", new DbObjectName("main", "mpiv_states"), ["state_id"], ["id"]);
+
+        var ex = await Should.ThrowAsync<InvalidOperationException>(
+            () => db.ApplyAllConfiguredChangesToDatabaseAsync());
+
+        ex.Message.ShouldContain("fk\"broken");
+    }
+
+    /// <summary>
+    ///     The other half of the policy settled in weasel#448: an interior space is a legitimate
+    ///     legacy name, every provider quotes for shape as of weasel#447, and the migration path
+    ///     lets it through and creates the column.
+    /// </summary>
+    [Fact]
+    public async Task an_interior_space_survives_the_whole_migration_path()
+    {
+        var db = NewDatabase();
+        var table = db.AddTable(new DbObjectName("main", "mpiv_legacy"));
+        table.AddPrimaryKeyColumn("id", typeof(int));
+        table.AddColumn("unit price", typeof(decimal));
+
+        await db.ApplyAllConfiguredChangesToDatabaseAsync();
+        await db.AssertDatabaseMatchesConfigurationAsync();
+    }
+}

--- a/src/Weasel.Sqlite/Tables/Table.cs
+++ b/src/Weasel.Sqlite/Tables/Table.cs
@@ -188,6 +188,14 @@ public partial class Table: TableBase<TableColumn, IndexDefinition, ForeignKey>
         {
             yield return new SqliteObjectName(index.Name);
         }
+
+        // SQLite writes its foreign keys inline in CREATE TABLE rather than as ALTER statements,
+        // which is why they were missing here -- but the constraint is still named, the name is
+        // still written into DDL, and every other provider yields it (weasel#448).
+        foreach (var fk in ForeignKeys)
+        {
+            yield return new SqliteObjectName(fk.Name);
+        }
     }
 
     private string PrimaryKeyDeclaration()


### PR DESCRIPTION
Closes #448. Second and final slice; #467 settled the whitespace half.

## The gap

`DatabaseBase` validated whatever `ISchemaObject.AllNames()` yielded. That is the table, its indexes and its foreign keys — on four providers. SQLite omitted foreign keys, because it writes them inline in `CREATE TABLE` and they never felt like separate objects. And **column names, the primary key constraint name and check constraint names were validated by no provider at all.**

## Why not just extend `AllNames()`

It yields `DbObjectName`, and its callers read the schema off every name it returns — `SchemaMigration.Schemas`, `DatabaseBase.ApplyAllConfiguredChangesToDatabaseAsync`. A column name arriving there would be claiming to be an object in a schema.

So the names that are *not* objects get their own seam:

```csharp
public interface ISchemaObjectWithLocalIdentifiers : ISchemaObject
{
    IEnumerable<string> LocalIdentifiers();
}
```

Implemented once on `TableBase` — columns, primary key name, check constraint names — so it is true of all five providers in one place. `ISchemaObject` itself is untouched, so nothing outside the repo has to implement anything.

Foreign key names stay where they belong: SQLite's `AllNames()` now yields them like everyone else's.

The primary key name is only offered when the table actually declares a primary key. `PrimaryKeyName` falls back to `DefaultPrimaryKeyName()` whenever it has not been set, so reading it unconditionally would validate a string that is never emitted — and every provider derives that fallback from the table name, which is already checked.

## The policy split, settled and documented

#448 asked for a decision, not just coverage. The rule now stated in the `IdentifierValidation` remarks:

- **Migration path is strict.** This is where Weasel chooses the names it will bring into existence. `na"me` is refused.
- **Direct API is not validated, and that is deliberate.** `WriteCreateStatement` / `ApplyChangesAsync` is how you drive a schema Weasel did not author, and there correct quoting (#447) is what keeps a hostile name safe.

That split is what lets `unit price` work against a legacy table while a new table still cannot be created with a name carrying a delimiter.

Those remarks also still described whitespace as rejected in full. #467 changed that and the doc had not caught up; fixed here.

## Tests

`Weasel.Core.Tests/table_identifier_coverage_conformance.cs` — built entirely through `ITable`, so a provider joins with one entry in `Providers` and nothing else. The load-bearing invariant is `every_name_the_table_writes_is_reachable_by_validation`: build a table carrying every kind of name, assert the union of `AllNames()` and `LocalIdentifiers()` contains each one. **11 of its 20 cases fail on `master`** — verified by reverting just the two product changes.

Names are compared case-insensitively: Oracle folds an unquoted identifier on the way into the model, and that is correct rather than a coverage gap.

`Weasel.Sqlite.Tests/migration_path_identifier_validation.cs` — proves the structural coverage actually reaches `Migrator.AssertValidIdentifier` on a real migration, including the other half of the policy: `an_interior_space_survives_the_whole_migration_path` creates a `unit price` column and asserts the database matches. SQLite because it needs no container.

## Verified locally

All five provider suites plus Core, against the compose stack: Core 155, SQLite 407, PostgreSQL 868, SQL Server 429, Oracle 228, MySQL 250. No failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)