### PR TITLE
feat(mysql): views

### DIFF
--- a/src/Weasel.MySql.Tests/Views/ViewTests.cs
+++ b/src/Weasel.MySql.Tests/Views/ViewTests.cs
@@ -1,0 +1,277 @@
+using MySqlConnector;
+using Shouldly;
+using Weasel.Core;
+using Weasel.MySql.Views;
+using Xunit;
+using MySqlTable = Weasel.MySql.Tables.Table;
+
+namespace Weasel.MySql.Tests.Views;
+
+/// <summary>
+///     MySQL view support, the last slice of weasel#450. It was blocked not on plumbing but on a
+///     design question: MySQL is the only provider of the five that does not store the view text it
+///     was given, so there is nothing to diff the caller's SQL against.
+/// </summary>
+/// <remarks>
+///     The chosen answer is to let the server canonicalize the expected SQL too — create a
+///     throwaway view, read back its <c>VIEW_DEFINITION</c>, drop it — on both the apply and the
+///     assert path, so a view never reports differently depending on which call you make. These
+///     tests pin the two properties that make that exact:
+///     <c>the_probe_renders_what_the_real_view_would</c> and
+///     <c>canonicalization_is_idempotent</c>.
+/// </remarks>
+[Collection("integration")]
+public class ViewTests: IAsyncLifetime
+{
+    private const string SchemaName = "weasel_views";
+
+    private MySqlConnection theConnection = default!;
+
+    public async ValueTask InitializeAsync()
+    {
+        var builder = new MySqlConnectionStringBuilder(ConnectionSource.ConnectionString)
+        {
+            // Root, because the `weasel` user CI connects as is granted rights on weasel_testing
+            // only and cannot create the schema these views live in. A default database is still
+            // needed: MySQL refuses statements that carry no schema context even when every name
+            // in them is qualified.
+            UserID = "root", Password = "P@55w0rd", Database = "weasel_testing"
+        };
+
+        theConnection = new MySqlConnection(builder.ConnectionString);
+        await theConnection.OpenAsync();
+        await theConnection.ResetSchemaAsync(SchemaName);
+
+        await createSourceTableAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await theConnection.DropSchemaAsync(SchemaName);
+        await theConnection.CloseAsync();
+        await theConnection.DisposeAsync();
+    }
+
+    private async Task createSourceTableAsync()
+    {
+        var table = new MySqlTable($"{SchemaName}.view_src");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn<string>("name");
+        table.AddColumn<int>("quantity");
+
+        await table.CreateAsync(theConnection);
+    }
+
+    private Task executeAsync(string sql)
+        => theConnection.CreateCommand(sql).ExecuteNonQueryAsync();
+
+    private async Task<string?> storedDefinitionAsync(string viewName)
+    {
+        var result = await theConnection
+            .CreateCommand(
+                "SELECT view_definition FROM information_schema.VIEWS WHERE table_schema = @schema AND table_name = @name")
+            .With("schema", SchemaName)
+            .With("name", viewName)
+            .ExecuteScalarAsync();
+
+        return result as string;
+    }
+
+    [Fact]
+    public void write_create_statement_uses_create_or_replace()
+    {
+        var view = new View($"{SchemaName}.simple_view", "select id, name from `weasel_views`.view_src");
+
+        var sql = view.ToBasicCreateViewSql();
+
+        sql.ShouldContain("CREATE OR REPLACE VIEW");
+        sql.ShouldContain("AS select id, name from `weasel_views`.view_src");
+    }
+
+    [Fact]
+    public void write_drop_statement_is_guarded()
+    {
+        var view = new View($"{SchemaName}.droppable", "select 1");
+
+        var writer = new StringWriter();
+        view.WriteDropStatement(new MySqlMigrator(), writer);
+
+        writer.ToString().ShouldContain("DROP VIEW IF EXISTS");
+    }
+
+    /// <summary>
+    ///     The property the whole design rests on: a view's own name never appears in its
+    ///     <c>VIEW_DEFINITION</c>, so a probe view created under a throwaway name renders
+    ///     byte-identically to what the real view would. Without this the probe would only be an
+    ///     approximation.
+    /// </summary>
+    [Fact]
+    public async Task the_probe_renders_what_the_real_view_would()
+    {
+        const string body = "select id, name from `weasel_views`.view_src where quantity > 0";
+
+        await executeAsync($"CREATE OR REPLACE VIEW `{SchemaName}`.real_view AS {body}");
+
+        var view = new View($"{SchemaName}.real_view", body);
+        var canonical = await view.CanonicalizeAsync(theConnection);
+
+        canonical.ShouldBe(await storedDefinitionAsync("real_view"));
+
+        // ...and it really is a rewrite, not a passthrough -- otherwise this test proves nothing.
+        canonical.ShouldNotBe(body);
+        canonical.ShouldContain($"`{SchemaName}`.`view_src`");
+    }
+
+    /// <summary>
+    ///     The second property: feeding MySQL its own canonical rendering produces that same
+    ///     rendering. Without it the comparison could oscillate.
+    /// </summary>
+    [Fact]
+    public async Task canonicalization_is_idempotent()
+    {
+        var view = new View($"{SchemaName}.idem_view", "select id, name from `weasel_views`.view_src where quantity > 0");
+
+        var once = await view.CanonicalizeAsync(theConnection);
+        var twice = await new View($"{SchemaName}.idem_view", once).CanonicalizeAsync(theConnection);
+
+        twice.ShouldBe(once);
+    }
+
+    /// <summary>
+    ///     An unqualified name in a view body resolves against the session's default schema at
+    ///     creation time, and MySQL bakes that resolution into the stored definition. So the probe
+    ///     has to run with the same default database as the connection the real view is created on
+    ///     — otherwise it canonicalizes to a different table and every such view reports drift.
+    /// </summary>
+    [Fact]
+    public async Task an_unqualified_name_resolves_the_same_way_in_the_probe()
+    {
+        await executeAsync("CREATE TABLE IF NOT EXISTS `weasel_testing`.unqualified_src (id INT PRIMARY KEY)");
+
+        try
+        {
+            const string body = "select id from unqualified_src";
+
+            await executeAsync($"CREATE OR REPLACE VIEW `{SchemaName}`.unqualified_view AS {body}");
+
+            var view = new View($"{SchemaName}.unqualified_view", body);
+
+            (await view.CanonicalizeAsync(theConnection))
+                .ShouldBe(await storedDefinitionAsync("unqualified_view"));
+
+            (await view.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+        }
+        finally
+        {
+            await executeAsync("DROP TABLE IF EXISTS `weasel_testing`.unqualified_src");
+        }
+    }
+
+    [Fact]
+    public async Task the_probe_leaves_nothing_behind()
+    {
+        var view = new View($"{SchemaName}.tidy_view", "select id from `weasel_views`.view_src");
+
+        await view.CanonicalizeAsync(theConnection);
+
+        var probes = await theConnection
+            .CreateCommand(
+                "SELECT COUNT(*) FROM information_schema.VIEWS WHERE table_schema = @schema AND table_name LIKE 'weasel_view_probe_%'")
+            .With("schema", SchemaName)
+            .ExecuteScalarAsync();
+
+        Convert.ToInt32(probes).ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task a_missing_view_reports_create_and_applying_it_converges()
+    {
+        var view = new View($"{SchemaName}.created_view", "select id, name from `weasel_views`.view_src");
+
+        (await view.ExistsInDatabaseAsync(theConnection)).ShouldBeFalse();
+
+        var delta = await view.FindDeltaAsync(theConnection);
+        delta.Difference.ShouldBe(SchemaPatchDifference.Create);
+
+        await view.ApplyChangesAsync(theConnection);
+
+        (await view.ExistsInDatabaseAsync(theConnection)).ShouldBeTrue();
+    }
+
+    /// <summary>
+    ///     The regression this design exists to prevent. Comparing the caller's SQL against MySQL's
+    ///     stored rewrite reports <c>Update</c> forever; the second check has to say <c>None</c>.
+    /// </summary>
+    [Fact]
+    public async Task an_unchanged_view_does_not_report_permanent_drift()
+    {
+        var view = new View($"{SchemaName}.stable_view", "select id, name from `weasel_views`.view_src where quantity > 0");
+
+        await view.ApplyChangesAsync(theConnection);
+
+        (await view.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+        (await view.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    /// <summary>
+    ///     Reformatting the same query must not read as a change either — that is the other half of
+    ///     "does not drift". Different whitespace, different case, same meaning.
+    /// </summary>
+    [Fact]
+    public async Task reformatting_the_same_query_is_not_a_change()
+    {
+        var view = new View($"{SchemaName}.reformat_view", "select id, name from `weasel_views`.view_src where quantity > 0");
+        await view.ApplyChangesAsync(theConnection);
+
+        var reformatted = new View(
+            $"{SchemaName}.reformat_view",
+            """
+            SELECT id,
+                   name
+            FROM   `weasel_views`.view_src
+            WHERE  quantity > 0
+            """);
+
+        (await reformatted.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task a_changed_body_reports_update_and_applying_it_converges()
+    {
+        var original = new View($"{SchemaName}.changing_view", "select id, name from `weasel_views`.view_src");
+        await original.ApplyChangesAsync(theConnection);
+
+        var changed = new View($"{SchemaName}.changing_view", "select id, name, quantity from `weasel_views`.view_src");
+
+        (await changed.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.Update);
+
+        await changed.ApplyChangesAsync(theConnection);
+
+        (await changed.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task fetch_existing_returns_the_stored_definition()
+    {
+        var view = new View($"{SchemaName}.fetched_view", "select id, name from `weasel_views`.view_src where quantity > 0");
+        await view.ApplyChangesAsync(theConnection);
+
+        var existing = await view.FetchExistingAsync(theConnection);
+
+        existing.ShouldNotBeNull();
+        existing!.ViewSql.ShouldBe(await storedDefinitionAsync("fetched_view"));
+    }
+
+    [Fact]
+    public async Task dropping_the_schema_takes_its_views_with_it()
+    {
+        var view = new View($"{SchemaName}.survivor_view", "select id from `weasel_views`.view_src");
+        await view.ApplyChangesAsync(theConnection);
+
+        (await view.ExistsInDatabaseAsync(theConnection)).ShouldBeTrue();
+
+        await theConnection.ResetSchemaAsync(SchemaName);
+
+        (await view.ExistsInDatabaseAsync(theConnection)).ShouldBeFalse();
+    }
+}

--- a/src/Weasel.MySql/Views/View.cs
+++ b/src/Weasel.MySql/Views/View.cs
@@ -1,0 +1,288 @@
+using System.Data;
+using System.Data.Common;
+using MySqlConnector;
+using Weasel.Core;
+using DbCommandBuilder = Weasel.Core.DbCommandBuilder;
+
+namespace Weasel.MySql.Views;
+
+/// <summary>
+///     A MySQL view.
+/// </summary>
+/// <remarks>
+///     <para>
+///         MySQL is the one provider that does not store the view text you gave it. It parses the
+///         body and re-renders it, fully qualifying every table, aliasing every column, and
+///         parenthesizing every predicate. Submit
+///         <c>select id, name from probe_src where qty > 0</c> and
+///         <c>information_schema.VIEWS.VIEW_DEFINITION</c> hands back
+///         <c>select `db`.`probe_src`.`id` AS `id`,`db`.`probe_src`.`name` AS `name` from
+///         `db`.`probe_src` where (`db`.`probe_src`.`qty` > 0)</c>.
+///     </para>
+///     <para>
+///         SQL Server, SQLite and Oracle all store the submitted text verbatim, which is why
+///         whitespace-insensitive comparison works for them. It cannot work here: no amount of
+///         local normalization bridges that rewrite, so comparing the caller's SQL against the
+///         stored text reports <c>Update</c> on every check forever — the permanent-drift disease
+///         weasel#445 and weasel#446 were about.
+///     </para>
+///     <para>
+///         So the expected SQL is canonicalized by the only thing that can canonicalize it: the
+///         server. <see cref="CanonicalizeAsync" /> creates a throwaway view from the caller's SQL,
+///         reads its <c>VIEW_DEFINITION</c>, drops it, and compares that against the stored text.
+///         This is exact rather than approximate — a view's own name never appears in its
+///         <c>VIEW_DEFINITION</c>, so the probe's rendering is byte-identical to what the real view
+///         would produce — and MySQL's canonicalization is idempotent, so the comparison is stable.
+///     </para>
+///     <para>
+///         The probe runs on the apply path and the assert path alike, so a view never reports one
+///         thing to <c>ApplyAllConfiguredChangesToDatabaseAsync</c> and another to
+///         <c>AssertDatabaseMatchesConfigurationAsync</c>. The price is that both paths need
+///         CREATE VIEW / DROP VIEW permission. The result is cached per instance, so it is one
+///         probe per view per process rather than one per check.
+///     </para>
+/// </remarks>
+public class View: ViewBase
+{
+    private string? _canonicalExpected;
+
+    /// <summary>
+    ///     Captured in <see cref="ConfigureQueryCommand" /> so <see cref="CreateDeltaAsync" /> —
+    ///     which is handed a reader and nothing else — can reach the server it is comparing
+    ///     against. The delta runs while the batch reader is still open, so the probe cannot
+    ///     borrow this connection; it clones it.
+    /// </summary>
+    private MySqlConnection? _connection;
+
+    public View(string viewName, string viewSql)
+        : this(
+            viewName != null
+                ? DbObjectName.Parse(MySqlProvider.Instance, viewName)
+                : throw new ArgumentNullException(nameof(viewName)),
+            viewSql)
+    {
+    }
+
+    public View(DbObjectName identifier, string viewSql): base(identifier, viewSql)
+    {
+    }
+
+    /// <inheritdoc />
+    protected override DbObjectName WithSchema(string schemaName)
+        => new MySqlObjectName(schemaName, Identifier.Name);
+
+    /// <inheritdoc />
+    protected override Migrator GetDefaultMigratorForBasicSql()
+        => new MySqlMigrator { Formatting = SqlFormatting.Concise };
+
+    /// <summary>
+    ///     <c>CREATE OR REPLACE VIEW</c>: idempotent, and one statement. MySQL's migrator splits a
+    ///     delta's SQL on semicolons to execute it, so a body carrying a semicolon inside a string
+    ///     literal is safest when the delta is a single statement to begin with.
+    /// </summary>
+    public override void WriteCreateStatement(Migrator migrator, TextWriter writer)
+    {
+        var body = ViewSql.TrimEnd().TrimEnd(';');
+
+        writer.WriteLine($"CREATE OR REPLACE VIEW {QualifiedName(Identifier)} AS {body}");
+    }
+
+    public override void WriteDropStatement(Migrator migrator, TextWriter writer)
+    {
+        writer.WriteLine($"DROP VIEW IF EXISTS {QualifiedName(Identifier)}");
+    }
+
+    public override void ConfigureQueryCommand(DbCommandBuilder builder)
+    {
+        _connection ??= builder.Command.Connection as MySqlConnection;
+
+        var schemaParam = builder.AddParameter(Identifier.Schema).ParameterName;
+        var nameParam = builder.AddParameter(Identifier.Name).ParameterName;
+
+        builder.Append(
+            $"SELECT view_definition FROM information_schema.VIEWS WHERE table_schema = @{schemaParam} AND table_name = @{nameParam}");
+    }
+
+    public override async Task<ISchemaObjectDelta> CreateDeltaAsync(DbDataReader reader, CancellationToken ct = default)
+    {
+        var existing = await readDefinitionAsync(reader, ct).ConfigureAwait(false);
+
+        if (existing == null)
+        {
+            return new ViewDelta(this, SchemaPatchDifference.Create);
+        }
+
+        if (_connection == null)
+        {
+            throw new InvalidOperationException(
+                $"Cannot compare MySQL view {Identifier} without a connection. MySQL rewrites a view's "
+                + "definition when it stores it, so the expected SQL has to be canonicalized by the server "
+                + "before the two can be compared; ConfigureQueryCommand is where that connection is "
+                + "captured, so it has to have run first.");
+        }
+
+        var expected = await CanonicalizeAsync(_connection, ct).ConfigureAwait(false);
+
+        return NormalizeSql(existing) == NormalizeSql(expected)
+            ? new ViewDelta(this, SchemaPatchDifference.None)
+            : new ViewDelta(this, SchemaPatchDifference.Update);
+    }
+
+    public async Task<View?> FetchExistingAsync(MySqlConnection conn, CancellationToken ct = default)
+    {
+        var builder = new DbCommandBuilder(conn);
+        ConfigureQueryCommand(builder);
+
+        await using var reader = await conn.ExecuteReaderAsync(builder, ct).ConfigureAwait(false);
+        var definition = await readDefinitionAsync(reader, ct).ConfigureAwait(false);
+        await reader.CloseAsync().ConfigureAwait(false);
+
+        return definition == null ? null : new View(Identifier, definition);
+    }
+
+    public static Task<View?> FetchExistingAsync(MySqlConnection conn, DbObjectName identifier,
+        CancellationToken ct = default)
+        => new View(identifier, "select 1").FetchExistingAsync(conn, ct);
+
+    public async Task<bool> ExistsInDatabaseAsync(MySqlConnection conn, CancellationToken ct = default)
+        => await FetchExistingAsync(conn, ct).ConfigureAwait(false) != null;
+
+    /// <summary>
+    ///     Render this view's SQL the way MySQL would store it, by having MySQL store it: create a
+    ///     throwaway view from the body, read its <c>VIEW_DEFINITION</c>, drop it.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         The probe runs on its own connection — cloned from <paramref name="template" />,
+    ///         which carries the credentials over — because the caller is typically holding an open
+    ///         reader on that one.
+    ///     </para>
+    ///     <para>
+    ///         The result is cached: the caller's SQL does not change over the life of the object,
+    ///         and neither does the server's rendering of it.
+    ///     </para>
+    /// </remarks>
+    public async Task<string> CanonicalizeAsync(MySqlConnection template, CancellationToken ct = default)
+    {
+        if (_canonicalExpected != null)
+        {
+            return _canonicalExpected;
+        }
+
+        var probeName = $"weasel_view_probe_{Guid.NewGuid():N}";
+        var probe = $"{SchemaUtils.QuoteName(Identifier.Schema)}.{SchemaUtils.QuoteName(probeName)}";
+        var body = ViewSql.TrimEnd().TrimEnd(';');
+
+        // The probe has to see the same default database as the connection the real view will be
+        // created on: an unqualified name in a view body resolves against the session's default
+        // schema at creation time, and MySQL bakes that resolution into the stored definition. A
+        // probe run with a different default would canonicalize to a different table.
+        var builder = new MySqlConnectionStringBuilder(template.ConnectionString)
+        {
+            Database = template.Database
+        };
+
+        await using var conn = template.CloneWith(builder.ConnectionString);
+        await conn.OpenAsync(ct).ConfigureAwait(false);
+
+        try
+        {
+            await conn.CreateCommand($"CREATE OR REPLACE VIEW {probe} AS {body}")
+                .ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+
+            var rendered = await conn
+                .CreateCommand(
+                    "SELECT view_definition FROM information_schema.VIEWS WHERE table_schema = @schema AND table_name = @name")
+                .With("schema", Identifier.Schema)
+                .With("name", probeName)
+                .ExecuteScalarAsync(ct).ConfigureAwait(false);
+
+            // Nothing came back only if the CREATE silently did not take, which MySQL does not do;
+            // falling back to the caller's own SQL keeps the comparison defined rather than null.
+            _canonicalExpected = rendered as string ?? body;
+            return _canonicalExpected;
+        }
+        catch (MySqlException e) when (e.Number is 1142 or 1044)
+        {
+            throw new InvalidOperationException(
+                $"Weasel needs CREATE VIEW and DROP VIEW permission on schema '{Identifier.Schema}' to compare "
+                + $"view {Identifier}. MySQL rewrites a view's definition when it stores it, so the only way to "
+                + "know whether the configured SQL matches what is in the database is to have the server render "
+                + "it. This applies to AssertDatabaseMatchesConfigurationAsync as well as to the apply path, so "
+                + "that a view does not report differently depending on which one you call.", e);
+        }
+        finally
+        {
+            await conn.CreateCommand($"DROP VIEW IF EXISTS {probe}")
+                .ExecuteNonQueryAsync(CancellationToken.None).ConfigureAwait(false);
+        }
+    }
+
+    private static string QualifiedName(DbObjectName identifier)
+        => $"{SchemaUtils.QuoteName(identifier.Schema)}.{SchemaUtils.QuoteName(identifier.Name)}";
+
+    private static async Task<string?> readDefinitionAsync(DbDataReader reader, CancellationToken ct)
+    {
+        if (!await reader.ReadAsync(ct).ConfigureAwait(false))
+        {
+            return null;
+        }
+
+        if (await reader.IsDBNullAsync(0, ct).ConfigureAwait(false))
+        {
+            return null;
+        }
+
+        var definition = await reader.GetFieldValueAsync<string>(0, ct).ConfigureAwait(false);
+
+        return string.IsNullOrWhiteSpace(definition) ? null : definition.Trim();
+    }
+
+    /// <summary>
+    ///     Both sides of the comparison are already canonical MySQL renderings by the time they get
+    ///     here, so this only has to absorb whitespace and case.
+    /// </summary>
+    internal static string NormalizeSql(string sql)
+        => sql.Replace("\r\n", "")
+            .Replace("\n", "")
+            .Replace("\r", "")
+            .Replace("\t", "")
+            .Replace(" ", "")
+            .Trim()
+            .TrimEnd(';')
+            .ToUpperInvariant();
+}
+
+/// <summary>
+///     MySQL applies a view change with <c>CREATE OR REPLACE VIEW</c> and nothing else, so the
+///     update is the create statement on its own — no DROP ahead of it, which would be a second
+///     statement for MySQL's semicolon-splitting executor to run for no reason.
+/// </summary>
+internal class ViewDelta: ISchemaObjectDelta
+{
+    private readonly View _view;
+
+    public ViewDelta(View view, SchemaPatchDifference difference)
+    {
+        _view = view;
+        Difference = difference;
+    }
+
+    public ISchemaObject SchemaObject => _view;
+
+    public SchemaPatchDifference Difference { get; }
+
+    public void WriteUpdate(Migrator rules, TextWriter writer)
+    {
+        _view.WriteCreateStatement(rules, writer);
+    }
+
+    public void WriteRollback(Migrator rules, TextWriter writer)
+    {
+    }
+
+    public void WriteRestorationOfPreviousState(Migrator rules, TextWriter writer)
+    {
+        throw new NotSupportedException();
+    }
+}


### PR DESCRIPTION
Closes #450. Last slice, after SQL Server (#464), the Oracle teardown fix (#466) and Oracle views (#470).

## The decision

MySQL is the only provider of the five that **does not store the view text you gave it**. It parses the body and re-renders it. Measured against `mysql:8.0`:

```sql
CREATE VIEW v AS select id, name from probe_src where qty > 0;
```
```
select `db`.`probe_src`.`id` AS `id`,`db`.`probe_src`.`name` AS `name`
from `db`.`probe_src` where (`db`.`probe_src`.`qty` > 0)
```

No local normalization bridges that, so comparing the caller's SQL against the stored text reports `Update` forever — the permanent-drift disease #445 and #446 were about.

**Chosen: canonicalize the expected SQL through the server, on both paths.** `CanonicalizeAsync` creates a throwaway view from the caller's body, reads its `VIEW_DEFINITION`, drops it, and *that* is compared against the stored text.

Two properties measured on `mysql:8.0` make this **exact rather than approximate**, and both are pinned by tests rather than assumed:

- **A view's own name never appears in its `VIEW_DEFINITION`**, so a probe under a throwaway name renders byte-identically to what the real view would — `the_probe_renders_what_the_real_view_would`.
- **Canonicalization is idempotent**, so the comparison cannot oscillate — `canonicalization_is_idempotent`.

### Why both paths, not just apply

The alternative on the table was probe-on-apply, existence-only-on-assert. That means the same view reports `Update` to `ApplyAllConfiguredChangesToDatabaseAsync` and `None` to `AssertDatabaseMatchesConfigurationAsync` — a discrepancy nobody can debug from the outside, and worse than the cost it avoids.

That cost is real and is stated on the type: **both paths need CREATE VIEW / DROP VIEW permission on the schema.** A permission failure (MySQL 1142 / 1044) is translated into an exception that explains *why* Weasel wanted it, rather than surfacing a bare access-denied. The rendering is cached per instance — one probe per view per process, not one per check.

## The subtle part

The probe runs on a **cloned connection**, because the delta is computed while the batch reader is still open on the original. It carries over the template's **current default database**, and that is not incidental:

> An unqualified name in a view body resolves against the session's default schema at creation time, and MySQL bakes that resolution into the stored definition.

A probe run under a different default canonicalizes to a different table, and every such view would report drift. Found by a test failing, not by reading the manual: `an_unqualified_name_resolves_the_same_way_in_the_probe`.

## Also

Views apply with `CREATE OR REPLACE VIEW` alone, so they get their own `ViewDelta` rather than the default drop-then-create — MySQL's migrator splits a delta's SQL on semicolons to execute it, and a single statement has nothing to split.

MySQL's teardown needs no change: `DROP DATABASE` cascades on the server, so the new object type cannot be left behind. That is the checklist item added to CLAUDE.md in #469, and this is the first slice to run it.

## Tests

`Weasel.MySql.Tests/Views/ViewTests.cs`, 12 tests: the two canonicalization properties above, probe cleanup, `Create`/`None`/`Update` and convergence after each, reformatting-is-not-a-change, unqualified-name resolution, `FetchExistingAsync`, and teardown.

`an_unchanged_view_does_not_report_permanent_drift` checks twice in a row, since a design that drifts would pass a single check.

Root credentials, following `MySqlMigratorTests.ensure_database_creates_database`: the `weasel` user CI connects as has rights on `weasel_testing` only.

Full MySQL suite: 266 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)