### PR TITLE
test: a shared index scenario matrix, and the three bugs it found

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,6 +31,9 @@
     <!-- Pomelo EF Core is framework-conditional - see below -->
     <PackageVersion Include="Shouldly" Version="4.3.0" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
+    <!-- The assertion/attribute surface without the runner, for Weasel.Testing: a library of
+         shared test bases is not itself a test project and must not build as an Exe. -->
+    <PackageVersion Include="xunit.v3.extensibility.core" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
   <!-- EF Core 9.x for net9.0 -->

--- a/Weasel.slnx
+++ b/Weasel.slnx
@@ -62,5 +62,6 @@
   </Folder>
   <Project Path="src/Weasel.Core.AotSmoke/Weasel.Core.AotSmoke.csproj" />
   <Project Path="src/Weasel.Core.Tests/Weasel.Core.Tests.csproj" />
+  <Project Path="src/Weasel.Testing/Weasel.Testing.csproj" />
   <Project Path="src/Weasel.Core/Weasel.Core.csproj" />
 </Solution>

--- a/src/Weasel.MySql.Tests/Tables/index_scenarios.cs
+++ b/src/Weasel.MySql.Tests/Tables/index_scenarios.cs
@@ -1,0 +1,54 @@
+using System.Data.Common;
+using MySqlConnector;
+using Weasel.Core;
+using Weasel.MySql.Tables;
+using Weasel.Testing;
+using Xunit;
+
+namespace Weasel.MySql.Tests.Tables;
+
+/// <summary>
+///     MySQL's rows of the shared index scenario matrix (weasel#449).
+/// </summary>
+/// <remarks>
+///     MySQL has no partial indexes, so <c>an_unsupported_index_property_is_refused_rather_than_ignored</c>
+///     is the live scenario here: <c>Predicate</c> used to be settable and did nothing at all.
+/// </remarks>
+[Collection("integration")]
+public class index_scenarios: IndexScenarioMatrix
+{
+    private const string SchemaName = "weasel_testing";
+
+    protected override async Task<DbConnection> OpenAsync()
+    {
+        var conn = new MySqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        return conn;
+    }
+
+    /// <summary>
+    ///     The schema is the test database itself — the `weasel` user CI connects as has rights on
+    ///     nothing else — so tables are dropped individually rather than by dropping the database.
+    /// </summary>
+    protected override async Task ResetSchemaAsync(DbConnection conn)
+    {
+        foreach (var table in new[]
+                 {
+                     "ism_single", "ism_multi", "ism_unique", "ism_reserved", "ism_spaced",
+                     "ism_idempotent", "ism_drift", "ism_removal", "ism_partial", "ism_included",
+                     "ism_refused"
+                 })
+        {
+            await conn.CreateCommand($"DROP TABLE IF EXISTS `{SchemaName}`.`{table}`").ExecuteNonQueryAsync();
+        }
+    }
+
+    protected override Migrator CreateMigrator() => new MySqlMigrator();
+
+    protected override ITable NewTable(string name) => new Table($"{SchemaName}.{name}");
+
+    protected override (int Different, int Extra, int Missing) IndexDifferences(ISchemaObjectDelta delta)
+        => delta is TableDelta table
+            ? (table.Indexes.Different.Count(), table.Indexes.Extras.Count(), table.Indexes.Missing.Count())
+            : (0, 0, 0);
+}

--- a/src/Weasel.MySql.Tests/Weasel.MySql.Tests.csproj
+++ b/src/Weasel.MySql.Tests/Weasel.MySql.Tests.csproj
@@ -11,6 +11,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\Weasel.MySql\Weasel.MySql.csproj" />
+      <ProjectReference Include="..\Weasel.Testing\Weasel.Testing.csproj" />
     </ItemGroup>
 
     <Import Project="../../Tests.Build.props" />

--- a/src/Weasel.MySql/Tables/IndexDefinition.cs
+++ b/src/Weasel.MySql/Tables/IndexDefinition.cs
@@ -33,10 +33,29 @@ public class IndexDefinition: ITableIndex
     }
 
     /// <summary>
-    ///     The constraint expression for a partial index (WHERE clause).
-    ///     Note: MySQL doesn't support partial indexes natively in the same way as PostgreSQL.
+    ///     Always <c>null</c>. MySQL has no partial indexes, so the setter throws rather than
+    ///     accepting a predicate it will not honour.
     /// </summary>
-    public string? Predicate { get; set; }
+    /// <remarks>
+    ///     This property used to be settable and did nothing at all — never emitted into DDL, never
+    ///     read during delta detection. A caller who set one got an index silently wider than the
+    ///     one they asked for, with no error and no drift to notice (weasel#449). The supported way
+    ///     to index a subset of rows on MySQL is a generated column carrying the condition, indexed
+    ///     normally.
+    /// </remarks>
+    public string? Predicate
+    {
+        get => null;
+        set
+        {
+            if (value != null)
+            {
+                throw new NotSupportedException(
+                    "MySQL does not support partial indexes. Add a generated column for the condition "
+                    + "and index that instead.");
+            }
+        }
+    }
 
     string[]? Weasel.Core.ITableIndex.IncludeColumns
     {

--- a/src/Weasel.Oracle.Tests/Tables/index_scenarios.cs
+++ b/src/Weasel.Oracle.Tests/Tables/index_scenarios.cs
@@ -1,0 +1,60 @@
+using System.Data.Common;
+using Oracle.ManagedDataAccess.Client;
+using Weasel.Core;
+using Weasel.Oracle.Tables;
+using Weasel.Testing;
+using Xunit;
+
+namespace Weasel.Oracle.Tests.Tables;
+
+/// <summary>
+///     Oracle's rows of the shared index scenario matrix (weasel#449).
+/// </summary>
+/// <remarks>
+///     Oracle has no partial indexes, so <c>an_unsupported_index_property_is_refused_rather_than_ignored</c>
+///     is the live scenario here: <c>Predicate</c> used to be settable and did nothing at all.
+/// </remarks>
+[Collection("integration")]
+public class index_scenarios: IndexScenarioMatrix
+{
+    private const string SchemaName = "WEASEL";
+
+    protected override async Task<DbConnection> OpenAsync()
+    {
+        var conn = new OracleConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        return conn;
+    }
+
+    protected override Task ResetSchemaAsync(DbConnection conn)
+        => ((OracleConnection)conn).ResetSchemaAsync(SchemaName);
+
+    protected override Migrator CreateMigrator() => new OracleMigrator();
+
+    protected override ITable NewTable(string name) => new Table($"{SchemaName}.{name}");
+
+    /// <summary>
+    ///     Oracle's batched delta path reads columns only — <c>CreateDeltaAsync(DbDataReader)</c>
+    ///     says so on the method — because ODP.NET cannot return several result sets from one
+    ///     command. So index drift is invisible to <c>SchemaMigration.DetermineAsync</c>, which is
+    ///     what <c>ApplyChangesAsync</c> and the whole migration path use. These scenarios go
+    ///     through <c>FindDeltaAsync</c>, the only path on Oracle that sees an index at all.
+    /// </summary>
+    protected override async Task<ISchemaObjectDelta> FindDeltaAsync(DbConnection conn, ITable table)
+        => await ((Table)table).FindDeltaAsync((OracleConnection)conn);
+
+    protected override (int Different, int Extra, int Missing) IndexDifferences(ISchemaObjectDelta delta)
+        => delta is TableDelta table
+            ? (table.Indexes.Different.Count(), table.Indexes.Extras.Count(), table.Indexes.Missing.Count())
+            : (0, 0, 0);
+
+    protected override string DescribeIndexes(ISchemaObjectDelta delta)
+        => delta is TableDelta table
+            ? string.Join("; ", table.Indexes.Different.Select(x =>
+                  $"expected [{x.Expected.ToDDL(new Table($"{SchemaName}.ism_single"))}] actual [{x.Actual.ToDDL(new Table($"{SchemaName}.ism_single"))}]"))
+              + $" | extras {table.Indexes.Extras.Count()} missing {table.Indexes.Missing.Count()}"
+            : string.Empty;
+
+    /// <summary>Oracle reserves ORDER; COMMENT is a reserved word that is also a plausible column.</summary>
+    protected override string ReservedWordColumnName => "comment";
+}

--- a/src/Weasel.Oracle.Tests/Weasel.Oracle.Tests.csproj
+++ b/src/Weasel.Oracle.Tests/Weasel.Oracle.Tests.csproj
@@ -11,6 +11,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\Weasel.Oracle\Weasel.Oracle.csproj" />
+        <ProjectReference Include="..\Weasel.Testing\Weasel.Testing.csproj" />
     </ItemGroup>
 
     <Import Project="../../Tests.Build.props" />

--- a/src/Weasel.Oracle/Tables/IndexDefinition.cs
+++ b/src/Weasel.Oracle/Tables/IndexDefinition.cs
@@ -49,9 +49,29 @@ public class IndexDefinition: ITableIndex
     }
 
     /// <summary>
-    ///     The constraint expression for a partial index (WHERE clause)
+    ///     Always <c>null</c>. Oracle has no partial indexes, so the setter throws rather than
+    ///     accepting a predicate it will not honour.
     /// </summary>
-    public string? Predicate { get; set; }
+    /// <remarks>
+    ///     This property used to be settable and did nothing at all — never emitted into DDL, never
+    ///     read during delta detection. A caller who set one got an index silently wider than the
+    ///     one they asked for, with no error and no drift to notice (weasel#449). The supported way
+    ///     to index a subset of rows on Oracle is a function-based index over a <c>CASE</c>
+    ///     expression that returns NULL for the rows to exclude.
+    /// </remarks>
+    public string? Predicate
+    {
+        get => null;
+        set
+        {
+            if (value != null)
+            {
+                throw new NotSupportedException(
+                    "Oracle does not support partial indexes. Use a function-based index over a CASE "
+                    + "expression that returns NULL for the excluded rows instead.");
+            }
+        }
+    }
 
     string[]? Weasel.Core.ITableIndex.IncludeColumns
     {

--- a/src/Weasel.Postgresql.Tests/Tables/index_scenarios.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/index_scenarios.cs
@@ -1,0 +1,41 @@
+using System.Data.Common;
+using Npgsql;
+using Weasel.Core;
+using Weasel.Postgresql.Tables;
+using Weasel.Testing;
+using Xunit;
+
+namespace Weasel.Postgresql.Tests.Tables;
+
+/// <summary>
+///     PostgreSQL's rows of the shared index scenario matrix (weasel#449).
+/// </summary>
+[Collection("indexscenarios")]
+public class index_scenarios: IndexScenarioMatrix
+{
+    private const string SchemaName = "indexscenarios";
+
+    protected override async Task<DbConnection> OpenAsync()
+    {
+        var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        return conn;
+    }
+
+    protected override Task ResetSchemaAsync(DbConnection conn)
+        => ((NpgsqlConnection)conn).ResetSchemaAsync(SchemaName);
+
+    protected override Migrator CreateMigrator() => new PostgresqlMigrator();
+
+    protected override ITable NewTable(string name) => new Table($"{SchemaName}.{name}");
+
+    protected override (int Different, int Extra, int Missing) IndexDifferences(ISchemaObjectDelta delta)
+        => delta is TableDelta table
+            ? (table.Indexes.Different.Count(), table.Indexes.Extras.Count(), table.Indexes.Missing.Count())
+            : (0, 0, 0);
+
+    protected override bool SupportsPartialIndexes => true;
+
+    /// <summary>PostgreSQL 11+ supports INCLUDE on a btree index.</summary>
+    protected override bool SupportsIncludedColumns => true;
+}

--- a/src/Weasel.Postgresql.Tests/Weasel.Postgresql.Tests.csproj
+++ b/src/Weasel.Postgresql.Tests/Weasel.Postgresql.Tests.csproj
@@ -13,6 +13,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\Weasel.Postgresql\Weasel.Postgresql.csproj" />
+        <ProjectReference Include="..\Weasel.Testing\Weasel.Testing.csproj" />
     </ItemGroup>
 
     <Import Project="../../Tests.Build.props" />

--- a/src/Weasel.SqlServer.Tests/Tables/index_scenarios.cs
+++ b/src/Weasel.SqlServer.Tests/Tables/index_scenarios.cs
@@ -1,0 +1,50 @@
+using System.Data.Common;
+using Microsoft.Data.SqlClient;
+using Weasel.Core;
+using Weasel.SqlServer.Tables;
+using Weasel.Testing;
+using Xunit;
+
+namespace Weasel.SqlServer.Tests.Tables;
+
+/// <summary>
+///     SQL Server's rows of the shared index scenario matrix (weasel#449). SQL Server was the
+///     thinnest provider at nine index tests, with the most modeled index properties after
+///     PostgreSQL.
+/// </summary>
+[Collection("integration")]
+public class index_scenarios: IndexScenarioMatrix
+{
+    private const string SchemaName = "indexscenarios";
+
+    protected override async Task<DbConnection> OpenAsync()
+    {
+        var conn = new SqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        return conn;
+    }
+
+    protected override Task ResetSchemaAsync(DbConnection conn)
+        => ((SqlConnection)conn).ResetSchemaAsync(SchemaName);
+
+    protected override Migrator CreateMigrator() => new SqlServerMigrator();
+
+    protected override ITable NewTable(string name) => new Table($"{SchemaName}.{name}");
+
+    protected override (int Different, int Extra, int Missing) IndexDifferences(ISchemaObjectDelta delta)
+        => delta is TableDelta table
+            ? (table.Indexes.Different.Count(), table.Indexes.Extras.Count(), table.Indexes.Missing.Count())
+            : (0, 0, 0);
+
+    protected override string DescribeIndexes(ISchemaObjectDelta delta)
+        => delta is TableDelta table
+            ? string.Join("; ",
+                table.Indexes.Different.Select(x =>
+                    $"expected [{x.Expected.ToDDL(new Table($"{SchemaName}.ism_partial"))}] actual [{x.Actual.ToDDL(new Table($"{SchemaName}.ism_partial"))}]"))
+            : string.Empty;
+
+    /// <summary>SQL Server calls them filtered indexes.</summary>
+    protected override bool SupportsPartialIndexes => true;
+
+    protected override bool SupportsIncludedColumns => true;
+}

--- a/src/Weasel.SqlServer.Tests/Weasel.SqlServer.Tests.csproj
+++ b/src/Weasel.SqlServer.Tests/Weasel.SqlServer.Tests.csproj
@@ -11,6 +11,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\Weasel.SqlServer\Weasel.SqlServer.csproj" />
+      <ProjectReference Include="..\Weasel.Testing\Weasel.Testing.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Weasel.SqlServer/Tables/IndexDefinition.cs
+++ b/src/Weasel.SqlServer/Tables/IndexDefinition.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using System.Text.RegularExpressions;
 using JasperFx.Core;
 using Weasel.Core;
 
@@ -208,18 +209,34 @@ public class IndexDefinition: ITableIndex
         }
     }
 
+    /// <summary>
+    ///     Normalize an index's DDL for comparison against the same index read back out of
+    ///     <c>sys.indexes</c>.
+    /// </summary>
+    /// <remarks>
+    ///     SQL Server rewrites a filtered index's predicate when it stores it: <c>quantity > 0</c>
+    ///     comes back as <c>([quantity]&gt;(0))</c>. Brackets and the spacing around comparison
+    ///     operators therefore have to be normalized away, or every filtered index reports drift on
+    ///     every check — the disease weasel#445 and weasel#446 were about, found here by the shared
+    ///     index scenario matrix (weasel#449).
+    /// </remarks>
     public static string CanonicizeDdl(IndexDefinition index, Table parent)
     {
-        return index.ToDDL(parent)
-                .Replace("\"\"", "\"")
-                .Replace("  ", " ")
-                .Replace("(", "")
-                .Replace(")", "")
-                .Replace("INDEX CONCURRENTLY", "INDEX")
-                .Replace("::text", "")
-                .Replace(" ->> ", "->>")
-                .Replace("->", "->").TrimEnd(new[] { ';' })
-            ;
+        var sql = index.ToDDL(parent)
+            .Replace("\"\"", "\"")
+            .Replace("  ", " ")
+            .Replace("(", "")
+            .Replace(")", "")
+            .Replace("[", "")
+            .Replace("]", "")
+            .Replace("INDEX CONCURRENTLY", "INDEX")
+            .Replace("::text", "")
+            .Replace(" ->> ", "->>")
+            .Replace("->", "->")
+            .TrimEnd(';');
+
+        // Collapse the whitespace SQL Server adds or removes around operators and separators.
+        return Regex.Replace(sql, @"\s*([<>=!+\-*/,]+)\s*", "$1");
     }
 
     public void AddColumn(string columnName)

--- a/src/Weasel.Sqlite.Tests/Tables/index_scenarios.cs
+++ b/src/Weasel.Sqlite.Tests/Tables/index_scenarios.cs
@@ -1,0 +1,44 @@
+using System.Data.Common;
+using Microsoft.Data.Sqlite;
+using Weasel.Core;
+using Weasel.Sqlite.Tables;
+using Weasel.Testing;
+
+namespace Weasel.Sqlite.Tests.Tables;
+
+/// <summary>
+///     SQLite's rows of the shared index scenario matrix (weasel#449). SQLite had **no** index
+///     round-trip test at all before this — nothing created an index, read it back, and asserted
+///     the delta was <c>None</c>.
+/// </summary>
+public class index_scenarios: IndexScenarioMatrix
+{
+    private readonly string _connectionString = $"Data Source={Path.GetTempFileName()};";
+
+    protected override async Task<DbConnection> OpenAsync()
+    {
+        var conn = new SqliteConnection(_connectionString);
+        await conn.OpenAsync();
+        return conn;
+    }
+
+    protected override Task ResetSchemaAsync(DbConnection conn)
+        => ((SqliteConnection)conn).ResetSchemaAsync("main");
+
+    protected override Migrator CreateMigrator() => new SqliteMigrator();
+
+    protected override ITable NewTable(string name) => new Table(name);
+
+    protected override (int Different, int Extra, int Missing) IndexDifferences(ISchemaObjectDelta delta)
+        => delta is TableDelta table
+            ? (table.Indexes.Different.Count(), table.Indexes.Extras.Count(), table.Indexes.Missing.Count())
+            : (0, 0, 0);
+
+    protected override string DescribeIndexes(ISchemaObjectDelta delta)
+        => delta is TableDelta table
+            ? string.Join("; ", table.Indexes.Different.Select(x => $"expected [{x.Expected}] actual [{x.Actual}]"))
+            : string.Empty;
+
+    /// <summary>SQLite supports partial indexes with a WHERE clause.</summary>
+    protected override bool SupportsPartialIndexes => true;
+}

--- a/src/Weasel.Sqlite.Tests/Weasel.Sqlite.Tests.csproj
+++ b/src/Weasel.Sqlite.Tests/Weasel.Sqlite.Tests.csproj
@@ -11,6 +11,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\Weasel.Sqlite\Weasel.Sqlite.csproj" />
+        <ProjectReference Include="..\Weasel.Testing\Weasel.Testing.csproj" />
     </ItemGroup>
 
     <Import Project="../../Tests.Build.props" />

--- a/src/Weasel.Sqlite/Tables/Table.FetchExisting.cs
+++ b/src/Weasel.Sqlite/Tables/Table.FetchExisting.cs
@@ -338,6 +338,46 @@ SELECT * FROM pragma_foreign_key_list('{tableName}');
     /// Parse simple (non-expression) column definitions from the index column list.
     /// Handles per-column sort orders (ASC/DESC) and COLLATE clauses.
     /// </summary>
+    /// <summary>
+    ///     Split one entry of an index column list into the column name and whatever follows it
+    ///     (ASC / DESC / COLLATE). A delimited name is read to its closing delimiter, doubling
+    ///     included, so a space inside it does not end the name.
+    /// </summary>
+    private static (string Name, string Remainder) takeColumnName(string entry)
+    {
+        var open = entry[0];
+        if (open is not ('"' or '[' or '`'))
+        {
+            var space = entry.IndexOf(' ');
+            return space < 0 ? (entry, string.Empty) : (entry[..space], entry[(space + 1)..]);
+        }
+
+        var close = open == '[' ? ']' : open;
+        var name = new System.Text.StringBuilder();
+
+        for (var i = 1; i < entry.Length; i++)
+        {
+            if (entry[i] != close)
+            {
+                name.Append(entry[i]);
+                continue;
+            }
+
+            // A doubled close delimiter is an escaped literal one, not the end of the name.
+            if (i + 1 < entry.Length && entry[i + 1] == close)
+            {
+                name.Append(close);
+                i++;
+                continue;
+            }
+
+            return (name.ToString(), entry[(i + 1)..].Trim());
+        }
+
+        // Unterminated: treat the whole thing as the name rather than losing it.
+        return (name.ToString(), string.Empty);
+    }
+
     private static void parseSimpleColumns(IndexDefinition index, string columnsPart)
     {
         var columnNames = new List<string>();
@@ -347,17 +387,23 @@ SELECT * FROM pragma_foreign_key_list('{tableName}');
 
         foreach (var raw in columnsPart.Split(','))
         {
-            var parts = raw.Trim().Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
-            if (parts.Length == 0)
+            var entry = raw.Trim();
+            if (entry.Length == 0)
             {
                 continue;
             }
 
-            // First token is the column name (strip quotes)
-            columnNames.Add(parts[0].Trim('"', '[', ']'));
+            // The name has to come off before the rest is tokenized on spaces: a delimited name
+            // may contain one. Splitting first turned an index over "order date" into an index
+            // over "order" -- and, since weasel#458, a column name with a space is something a
+            // caller can legitimately have (weasel#449).
+            var (columnName, remainder) = takeColumnName(entry);
+            columnNames.Add(columnName);
+
+            var parts = remainder.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
 
             // Scan remaining tokens for sort order and collation
-            for (var i = 1; i < parts.Length; i++)
+            for (var i = 0; i < parts.Length; i++)
             {
                 if (parts[i].Equals("DESC", StringComparison.OrdinalIgnoreCase))
                 {

--- a/src/Weasel.Sqlite/Tables/TableDelta.cs
+++ b/src/Weasel.Sqlite/Tables/TableDelta.cs
@@ -36,9 +36,15 @@ public class TableDelta: SchemaObjectDelta<Table>
         }
 
         Columns = new ItemDelta<TableColumn>(expected.Columns, actual.Columns);
+        // The comparison is not optional. Without it ItemDelta falls back to IndexDefinition's
+        // Equals, which compares the name and nothing else -- so an index that changed from
+        // non-unique to unique, or moved to different columns, reported no difference at all and
+        // was never corrected. SQLite was the only provider not passing its Matches (weasel#449);
+        // PostgreSQL, SQL Server and Oracle all did.
         Indexes = new ItemDelta<IndexDefinition>(
             expected.Indexes.Where(x => !expected.IgnoredIndexes.Contains(x.Name)),
-            actual.Indexes.Where(x => !expected.IgnoredIndexes.Contains(x.Name)));
+            actual.Indexes.Where(x => !expected.IgnoredIndexes.Contains(x.Name)),
+            (e, a) => e.Matches(a, expected));
 
         ForeignKeys = new ItemDelta<ForeignKey>(expected.ForeignKeys, actual.ForeignKeys);
 

--- a/src/Weasel.Testing/IndexScenarioMatrix.cs
+++ b/src/Weasel.Testing/IndexScenarioMatrix.cs
@@ -1,0 +1,331 @@
+using System.Data.Common;
+using JasperFx;
+using Shouldly;
+using Weasel.Core;
+using Xunit;
+
+namespace Weasel.Testing;
+
+/// <summary>
+///     One index scenario list, run against every provider (weasel#449). Every scenario is
+///     create-then-introspect: the table goes into a real database, comes back through
+///     <c>FetchExisting</c>, and the assertion is about the delta — never about a generated string.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Index DDL generation was already well covered — 45 tests on PostgreSQL, 21 on MySQL, 14
+///         on SQLite, 11 on Oracle, 9 on SQL Server. What was thin is everything past the generated
+///         string: SQLite had no index round-trip test at all, and no provider systematically proved
+///         that changing one modeled property produces exactly one difference. That untested middle
+///         is where weasel#445 lived.
+///     </para>
+///     <para>
+///         A provider joins by deriving from this class and implementing the four hooks. A scenario
+///         that does not apply to an engine is turned off by a capability flag rather than by being
+///         absent, so the gap is visible in the source instead of being an absent thought.
+///     </para>
+/// </remarks>
+public abstract class IndexScenarioMatrix
+{
+    /// <summary>Open a connection to the test database. The caller disposes it.</summary>
+    protected abstract Task<DbConnection> OpenAsync();
+
+    /// <summary>Empty the schema these scenarios build in.</summary>
+    protected abstract Task ResetSchemaAsync(DbConnection conn);
+
+    /// <summary>A migrator for this provider, used to apply every migration.</summary>
+    protected abstract Migrator CreateMigrator();
+
+    /// <summary>
+    ///     A new, empty table in the schema under test. Implementations return their own concrete
+    ///     <c>Table</c>; everything here drives it through <see cref="ITable" />.
+    /// </summary>
+    protected abstract ITable NewTable(string name);
+
+    /// <summary>
+    ///     How many index differences this table delta reports. Each provider's <c>TableDelta</c>
+    ///     exposes its <c>ItemDelta&lt;IndexDefinition&gt;</c> as <c>internal</c>, visible only to
+    ///     that provider's own test assembly — which is exactly where the subclass lives, so the
+    ///     override is one line.
+    /// </summary>
+    protected abstract (int Different, int Extra, int Missing) IndexDifferences(ISchemaObjectDelta delta);
+
+    // Capability flags. Off means "this engine does not have the feature", not "untested".
+    protected virtual bool SupportsUniqueIndexes => true;
+    protected virtual bool SupportsDescendingIndexes => true;
+    protected virtual bool SupportsPartialIndexes => false;
+    protected virtual bool SupportsIncludedColumns => false;
+
+    /// <summary>
+    ///     Whether an unquoted mixed-case name survives as written. Oracle folds to uppercase and
+    ///     SQLite and PostgreSQL fold to lowercase, so the round trip is case-insensitive there —
+    ///     which is correct behaviour rather than a gap.
+    /// </summary>
+    protected virtual StringComparison NameComparison => StringComparison.OrdinalIgnoreCase;
+
+    /// <summary>A column name that is a reserved word in this dialect.</summary>
+    protected virtual string ReservedWordColumnName => "order";
+
+    /// <summary>
+    ///     Optional detail for a failure message — the expected and actual index as the provider
+    ///     sees them. Default is nothing; a provider that can cheaply render both overrides it.
+    /// </summary>
+    protected virtual string DescribeIndexes(ISchemaObjectDelta delta) => string.Empty;
+
+    /// <summary>
+    ///     Apply this table, then report the delta that remains — which must be
+    ///     <see cref="SchemaPatchDifference.None" /> for every scenario that converges.
+    /// </summary>
+    /// <remarks>
+    ///     The migration is built from <see cref="FindDeltaAsync" /> rather than from
+    ///     <c>SchemaMigration.DetermineAsync</c> directly, so that a provider which overrides how a
+    ///     delta is found applies through the same path it compares through. Otherwise Oracle would
+    ///     compare with one mechanism and correct with another, and the fix would never include the
+    ///     difference the comparison had just reported.
+    /// </remarks>
+    protected async Task<ISchemaObjectDelta> ApplyAndFindDeltaAsync(DbConnection conn, ITable table)
+    {
+        var migrator = CreateMigrator();
+        var delta = await FindDeltaAsync(conn, table).ConfigureAwait(false);
+        await migrator.ApplyAllAsync(conn, new SchemaMigration(delta), AutoCreate.CreateOrUpdate)
+            .ConfigureAwait(false);
+
+        return await FindDeltaAsync(conn, table).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    ///     Compute the delta for this table the way this provider's own callers do.
+    /// </summary>
+    /// <remarks>
+    ///     The default is <see cref="SchemaMigration.DetermineAsync(DbConnection, CancellationToken, ISchemaObject[])" />,
+    ///     which is the migration path. Oracle overrides it: its
+    ///     <c>CreateDeltaAsync(DbDataReader)</c> reads columns only — ODP.NET cannot return several
+    ///     result sets from one command — so index drift is invisible on the batched path and only
+    ///     <c>Table.FindDeltaAsync(OracleConnection)</c> sees it. That limitation is documented on
+    ///     the method and is a real gap in Oracle's migration path, not something for this harness
+    ///     to paper over silently.
+    /// </remarks>
+    protected virtual async Task<ISchemaObjectDelta> FindDeltaAsync(DbConnection conn, ITable table)
+    {
+        var migration = await SchemaMigration.DetermineAsync(conn, CancellationToken.None, table).ConfigureAwait(false);
+        return migration.Deltas.Single();
+    }
+
+    private async Task RoundTripsWithNoDeltaAsync(string tableName, Action<ITable> configure)
+    {
+        await using var conn = await OpenAsync().ConfigureAwait(false);
+        await ResetSchemaAsync(conn).ConfigureAwait(false);
+
+        var table = NewTable(tableName);
+        table.AddPrimaryKeyColumn("id", typeof(int));
+        table.AddColumn("name", typeof(string));
+        table.AddColumn("quantity", typeof(int));
+        configure(table);
+
+        var delta = await ApplyAndFindDeltaAsync(conn, table).ConfigureAwait(false);
+
+        delta.Difference.ShouldBe(SchemaPatchDifference.None,
+            $"{tableName} does not round trip: {DescribeIndexes(delta)}");
+    }
+
+    [Fact]
+    public Task a_single_column_index_round_trips()
+        => RoundTripsWithNoDeltaAsync("ism_single", t => t.AddIndex("ism_single_idx", ["name"]));
+
+    [Fact]
+    public Task a_multi_column_index_round_trips()
+        => RoundTripsWithNoDeltaAsync("ism_multi", t => t.AddIndex("ism_multi_idx", ["name", "quantity"]));
+
+    [Fact]
+    public async Task a_unique_index_round_trips()
+    {
+        if (!SupportsUniqueIndexes) return;
+
+        await RoundTripsWithNoDeltaAsync("ism_unique",
+            t => t.AddIndex("ism_unique_idx", ["name"], true)).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    ///     A column named for a reserved word. This is the scenario that needed weasel#447 first:
+    ///     the index has to quote the column the same way the table did, or it names something else.
+    /// </summary>
+    [Fact]
+    public async Task an_index_over_a_reserved_word_column_round_trips()
+    {
+        await using var conn = await OpenAsync().ConfigureAwait(false);
+        await ResetSchemaAsync(conn).ConfigureAwait(false);
+
+        var table = NewTable("ism_reserved");
+        table.AddPrimaryKeyColumn("id", typeof(int));
+        table.AddColumn(ReservedWordColumnName, typeof(int));
+        table.AddIndex("ism_reserved_idx", [ReservedWordColumnName]);
+
+        var delta = await ApplyAndFindDeltaAsync(conn, table).ConfigureAwait(false);
+
+        delta.Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    /// <summary>
+    ///     A column name carrying a space — legal since weasel#448, and no longer rewritten into an
+    ///     underscore since weasel#458. The index and the column have to agree on it.
+    /// </summary>
+    [Fact]
+    public async Task an_index_over_a_column_name_with_a_space_round_trips()
+    {
+        await using var conn = await OpenAsync().ConfigureAwait(false);
+        await ResetSchemaAsync(conn).ConfigureAwait(false);
+
+        var table = NewTable("ism_spaced");
+        table.AddPrimaryKeyColumn("id", typeof(int));
+        table.AddColumn("order date", typeof(int));
+        table.AddIndex("ism_spaced_idx", ["order date"]);
+
+        var delta = await ApplyAndFindDeltaAsync(conn, table).ConfigureAwait(false);
+
+        delta.Difference.ShouldBe(SchemaPatchDifference.None,
+            $"expected index DDL and the one read back disagree; {DescribeIndexes(delta)}");
+        table.Columns.ShouldContain(x => x.Name.Equals("order date", NameComparison));
+    }
+
+    /// <summary>
+    ///     Applying the same table twice is a no-op the second time. The cheapest possible check,
+    ///     and the one that catches permanent drift — the disease weasel#445 and weasel#446 were
+    ///     about.
+    /// </summary>
+    [Fact]
+    public async Task applying_the_same_table_twice_is_a_no_op()
+    {
+        await using var conn = await OpenAsync().ConfigureAwait(false);
+        await ResetSchemaAsync(conn).ConfigureAwait(false);
+
+        var table = NewTable("ism_idempotent");
+        table.AddPrimaryKeyColumn("id", typeof(int));
+        table.AddColumn("name", typeof(string));
+        table.AddIndex("ism_idempotent_idx", ["name"]);
+
+        await ApplyAndFindDeltaAsync(conn, table).ConfigureAwait(false);
+        var second = await ApplyAndFindDeltaAsync(conn, table).ConfigureAwait(false);
+
+        second.Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    /// <summary>
+    ///     Change one property and exactly one index reports as different — not zero, which would
+    ///     mean the property is not compared at all, and not several, which would mean the
+    ///     comparison is matching on the wrong thing. Then the generated fix has to execute and
+    ///     converge.
+    /// </summary>
+    [Fact]
+    public async Task changing_an_index_reports_exactly_one_difference_and_the_fix_converges()
+    {
+        if (!SupportsUniqueIndexes) return;
+
+        await using var conn = await OpenAsync().ConfigureAwait(false);
+        await ResetSchemaAsync(conn).ConfigureAwait(false);
+
+        var original = NewTable("ism_drift");
+        original.AddPrimaryKeyColumn("id", typeof(int));
+        original.AddColumn("name", typeof(string));
+        original.AddIndex("ism_drift_idx", ["name"]);
+
+        await ApplyAndFindDeltaAsync(conn, original).ConfigureAwait(false);
+
+        var changed = NewTable("ism_drift");
+        changed.AddPrimaryKeyColumn("id", typeof(int));
+        changed.AddColumn("name", typeof(string));
+        changed.AddIndex("ism_drift_idx", ["name"], true);
+
+        var drift = await FindDeltaAsync(conn, changed).ConfigureAwait(false);
+
+        drift.Difference.ShouldBe(SchemaPatchDifference.Update);
+        IndexDifferences(drift).Different.ShouldBe(1);
+
+        var converged = await ApplyAndFindDeltaAsync(conn, changed).ConfigureAwait(false);
+        converged.Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    /// <summary>
+    ///     Drop the declaration and the index is reported as extra, and the generated DROP runs.
+    /// </summary>
+    [Fact]
+    public async Task removing_an_index_reports_exactly_one_extra_and_the_drop_executes()
+    {
+        await using var conn = await OpenAsync().ConfigureAwait(false);
+        await ResetSchemaAsync(conn).ConfigureAwait(false);
+
+        var original = NewTable("ism_removal");
+        original.AddPrimaryKeyColumn("id", typeof(int));
+        original.AddColumn("name", typeof(string));
+        original.AddIndex("ism_removal_idx", ["name"]);
+
+        await ApplyAndFindDeltaAsync(conn, original).ConfigureAwait(false);
+
+        var without = NewTable("ism_removal");
+        without.AddPrimaryKeyColumn("id", typeof(int));
+        without.AddColumn("name", typeof(string));
+
+        var drift = await FindDeltaAsync(conn, without).ConfigureAwait(false);
+
+        IndexDifferences(drift).Extra.ShouldBe(1);
+
+        var converged = await ApplyAndFindDeltaAsync(conn, without).ConfigureAwait(false);
+        converged.Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task a_partial_index_round_trips()
+    {
+        if (!SupportsPartialIndexes) return;
+
+        await using var conn = await OpenAsync().ConfigureAwait(false);
+        await ResetSchemaAsync(conn).ConfigureAwait(false);
+
+        var table = NewTable("ism_partial");
+        table.AddPrimaryKeyColumn("id", typeof(int));
+        table.AddColumn("quantity", typeof(int));
+        var index = table.AddIndex("ism_partial_idx", ["quantity"]);
+        index.Predicate = "quantity > 0";
+
+        var delta = await ApplyAndFindDeltaAsync(conn, table).ConfigureAwait(false);
+
+        delta.Difference.ShouldBe(SchemaPatchDifference.None, DescribeIndexes(delta));
+    }
+
+    [Fact]
+    public async Task an_index_with_included_columns_round_trips()
+    {
+        if (!SupportsIncludedColumns) return;
+
+        await using var conn = await OpenAsync().ConfigureAwait(false);
+        await ResetSchemaAsync(conn).ConfigureAwait(false);
+
+        var table = NewTable("ism_included");
+        table.AddPrimaryKeyColumn("id", typeof(int));
+        table.AddColumn("name", typeof(string));
+        table.AddColumn("quantity", typeof(int));
+        var index = table.AddIndex("ism_included_idx", ["name"]);
+        index.IncludeColumns = ["quantity"];
+
+        var delta = await ApplyAndFindDeltaAsync(conn, table).ConfigureAwait(false);
+
+        delta.Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    /// <summary>
+    ///     An engine that does not support a property must reject it rather than ignore it. MySQL
+    ///     and Oracle both exposed a <c>Predicate</c> that was never emitted and never compared, so
+    ///     a caller who set one got an index silently wider than the one they asked for
+    ///     (weasel#449).
+    /// </summary>
+    [Fact]
+    public void an_unsupported_index_property_is_refused_rather_than_ignored()
+    {
+        if (SupportsPartialIndexes) return;
+
+        var table = NewTable("ism_refused");
+        table.AddColumn("quantity", typeof(int));
+        var index = table.AddIndex("ism_refused_idx", ["quantity"]);
+
+        Should.Throw<NotSupportedException>(() => index.Predicate = "quantity > 0");
+    }
+}

--- a/src/Weasel.Testing/Weasel.Testing.csproj
+++ b/src/Weasel.Testing/Weasel.Testing.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <!-- A library, not a test project: it holds the shared scenario base that each
+             provider's test project derives from. It never runs on its own, so it has no
+             runner and is not an Exe. -->
+        <PackageReference Include="xunit.v3.extensibility.core" ExcludeAssets="analyzers" />
+        <PackageReference Include="Shouldly" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Weasel.Core\Weasel.Core.csproj" />
+    </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Closes #449.

## The harness

`Weasel.Testing` is a new library — deliberately **not** a test project, so it references `xunit.v3.extensibility.core` rather than `xunit.v3` and does not build as an Exe — holding one scenario list that every provider runs.

Every scenario is **create-then-introspect**: the table goes into a real database, comes back through the provider's own delta path, and the assertion is about the delta. Never about a generated string.

A provider joins by implementing four hooks. A scenario that does not apply to an engine is turned off by a **capability flag** rather than by being absent, so a gap is visible in the source instead of being an absent thought — which is what #449 asked for.

Eleven scenarios × five providers, all green.

## It found three real defects on its first run

### SQLite never compared indexes at all

`Weasel.Sqlite.Tables.TableDelta` was the only one of the five not passing `IndexDefinition.Matches` into `ItemDelta`, so comparison fell back to `IndexDefinition.Equals` — which compares **the name and nothing else**.

An index that changed from non-unique to unique, or moved to different columns, reported no difference and was never corrected. `Matches` existed and worked the whole time; nothing called it.

### SQLite's index parser could not read a column name with a space

`parseSimpleColumns` split each entry on spaces and took the first token, so an index over `"order date"` came back as an index over `order` — permanent drift. Harmless while column names could not contain spaces; **#458 changed that two PRs ago.** The name now comes off first, delimiter-aware, doubled-delimiter included.

This one only became reachable *because* the first bug was fixed — with name-only comparison it could never have been noticed.

### SQL Server reported drift on every filtered index

SQL Server rewrites a filtered predicate when it stores it:

```
expected  CREATE INDEX … WHERE (quantity > 0)
actual    CREATE INDEX … WHERE (([quantity]>(0)))
```

`CanonicizeDdl` stripped parentheses but not brackets, and never touched operator spacing. Both are normalized now — the same permanent-drift disease #445 and #446 were about.

## Two properties that did nothing are now refusals

MySQL and Oracle both exposed a `Predicate` documented as "the constraint expression for a partial index". Neither engine has partial indexes, and in both providers the property was **never emitted into DDL and never read during delta detection**. A caller who set one got an index silently wider than the one they asked for, with no error and no drift to notice.

Both setters now throw and name the supported alternative — a generated column on MySQL, a function-based index over a `CASE` expression on Oracle. The matrix has a scenario for exactly this: `an_unsupported_index_property_is_refused_rather_than_ignored`, live on the two providers where `SupportsPartialIndexes` is false.

## ⚠️ Oracle: a gap this does not paper over

Oracle's rows route through `Table.FindDeltaAsync` rather than the migration path, because on Oracle `CreateDeltaAsync(DbDataReader)` reads **columns only** — ODP.NET cannot return several result sets from one command, and the method's own doc comment says so.

**So index, foreign key and primary key drift is invisible to the entire migration path on Oracle.** Oracle failed eight of eleven scenarios where the others passed, and a manual `all_indexes` query confirmed the index was there all along — Weasel just never asked.

Filed as #474 with the fix sketched (`CommandBuilderBase.StartNewCommand` / `CompileCommands` already exist for exactly this). The override in `Weasel.Oracle.Tests.Tables.index_scenarios` points at it, so the index *behaviour* is covered while the gap stays visible rather than being quietly worked around.

## Verified locally

Core 180, SQLite 418, PostgreSQL 879, SQL Server 440, Oracle 254, MySQL 277. No failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)