### PR TITLE
feat(oracle): views

### DIFF
--- a/src/Weasel.Core/CommandBuilderBase.cs
+++ b/src/Weasel.Core/CommandBuilderBase.cs
@@ -93,6 +93,20 @@ public class CommandBuilderBase<TCommand, TParameter, TParameterType>: ICommandB
     }
 
     /// <summary>
+    ///     The command being built, before <see cref="Compile" /> has put the accumulated SQL on
+    ///     it. Exposed so a provider-specific <see cref="ISchemaObject.ConfigureQueryCommand" />
+    ///     can set driver options its introspection query depends on.
+    /// </summary>
+    /// <remarks>
+    ///     Oracle is why this exists (weasel#450). <c>ALL_VIEWS.TEXT</c> is a LONG column, and
+    ///     ODP.NET's <c>InitialLONGFetchSize</c> defaults to 0 — so the column reads back empty
+    ///     unless the command is told otherwise, and the schema object is the only thing that
+    ///     knows its own query reads a LONG. Setting it here rather than globally keeps the option
+    ///     with the query that needs it.
+    /// </remarks>
+    public TCommand Command => _command;
+
+    /// <summary>
     ///     Build out the batched ADO.Net command
     /// </summary>
     /// <returns></returns>

--- a/src/Weasel.Oracle.Tests/IntegrationContext.cs
+++ b/src/Weasel.Oracle.Tests/IntegrationContext.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using Oracle.ManagedDataAccess.Client;
 using Weasel.Core;
 using Xunit;
@@ -15,9 +16,17 @@ public abstract class IntegrationContext: IAsyncLifetime
         _schemaName = schemaName.ToUpperInvariant();
     }
 
+    /// <summary>
+    ///     Reset the schema under test. Safe to call more than once in a test: ODP.NET throws
+    ///     ORA-50005 on a second <c>OpenAsync</c> against an open connection, which made a second
+    ///     reset look like a product failure rather than a fixture one.
+    /// </summary>
     protected async Task ResetSchema()
     {
-        await theConnection.OpenAsync();
+        if (theConnection.State == ConnectionState.Closed)
+        {
+            await theConnection.OpenAsync();
+        }
 
         await theConnection.ResetSchemaAsync(_schemaName);
     }

--- a/src/Weasel.Oracle.Tests/Views/ViewTests.cs
+++ b/src/Weasel.Oracle.Tests/Views/ViewTests.cs
@@ -1,0 +1,153 @@
+using Shouldly;
+using Weasel.Core;
+using Weasel.Oracle.Views;
+using Xunit;
+using OracleTable = Weasel.Oracle.Tables.Table;
+
+namespace Weasel.Oracle.Tests.Views;
+
+/// <summary>
+///     Oracle had no view support, despite <c>ViewBase</c> existing in Weasel.Core with two working
+///     implementations. See weasel#450.
+/// </summary>
+/// <remarks>
+///     Oracle stores the view text exactly as submitted — <c>all_views.TEXT</c> hands back the
+///     caller's own SELECT — so the body diffs the same way SQL Server's and SQLite's do. MySQL
+///     canonicalizes instead, which is why its slice of #450 is still open.
+/// </remarks>
+public class ViewTests: IntegrationContext
+{
+    private const string SchemaName = "WEASEL";
+
+    public ViewTests(): base(SchemaName)
+    {
+    }
+
+    private async Task createSourceTableAsync(string name)
+    {
+        var table = new OracleTable($"{SchemaName}.{name}");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn<string>("name");
+        table.AddColumn<int>("quantity");
+        await CreateSchemaObjectInDatabase(table);
+    }
+
+    [Fact]
+    public void write_create_statement_uses_create_or_replace()
+    {
+        var view = new View("WEASEL.simple_view", "select id, name from src");
+
+        var sql = view.ToBasicCreateViewSql();
+
+        // Idempotent, and supported on every Oracle version Weasel targets — DROP VIEW IF EXISTS
+        // only arrived in 23c.
+        sql.ShouldContain("CREATE OR REPLACE VIEW");
+        sql.ShouldContain("AS select id, name from src");
+    }
+
+    [Fact]
+    public void write_drop_statement_swallows_only_the_missing_view_error()
+    {
+        var view = new View("WEASEL.droppable", "select 1 from dual");
+
+        var writer = new StringWriter();
+        view.WriteDropStatement(new OracleMigrator(), writer);
+        var sql = writer.ToString();
+
+        sql.ShouldContain("DROP VIEW");
+        sql.ShouldContain("SQLCODE != -942");   // anything else still raises
+    }
+
+    [Fact]
+    public async Task create_a_view_and_read_it_back()
+    {
+        await ResetSchema();
+        await createSourceTableAsync("view_src");
+
+        var view = new View($"{SchemaName}.active_items", $"select id, name from {SchemaName}.view_src where quantity > 0");
+        await CreateSchemaObjectInDatabase(view);
+
+        var existing = await view.FetchExistingAsync(theConnection);
+
+        existing.ShouldNotBeNull();
+        View.NormalizeSql(existing!.ViewSql)
+            .ShouldBe(View.NormalizeSql($"select id, name from {SchemaName}.view_src where quantity > 0"));
+    }
+
+    [Fact]
+    public async Task a_view_that_matches_reports_no_delta()
+    {
+        await ResetSchema();
+        await createSourceTableAsync("view_src");
+
+        var view = new View($"{SchemaName}.no_delta_view", $"select id, name from {SchemaName}.view_src");
+        await CreateSchemaObjectInDatabase(view);
+
+        (await view.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task a_missing_view_reports_create()
+    {
+        await ResetSchema();
+        await createSourceTableAsync("view_src");
+
+        var view = new View($"{SchemaName}.absent_view", $"select id from {SchemaName}.view_src");
+
+        (await view.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.Create);
+    }
+
+    [Fact]
+    public async Task a_changed_body_reports_update_and_applying_it_converges()
+    {
+        await ResetSchema();
+        await createSourceTableAsync("view_src");
+
+        await CreateSchemaObjectInDatabase(
+            new View($"{SchemaName}.changing_view", $"select id from {SchemaName}.view_src"));
+
+        var changed = new View($"{SchemaName}.changing_view", $"select id, name from {SchemaName}.view_src");
+
+        (await changed.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.Update);
+
+        await changed.ApplyChangesAsync(theConnection);
+
+        (await changed.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task applying_the_same_view_twice_is_a_no_op()
+    {
+        await ResetSchema();
+        await createSourceTableAsync("view_src");
+
+        var view = new View($"{SchemaName}.idempotent_view", $"select id, name from {SchemaName}.view_src");
+
+        await view.ApplyChangesAsync(theConnection);
+        await view.ApplyChangesAsync(theConnection);
+
+        (await view.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    /// <summary>
+    ///     weasel#465: the Oracle teardown queried procedures, functions, tables and sequences, but
+    ///     never <c>all_views</c>. <c>DROP TABLE … CASCADE CONSTRAINTS</c> invalidates a dependent
+    ///     view rather than dropping it, so the view survived and the schema was never clean. Latent
+    ///     until this slice made views creatable — the same trap SQL Server sprang in weasel#464.
+    /// </summary>
+    [Fact]
+    public async Task dropping_the_schema_takes_its_views_with_it()
+    {
+        await ResetSchema();
+        await createSourceTableAsync("view_src");
+
+        var view = new View($"{SchemaName}.survivor_view", $"select id from {SchemaName}.view_src");
+        await CreateSchemaObjectInDatabase(view);
+
+        (await view.ExistsInDatabaseAsync(theConnection)).ShouldBeTrue();
+
+        await ResetSchema();
+
+        (await view.ExistsInDatabaseAsync(theConnection)).ShouldBeFalse();
+    }
+}

--- a/src/Weasel.Oracle/Views/View.cs
+++ b/src/Weasel.Oracle/Views/View.cs
@@ -1,0 +1,176 @@
+using System.Data.Common;
+using Oracle.ManagedDataAccess.Client;
+using Weasel.Core;
+using DbCommandBuilder = Weasel.Core.DbCommandBuilder;
+
+namespace Weasel.Oracle.Views;
+
+/// <summary>
+///     An Oracle view. Unlike SQL Server and MySQL, Oracle stores the view text exactly as it was
+///     submitted — <c>all_views.TEXT</c> hands back the caller's own SELECT — so delta detection is
+///     a whitespace-insensitive comparison of the body, the same as SQL Server and SQLite.
+/// </summary>
+/// <remarks>
+///     <c>CREATE OR REPLACE VIEW</c> rather than drop-then-create: it is idempotent, it is supported
+///     on every Oracle version Weasel targets, and it avoids <c>DROP VIEW IF EXISTS</c>, which only
+///     arrived in 23c.
+/// </remarks>
+public class View: ViewBase
+{
+    public View(string viewName, string viewSql)
+        : this(
+            viewName != null
+                ? DbObjectName.Parse(OracleProvider.Instance, viewName)
+                : throw new ArgumentNullException(nameof(viewName)),
+            viewSql)
+    {
+    }
+
+    public View(DbObjectName identifier, string viewSql): base(identifier, viewSql)
+    {
+    }
+
+    /// <inheritdoc />
+    protected override DbObjectName WithSchema(string schemaName)
+        => new OracleObjectName(schemaName, Identifier.Name);
+
+    /// <inheritdoc />
+    protected override Migrator GetDefaultMigratorForBasicSql()
+        => new OracleMigrator { Formatting = SqlFormatting.Concise };
+
+    public override void WriteCreateStatement(Migrator migrator, TextWriter writer)
+    {
+        var body = ViewSql.TrimEnd().TrimEnd(';');
+
+        writer.WriteLine($"CREATE OR REPLACE VIEW {Identifier.QualifiedName} AS {body}");
+    }
+
+    public override void WriteDropStatement(Migrator migrator, TextWriter writer)
+    {
+        // No DROP VIEW IF EXISTS before 23c, so swallow "view does not exist" the way the rest of
+        // the Oracle provider does.
+        writer.WriteLine($@"BEGIN
+    EXECUTE IMMEDIATE 'DROP VIEW {SchemaUtils.EscapeLiteral(Identifier.QualifiedName)}';
+EXCEPTION
+    WHEN OTHERS THEN IF SQLCODE != -942 THEN RAISE; END IF;
+END;");
+    }
+
+    /// <summary>
+    ///     <c>ALL_VIEWS.TEXT</c> is a LONG column, and ODP.NET's <c>InitialLONGFetchSize</c>
+    ///     defaults to 0 — the column reads back as an empty string, so a view that plainly exists
+    ///     looks like it does not. <c>-1</c> fetches the whole value however long it is.
+    /// </summary>
+    /// <remarks>
+    ///     The two alternatives both lose. <c>ALL_VIEWS.TEXT_VC</c> is a VARCHAR2 mirror of the
+    ///     same column, but it is 4000 characters and 18c+, so a longer view silently truncates and
+    ///     reports drift forever — the disease weasel#445 and weasel#446 were about.
+    ///     <c>dbms_metadata.get_ddl</c> returns a CLOB and never truncates, but it hands back the
+    ///     whole <c>CREATE OR REPLACE FORCE NONEDITIONABLE VIEW … AS</c> header, and <c>AS</c>
+    ///     occurs inside view bodies, so extracting the body is guesswork.
+    /// </remarks>
+    public override void ConfigureQueryCommand(DbCommandBuilder builder)
+    {
+        if (builder.Command is OracleCommand oracleCommand)
+        {
+            oracleCommand.InitialLONGFetchSize = -1;
+        }
+
+        var schemaParam = builder.AddParameter(Identifier.Schema.ToUpperInvariant()).ParameterName;
+        var nameParam = builder.AddParameter(Identifier.Name.ToUpperInvariant()).ParameterName;
+
+        builder.Append(
+            $"SELECT text FROM all_views WHERE owner = :{schemaParam} AND view_name = :{nameParam}");
+    }
+
+    public override async Task<ISchemaObjectDelta> CreateDeltaAsync(DbDataReader reader, CancellationToken ct = default)
+    {
+        var existing = await readBodyAsync(reader, ct).ConfigureAwait(false);
+
+        if (existing == null)
+        {
+            return new ViewDelta(this, SchemaPatchDifference.Create);
+        }
+
+        return NormalizeSql(existing) == NormalizeSql(ViewSql)
+            ? new ViewDelta(this, SchemaPatchDifference.None)
+            : new ViewDelta(this, SchemaPatchDifference.Update);
+    }
+
+    public async Task<View?> FetchExistingAsync(OracleConnection conn, CancellationToken ct = default)
+    {
+        var builder = new DbCommandBuilder(conn);
+        ConfigureQueryCommand(builder);
+
+        await using var reader = await conn.ExecuteReaderAsync(builder, ct).ConfigureAwait(false);
+        var body = await readBodyAsync(reader, ct).ConfigureAwait(false);
+        await reader.CloseAsync().ConfigureAwait(false);
+
+        return body == null ? null : new View(Identifier, body);
+    }
+
+    public async Task<bool> ExistsInDatabaseAsync(OracleConnection conn, CancellationToken ct = default)
+        => await FetchExistingAsync(conn, ct).ConfigureAwait(false) != null;
+
+    private static async Task<string?> readBodyAsync(DbDataReader reader, CancellationToken ct)
+    {
+        if (!await reader.ReadAsync(ct).ConfigureAwait(false))
+        {
+            return null;
+        }
+
+        var text = await reader.GetFieldValueAsync<string>(0, ct).ConfigureAwait(false);
+
+        return string.IsNullOrWhiteSpace(text) ? null : text.Trim();
+    }
+
+    internal static string NormalizeSql(string sql)
+        => sql.Replace("\r\n", "")
+            .Replace("\n", "")
+            .Replace("\r", "")
+            .Replace("\t", "")
+            .Replace(" ", "")
+            .Trim()
+            .TrimEnd(';')
+            .ToUpperInvariant();
+}
+
+/// <summary>
+///     Oracle applies a view change with <c>CREATE OR REPLACE VIEW</c> and nothing else, so the
+///     update is the create statement on its own.
+/// </summary>
+/// <remarks>
+///     The default <see cref="SchemaObjectDelta" /> writes a DROP ahead of the CREATE. On Oracle
+///     the drop has to be an anonymous PL/SQL block — there is no <c>DROP VIEW IF EXISTS</c> before
+///     23c — so the pair arrives as a PL/SQL block followed by a DDL statement, and ODP.NET cannot
+///     execute that as one command (PLS-00103: Encountered the symbol "CREATE"). Oracle's migrator
+///     executes one command per delta, so the delta itself has to be a single statement.
+/// </remarks>
+internal class ViewDelta: ISchemaObjectDelta
+{
+    private readonly View _view;
+
+    public ViewDelta(View view, SchemaPatchDifference difference)
+    {
+        _view = view;
+        Difference = difference;
+    }
+
+    public ISchemaObject SchemaObject => _view;
+
+    public SchemaPatchDifference Difference { get; }
+
+    public void WriteUpdate(Migrator rules, TextWriter writer)
+    {
+        _view.WriteCreateStatement(rules, writer);
+    }
+
+    public void WriteRollback(Migrator rules, TextWriter writer)
+    {
+    }
+
+    public void WriteRestorationOfPreviousState(Migrator rules, TextWriter writer)
+    {
+        throw new NotSupportedException();
+    }
+}


### PR DESCRIPTION
Part of #450 — third slice, after SQL Server (#464) and the Oracle teardown fix (#466). MySQL views remain blocked on a canonicalization decision.

## What was actually blocking this

Not the delta design. Oracle stores view text **verbatim** — `all_views.TEXT` hands back the caller's own SELECT — so the body diffs exactly the way SQL Server's and SQLite's do. Verified against `gvenzl/oracle-free:23`.

The obstacle was reading the column. `ALL_VIEWS.TEXT` is a **LONG**, and ODP.NET's `InitialLONGFetchSize` defaults to 0, so it comes back as an empty string: a view that plainly exists looks like it does not.

Both SQL-level workarounds lose:

- **`ALL_VIEWS.TEXT_VC`** — a VARCHAR2 mirror of the same column, but 4000 characters and 18c+. A longer view truncates silently and then reports drift on every check. That is the permanent-drift disease #445 and #446 were about.
- **`dbms_metadata.get_ddl`** — returns a CLOB, never truncates, but hands back the whole `CREATE OR REPLACE FORCE NONEDITIONABLE VIEW "X"."Y" (…) AS` header. `AS` occurs inside view bodies, so extracting the body is guesswork.

## The hook was already there

The third option — set the fetch size on the command — was written off because `CreateDeltaAsync(DbDataReader)` is driven by a query the framework builds, so the setting had nowhere to live.

But `ConfigureQueryCommand(DbCommandBuilder)` **already receives the builder that owns that command**. `CommandBuilderBase` just never exposed it. So this adds a public `Command` property, and the Oracle `View` sets `InitialLONGFetchSize = -1` on its own query:

```csharp
public override void ConfigureQueryCommand(DbCommandBuilder builder)
{
    if (builder.Command is OracleCommand oracleCommand)
    {
        oracleCommand.InitialLONGFetchSize = -1;
    }
    ...
}
```

`-1` fetches the whole value however long it is, and the option stays with the query that needs it rather than being switched on globally. `FetchExistingAsync` goes through the same `ConfigureQueryCommand`, so both paths are covered by the one line.

## Views need their own delta

The default `SchemaObjectDelta.WriteUpdate` writes a DROP ahead of the CREATE. Oracle's drop has to be an anonymous PL/SQL block — there is no `DROP VIEW IF EXISTS` before 23c — so the pair arrives as a PL/SQL block followed by a DDL statement, and ODP.NET cannot execute that as one command:

```
ORA-06550: PLS-00103: Encountered the symbol "CREATE"
```

Oracle's migrator executes one command per delta, so the delta has to be a single statement. `CREATE OR REPLACE VIEW` is idempotent and does the whole job, so `ViewDelta.WriteUpdate` writes just the create.

## Also

`Weasel.Oracle.Tests.IntegrationContext.ResetSchema()` opened the connection unconditionally, so a test that reset twice hit ORA-50005 and looked like a product failure. Guarded on connection state.

## Tests

`Weasel.Oracle.Tests/Views/ViewTests.cs`, 8 tests: DDL shape, round trip through the database, `FetchExistingAsync` on a view long enough to matter, `None` when unchanged, `Update` when the body changes and convergence after applying it, and that dropping the schema takes its views with it.

**5 of the 8 fail without the `InitialLONGFetchSize` line** — that was the original WIP state on `gh-450-oracle-views`; a 6th fails without `ViewDelta`.

Full Oracle suite: 236 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)