### PR TITLE
fix(oracle): let a schema object register more than one introspection query

### DIFF
--- a/src/Weasel.Core/CommandBuilderBase.cs
+++ b/src/Weasel.Core/CommandBuilderBase.cs
@@ -6,6 +6,21 @@ using JasperFx.Core;
 
 namespace Weasel.Core;
 
+/// <summary>
+///     A command builder that can hand back its batch as one or more executable commands. Every
+///     Weasel builder can, because <see cref="CommandBuilderBase{TCommand,TParameter,TParameterType}" />
+///     implements it — but only Oracle's ever returns more than one, since ODP.NET will not execute
+///     several statements from a single command (weasel#474).
+/// </summary>
+/// <remarks>
+///     Separate from <see cref="ICommandBuilder{TCommand}" /> so that adding it breaks nothing that
+///     implements that interface outside this repository.
+/// </remarks>
+public interface IBatchedCommandBuilder
+{
+    IReadOnlyList<DbCommand> CompileCommands();
+}
+
 public interface ICommandBuilder<out TCommand>
     where TCommand : DbCommand
 {
@@ -20,7 +35,7 @@ public interface ICommandBuilder<out TCommand>
 /// <typeparam name="TTransaction"></typeparam>
 /// <typeparam name="TParameterType"></typeparam>
 /// <typeparam name="TDataReader"></typeparam>
-public class CommandBuilderBase<TCommand, TParameter, TParameterType>: ICommandBuilder<TCommand>
+public class CommandBuilderBase<TCommand, TParameter, TParameterType>: ICommandBuilder<TCommand>, IBatchedCommandBuilder
     where TCommand : DbCommand
     where TParameter : DbParameter
     where TParameterType : struct
@@ -607,6 +622,32 @@ public static class CommandBuilderExtensions
         CancellationToken ct = default
     ) where T : DbCommand
     {
+        // A builder that splits its batch hands back one command per statement -- Oracle is the
+        // only one that does, because ODP.NET cannot execute several statements from a single
+        // command. Chaining the readers makes the split invisible to whatever reads the results,
+        // which is what lets Oracle register more than one introspection query (weasel#474).
+        if (commandBuilder is IBatchedCommandBuilder batched)
+        {
+            var commands = batched.CompileCommands();
+
+            if (commands.Count > 0)
+            {
+                foreach (var command in commands)
+                {
+                    command.Connection = connection;
+                    command.Transaction = tx;
+                }
+
+                // Got to remember to make this disposed by caller.
+                // The single-command case cannot fall through to Compile(): a builder that splits
+                // consumes its accumulated SQL while compiling, so a second Compile() would hand
+                // back a command with empty CommandText.
+                return commands.Count == 1
+                    ? commands[0].ExecuteReaderAsync(ct)
+                    : MultiCommandDataReader.OpenAsync(commands, ct);
+            }
+        }
+
         var cmd = commandBuilder.Compile();
 
         cmd.Connection = connection;

--- a/src/Weasel.Core/Migrations/DatabaseBase.cs
+++ b/src/Weasel.Core/Migrations/DatabaseBase.cs
@@ -140,7 +140,7 @@ public abstract class DatabaseBase<TConnection>: IDatabase<TConnection>, IDataba
 
         await initializeSchema(conn, ct).ConfigureAwait(false);
 
-        var migration = await SchemaMigration.DetermineAsync(conn, ct, group.Objects).ConfigureAwait(false);
+        var migration = await SchemaMigration.DetermineAsync(conn, Migrator.CreateCommandBuilder(conn), ct, group.Objects).ConfigureAwait(false);
 
         await conn.CloseAsync().ConfigureAwait(false);
 
@@ -260,7 +260,7 @@ public abstract class DatabaseBase<TConnection>: IDatabase<TConnection>, IDataba
         await conn.OpenAsync(ct).ConfigureAwait(false);
         await initializeSchema(conn, ct).ConfigureAwait(false);
 
-        var result = await SchemaMigration.DetermineAsync(conn, ct, objects).ConfigureAwait(false);
+        var result = await SchemaMigration.DetermineAsync(conn, Migrator.CreateCommandBuilder(conn), ct, objects).ConfigureAwait(false);
         await conn.CloseAsync().ConfigureAwait(false);
         return result;
     }
@@ -405,7 +405,7 @@ public abstract class DatabaseBase<TConnection>: IDatabase<TConnection>, IDataba
                 }
 
                 await initializeSchema(conn, ct).ConfigureAwait(false);
-                var patch = await SchemaMigration.DetermineAsync(conn, ct, objects).ConfigureAwait(false);
+                var patch = await SchemaMigration.DetermineAsync(conn, Migrator.CreateCommandBuilder(conn), ct, objects).ConfigureAwait(false);
 
                 if (patch.Difference != SchemaPatchDifference.None)
                 {
@@ -611,7 +611,7 @@ public abstract class DatabaseBase<TConnection>: IDatabase<TConnection>, IDataba
         await conn.OpenAsync(ct).ConfigureAwait(false);
         await initializeSchema(conn, ct).ConfigureAwait(false);
 
-        var migration = await SchemaMigration.DetermineAsync(conn, ct, schemaObjects).ConfigureAwait(false);
+        var migration = await SchemaMigration.DetermineAsync(conn, Migrator.CreateCommandBuilder(conn), ct, schemaObjects).ConfigureAwait(false);
 
         if (migration.Difference == SchemaPatchDifference.None)
         {

--- a/src/Weasel.Core/Migrator.cs
+++ b/src/Weasel.Core/Migrator.cs
@@ -274,6 +274,19 @@ public abstract class
     ///     this database engine
     /// </summary>
     /// <param name="name"></param>
+    /// <summary>
+    ///     A command builder for this dialect, used by <c>SchemaMigration.DetermineAsync</c> to
+    ///     assemble the batch of introspection queries.
+    /// </summary>
+    /// <remarks>
+    ///     The default is the dialect-neutral <see cref="DbCommandBuilder" />, which concatenates
+    ///     every statement into one command and reads one result set per statement. Oracle
+    ///     overrides it: ODP.NET will not execute several statements from a single command, so its
+    ///     builder splits the batch and the reader chains across the pieces (weasel#474). A provider
+    ///     that does not override this behaves exactly as it always has.
+    /// </remarks>
+    public virtual DbCommandBuilder CreateCommandBuilder(DbConnection conn) => new(conn);
+
     public abstract void AssertValidIdentifier(string name);
 
     /// <summary>

--- a/src/Weasel.Core/MultiCommandDataReader.cs
+++ b/src/Weasel.Core/MultiCommandDataReader.cs
@@ -1,0 +1,160 @@
+using System.Collections;
+using System.Data.Common;
+
+namespace Weasel.Core;
+
+/// <summary>
+///     Presents an ordered list of commands as one continuous sequence of result sets:
+///     <see cref="NextResult" /> walks the current command's result sets and then rolls over into
+///     the next command's.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Every Weasel provider except Oracle can execute a whole batch from a single
+///         <see cref="DbCommand" /> and hand back one result set per statement, which is what
+///         <c>SchemaMigration.DetermineAsync</c> assumes. ODP.NET cannot: it does not implement the
+///         ADO.NET batching API and Oracle will not execute several semicolon-separated statements
+///         from one command. <see cref="CommandBuilderBase.CompileCommands" /> already splits an
+///         Oracle batch into one command per statement; this is what makes the split invisible to
+///         the code reading the results (weasel#474).
+///     </para>
+///     <para>
+///         Only used when there is more than one command. A single-command batch executes exactly
+///         as it always did, so the providers that never split pay nothing for this.
+///     </para>
+/// </remarks>
+internal sealed class MultiCommandDataReader: DbDataReader
+{
+    private readonly IReadOnlyList<DbCommand> _commands;
+    private DbDataReader _current;
+    private int _index;
+
+    private MultiCommandDataReader(IReadOnlyList<DbCommand> commands, DbDataReader first)
+    {
+        _commands = commands;
+        _current = first;
+        _index = 0;
+    }
+
+    public static async Task<DbDataReader> OpenAsync(
+        IReadOnlyList<DbCommand> commands,
+        CancellationToken ct = default)
+    {
+        var first = await commands[0].ExecuteReaderAsync(ct).ConfigureAwait(false);
+        return new MultiCommandDataReader(commands, first);
+    }
+
+    /// <summary>
+    ///     Advance to the next result set, crossing into the next command when the current one is
+    ///     exhausted. A freshly executed reader is positioned before its first row, which is exactly
+    ///     where <see cref="DbDataReader.NextResult" /> leaves a caller, so the rollover is
+    ///     indistinguishable from an ordinary result set boundary.
+    /// </summary>
+    public override async Task<bool> NextResultAsync(CancellationToken ct)
+    {
+        if (await _current.NextResultAsync(ct).ConfigureAwait(false))
+        {
+            return true;
+        }
+
+        if (_index + 1 >= _commands.Count)
+        {
+            return false;
+        }
+
+        await _current.DisposeAsync().ConfigureAwait(false);
+        _index++;
+        _current = await _commands[_index].ExecuteReaderAsync(ct).ConfigureAwait(false);
+
+        return true;
+    }
+
+    public override bool NextResult()
+    {
+        if (_current.NextResult())
+        {
+            return true;
+        }
+
+        if (_index + 1 >= _commands.Count)
+        {
+            return false;
+        }
+
+        _current.Dispose();
+        _index++;
+        _current = _commands[_index].ExecuteReader();
+
+        return true;
+    }
+
+    public override async Task<bool> ReadAsync(CancellationToken ct) =>
+        await _current.ReadAsync(ct).ConfigureAwait(false);
+
+    public override bool Read() => _current.Read();
+
+    public override async Task<T> GetFieldValueAsync<T>(int ordinal, CancellationToken ct) =>
+        await _current.GetFieldValueAsync<T>(ordinal, ct).ConfigureAwait(false);
+
+    public override async Task<bool> IsDBNullAsync(int ordinal, CancellationToken ct) =>
+        await _current.IsDBNullAsync(ordinal, ct).ConfigureAwait(false);
+
+    public override async Task CloseAsync()
+    {
+        await _current.CloseAsync().ConfigureAwait(false);
+    }
+
+    public override void Close() => _current.Close();
+
+    public override async ValueTask DisposeAsync()
+    {
+        await _current.DisposeAsync().ConfigureAwait(false);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _current.Dispose();
+        }
+    }
+
+    // Everything below is plain delegation to whichever reader is current.
+
+    public override int Depth => _current.Depth;
+    public override int FieldCount => _current.FieldCount;
+    public override bool HasRows => _current.HasRows;
+    public override bool IsClosed => _current.IsClosed;
+    public override int RecordsAffected => _current.RecordsAffected;
+    public override object this[int ordinal] => _current[ordinal];
+    public override object this[string name] => _current[name];
+
+    public override bool GetBoolean(int ordinal) => _current.GetBoolean(ordinal);
+    public override byte GetByte(int ordinal) => _current.GetByte(ordinal);
+
+    public override long GetBytes(int ordinal, long dataOffset, byte[]? buffer, int bufferOffset, int length) =>
+        _current.GetBytes(ordinal, dataOffset, buffer, bufferOffset, length);
+
+    public override char GetChar(int ordinal) => _current.GetChar(ordinal);
+
+    public override long GetChars(int ordinal, long dataOffset, char[]? buffer, int bufferOffset, int length) =>
+        _current.GetChars(ordinal, dataOffset, buffer, bufferOffset, length);
+
+    public override string GetDataTypeName(int ordinal) => _current.GetDataTypeName(ordinal);
+    public override DateTime GetDateTime(int ordinal) => _current.GetDateTime(ordinal);
+    public override decimal GetDecimal(int ordinal) => _current.GetDecimal(ordinal);
+    public override double GetDouble(int ordinal) => _current.GetDouble(ordinal);
+    public override Type GetFieldType(int ordinal) => _current.GetFieldType(ordinal);
+    public override float GetFloat(int ordinal) => _current.GetFloat(ordinal);
+    public override Guid GetGuid(int ordinal) => _current.GetGuid(ordinal);
+    public override short GetInt16(int ordinal) => _current.GetInt16(ordinal);
+    public override int GetInt32(int ordinal) => _current.GetInt32(ordinal);
+    public override long GetInt64(int ordinal) => _current.GetInt64(ordinal);
+    public override string GetName(int ordinal) => _current.GetName(ordinal);
+    public override int GetOrdinal(string name) => _current.GetOrdinal(name);
+    public override string GetString(int ordinal) => _current.GetString(ordinal);
+    public override object GetValue(int ordinal) => _current.GetValue(ordinal);
+    public override int GetValues(object[] values) => _current.GetValues(values);
+    public override bool IsDBNull(int ordinal) => _current.IsDBNull(ordinal);
+    public override IEnumerator GetEnumerator() => _current.GetEnumerator();
+}

--- a/src/Weasel.Core/SchemaMigration.cs
+++ b/src/Weasel.Core/SchemaMigration.cs
@@ -62,8 +62,26 @@ public class SchemaMigration
     /// <param name="conn"></param>
     /// <param name="schemaObjects"></param>
     /// <returns></returns>
+    public static Task<SchemaMigration> DetermineAsync(
+        DbConnection conn,
+        CancellationToken ct,
+        params ISchemaObject[] schemaObjects
+    ) => DetermineAsync(conn, new DbCommandBuilder(conn), ct, schemaObjects);
+
+    /// <summary>
+    ///     Create a SchemaMigration using a command builder the caller supplies.
+    /// </summary>
+    /// <remarks>
+    ///     Only Oracle needs this: ODP.NET will not execute several statements from a single
+    ///     command, so <c>OracleDbCommandBuilder</c> splits the batch and the reader chains across
+    ///     the pieces. Without it every Oracle schema object was limited to one introspection query,
+    ///     which is why index, foreign key and primary key drift was invisible to the whole
+    ///     migration path (weasel#474). Callers reach it through
+    ///     <see cref="Migrator.CreateCommandBuilder" />.
+    /// </remarks>
     public static async Task<SchemaMigration> DetermineAsync(
         DbConnection conn,
+        DbCommandBuilder builder,
         CancellationToken ct,
         params ISchemaObject[] schemaObjects
     )
@@ -75,9 +93,14 @@ public class SchemaMigration
             return new SchemaMigration(deltas);
         }
 
-        var builder = new DbCommandBuilder(conn);
+        for (var i = 0; i < schemaObjects.Length; i++)
+        {
+            // Between objects, not before the first: a builder that splits on this boundary would
+            // otherwise open with an empty statement.
+            if (i > 0) builder.StartNewCommand();
 
-        foreach (var schemaObject in schemaObjects) schemaObject.ConfigureQueryCommand(builder);
+            schemaObjects[i].ConfigureQueryCommand(builder);
+        }
 
         await using var reader = await conn.ExecuteReaderAsync(builder, ct).ConfigureAwait(false);
 

--- a/src/Weasel.Oracle.Tests/Tables/index_scenarios.cs
+++ b/src/Weasel.Oracle.Tests/Tables/index_scenarios.cs
@@ -11,8 +11,16 @@ namespace Weasel.Oracle.Tests.Tables;
 ///     Oracle's rows of the shared index scenario matrix (weasel#449).
 /// </summary>
 /// <remarks>
-///     Oracle has no partial indexes, so <c>an_unsupported_index_property_is_refused_rather_than_ignored</c>
-///     is the live scenario here: <c>Predicate</c> used to be settable and did nothing at all.
+///     <para>
+///         Oracle has no partial indexes, so <c>an_unsupported_index_property_is_refused_rather_than_ignored</c>
+///         is the live scenario here: <c>Predicate</c> used to be settable and did nothing at all.
+///     </para>
+///     <para>
+///         These ran through <c>Table.FindDeltaAsync</c> rather than the migration path when the
+///         matrix landed, because Oracle's batched delta read columns only. weasel#474 fixed that,
+///         and the override is gone — this is the ordinary path now, the same one every other
+///         provider's rows use.
+///     </para>
 /// </remarks>
 [Collection("integration")]
 public class index_scenarios: IndexScenarioMatrix
@@ -32,16 +40,6 @@ public class index_scenarios: IndexScenarioMatrix
     protected override Migrator CreateMigrator() => new OracleMigrator();
 
     protected override ITable NewTable(string name) => new Table($"{SchemaName}.{name}");
-
-    /// <summary>
-    ///     Oracle's batched delta path reads columns only — <c>CreateDeltaAsync(DbDataReader)</c>
-    ///     says so on the method — because ODP.NET cannot return several result sets from one
-    ///     command. So index drift is invisible to <c>SchemaMigration.DetermineAsync</c>, which is
-    ///     what <c>ApplyChangesAsync</c> and the whole migration path use. These scenarios go
-    ///     through <c>FindDeltaAsync</c>, the only path on Oracle that sees an index at all.
-    /// </summary>
-    protected override async Task<ISchemaObjectDelta> FindDeltaAsync(DbConnection conn, ITable table)
-        => await ((Table)table).FindDeltaAsync((OracleConnection)conn);
 
     protected override (int Different, int Extra, int Missing) IndexDifferences(ISchemaObjectDelta delta)
         => delta is TableDelta table

--- a/src/Weasel.Oracle.Tests/Tables/migration_path_sees_more_than_columns.cs
+++ b/src/Weasel.Oracle.Tests/Tables/migration_path_sees_more_than_columns.cs
@@ -1,0 +1,155 @@
+using Shouldly;
+using Weasel.Core;
+using Weasel.Oracle.Tables;
+using Xunit;
+
+namespace Weasel.Oracle.Tests.Tables;
+
+/// <summary>
+///     weasel#474: on Oracle the migration path could only see a table's columns. ODP.NET will not
+///     execute several statements from one command, so a schema object could register exactly one
+///     introspection query and <c>Table</c> spent it on columns — leaving indexes, foreign keys and
+///     the primary key invisible to <c>SchemaMigration.DetermineAsync</c>, which is what
+///     <c>ApplyChangesAsync</c>, <c>ApplyAllConfiguredChangesToDatabaseAsync</c> and
+///     <c>AssertDatabaseMatchesConfigurationAsync</c> all go through.
+/// </summary>
+/// <remarks>
+///     <para>
+///         The practical effect: a declared index was created with the table and never touched
+///         again. Add one to an existing table and nothing happened. Change one and nothing
+///         happened. Remove one and it stayed. And the assert method reported a match throughout.
+///     </para>
+///     <para>
+///         These go through <c>ApplyChangesAsync</c> deliberately — the point is the path, not the
+///         introspection. <c>Table.FetchExistingAsync</c> could always see all of this.
+///     </para>
+/// </remarks>
+[Collection("integration")]
+public class migration_path_sees_more_than_columns: IntegrationContext
+{
+    private const string SchemaName = "WEASEL";
+
+    public migration_path_sees_more_than_columns(): base(SchemaName)
+    {
+    }
+
+    private static Table NewTable()
+    {
+        var table = new Table($"{SchemaName}.mp_orders");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn<string>("name");
+        table.AddColumn<int>("quantity");
+        return table;
+    }
+
+    [Fact]
+    public async Task an_index_added_after_the_table_exists_is_created()
+    {
+        await ResetSchema();
+
+        await NewTable().ApplyChangesAsync(theConnection);
+
+        var withIndex = NewTable();
+        withIndex.Indexes.Add(new IndexDefinition("mp_orders_name_idx") { Columns = ["name"] });
+
+        var before = await withIndex.FindDeltaAsync(theConnection);
+        before.Difference.ShouldBe(SchemaPatchDifference.Update);
+
+        await withIndex.ApplyChangesAsync(theConnection);
+
+        var after = await withIndex.FindDeltaAsync(theConnection);
+        after.Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    /// <summary>
+    ///     The one that matters most for anyone running <c>db-assert</c> in CI: an index the model
+    ///     declares and the database does not have used to report a clean match.
+    /// </summary>
+    [Fact]
+    public async Task a_missing_index_is_reported_by_the_migration_path()
+    {
+        await ResetSchema();
+
+        await NewTable().ApplyChangesAsync(theConnection);
+
+        var withIndex = NewTable();
+        withIndex.Indexes.Add(new IndexDefinition("mp_orders_qty_idx") { Columns = ["quantity"] });
+
+        var migration = await SchemaMigration.DetermineAsync(
+            theConnection, new OracleMigrator().CreateCommandBuilder(theConnection), default, withIndex);
+
+        migration.Difference.ShouldBe(SchemaPatchDifference.Update);
+    }
+
+    [Fact]
+    public async Task the_primary_key_is_read_back_by_the_migration_path()
+    {
+        await ResetSchema();
+
+        var table = NewTable();
+        await table.ApplyChangesAsync(theConnection);
+
+        var migration = await SchemaMigration.DetermineAsync(
+            theConnection, new OracleMigrator().CreateCommandBuilder(theConnection), default, table);
+
+        var delta = migration.Deltas.Single().ShouldBeOfType<TableDelta>();
+
+        delta.Actual.ShouldNotBeNull();
+        delta.Actual!.PrimaryKeyColumns.ShouldContain(x => x.Equals("id", StringComparison.OrdinalIgnoreCase));
+        delta.Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task a_foreign_key_is_read_back_by_the_migration_path()
+    {
+        await ResetSchema();
+
+        var states = new Table($"{SchemaName}.mp_states");
+        states.AddColumn<int>("id").AsPrimaryKey();
+        await states.ApplyChangesAsync(theConnection);
+
+        var orders = NewTable();
+        orders.AddColumn<int>("state_id").ForeignKeyTo(states, "id");
+        await orders.ApplyChangesAsync(theConnection);
+
+        var migration = await SchemaMigration.DetermineAsync(
+            theConnection, new OracleMigrator().CreateCommandBuilder(theConnection), default, orders);
+
+        var delta = migration.Deltas.Single().ShouldBeOfType<TableDelta>();
+
+        delta.Actual!.ForeignKeys.ShouldNotBeEmpty();
+        delta.Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    /// <summary>
+    ///     Several tables in one batch: the reader has to walk six result sets per table and land on
+    ///     the right boundary, or the second table reads the first one's rows.
+    /// </summary>
+    [Fact]
+    public async Task several_tables_in_one_batch_each_read_their_own_result_sets()
+    {
+        await ResetSchema();
+
+        var first = NewTable();
+        first.Indexes.Add(new IndexDefinition("mp_orders_name_idx") { Columns = ["name"] });
+
+        var second = new Table($"{SchemaName}.mp_customers");
+        second.AddColumn<int>("id").AsPrimaryKey();
+        second.AddColumn<string>("email");
+        second.Indexes.Add(new IndexDefinition("mp_customers_email_idx") { Columns = ["email"] });
+
+        await first.ApplyChangesAsync(theConnection);
+        await second.ApplyChangesAsync(theConnection);
+
+        var migration = await SchemaMigration.DetermineAsync(
+            theConnection, new OracleMigrator().CreateCommandBuilder(theConnection), default, first, second);
+
+        migration.Deltas.Count.ShouldBe(2);
+        migration.Difference.ShouldBe(SchemaPatchDifference.None);
+
+        foreach (var delta in migration.Deltas.Cast<TableDelta>())
+        {
+            delta.Actual!.Indexes.Count.ShouldBe(1);
+        }
+    }
+}

--- a/src/Weasel.Oracle/OracleMigrator.cs
+++ b/src/Weasel.Oracle/OracleMigrator.cs
@@ -138,6 +138,20 @@ END;");
     ///     included -- is written inside a string literal.
     /// </remarks>
     /// <exception cref="InvalidOperationException">The name cannot be safely written into DDL.</exception>
+    /// <summary>
+    ///     Oracle builds its introspection batch through <see cref="OracleDbCommandBuilder" />,
+    ///     which splits on <c>StartNewCommand</c> and hands back one command per statement.
+    /// </summary>
+    /// <remarks>
+    ///     ODP.NET does not implement the ADO.NET batching API and Oracle will not execute several
+    ///     semicolon-separated statements from one command, so before weasel#474 an Oracle schema
+    ///     object could register exactly one query — and <c>Table</c> spent it on columns. Indexes,
+    ///     foreign keys and the primary key were therefore invisible to every caller that went
+    ///     through <c>SchemaMigration.DetermineAsync</c>, which is the entire migration path.
+    /// </remarks>
+    public override Weasel.Core.DbCommandBuilder CreateCommandBuilder(DbConnection conn)
+        => new OracleDbCommandBuilder();
+
     public override void AssertValidIdentifier(string name)
     {
         var problem = IdentifierValidation.FindProblem(name, UnsafeIdentifierCharacters);

--- a/src/Weasel.Oracle/SchemaObjectsExtensions.cs
+++ b/src/Weasel.Oracle/SchemaObjectsExtensions.cs
@@ -400,36 +400,20 @@ public static class SchemaObjectsExtensions
     /// Oracle doesn't support multiple result sets in a single command like PostgreSQL or SQL Server,
     /// so we must execute each schema object's query individually.
     /// </summary>
-    private static async Task<SchemaMigration> DetermineOracleMigrationAsync(
+    /// <summary>
+    ///     Determine a migration for these objects, through the Oracle command builder.
+    /// </summary>
+    /// <remarks>
+    ///     This used to sniff for <c>Tables.Table</c> and route it to
+    ///     <c>Table.FindDeltaAsync</c>, because the generic path read columns only and would have
+    ///     missed every index, foreign key and primary key. weasel#474 removed the reason:
+    ///     <c>OracleDbCommandBuilder</c> splits the batch into one command per statement and the
+    ///     reader chains across them, so an Oracle schema object can register as many introspection
+    ///     queries as it needs. One path for every object type now, and no type test.
+    /// </remarks>
+    private static Task<SchemaMigration> DetermineOracleMigrationAsync(
         OracleConnection conn,
         CancellationToken ct,
         params ISchemaObject[] schemaObjects)
-    {
-        var deltas = new List<ISchemaObjectDelta>();
-
-        foreach (var schemaObject in schemaObjects)
-        {
-            // For Table objects, use the Oracle-specific FindDeltaAsync which fetches
-            // full metadata (columns, PKs, FKs, indexes) via separate queries.
-            // The generic CreateDeltaAsync only reads columns from a single result set.
-            if (schemaObject is Tables.Table table)
-            {
-                var delta = await table.FindDeltaAsync(conn, ct).ConfigureAwait(false);
-                deltas.Add(delta);
-            }
-            else
-            {
-                var builder = new Weasel.Core.DbCommandBuilder(conn);
-                schemaObject.ConfigureQueryCommand(builder);
-
-                await using var reader = await conn.ExecuteReaderAsync(builder, ct).ConfigureAwait(false);
-                var delta = await schemaObject.CreateDeltaAsync(reader, ct).ConfigureAwait(false);
-                deltas.Add(delta);
-
-                await reader.CloseAsync().ConfigureAwait(false);
-            }
-        }
-
-        return new SchemaMigration(deltas);
-    }
+        => SchemaMigration.DetermineAsync(conn, new OracleDbCommandBuilder(), ct, schemaObjects);
 }

--- a/src/Weasel.Oracle/Tables/Table.Deltas.cs
+++ b/src/Weasel.Oracle/Tables/Table.Deltas.cs
@@ -7,10 +7,16 @@ namespace Weasel.Oracle.Tables;
 public partial class Table
 {
     /// <summary>
-    /// Creates a delta from a DbDataReader. Oracle limitation: this only reads columns,
-    /// not PKs, FKs, or indexes, since Oracle doesn't support multiple result sets.
-    /// For full schema detection, use FindDeltaAsync instead.
+    ///     Creates a delta from the six result sets <see cref="ConfigureQueryCommand" /> registers:
+    ///     columns, primary key, foreign keys, index metadata, index expressions, index columns.
     /// </summary>
+    /// <remarks>
+    ///     This used to read columns only, because ODP.NET will not execute several statements from
+    ///     one command and a schema object could therefore register one query. Indexes, foreign keys
+    ///     and the primary key were invisible to every caller that went through
+    ///     <c>SchemaMigration.DetermineAsync</c> — the entire migration path — and only
+    ///     <see cref="FetchExistingAsync" /> saw them (weasel#474).
+    /// </remarks>
     public override async Task<ISchemaObjectDelta> CreateDeltaAsync(DbDataReader reader, CancellationToken ct = default)
     {
         var existing = await ReadExistingFromReaderAsync(reader, ct).ConfigureAwait(false);

--- a/src/Weasel.Oracle/Tables/Table.FetchExisting.cs
+++ b/src/Weasel.Oracle/Tables/Table.FetchExisting.cs
@@ -1,4 +1,5 @@
 using System.Data.Common;
+using System.Text.RegularExpressions;
 using Oracle.ManagedDataAccess.Client;
 using Weasel.Core;
 using DbCommandBuilder = Weasel.Core.DbCommandBuilder;
@@ -7,71 +8,179 @@ namespace Weasel.Oracle.Tables;
 
 public partial class Table
 {
-    // Oracle doesn't support multiple result sets in a single command like PostgreSQL or SQL Server.
-    // ConfigureQueryCommand includes columns and primary key info in a single query via LEFT JOIN.
-    // For full schema detection (including FKs and indexes), use FetchExistingAsync directly.
+    private const string ColumnSql = @"
+SELECT column_name, data_type, data_length, data_precision, data_scale, nullable
+FROM all_tab_columns
+WHERE owner = :schemaName AND table_name = :tableName
+ORDER BY column_id";
+
+    private const string PrimaryKeySql = @"
+SELECT cols.column_name, cons.constraint_name
+FROM all_constraints cons
+JOIN all_cons_columns cols ON cons.constraint_name = cols.constraint_name AND cons.owner = cols.owner
+WHERE cons.owner = :schemaName
+  AND cons.table_name = :tableName
+  AND cons.constraint_type = 'P'
+ORDER BY cols.position";
+
+    private const string ForeignKeySql = @"
+SELECT
+    cons.constraint_name,
+    ref_cons.table_name AS referenced_table,
+    ref_cons.owner AS referenced_schema,
+    cols.column_name,
+    ref_cols.column_name AS referenced_column,
+    cons.delete_rule
+FROM all_constraints cons
+JOIN all_cons_columns cols ON cons.constraint_name = cols.constraint_name AND cons.owner = cols.owner
+JOIN all_constraints ref_cons ON cons.r_constraint_name = ref_cons.constraint_name AND cons.r_owner = ref_cons.owner
+JOIN all_cons_columns ref_cols ON ref_cons.constraint_name = ref_cols.constraint_name
+    AND ref_cons.owner = ref_cols.owner AND cols.position = ref_cols.position
+WHERE cons.owner = :schemaName
+  AND cons.table_name = :tableName
+  AND cons.constraint_type = 'R'
+ORDER BY cons.constraint_name, cols.position";
+
+    private const string IndexSql = @"
+SELECT
+    i.index_name,
+    i.uniqueness,
+    i.index_type
+FROM all_indexes i
+WHERE i.owner = :schemaName
+  AND i.table_name = :tableName
+  AND NOT EXISTS (
+      SELECT 1 FROM all_constraints c
+      WHERE c.owner = i.owner AND c.index_name = i.index_name AND c.constraint_type = 'P'
+  )";
+
+    private const string IndexExpressionSql = @"
+SELECT
+    index_name,
+    column_position,
+    column_expression
+FROM all_ind_expressions
+WHERE index_owner = :indexOwner
+  AND table_owner = :tableOwner
+  AND table_name = :tableName";
+
+    private const string IndexColumnSql = @"
+SELECT
+    ic.index_name,
+    ic.column_name,
+    ic.descend
+FROM all_ind_columns ic
+JOIN all_indexes i ON ic.index_owner = i.owner AND ic.index_name = i.index_name
+WHERE ic.index_owner = :indexOwner
+  AND ic.table_owner = :tableOwner
+  AND ic.table_name = :tableName
+  AND NOT EXISTS (
+      SELECT 1 FROM all_constraints c
+      WHERE c.owner = i.owner AND c.index_name = i.index_name AND c.constraint_type = 'P'
+  )
+ORDER BY ic.index_name, ic.column_position";
+
+    /// <summary>
+    ///     Register every introspection query this table needs — columns, primary key, foreign
+    ///     keys, index metadata, index expressions, index columns — as five statements separated by
+    ///     <see cref="CommandBuilderBase{TCommand,TParameter,TParameterType}.StartNewCommand" />.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Until weasel#474 this registered one query and spent it on columns, because ODP.NET
+    ///         will not execute several statements from a single command. Indexes, foreign keys and
+    ///         the primary key were therefore invisible to <c>SchemaMigration.DetermineAsync</c> —
+    ///         which is the whole migration path — and only <see cref="FetchExistingAsync" /> saw
+    ///         them. <c>OracleDbCommandBuilder</c> splits on the boundary and the reader chains
+    ///         across the pieces, so the statements arrive as ordinary consecutive result sets.
+    ///     </para>
+    ///     <para>
+    ///         <c>all_ind_expressions.column_expression</c> is a LONG, so the command needs
+    ///         <c>InitialLONGFetchSize</c> set or it reads back empty — the same trap the Oracle
+    ///         view slice hit in weasel#450.
+    ///     </para>
+    /// </remarks>
     public override void ConfigureQueryCommand(DbCommandBuilder builder)
     {
-        var schemaParam = builder.AddParameter(Identifier.Schema.ToUpperInvariant()).ParameterName;
-        var nameParam = builder.AddParameter(Identifier.Name.ToUpperInvariant()).ParameterName;
+        if (builder.Command is OracleCommand oracleCommand)
+        {
+            oracleCommand.InitialLONGFetchSize = -1;
+        }
 
-        builder.Append($@"
-SELECT c.column_name, c.data_type, c.data_length, c.data_precision, c.data_scale, c.nullable,
-       CASE WHEN pk_cols.column_name IS NOT NULL THEN 1 ELSE 0 END AS is_pk,
-       pk_cons.constraint_name AS pk_name
-FROM all_tab_columns c
-LEFT JOIN all_constraints pk_cons
-    ON pk_cons.owner = c.owner AND pk_cons.table_name = c.table_name AND pk_cons.constraint_type = 'P'
-LEFT JOIN all_cons_columns pk_cols
-    ON pk_cols.owner = pk_cons.owner AND pk_cols.constraint_name = pk_cons.constraint_name AND pk_cols.column_name = c.column_name
-WHERE c.owner = :{schemaParam} AND c.table_name = :{nameParam}
-ORDER BY c.column_id
-");
+        var schema = builder.AddParameter(Identifier.Schema.ToUpperInvariant()).ParameterName;
+        var name = builder.AddParameter(Identifier.Name.ToUpperInvariant()).ParameterName;
+
+        builder.Append(ColumnSql.Replace(":schemaName", $":{schema}").Replace(":tableName", $":{name}"));
+        builder.StartNewCommand();
+
+        builder.Append(PrimaryKeySql.Replace(":schemaName", $":{schema}").Replace(":tableName", $":{name}"));
+        builder.StartNewCommand();
+
+        builder.Append(ForeignKeySql.Replace(":schemaName", $":{schema}").Replace(":tableName", $":{name}"));
+        builder.StartNewCommand();
+
+        builder.Append(IndexSql.Replace(":schemaName", $":{schema}").Replace(":tableName", $":{name}"));
+        builder.StartNewCommand();
+
+        builder.Append(IndexExpressionSql.Replace(":indexOwner", $":{schema}").Replace(":tableOwner", $":{schema}")
+            .Replace(":tableName", $":{name}"));
+        builder.StartNewCommand();
+
+        builder.Append(IndexColumnSql.Replace(":indexOwner", $":{schema}").Replace(":tableOwner", $":{schema}")
+            .Replace(":tableName", $":{name}"));
     }
 
     /// <summary>
-    /// Reads table metadata from a DbDataReader including columns and primary key info.
-    /// Oracle limitation: FKs and indexes are not included since Oracle doesn't support
-    /// multiple result sets. For full schema detection, use FetchExistingAsync instead.
+    ///     Read the six result sets <see cref="ConfigureQueryCommand" /> registers, in order.
     /// </summary>
     internal async Task<Table?> ReadExistingFromReaderAsync(DbDataReader reader, CancellationToken ct = default)
     {
         var existing = new Table(Identifier);
-        string? pkName = null;
 
-        while (await reader.ReadAsync(ct).ConfigureAwait(false))
+        await readColumnsFromReaderAsync(reader, existing, ct).ConfigureAwait(false);
+
+        if (!existing.Columns.Any())
         {
-            var column = await readColumnAsync(reader, ct).ConfigureAwait(false);
-
-            // Read PK info from the additional columns in the query
-            if (reader.FieldCount > 6)
-            {
-                var isPk = !await reader.IsDBNullAsync(6, ct).ConfigureAwait(false)
-                    && Convert.ToInt32(await reader.GetFieldValueAsync<decimal>(6, ct).ConfigureAwait(false)) == 1;
-                if (isPk)
-                {
-                    column.IsPrimaryKey = true;
-                }
-
-                if (!await reader.IsDBNullAsync(7, ct).ConfigureAwait(false))
-                {
-                    pkName = await reader.GetFieldValueAsync<string>(7, ct).ConfigureAwait(false);
-                }
-            }
-
-            existing._columns.Add(column);
+            // The table does not exist. The remaining result sets are still there and still have to
+            // be walked, or the next schema object in the batch reads this table's rows.
+            for (var i = 0; i < 5; i++) await reader.NextResultAsync(ct).ConfigureAwait(false);
+            return null;
         }
 
-        if (!existing.Columns.Any()) return null;
-
-        if (pkName != null)
+        await reader.NextResultAsync(ct).ConfigureAwait(false);
+        var (pks, primaryKeyName) = await readPrimaryKeysFromReaderAsync(reader, ct).ConfigureAwait(false);
+        foreach (var pkColumn in pks)
         {
-            existing.PrimaryKeyName = pkName;
+            var column = existing.ColumnFor(pkColumn);
+            if (column != null) column.IsPrimaryKey = true;
         }
+
+        if (primaryKeyName != null)
+        {
+            existing.PrimaryKeyName = primaryKeyName;
+        }
+
+        await reader.NextResultAsync(ct).ConfigureAwait(false);
+        await readForeignKeysFromReaderAsync(reader, existing, ct).ConfigureAwait(false);
+
+        await reader.NextResultAsync(ct).ConfigureAwait(false);
+        var indexes = await readIndexMetadataFromReaderAsync(reader, existing, ct).ConfigureAwait(false);
+
+        await reader.NextResultAsync(ct).ConfigureAwait(false);
+        var expressions = await readIndexExpressionsFromReaderAsync(reader, ct).ConfigureAwait(false);
+
+        await reader.NextResultAsync(ct).ConfigureAwait(false);
+        await readIndexColumnsFromReaderAsync(reader, existing, indexes, expressions, ct).ConfigureAwait(false);
 
         return existing;
     }
 
+    /// <summary>
+    ///     Read this table directly, one command per query. Kept alongside the batched path in
+    ///     <see cref="ConfigureQueryCommand" /> because it is the convenient entry point for a
+    ///     caller holding an <see cref="OracleConnection" /> and wanting one table; both share the
+    ///     same SQL and the same readers, so they cannot drift apart.
+    /// </summary>
     public async Task<Table?> FetchExistingAsync(OracleConnection conn, CancellationToken ct = default)
     {
         var schemaName = Identifier.Schema.ToUpperInvariant();
@@ -79,49 +188,249 @@ ORDER BY c.column_id
 
         var existing = new Table(Identifier);
 
-        // Query 1: Columns
-        await readColumnsAsync(conn, existing, schemaName, tableName, ct).ConfigureAwait(false);
+        await using (var reader = await queryAsync(conn, ColumnSql, schemaName, tableName, ct).ConfigureAwait(false))
+        {
+            await readColumnsFromReaderAsync(reader, existing, ct).ConfigureAwait(false);
+        }
 
         if (!existing.Columns.Any())
         {
             return null;
         }
 
-        // Query 2: Primary Keys
-        var (pks, primaryKeyName) = await readPrimaryKeysAsync(conn, schemaName, tableName, ct).ConfigureAwait(false);
-        foreach (var pkColumn in pks) existing.ColumnFor(pkColumn)!.IsPrimaryKey = true;
-        if (primaryKeyName != null)
+        await using (var reader =
+                     await queryAsync(conn, PrimaryKeySql, schemaName, tableName, ct).ConfigureAwait(false))
         {
-            existing.PrimaryKeyName = primaryKeyName;
+            var (pks, primaryKeyName) = await readPrimaryKeysFromReaderAsync(reader, ct).ConfigureAwait(false);
+            applyPrimaryKey(existing, pks, primaryKeyName);
         }
 
-        // Query 3: Foreign Keys
-        await readForeignKeysAsync(conn, existing, schemaName, tableName, ct).ConfigureAwait(false);
+        await using (var reader =
+                     await queryAsync(conn, ForeignKeySql, schemaName, tableName, ct).ConfigureAwait(false))
+        {
+            await readForeignKeysFromReaderAsync(reader, existing, ct).ConfigureAwait(false);
+        }
 
-        // Query 4 & 5: Indexes
-        await readIndexesAsync(conn, existing, schemaName, tableName, ct).ConfigureAwait(false);
+        Dictionary<string, IndexDefinition> indexes;
+        await using (var reader = await queryAsync(conn, IndexSql, schemaName, tableName, ct).ConfigureAwait(false))
+        {
+            indexes = await readIndexMetadataFromReaderAsync(reader, existing, ct).ConfigureAwait(false);
+        }
+
+        Dictionary<(string, int), string> expressions;
+        await using (var reader =
+                     await queryAsync(conn, IndexExpressionSql, schemaName, tableName, ct).ConfigureAwait(false))
+        {
+            expressions = await readIndexExpressionsFromReaderAsync(reader, ct).ConfigureAwait(false);
+        }
+
+        await using (var reader =
+                     await queryAsync(conn, IndexColumnSql, schemaName, tableName, ct).ConfigureAwait(false))
+        {
+            await readIndexColumnsFromReaderAsync(reader, existing, indexes, expressions, ct).ConfigureAwait(false);
+        }
 
         return existing;
     }
 
-    private static async Task readColumnsAsync(OracleConnection conn, Table existing, string schemaName, string tableName, CancellationToken ct = default)
+    private static void applyPrimaryKey(Table existing, List<string> pks, string? primaryKeyName)
     {
-        var sql = @"
-SELECT column_name, data_type, data_length, data_precision, data_scale, nullable
-FROM all_tab_columns
-WHERE owner = :schemaName AND table_name = :tableName
-ORDER BY column_id";
+        foreach (var pkColumn in pks)
+        {
+            var column = existing.ColumnFor(pkColumn);
+            if (column != null)
+            {
+                column.IsPrimaryKey = true;
+            }
+        }
 
-        await using var cmd = conn.CreateCommand();
+        if (primaryKeyName != null)
+        {
+            existing.PrimaryKeyName = primaryKeyName;
+        }
+    }
+
+    /// <summary>
+    ///     Run one of the introspection queries. Each binds the schema under one name or another
+    ///     and most bind the table, so whichever the SQL mentions is what gets supplied.
+    /// </summary>
+    private static async Task<DbDataReader> queryAsync(
+        OracleConnection conn, string sql, string schemaName, string tableName, CancellationToken ct)
+    {
+        var cmd = conn.CreateCommand();
         cmd.CommandText = sql;
-        cmd.Parameters.Add(new OracleParameter("schemaName", schemaName));
-        cmd.Parameters.Add(new OracleParameter("tableName", tableName));
+        cmd.BindByName = true;
 
-        await using var reader = await cmd.ExecuteReaderAsync(ct).ConfigureAwait(false);
+        // column_expression on all_ind_expressions is a LONG, and ODP.NET reads a LONG back empty
+        // unless told how much to fetch. -1 is "all of it" (weasel#450).
+        cmd.InitialLONGFetchSize = -1;
+
+        foreach (var name in new[] { "schemaName", "indexOwner", "tableOwner" })
+        {
+            if (sql.Contains(':' + name, StringComparison.Ordinal))
+            {
+                cmd.Parameters.Add(new OracleParameter(name, schemaName));
+            }
+        }
+
+        if (sql.Contains(":tableName", StringComparison.Ordinal))
+        {
+            cmd.Parameters.Add(new OracleParameter("tableName", tableName));
+        }
+
+        return await cmd.ExecuteReaderAsync(ct).ConfigureAwait(false);
+    }
+
+    private static async Task readColumnsFromReaderAsync(
+        DbDataReader reader, Table existing, CancellationToken ct = default)
+    {
         while (await reader.ReadAsync(ct).ConfigureAwait(false))
         {
             var column = await readColumnAsync(reader, ct).ConfigureAwait(false);
             existing._columns.Add(column);
+        }
+    }
+
+    private static async Task<(List<string>, string?)> readPrimaryKeysFromReaderAsync(
+        DbDataReader reader, CancellationToken ct = default)
+    {
+        string? pkName = null;
+        var pks = new List<string>();
+
+        while (await reader.ReadAsync(ct).ConfigureAwait(false))
+        {
+            pks.Add(await reader.GetFieldValueAsync<string>(0, ct).ConfigureAwait(false));
+            pkName = await reader.GetFieldValueAsync<string>(1, ct).ConfigureAwait(false);
+        }
+
+        return (pks, pkName);
+    }
+
+    private static async Task readForeignKeysFromReaderAsync(
+        DbDataReader reader, Table existing, CancellationToken ct = default)
+    {
+        while (await reader.ReadAsync(ct).ConfigureAwait(false))
+        {
+            var fkName = await reader.GetFieldValueAsync<string>(0, ct).ConfigureAwait(false);
+            var refTableName = await reader.GetFieldValueAsync<string>(1, ct).ConfigureAwait(false);
+            var refSchemaName = await reader.GetFieldValueAsync<string>(2, ct).ConfigureAwait(false);
+            var columnName = await reader.GetFieldValueAsync<string>(3, ct).ConfigureAwait(false);
+            var referencedName = await reader.GetFieldValueAsync<string>(4, ct).ConfigureAwait(false);
+
+            var onDelete = await reader.IsDBNullAsync(5, ct).ConfigureAwait(false)
+                ? null
+                : await reader.GetFieldValueAsync<string>(5, ct).ConfigureAwait(false);
+
+            var fk = existing.FindOrCreateForeignKey(fkName);
+            fk.LinkedTable = new OracleObjectName(refSchemaName, refTableName);
+            fk.ReadReferentialActions(onDelete);
+
+            fk.LinkColumns(columnName, referencedName);
+        }
+    }
+
+    private static async Task<Dictionary<string, IndexDefinition>> readIndexMetadataFromReaderAsync(
+        DbDataReader reader, Table existing, CancellationToken ct = default)
+    {
+        var indexes = new Dictionary<string, IndexDefinition>(StringComparer.OrdinalIgnoreCase);
+
+        while (await reader.ReadAsync(ct).ConfigureAwait(false))
+        {
+            var name = await reader.GetFieldValueAsync<string>(0, ct).ConfigureAwait(false);
+            var uniqueness = await reader.GetFieldValueAsync<string>(1, ct).ConfigureAwait(false);
+            var indexType = await reader.GetFieldValueAsync<string>(2, ct).ConfigureAwait(false);
+
+            var index = new IndexDefinition(name)
+            {
+                IsUnique = uniqueness == "UNIQUE",
+                IndexType = indexType == "BITMAP" ? OracleIndexType.Bitmap :
+                    indexType.Contains("FUNCTION") ? OracleIndexType.FunctionBased :
+                    OracleIndexType.BTree
+            };
+
+            indexes.Add(name, index);
+            existing.Indexes.Add(index);
+        }
+
+        return indexes;
+    }
+
+    /// <summary>
+    ///     For a descending or function-based index Oracle stores a system-generated column name
+    ///     like <c>SYS_NC00006$</c>, and the real column only appears in the expression.
+    /// </summary>
+    private static async Task<Dictionary<(string, int), string>> readIndexExpressionsFromReaderAsync(
+        DbDataReader reader, CancellationToken ct = default)
+    {
+        var expressionMap = new Dictionary<(string, int), string>();
+
+        while (await reader.ReadAsync(ct).ConfigureAwait(false))
+        {
+            var idxName = await reader.GetFieldValueAsync<string>(0, ct).ConfigureAwait(false);
+            var position = Convert.ToInt32(await reader.GetFieldValueAsync<decimal>(1, ct).ConfigureAwait(false));
+
+            if (!await reader.IsDBNullAsync(2, ct).ConfigureAwait(false))
+            {
+                var expression = await reader.GetFieldValueAsync<string>(2, ct).ConfigureAwait(false);
+                expressionMap[(idxName.ToUpperInvariant(), position)] = expression;
+            }
+        }
+
+        return expressionMap;
+    }
+
+    private static async Task readIndexColumnsFromReaderAsync(
+        DbDataReader reader,
+        Table existing,
+        Dictionary<string, IndexDefinition> indexes,
+        Dictionary<(string, int), string> expressionMap,
+        CancellationToken ct = default)
+    {
+        var columnPositions = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+        while (await reader.ReadAsync(ct).ConfigureAwait(false))
+        {
+            var indexName = await reader.GetFieldValueAsync<string>(0, ct).ConfigureAwait(false);
+            if (!indexes.TryGetValue(indexName, out var index))
+            {
+                continue;
+            }
+
+            if (!columnPositions.ContainsKey(indexName))
+            {
+                columnPositions[indexName] = 1;
+            }
+
+            var position = columnPositions[indexName]++;
+
+            var columnName = await reader.GetFieldValueAsync<string>(1, ct).ConfigureAwait(false);
+            var descend = await reader.GetFieldValueAsync<string>(2, ct).ConfigureAwait(false);
+
+            if (columnName.StartsWith("SYS_", StringComparison.OrdinalIgnoreCase)
+                && expressionMap.TryGetValue((indexName.ToUpperInvariant(), position), out var expression))
+            {
+                // SYS_OP_DESCEND("USER_NAME"), or just "USER_NAME"
+                var match = Regex.Match(expression, "\"([^\"]+)\"");
+                if (match.Success)
+                {
+                    columnName = match.Groups[1].Value;
+                }
+            }
+
+            index.AddColumn(columnName);
+
+            if (descend == "DESC")
+            {
+                index.SortOrder = SortOrder.Desc;
+            }
+        }
+
+        // An index with no columns is one this reader could not make sense of -- a system-generated
+        // or function-based index whose expression did not name a column. Better to leave it out of
+        // the model than to report drift against something that cannot be reproduced.
+        foreach (var emptyIndex in existing.Indexes.Where(i => !i.Columns.Any()).ToList())
+        {
+            existing.Indexes.Remove(emptyIndex);
         }
     }
 
@@ -189,238 +498,4 @@ ORDER BY column_id";
         }
     }
 
-    private static async Task<(List<string>, string?)> readPrimaryKeysAsync(
-        OracleConnection conn,
-        string schemaName,
-        string tableName,
-        CancellationToken ct = default
-    )
-    {
-        var sql = @"
-SELECT cols.column_name, cons.constraint_name
-FROM all_constraints cons
-JOIN all_cons_columns cols ON cons.constraint_name = cols.constraint_name AND cons.owner = cols.owner
-WHERE cons.owner = :schemaName
-  AND cons.table_name = :tableName
-  AND cons.constraint_type = 'P'
-ORDER BY cols.position";
-
-        string? pkName = null;
-        var pks = new List<string>();
-
-        await using var cmd = conn.CreateCommand();
-        cmd.CommandText = sql;
-        cmd.Parameters.Add(new OracleParameter("schemaName", schemaName));
-        cmd.Parameters.Add(new OracleParameter("tableName", tableName));
-
-        await using var reader = await cmd.ExecuteReaderAsync(ct).ConfigureAwait(false);
-        while (await reader.ReadAsync(ct).ConfigureAwait(false))
-        {
-            pks.Add(await reader.GetFieldValueAsync<string>(0, ct).ConfigureAwait(false));
-            pkName = await reader.GetFieldValueAsync<string>(1, ct).ConfigureAwait(false);
-        }
-
-        return (pks, pkName);
-    }
-
-    private async Task readForeignKeysAsync(OracleConnection conn, Table existing, string schemaName, string tableName, CancellationToken ct = default)
-    {
-        var sql = @"
-SELECT
-    cons.constraint_name,
-    ref_cons.table_name AS referenced_table,
-    ref_cons.owner AS referenced_schema,
-    cols.column_name,
-    ref_cols.column_name AS referenced_column,
-    cons.delete_rule
-FROM all_constraints cons
-JOIN all_cons_columns cols ON cons.constraint_name = cols.constraint_name AND cons.owner = cols.owner
-JOIN all_constraints ref_cons ON cons.r_constraint_name = ref_cons.constraint_name AND cons.r_owner = ref_cons.owner
-JOIN all_cons_columns ref_cols ON ref_cons.constraint_name = ref_cols.constraint_name
-    AND ref_cons.owner = ref_cols.owner AND cols.position = ref_cols.position
-WHERE cons.owner = :schemaName
-  AND cons.table_name = :tableName
-  AND cons.constraint_type = 'R'
-ORDER BY cons.constraint_name, cols.position";
-
-        await using var cmd = conn.CreateCommand();
-        cmd.CommandText = sql;
-        cmd.Parameters.Add(new OracleParameter("schemaName", schemaName));
-        cmd.Parameters.Add(new OracleParameter("tableName", tableName));
-
-        await using var reader = await cmd.ExecuteReaderAsync(ct).ConfigureAwait(false);
-        while (await reader.ReadAsync(ct).ConfigureAwait(false))
-        {
-            var fkName = await reader.GetFieldValueAsync<string>(0, ct).ConfigureAwait(false);
-            var refTableName = await reader.GetFieldValueAsync<string>(1, ct).ConfigureAwait(false);
-            var refSchemaName = await reader.GetFieldValueAsync<string>(2, ct).ConfigureAwait(false);
-            var columnName = await reader.GetFieldValueAsync<string>(3, ct).ConfigureAwait(false);
-            var referencedName = await reader.GetFieldValueAsync<string>(4, ct).ConfigureAwait(false);
-
-            var onDelete = await reader.IsDBNullAsync(5, ct).ConfigureAwait(false)
-                ? null
-                : await reader.GetFieldValueAsync<string>(5, ct).ConfigureAwait(false);
-
-            var fk = existing.FindOrCreateForeignKey(fkName);
-            fk.LinkedTable = new OracleObjectName(refSchemaName, refTableName);
-            fk.ReadReferentialActions(onDelete);
-
-            fk.LinkColumns(columnName, referencedName);
-        }
-    }
-
-    private async Task readIndexesAsync(OracleConnection conn, Table existing, string schemaName, string tableName, CancellationToken ct = default)
-    {
-        // Query 4: Index metadata
-        var indexSql = @"
-SELECT
-    i.index_name,
-    i.uniqueness,
-    i.index_type
-FROM all_indexes i
-WHERE i.owner = :schemaName
-  AND i.table_name = :tableName
-  AND NOT EXISTS (
-      SELECT 1 FROM all_constraints c
-      WHERE c.owner = i.owner AND c.index_name = i.index_name AND c.constraint_type = 'P'
-  )";
-
-        var indexes = new Dictionary<string, IndexDefinition>(StringComparer.OrdinalIgnoreCase);
-
-        await using (var cmd = conn.CreateCommand())
-        {
-            cmd.CommandText = indexSql;
-            cmd.Parameters.Add(new OracleParameter("schemaName", schemaName));
-            cmd.Parameters.Add(new OracleParameter("tableName", tableName));
-
-            await using var reader = await cmd.ExecuteReaderAsync(ct).ConfigureAwait(false);
-            while (await reader.ReadAsync(ct).ConfigureAwait(false))
-            {
-                var name = await reader.GetFieldValueAsync<string>(0, ct).ConfigureAwait(false);
-                var uniqueness = await reader.GetFieldValueAsync<string>(1, ct).ConfigureAwait(false);
-                var indexType = await reader.GetFieldValueAsync<string>(2, ct).ConfigureAwait(false);
-
-                var index = new IndexDefinition(name)
-                {
-                    IsUnique = uniqueness == "UNIQUE",
-                    IndexType = indexType == "BITMAP" ? OracleIndexType.Bitmap :
-                               indexType.Contains("FUNCTION") ? OracleIndexType.FunctionBased :
-                               OracleIndexType.BTree
-                };
-
-                indexes.Add(name, index);
-                existing.Indexes.Add(index);
-            }
-        }
-
-        // Query 5: Index columns
-        var columnSql = @"
-SELECT
-    ic.index_name,
-    ic.column_name,
-    ic.descend
-FROM all_ind_columns ic
-JOIN all_indexes i ON ic.index_owner = i.owner AND ic.index_name = i.index_name
-WHERE ic.index_owner = :indexOwner
-  AND ic.table_owner = :tableOwner
-  AND ic.table_name = :tableName
-  AND NOT EXISTS (
-      SELECT 1 FROM all_constraints c
-      WHERE c.owner = i.owner AND c.index_name = i.index_name AND c.constraint_type = 'P'
-  )
-ORDER BY ic.index_name, ic.column_position";
-
-        // For function-based indexes, we need to map system-generated column names back to actual columns.
-        // Query all_ind_expressions separately because column_expression is a LONG type.
-        var expressionMap = new Dictionary<(string indexName, int position), string>();
-        var expressionSql = @"
-SELECT
-    index_name,
-    column_position,
-    column_expression
-FROM all_ind_expressions
-WHERE index_owner = :indexOwner
-  AND table_owner = :tableOwner
-  AND table_name = :tableName";
-
-        await using (var cmd = conn.CreateCommand())
-        {
-            cmd.CommandText = expressionSql;
-            cmd.Parameters.Add(new OracleParameter("indexOwner", schemaName));
-            cmd.Parameters.Add(new OracleParameter("tableOwner", schemaName));
-            cmd.Parameters.Add(new OracleParameter("tableName", tableName));
-
-            // Set InitialLONGFetchSize to read LONG data types (column_expression is LONG)
-            cmd.InitialLONGFetchSize = 4000;
-
-            await using var reader = await cmd.ExecuteReaderAsync(ct).ConfigureAwait(false);
-            while (await reader.ReadAsync(ct).ConfigureAwait(false))
-            {
-                var idxName = await reader.GetFieldValueAsync<string>(0, ct).ConfigureAwait(false);
-                var position = Convert.ToInt32(await reader.GetFieldValueAsync<decimal>(1, ct).ConfigureAwait(false));
-                if (!await reader.IsDBNullAsync(2, ct).ConfigureAwait(false))
-                {
-                    var expression = await reader.GetFieldValueAsync<string>(2, ct).ConfigureAwait(false);
-                    expressionMap[(idxName.ToUpperInvariant(), position)] = expression;
-                }
-            }
-        }
-
-        var columnPositions = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
-
-        await using (var cmd = conn.CreateCommand())
-        {
-            cmd.CommandText = columnSql;
-            cmd.Parameters.Add(new OracleParameter("indexOwner", schemaName));
-            cmd.Parameters.Add(new OracleParameter("tableOwner", schemaName));
-            cmd.Parameters.Add(new OracleParameter("tableName", tableName));
-
-            await using var reader = await cmd.ExecuteReaderAsync(ct).ConfigureAwait(false);
-            while (await reader.ReadAsync(ct).ConfigureAwait(false))
-            {
-                var indexName = await reader.GetFieldValueAsync<string>(0, ct).ConfigureAwait(false);
-                if (indexes.TryGetValue(indexName, out var index))
-                {
-                    // Track column position for this index
-                    if (!columnPositions.ContainsKey(indexName))
-                    {
-                        columnPositions[indexName] = 1;
-                    }
-                    var position = columnPositions[indexName]++;
-
-                    var columnName = await reader.GetFieldValueAsync<string>(1, ct).ConfigureAwait(false);
-                    var descend = await reader.GetFieldValueAsync<string>(2, ct).ConfigureAwait(false);
-
-                    // For function-based indexes (DESC), Oracle stores system-generated column names
-                    // like SYS_NC00006$. Extract the actual column name from the expression.
-                    if (columnName.StartsWith("SYS_", StringComparison.OrdinalIgnoreCase) &&
-                        expressionMap.TryGetValue((indexName.ToUpperInvariant(), position), out var expression))
-                    {
-                        // Expression is like SYS_OP_DESCEND("USER_NAME") or just "USER_NAME"
-                        // Extract the column name from within quotes
-                        var match = System.Text.RegularExpressions.Regex.Match(expression, "\"([^\"]+)\"");
-                        if (match.Success)
-                        {
-                            columnName = match.Groups[1].Value;
-                        }
-                    }
-
-                    index.AddColumn(columnName);
-
-                    if (descend == "DESC")
-                    {
-                        index.SortOrder = SortOrder.Desc;
-                    }
-                }
-            }
-        }
-
-        // Remove any indexes that have no columns (possibly system-generated or function-based indexes
-        // that we can't properly detect)
-        var emptyIndexes = existing.Indexes.Where(i => !i.Columns.Any()).ToList();
-        foreach (var emptyIndex in emptyIndexes)
-        {
-            existing.Indexes.Remove(emptyIndex);
-        }
-    }
 }

--- a/src/Weasel.Testing/IndexScenarioMatrix.cs
+++ b/src/Weasel.Testing/IndexScenarioMatrix.cs
@@ -97,17 +97,19 @@ public abstract class IndexScenarioMatrix
     ///     Compute the delta for this table the way this provider's own callers do.
     /// </summary>
     /// <remarks>
-    ///     The default is <see cref="SchemaMigration.DetermineAsync(DbConnection, CancellationToken, ISchemaObject[])" />,
-    ///     which is the migration path. Oracle overrides it: its
-    ///     <c>CreateDeltaAsync(DbDataReader)</c> reads columns only — ODP.NET cannot return several
-    ///     result sets from one command — so index drift is invisible on the batched path and only
-    ///     <c>Table.FindDeltaAsync(OracleConnection)</c> sees it. That limitation is documented on
-    ///     the method and is a real gap in Oracle's migration path, not something for this harness
-    ///     to paper over silently.
+    ///     The migration path, through the provider's own command builder. No provider overrides
+    ///     this any more: Oracle did while its batched delta read columns only, and weasel#474
+    ///     closed that.
     /// </remarks>
     protected virtual async Task<ISchemaObjectDelta> FindDeltaAsync(DbConnection conn, ITable table)
     {
-        var migration = await SchemaMigration.DetermineAsync(conn, CancellationToken.None, table).ConfigureAwait(false);
+        // Through the provider's own builder, because that is how the migration path assembles the
+        // batch -- and on Oracle it is the difference between one introspection query and six
+        // (weasel#474).
+        var builder = CreateMigrator().CreateCommandBuilder(conn);
+        var migration = await SchemaMigration.DetermineAsync(conn, builder, CancellationToken.None, table)
+            .ConfigureAwait(false);
+
         return migration.Deltas.Single();
     }
 


### PR DESCRIPTION
Closes #474.

## The bug

On Oracle, **the migration path could only see a table's columns.**

ODP.NET will not execute several statements from a single command, so `ConfigureQueryCommand` got one query — and `Table` spent it on columns. Indexes, foreign keys and the primary key were invisible to `SchemaMigration.DetermineAsync`, which is what `ApplyChangesAsync`, `ApplyAllConfiguredChangesToDatabaseAsync` and `AssertDatabaseMatchesConfigurationAsync` all go through.

What that meant in practice:

- A declared index was created with the table and **never touched again**.
- Add an index to an existing table → nothing happens.
- Change one → nothing happens.
- Remove one → it stays.
- `db-assert` reports a clean match throughout.

## The fix

`OracleDbCommandBuilder` **already** knew how to split a batch into one command per `StartNewCommand()` boundary — that machinery went in for the batching work and nothing used it here. What was missing was the other half: something to *read across* the split.

`MultiCommandDataReader` presents an ordered list of commands as one continuous sequence of result sets. `NextResultAsync` walks the current command's result sets and then rolls over into the next command's — and since a freshly executed reader sits exactly where `NextResult()` leaves a caller, the rollover is indistinguishable from an ordinary result-set boundary. Nothing consuming the results has to know.

Three small seams carry it:

| Seam | Why |
|---|---|
| `IBatchedCommandBuilder` | Deliberately **separate from `ICommandBuilder<T>`**, so adding it breaks nothing that implements that interface outside this repo |
| `Migrator.CreateCommandBuilder` | Defaults to the dialect-neutral builder; Oracle is the only override |
| `SchemaMigration.DetermineAsync(conn, builder, ct, objects)` | Plus `StartNewCommand()` *between* objects — not before the first, or a splitting builder opens with an empty statement |

**Every provider except Oracle returns a single command from `CompileCommands()` and executes exactly as before.**

One trap worth naming: the single-command case cannot fall through to `Compile()`. A splitting builder consumes its accumulated SQL while compiling, so a second `Compile()` hands back a command with empty `CommandText` — which is ORA-50029, and how I found it.

## Oracle's introspection is now one implementation

`Table` registers all six queries it needs (columns, PK, FKs, index metadata, index expressions, index columns), and the batched path and `FetchExistingAsync` now share **the same SQL constants and the same readers** rather than being two copies that can drift apart. `InitialLONGFetchSize` is set on both — `all_ind_expressions.column_expression` is a LONG and reads back empty without it, the same trap #450 hit.

## Two workarounds go away with the cause

- **`DetermineOracleMigrationAsync` sniffed for `Tables.Table`** and rerouted it to `FindDeltaAsync`, because the generic path would have missed everything. It is now a one-line delegation with no type test — and it batches the objects instead of looping one at a time.
- **The Oracle rows of the index scenario matrix** no longer override how a delta is found. They run the ordinary path, like every other provider's.

## Tests

`Weasel.Oracle.Tests/Tables/migration_path_sees_more_than_columns.cs` — five tests going through `ApplyChangesAsync` and `DetermineAsync` deliberately, since the point is the *path*; `FetchExistingAsync` could always see all of this. Including `several_tables_in_one_batch_each_read_their_own_result_sets`, because the reader now has to walk six result sets per table and land on the right boundary or the second table reads the first one's rows.

The regression proof is #449's matrix: with the override removed and before this fix, **Oracle failed 8 of its 11 scenarios** with "missing 1", while querying `all_indexes` by hand showed the index had been there the whole time. All 11 pass now through the ordinary path.

## Verified locally

Core 216, SQLite 418, PostgreSQL 879, SQL Server 440, Oracle 259, MySQL 277, EF Core 106. No failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)