### PR TITLE
fix: stop rewriting column names, and quote the ones that need it

### DIFF
--- a/src/Weasel.Core.Tests/column_name_conformance.cs
+++ b/src/Weasel.Core.Tests/column_name_conformance.cs
@@ -1,0 +1,132 @@
+using Shouldly;
+using Weasel.Core;
+using Xunit;
+
+namespace Weasel.Core.Tests;
+
+/// <summary>
+///     The name a caller gives a column is the name of the column that gets created, and everything
+///     that references that column agrees with it. Five providers used to do four different things
+///     here, and three of them rewrote a space into an underscore — but only in
+///     <c>TableColumn</c>, not in the index, foreign key or primary key column lists, so an index
+///     over <c>Order Date</c> named a column that did not exist (weasel#458).
+/// </summary>
+/// <remarks>
+///     <para>
+///         Rewriting was never anyone's decision — it predates the identifier work, and weasel#448
+///         settled that a name is either honoured (quoted where it needs quoting, per weasel#447)
+///         or rejected. Silently changing it is the third option, and nobody chose it.
+///     </para>
+///     <para>
+///         Case folding is a separate question and stays: PostgreSQL, Oracle and SQLite still fold
+///         to lowercase unless <see cref="ITable.PreserveIdentifierCase" /> is set. What changed is
+///         that the flag now controls that and nothing else — it used to switch off the space
+///         rewrite as a side effect, so two unrelated decisions travelled on one bool.
+///     </para>
+/// </remarks>
+public class column_name_conformance
+{
+    public static TheoryData<string, Func<ITable>> Providers =>
+        new()
+        {
+            { "SqlServer", () => new SqlServer.Tables.Table("dbo.orders") },
+            { "MySql", () => new MySql.Tables.Table("weasel_testing.orders") },
+            { "Sqlite", () => new Sqlite.Tables.Table("orders") },
+            { "Postgresql", () => new Postgresql.Tables.Table("public.orders") },
+            { "Oracle", () => new Oracle.Tables.Table("WEASEL.ORDERS") }
+        };
+
+    [Theory]
+    [MemberData(nameof(Providers))]
+    public void a_space_in_a_column_name_is_not_rewritten(string provider, Func<ITable> factory)
+    {
+        var table = factory();
+        table.AddColumn("Order Date", typeof(DateTime));
+
+        table.Columns.Single().Name
+            .ShouldBe("order date", StringCompareShould.IgnoreCase);
+    }
+
+    /// <summary>
+    ///     The bug in the issue title. The column list and the column have to name the same thing.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(Providers))]
+    public void an_index_over_a_spaced_column_references_the_column_that_exists(
+        string provider, Func<ITable> factory)
+    {
+        var table = factory();
+        table.AddColumn("Order Date", typeof(DateTime));
+        table.AddIndex("ix_orders_date", ["Order Date"]);
+
+        var created = table.Columns.Single().Name;
+        var referenced = table.Indexes.Single().Columns!.Single();
+
+        referenced.ShouldBe(created, StringCompareShould.IgnoreCase);
+    }
+
+    [Theory]
+    [MemberData(nameof(Providers))]
+    public void a_foreign_key_over_a_spaced_column_references_the_column_that_exists(
+        string provider, Func<ITable> factory)
+    {
+        var table = factory();
+        table.AddColumn("Customer Id", typeof(int));
+        table.AddForeignKey("fk_orders_customer", table.Identifier, ["Customer Id"], ["id"]);
+
+        var created = table.Columns.Single().Name;
+        var referenced = table.ForeignKeys.Single().ColumnNames.Single();
+
+        referenced.ShouldBe(created, StringCompareShould.IgnoreCase);
+    }
+
+    [Theory]
+    [MemberData(nameof(Providers))]
+    public void a_primary_key_over_a_spaced_column_references_the_column_that_exists(
+        string provider, Func<ITable> factory)
+    {
+        var table = factory();
+        table.AddPrimaryKeyColumn("Order Id", typeof(int));
+
+        var created = table.Columns.Single().Name;
+
+        table.PrimaryKeyColumns.Single().ShouldBe(created, StringCompareShould.IgnoreCase);
+    }
+
+    /// <summary>
+    ///     The DDL is where the mismatch actually bit: the model could be self-consistent and the
+    ///     generated statement still name something else, because the index writers apply their own
+    ///     quoting heuristics. Asserting on the emitted text catches both halves at once.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(Providers))]
+    public void the_generated_ddl_names_the_same_column_everywhere(string provider, Func<ITable> factory)
+    {
+        var table = factory();
+        table.AddPrimaryKeyColumn("Order Id", typeof(int));
+        table.AddColumn("Order Date", typeof(DateTime));
+        table.AddIndex("ix_orders_date", ["Order Date"]);
+
+        var writer = new StringWriter();
+        table.WriteCreateStatement(MigratorFor(provider), writer);
+        var ddl = writer.ToString();
+
+        // Whatever the provider delimits with, the name inside it is the caller's -- never
+        // Order_Date, and never bare across the space where the parser would split it in two.
+        ddl.ShouldNotContain("Order_Date", Case.Insensitive,
+            $"{provider} still rewrites a space into an underscore");
+        ddl.ShouldContain("Order Date", Case.Insensitive,
+            $"{provider} did not emit the column the caller asked for");
+    }
+
+    private static Migrator MigratorFor(string provider)
+        => provider switch
+        {
+            "SqlServer" => new SqlServer.SqlServerMigrator { Formatting = SqlFormatting.Concise },
+            "MySql" => new MySql.MySqlMigrator { Formatting = SqlFormatting.Concise },
+            "Sqlite" => new Sqlite.SqliteMigrator { Formatting = SqlFormatting.Concise },
+            "Postgresql" => new Postgresql.PostgresqlMigrator { Formatting = SqlFormatting.Concise },
+            "Oracle" => new Oracle.OracleMigrator { Formatting = SqlFormatting.Concise },
+            _ => throw new ArgumentOutOfRangeException(nameof(provider), provider, null)
+        };
+}

--- a/src/Weasel.Oracle.Tests/Tables/TableColumnTests.cs
+++ b/src/Weasel.Oracle.Tests/Tables/TableColumnTests.cs
@@ -20,11 +20,22 @@ public class TableColumnTests
         column.Type.ShouldBe("VARCHAR2(100)");
     }
 
+    /// <summary>
+    ///     This asserted <c>first name</c> becoming <c>first_name</c> until weasel#458. The
+    ///     expectation changed rather than the test being deleted, because the rewrite was real
+    ///     and long-standing — it just was not anybody's decision. Only <c>TableColumn</c> did it,
+    ///     so an index or foreign key over the same name still said <c>first name</c> and
+    ///     referenced a column that did not exist.
+    /// </summary>
+    /// <remarks>
+    ///     A space is a legal identifier character (weasel#448) and every provider quotes for shape
+    ///     (weasel#447), so the caller's name is now the column's name.
+    /// </remarks>
     [Fact]
-    public void spaces_in_name_are_replaced_with_underscores()
+    public void a_space_in_a_name_is_kept_rather_than_rewritten()
     {
         var column = new TableColumn("first name", "VARCHAR2(100)");
-        column.Name.ShouldBe("first_name");
+        column.Name.ShouldBe("first name");
     }
 
     [Fact]

--- a/src/Weasel.Oracle/Tables/IndexDefinition.cs
+++ b/src/Weasel.Oracle/Tables/IndexDefinition.cs
@@ -155,7 +155,10 @@ public class IndexDefinition: ITableIndex
             throw new InvalidOperationException("IndexDefinition requires at least one field");
         }
 
-        var expression = Columns.Join(", ");
+        // Quoted: a column named "Order Date" or a reserved word is legal and now reaches here
+        // unrewritten (weasel#458). QuoteName leaves a conventional Oracle identifier bare, so
+        // the folded path is unchanged.
+        var expression = Columns.Select(SchemaUtils.QuoteName).Join(", ");
 
         if (SortOrder != SortOrder.Asc)
         {

--- a/src/Weasel.Oracle/Tables/Table.cs
+++ b/src/Weasel.Oracle/Tables/Table.cs
@@ -231,7 +231,11 @@ END;
             return $"CONSTRAINT \"{PrimaryKeyName}\" PRIMARY KEY ({columns})";
         }
 
-        return $"CONSTRAINT {PrimaryKeyName} PRIMARY KEY ({PrimaryKeyColumns.Join(", ")})";
+        // Quoted for shape: a primary key over a column named "Order Date" reaches here
+        // unrewritten now (weasel#458), and QuoteName leaves a conventional identifier bare so
+        // the folded path emits exactly what it did before.
+        return
+            $"CONSTRAINT {SchemaUtils.QuoteName(PrimaryKeyName)} PRIMARY KEY ({PrimaryKeyColumns.Select(SchemaUtils.QuoteName).Join(", ")})";
     }
 
     public ColumnExpression AddColumn(TableColumn column)

--- a/src/Weasel.Oracle/Tables/TableColumn.cs
+++ b/src/Weasel.Oracle/Tables/TableColumn.cs
@@ -34,13 +34,11 @@ public class TableColumn: ITableColumn
 
         _preserveCase = preserveCase;
         // Undelimited first: a caller who wrote "ORDER DATE" means that column, and Oracle
-        // reports it back bare. The casing and space handling that follow are long-standing
-        // behaviour, untouched here (see weasel#458).
+        // reports it back bare. Case folding is what preserveCase turns off, and nothing else --
+        // it used to silently turn off a space-to-underscore rewrite as well (weasel#458).
         var unquoted = SchemaUtils.Unquote(name.Trim());
 
-        Name = preserveCase
-            ? unquoted.Trim()
-            : unquoted.ToLowerInvariant().Trim().Replace(' ', '_');
+        Name = preserveCase ? unquoted : unquoted.ToLowerInvariant();
         Type = type.ToUpperInvariant();
     }
 

--- a/src/Weasel.Postgresql/Tables/IndexDefinition.cs
+++ b/src/Weasel.Postgresql/Tables/IndexDefinition.cs
@@ -333,6 +333,16 @@ public class IndexDefinition: ITableIndex
 
         var expression = Columns.Select(x =>
         {
+            // A name the parent actually declares as a column is a column, whatever it looks
+            // like. Without this check the heuristic below reads "Order Date" as an expression
+            // and emits it bare, producing an index over a column that does not exist -- the
+            // bug weasel#458 was opened for. Columns may legally carry spaces now that nothing
+            // rewrites them into underscores.
+            if (parent?.HasColumn(x) == true)
+            {
+                return SchemaUtils.QuoteName(x);
+            }
+
             if (x.StartsWith('(') || x.Contains(' ') || x.Contains('-') || x.Contains('\''))
                 return x;
 

--- a/src/Weasel.Postgresql/Tables/TableColumn.cs
+++ b/src/Weasel.Postgresql/Tables/TableColumn.cs
@@ -31,13 +31,11 @@ public class TableColumn: ITableColumn
         }
 
         // Unquoted first: a caller who wrote "Order Date" means that column, and the catalog
-        // reports it back bare. The casing and space handling that follow are long-standing
-        // behaviour, untouched here (see weasel#458).
+        // reports it back bare. Case folding is what preserveCase turns off, and nothing else --
+        // it used to silently turn off a space-to-underscore rewrite as well (weasel#458).
         var unquoted = SchemaUtils.Unquote(name.Trim());
 
-        Name = preserveCase
-            ? unquoted.Trim()
-            : unquoted.ToLowerInvariant().Trim().Replace(' ', '_');
+        Name = preserveCase ? unquoted : unquoted.ToLowerInvariant();
         Type = type.ToLowerInvariant();
     }
 

--- a/src/Weasel.SqlServer/Tables/TableColumn.cs
+++ b/src/Weasel.SqlServer/Tables/TableColumn.cs
@@ -23,8 +23,9 @@ public class TableColumn: ITableColumn
         // produced duplicate-column DDL when callers added the same logical column
         // with different casings (issue: JasperFx/polecat#45).
         // Unbracketed first: a caller who wrote "[Order Date]" means the column Order Date,
-        // and the database will report it back that way.
-        Name = SchemaUtils.Unbracket(name.Trim()).Replace(' ', '_');
+        // and the database will report it back that way -- so that is the column that gets
+        // created, rather than Order_Date (weasel#458).
+        Name = SchemaUtils.Unbracket(name.Trim());
         Type = type.ToLowerInvariant();
     }
 

--- a/src/Weasel.Sqlite/Tables/Table.cs
+++ b/src/Weasel.Sqlite/Tables/Table.cs
@@ -219,7 +219,7 @@ public partial class Table: TableBase<TableColumn, IndexDefinition, ForeignKey>
     /// </summary>
     public ColumnExpression AddColumn(string name, string type)
     {
-        var column = new TableColumn(name, type) { Parent = this };
+        var column = new TableColumn(name, type, PreserveIdentifierCase) { Parent = this };
         _columns.Add(column);
         return new ColumnExpression(this, column);
     }

--- a/src/Weasel.Sqlite/Tables/TableColumn.cs
+++ b/src/Weasel.Sqlite/Tables/TableColumn.cs
@@ -6,7 +6,13 @@ namespace Weasel.Sqlite.Tables;
 
 public class TableColumn: ITableColumn
 {
-    public TableColumn(string name, string type)
+    /// <param name="preserveCase">
+    ///     Keep the caller's casing instead of folding to lowercase. SQLite identifiers are
+    ///     case-insensitive so the folding is only cosmetic, but it was the one provider with no
+    ///     way to turn it off, which meant a table reproducing a schema another tool created came
+    ///     back reporting the wrong casing (weasel#458).
+    /// </param>
+    public TableColumn(string name, string type, bool preserveCase = false)
     {
         if (string.IsNullOrEmpty(name))
         {
@@ -18,11 +24,12 @@ public class TableColumn: ITableColumn
             throw new ArgumentOutOfRangeException(nameof(type));
         }
 
-        // SQLite is case-insensitive, normalize names to lowercase
-        // Undelimited first: a caller who wrote "order date" means that column, and the
-        // catalog reports it back bare. The lowercasing and space handling that follow are
-        // long-standing SQLite behaviour, untouched here (see weasel#458).
-        Name = SchemaUtils.Unquote(name.Trim()).ToLowerInvariant().Trim().Replace(' ', '_');
+        // Undelimited first: a caller who wrote "order date" means that column, and the catalog
+        // reports it back bare -- so that is the column that gets created, rather than order_date
+        // (weasel#458).
+        var unquoted = SchemaUtils.Unquote(name.Trim());
+
+        Name = preserveCase ? unquoted : unquoted.ToLowerInvariant();
         // Normalize type using provider
         Type = SqliteProvider.Instance.ConvertSynonyms(type);
     }


### PR DESCRIPTION
Closes #458.

## The bug

Three of five providers turned a space in a column name into an underscore — **but only in `TableColumn`**. Index, foreign key and primary key column lists were left alone:

```csharp
table.AddColumn("Order Date", "datetime2");       // created as Order_Date
table.AddIndex("ix", ["Order Date"]);             // indexes "Order Date"
```

No error at model time. The DDL fails at the server, or the index drifts forever.

## The call

**Option 1 from the issue: stop rewriting.** The rewrite was never anybody's decision — it predates all the identifier work. #448 settled that a supplied name is either honoured (quoted where it needs quoting, #447) or rejected; silently changing it is the third option and nobody chose it.

The mismatch dissolves with it. Nothing rewrites, so nothing disagrees — no need for the "apply the rewrite everywhere too" variant, which would have entrenched a behaviour we are saying was never chosen.

| Provider | Before | After |
|---|---|---|
| PostgreSQL | `preserveCase ? name.Trim() : name.ToLower().Trim().Replace(' ','_')` | `preserveCase ? name : name.ToLower()` |
| Oracle | same | same |
| SQLite | `name.ToLower().Trim().Replace(' ','_')`, **no opt-out** | `preserveCase ? name : name.ToLower()` |
| SQL Server | `Unbracket(name.Trim()).Replace(' ','_')` | `Unbracket(name.Trim())` |
| MySQL | `Name = name` | unchanged — it never rewrote |

**`preserveCase` stops doing double duty.** It controlled lowercasing *and*, as a side effect, the space rewrite — two unrelated decisions on one bool, the same conflation #447 untangled in Oracle's `QuoteName`. It now controls case folding and nothing else, and **SQLite gains the opt-out it was the only provider to lack** (it matters for a table reproducing a schema another tool created).

SQL Server needs no such flag: it never folded case, deliberately (polecat#45), so after the rewrite is gone there is nothing left to opt out of.

## Two DDL writers assumed no column could contain a space

Removing the rewrite lets names reach places that were not expecting them:

- **PostgreSQL's index expression** treated anything containing a space as a SQL *expression* rather than a column and emitted it bare. It now asks the parent table first — a name the table declares as a column is a column, whatever it looks like — and falls back to the expression heuristic only for names it does not recognise.
- **Oracle emitted index columns and primary key columns unquoted.** Now quoted through `SchemaUtils.QuoteName`, which leaves a conventional Oracle identifier bare, so the folded path emits exactly what it did before.

## ⚠️ Breaking

**A column declared `"Order Date"` is now created as `"Order Date"` rather than `Order_Date`** on PostgreSQL, Oracle, SQLite and SQL Server. On an existing database Weasel will see the underscore column as unexpected. Callers relying on the rewrite should write the underscore themselves. Needs a line in the #457 release notes.

## Tests

`Weasel.Core.Tests/column_name_conformance.cs`, built entirely through `ITable` so a provider joins with one entry. Five theories × five providers: the name is not rewritten; index, FK and PK column lists name the column that exists; and — the one that catches both halves at once — the generated DDL contains `Order Date` and never `Order_Date`, since the model can be self-consistent while the index writer still emits something else.

**16 of 25 fail on `master`** (MySQL passes throughout — it never rewrote), verified by stashing only the product changes.

### One existing test asserted the bug

`Weasel.Oracle.Tests.Tables.TableColumnTests.spaces_in_name_are_replaced_with_underscores` pinned `first name` → `first_name`. Rewritten to assert the corrected behaviour and renamed, with a doc comment recording why the expectation changed — not deleted, and not silently flipped.

## Verified locally

Core 180, SQLite 407, PostgreSQL 868, SQL Server 429, Oracle 243, MySQL 254, EF Core 106. No failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)