### PR TITLE
feat: triggers, on all five providers

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -60,7 +60,8 @@ export default withMermaid(
             { text: 'Multi-Tenancy', link: '/core/multi-tenancy' },
             { text: 'Provider Trait Matrix', link: '/core/provider-trait-matrix' },
             { text: 'Object Type Support', link: '/core/object-types' },
-            { text: 'Identifiers & Quoting', link: '/core/identifiers' }
+            { text: 'Identifiers & Quoting', link: '/core/identifiers' },
+            { text: 'Triggers', link: '/core/triggers' }
           ]
         },
         {

--- a/docs/core/object-types.md
+++ b/docs/core/object-types.md
@@ -26,7 +26,7 @@ Three symbols, and the distinction between the last two matters:
 | Materialized view | ✓ | — | ✗ | — | — |
 | Function | ✓ | ✓ | ✗ | ✗ | connection-scoped |
 | Stored procedure | ✗ | ✓ | ✗ | ✗ | — |
-| Trigger | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Trigger | ✓ | ✓ | ✓ | ✓ | ✓ |
 | Package | — | — | ✗ | — | — |
 | Synonym | — | ✗ | ✗ | — | — |
 | User-defined type | ✗ | ✓ (table types) | ✗ | — | — |
@@ -35,7 +35,7 @@ Three symbols, and the distinction between the last two matters:
 
 ### Reading the gaps
 
-- **Triggers are the one category no provider supports** — [#452](https://github.com/JasperFx/weasel/issues/452). They are modelled as independent schema objects that declare a target rather than as something a table owns, which is why they are a row here and not a column of the table row.
+- **Triggers** are modelled as independent schema objects that declare a target rather than as something a table owns, which is why they are a row here and not part of the table row. A trigger does not always have a table — SQL Server's `INSTEAD OF` triggers attach to views — and PostgreSQL's call a function, so they compose with `Function` rather than carrying their own body. See [Triggers](/core/triggers).
 - **Functions on Oracle and MySQL, and stored procedures on PostgreSQL, MySQL and Oracle**, are [#450](https://github.com/JasperFx/weasel/issues/450) and [#451](https://github.com/JasperFx/weasel/issues/451).
 - **The long tail** — Oracle packages, materialized views and synonyms, SQL Server synonyms, PostgreSQL user-defined types — is [#453](https://github.com/JasperFx/weasel/issues/453).
 - **PostgreSQL materialized views already work**, through `Weasel.Postgresql.Views.MaterializedView`, which is `View` with a different `ViewType` and an optional access method. That row was ✗ in the first draft of this page and the check below caught it on its first run, which is the argument for the check.

--- a/docs/core/triggers.md
+++ b/docs/core/triggers.md
@@ -1,0 +1,107 @@
+# Triggers
+
+Triggers work on all five providers. They are the one whole category of database object that no
+provider modelled until 9.26, and the one with the most variation between engines — so the shared
+model is deliberately small and each provider refuses what it cannot express rather than quietly
+narrowing it.
+
+## A trigger is not owned by its table
+
+```csharp
+var trigger = new Trigger("audit.stamp_orders", "audit.orders", body)
+{
+    Timing = TriggerTiming.Before,
+    Events = TriggerEvents.Insert | TriggerEvents.Update
+};
+
+await trigger.ApplyChangesAsync(connection);
+```
+
+Indexes and foreign keys hang off `Table`. Triggers do not — they are independent schema objects
+that *declare* a target. Three reasons:
+
+- **A trigger does not always have a table.** SQL Server's `INSTEAD OF` triggers attach to views;
+  Oracle has schema- and database-level triggers with no target object at all.
+- **A PostgreSQL trigger calls a function**, so it depends on another schema object rather than on
+  its table.
+- **Indexes and foreign keys are part of the table's own definition** and several are emitted
+  inside `CREATE TABLE`. A trigger is always a separate statement with its own lifecycle.
+
+The cost, stated plainly: a trigger and its target can drift apart in your model, because nothing
+forces you to register them together. Views and functions already behave this way.
+
+::: warning SQLite rebuilds a table by dropping it
+`DROP TABLE` takes the table's triggers with it and says nothing. Weasel's SQLite table rebuild
+captures the triggers from `sqlite_master` first and re-emits them afterwards — including triggers
+Weasel never declared, because a hand-written trigger is still yours. Note that the rebuild path
+itself is currently unreachable through the migrator; see
+[#477](https://github.com/JasperFx/weasel/issues/477).
+:::
+
+## What each engine accepts
+
+| | PostgreSQL | SQL Server | Oracle | MySQL | SQLite |
+| --- | --- | --- | --- | --- | --- |
+| `BEFORE` | ✓ | — | ✓ | ✓ | ✓ |
+| `AFTER` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `INSTEAD OF` | ✓ (views) | ✓ (views) | ✓ | — | ✓ (views) |
+| Several events on one trigger | ✓ | ✓ | ✓ | — | — |
+| `TRUNCATE` event | ✓ | — | — | — | — |
+| Row-level (`FOR EACH ROW`) | ✓ | — always statement | ✓ | always | always |
+| `WHEN` condition | ✓ | — | ✓ | — | ✓ |
+| Body | a function call | T-SQL | PL/SQL | SQL | SQL |
+
+**An engine that cannot express something refuses it.** Setting `Condition` on SQL Server throws
+and names the alternative; asking MySQL for two events throws and tells you to declare two
+triggers. This is the rule settled in [#449](https://github.com/JasperFx/weasel/issues/449) after
+two index properties were found to be silently ignored — a caller who sets a property gets it, or
+gets an exception, never a quietly narrower object.
+
+## PostgreSQL composes with a function
+
+PostgreSQL triggers have no body. They execute a function, which must exist first, so
+`Trigger.Body` is the call:
+
+```csharp
+var function = new Function(new PostgresqlObjectName("audit", "stamp_note"), @"
+CREATE OR REPLACE FUNCTION audit.stamp_note() RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+    NEW.note := 'touched';
+    RETURN NEW;
+END;
+$$;");
+
+var trigger = new Trigger("audit.stamp_note_trigger", "audit.orders", "audit.stamp_note()");
+```
+
+Register both. Nothing enforces the ordering for you, which is the same trade-off as the target.
+
+## MySQL needs more than the TRIGGER privilege
+
+Creating a trigger needs `TRIGGER`, and on a server with binary logging enabled it also needs
+`SUPER` or `log_bin_trust_function_creators`. MySQL refuses otherwise with a message about the
+SUPER privilege that never mentions triggers, which is worth recognising:
+
+```
+You do not have the SUPER privilege and binary logging is enabled
+```
+
+## Delta detection
+
+Every provider compares the trigger it would create against what the catalog holds, ignoring
+whitespace and case:
+
+| Provider | Read from | Stored |
+| --- | --- | --- |
+| PostgreSQL | `pg_get_triggerdef` | rendered by the server |
+| SQL Server | `sys.sql_modules` | verbatim |
+| Oracle | `all_triggers.trigger_body` | verbatim |
+| MySQL | `information_schema.TRIGGERS.action_statement` | verbatim |
+| SQLite | `sqlite_master.sql` | verbatim |
+
+MySQL is the interesting one: it rewrites a *view* definition but stores a *trigger* body as
+submitted, so triggers need none of the probe machinery
+[views do](/core/object-types).
+
+Only Oracle has `CREATE OR REPLACE TRIGGER`. The other four drop and recreate, which their
+`WriteCreateStatement` does in one go — so applying a trigger is idempotent everywhere.

--- a/src/Weasel.Core.Tests/object_type_support_matrix.cs
+++ b/src/Weasel.Core.Tests/object_type_support_matrix.cs
@@ -47,6 +47,7 @@ public class object_type_support_matrix
         ("Postgresql", "MaterializedView", "Weasel.Postgresql.Views.MaterializedView"),
         ("Postgresql", "Function", "Weasel.Postgresql.Functions.Function"),
         ("Postgresql", "Extension", "Weasel.Postgresql.Extension"),
+        ("Postgresql", "Trigger", "Weasel.Postgresql.Triggers.Trigger"),
 
         ("SqlServer", "Table", "Weasel.SqlServer.Tables.Table"),
         ("SqlServer", "Sequence", "Weasel.SqlServer.Sequence"),
@@ -54,17 +55,21 @@ public class object_type_support_matrix
         ("SqlServer", "Function", "Weasel.SqlServer.Functions.Function"),
         ("SqlServer", "StoredProcedure", "Weasel.SqlServer.Procedures.StoredProcedure"),
         ("SqlServer", "TableType", "Weasel.SqlServer.Tables.TableType"),
+        ("SqlServer", "Trigger", "Weasel.SqlServer.Triggers.Trigger"),
 
         ("Oracle", "Table", "Weasel.Oracle.Tables.Table"),
         ("Oracle", "Sequence", "Weasel.Oracle.Sequence"),
         ("Oracle", "View", "Weasel.Oracle.Views.View"),
+        ("Oracle", "Trigger", "Weasel.Oracle.Triggers.Trigger"),
 
         ("MySql", "Table", "Weasel.MySql.Tables.Table"),
         ("MySql", "Sequence", "Weasel.MySql.Sequence"),
         ("MySql", "View", "Weasel.MySql.Views.View"),
+        ("MySql", "Trigger", "Weasel.MySql.Triggers.Trigger"),
 
         ("Sqlite", "Table", "Weasel.Sqlite.Tables.Table"),
-        ("Sqlite", "View", "Weasel.Sqlite.Views.View")
+        ("Sqlite", "View", "Weasel.Sqlite.Views.View"),
+        ("Sqlite", "Trigger", "Weasel.Sqlite.Triggers.Trigger")
     ];
 
     public static TheoryData<string, string, string> Supported
@@ -87,14 +92,9 @@ public class object_type_support_matrix
             { "Postgresql", "Weasel.Postgresql.Procedures.StoredProcedure", "#451" },
             { "MySql", "Weasel.MySql.Procedures.StoredProcedure", "#451" },
             { "Oracle", "Weasel.Oracle.Procedures.StoredProcedure", "#451" },
-                { "Oracle", "Weasel.Oracle.Functions.Function", "#450" },
+            { "Oracle", "Weasel.Oracle.Functions.Function", "#450" },
             { "Oracle", "Weasel.Oracle.Views.MaterializedView", "#453" },
-            { "MySql", "Weasel.MySql.Functions.Function", "#450" },
-            { "Postgresql", "Weasel.Postgresql.Triggers.Trigger", "#452" },
-            { "SqlServer", "Weasel.SqlServer.Triggers.Trigger", "#452" },
-            { "Oracle", "Weasel.Oracle.Triggers.Trigger", "#452" },
-            { "MySql", "Weasel.MySql.Triggers.Trigger", "#452" },
-            { "Sqlite", "Weasel.Sqlite.Triggers.Trigger", "#452" }
+            { "MySql", "Weasel.MySql.Functions.Function", "#450" }
         };
 
     [Theory]

--- a/src/Weasel.Core/TriggerBase.cs
+++ b/src/Weasel.Core/TriggerBase.cs
@@ -1,0 +1,168 @@
+namespace Weasel.Core;
+
+/// <summary>When a trigger fires relative to the statement that caused it.</summary>
+public enum TriggerTiming
+{
+    Before,
+    After,
+
+    /// <summary>
+    ///     Replaces the statement rather than running alongside it. SQL Server and PostgreSQL use
+    ///     this to make a view writable; SQLite uses it on views too. MySQL and Oracle spell the
+    ///     equivalent differently or not at all.
+    /// </summary>
+    InsteadOf
+}
+
+/// <summary>
+///     The statements a trigger fires on. A flags enum because most engines let one trigger cover
+///     several — MySQL is the exception and accepts exactly one.
+/// </summary>
+[Flags]
+public enum TriggerEvents
+{
+    None = 0,
+    Insert = 1,
+    Update = 2,
+    Delete = 4,
+
+    /// <summary>PostgreSQL only, and statement-level only.</summary>
+    Truncate = 8
+}
+
+/// <summary>
+///     Cross-provider base for a database trigger.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <strong>A trigger is an independent schema object that declares its target, not
+///         something a table owns</strong> (weasel#452). Indexes and foreign keys are table-owned
+///         because they are part of the table's own definition and several are emitted inside
+///         <c>CREATE TABLE</c>; a trigger is always a separate statement with its own name and
+///         lifecycle. It also does not always have a table — SQL Server's <c>INSTEAD OF</c> triggers
+///         attach to views, and Oracle has schema- and database-level triggers with no target object
+///         at all. Table ownership would leave both homeless.
+///     </para>
+///     <para>
+///         The accepted cost is that a trigger and its target can drift apart in the model, since
+///         nothing forces them to be registered together. Views and functions already behave that
+///         way, so it is consistent rather than novel.
+///     </para>
+///     <para>
+///         <strong>SQLite has a standing hazard here.</strong> Its <c>TableDelta</c> rebuilds the
+///         table for most column, foreign key and primary key changes, and dropping a table silently
+///         drops its triggers — so the recreate path has to re-emit the triggers targeting the table
+///         it rebuilt. That is a lookup, not ownership, and it is covered by a test, because the
+///         failure mode destroys user data-integrity logic without saying anything.
+///     </para>
+/// </remarks>
+public abstract class TriggerBase: SchemaObjectBase
+{
+    protected TriggerBase(DbObjectName identifier, DbObjectName target, string body) : base(identifier)
+    {
+        Target = target ?? throw new ArgumentNullException(nameof(target));
+        Body = body ?? throw new ArgumentNullException(nameof(body));
+    }
+
+    /// <summary>
+    ///     The table or view this trigger fires on.
+    /// </summary>
+    public DbObjectName Target { get; }
+
+    /// <summary>
+    ///     The action the trigger performs, in the provider's own dialect. PostgreSQL is the odd one
+    ///     out: its body is a call to a function that must exist already, rather than a block of
+    ///     statements, so a PostgreSQL trigger composes with <c>Function</c> rather than carrying
+    ///     its own logic.
+    /// </summary>
+    public string Body { get; }
+
+    public TriggerTiming Timing { get; set; } = TriggerTiming.Before;
+
+    public TriggerEvents Events { get; set; } = TriggerEvents.Insert;
+
+    /// <summary>
+    ///     Fire once per affected row rather than once per statement. SQL Server has no row-level
+    ///     triggers and ignores this; SQLite and MySQL are always row-level.
+    /// </summary>
+    public bool ForEachRow { get; set; } = true;
+
+    /// <summary>
+    ///     Optional <c>WHEN</c> condition. Not supported by every engine; a provider that cannot
+    ///     emit one throws rather than dropping it silently.
+    /// </summary>
+    public string? Condition { get; set; }
+
+    /// <summary>
+    ///     Render <see cref="Events" /> as the dialect's event list. Ordered <c>INSERT</c>,
+    ///     <c>UPDATE</c>, <c>DELETE</c>, <c>TRUNCATE</c> so that the generated text is stable and
+    ///     comparable regardless of the order the flags were set in.
+    /// </summary>
+    /// <param name="separator">
+    ///     <c>" OR "</c> for PostgreSQL and Oracle, <c>", "</c> for SQL Server.
+    /// </param>
+    protected string EventList(string separator)
+    {
+        var events = new List<string>();
+
+        if (Events.HasFlag(TriggerEvents.Insert)) events.Add("INSERT");
+        if (Events.HasFlag(TriggerEvents.Update)) events.Add("UPDATE");
+        if (Events.HasFlag(TriggerEvents.Delete)) events.Add("DELETE");
+        if (Events.HasFlag(TriggerEvents.Truncate)) events.Add("TRUNCATE");
+
+        if (events.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"Trigger {Identifier} declares no events. Set {nameof(Events)} to at least one of "
+                + "Insert, Update, Delete or Truncate.");
+        }
+
+        return string.Join(separator, events);
+    }
+
+    /// <summary>
+    ///     The single event this trigger fires on, for the engines that accept exactly one.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    ///     When more than one event is set. Silently dropping the extras would leave the caller with
+    ///     a trigger narrower than the one they asked for, which is the failure mode weasel#449
+    ///     removed from index predicates.
+    /// </exception>
+    protected string SingleEvent(string providerName)
+    {
+        var events = EventList(",").Split(',');
+
+        if (events.Length > 1)
+        {
+            throw new InvalidOperationException(
+                $"{providerName} triggers fire on exactly one event, but trigger {Identifier} declares "
+                + $"{string.Join(", ", events)}. Declare one trigger per event.");
+        }
+
+        return events[0];
+    }
+
+    protected string TimingKeyword()
+        => Timing switch
+        {
+            TriggerTiming.Before => "BEFORE",
+            TriggerTiming.After => "AFTER",
+            TriggerTiming.InsteadOf => "INSTEAD OF",
+            _ => throw new ArgumentOutOfRangeException(nameof(Timing), Timing, null)
+        };
+
+    /// <summary>
+    ///     Normalize a trigger body for comparison against the one the catalog hands back. Every
+    ///     engine reformats what it stores to some degree, so the comparison is whitespace- and
+    ///     case-insensitive, the same way <c>ViewBase</c>'s implementations compare a view.
+    /// </summary>
+    public static string NormalizeBody(string body)
+        => body.Replace("\r\n", "")
+            .Replace("\n", "")
+            .Replace("\r", "")
+            .Replace("\t", "")
+            .Replace(" ", "")
+            .Trim()
+            .TrimEnd(';')
+            .ToUpperInvariant();
+}

--- a/src/Weasel.MySql.Tests/Triggers/TriggerTests.cs
+++ b/src/Weasel.MySql.Tests/Triggers/TriggerTests.cs
@@ -1,0 +1,157 @@
+using MySqlConnector;
+using Shouldly;
+using Weasel.Core;
+using Weasel.MySql.Tables;
+using Weasel.MySql.Triggers;
+using Xunit;
+
+namespace Weasel.MySql.Tests.Triggers;
+
+/// <summary>
+///     MySQL trigger support (weasel#452). MySQL stores the action statement verbatim — unlike a
+///     view definition, which it rewrites — so the delta is a straight comparison of the body.
+/// </summary>
+/// <remarks>
+///     Root credentials, and not only for the usual schema-permission reason: creating a trigger
+///     needs the TRIGGER privilege, and on a server with binary logging enabled it also needs SUPER
+///     or <c>log_bin_trust_function_creators</c>. MySQL refuses otherwise with a message about the
+///     SUPER privilege that never mentions triggers.
+/// </remarks>
+[Collection("integration")]
+public class TriggerTests: IAsyncLifetime
+{
+    private const string SchemaName = "weasel_testing";
+
+    private MySqlConnection theConnection = default!;
+
+    public async ValueTask InitializeAsync()
+    {
+        var builder = new MySqlConnectionStringBuilder(ConnectionSource.ConnectionString)
+        {
+            UserID = "root", Password = "P@55w0rd", Database = SchemaName
+        };
+
+        theConnection = new MySqlConnection(builder.ConnectionString);
+        await theConnection.OpenAsync();
+
+        await theConnection.CreateCommand($"DROP TRIGGER IF EXISTS `{SchemaName}`.trg_stamp_note")
+            .ExecuteNonQueryAsync();
+        await theConnection.CreateCommand($"DROP TABLE IF EXISTS `{SchemaName}`.trg_orders")
+            .ExecuteNonQueryAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await theConnection.CreateCommand($"DROP TRIGGER IF EXISTS `{SchemaName}`.trg_stamp_note")
+            .ExecuteNonQueryAsync();
+        await theConnection.CreateCommand($"DROP TABLE IF EXISTS `{SchemaName}`.trg_orders")
+            .ExecuteNonQueryAsync();
+        await theConnection.CloseAsync();
+        await theConnection.DisposeAsync();
+    }
+
+    private static Table SourceTable()
+    {
+        var table = new Table($"{SchemaName}.trg_orders");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn<string>("note");
+        return table;
+    }
+
+    private static Trigger NewTrigger(string note = "touched") => new(
+        $"{SchemaName}.trg_stamp_note",
+        $"{SchemaName}.trg_orders",
+        $"SET NEW.note = '{note}'")
+    {
+        Timing = TriggerTiming.Before, Events = TriggerEvents.Insert
+    };
+
+    [Fact]
+    public void more_than_one_event_is_refused_rather_than_narrowed()
+    {
+        var trigger = NewTrigger();
+        trigger.Events = TriggerEvents.Insert | TriggerEvents.Update;
+
+        var ex = Should.Throw<InvalidOperationException>(() => trigger.CreateStatement());
+        ex.Message.ShouldContain("exactly one event");
+    }
+
+    [Fact]
+    public void a_when_condition_is_refused_rather_than_dropped()
+    {
+        var trigger = NewTrigger();
+        trigger.Condition = "NEW.id > 0";
+
+        Should.Throw<NotSupportedException>(() => trigger.CreateStatement());
+    }
+
+    [Fact]
+    public async Task a_trigger_round_trips_and_reports_no_delta()
+    {
+        await SourceTable().ApplyChangesAsync(theConnection);
+
+        var trigger = NewTrigger();
+        await trigger.ApplyChangesAsync(theConnection);
+
+        (await trigger.ExistsInDatabaseAsync(theConnection)).ShouldBeTrue();
+        (await trigger.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task the_trigger_actually_fires()
+    {
+        await SourceTable().ApplyChangesAsync(theConnection);
+        await NewTrigger().ApplyChangesAsync(theConnection);
+
+        await theConnection.CreateCommand($"INSERT INTO `{SchemaName}`.trg_orders (id) VALUES (1)")
+            .ExecuteNonQueryAsync();
+
+        var note = await theConnection.CreateCommand($"SELECT note FROM `{SchemaName}`.trg_orders WHERE id = 1")
+            .ExecuteScalarAsync();
+
+        note.ShouldBe("touched");
+    }
+
+    /// <summary>
+    ///     A multi-statement body, which is the case that made MySQL's migrator stop splitting delta
+    ///     SQL on semicolons — the split shredded every <c>BEGIN … END</c> block it saw.
+    /// </summary>
+    [Fact]
+    public async Task a_begin_end_body_with_semicolons_survives_execution()
+    {
+        await SourceTable().ApplyChangesAsync(theConnection);
+
+        var trigger = new Trigger(
+            $"{SchemaName}.trg_stamp_note",
+            $"{SchemaName}.trg_orders",
+            "BEGIN SET NEW.note = 'first'; SET NEW.note = CONCAT(NEW.note, '-second'); END")
+        {
+            Timing = TriggerTiming.Before, Events = TriggerEvents.Insert
+        };
+
+        await trigger.ApplyChangesAsync(theConnection);
+
+        await theConnection.CreateCommand($"INSERT INTO `{SchemaName}`.trg_orders (id) VALUES (2)")
+            .ExecuteNonQueryAsync();
+
+        var note = await theConnection.CreateCommand($"SELECT note FROM `{SchemaName}`.trg_orders WHERE id = 2")
+            .ExecuteScalarAsync();
+
+        note.ShouldBe("first-second");
+    }
+
+    [Fact]
+    public async Task a_changed_body_reports_update_and_applying_it_converges()
+    {
+        await SourceTable().ApplyChangesAsync(theConnection);
+        await NewTrigger().ApplyChangesAsync(theConnection);
+
+        var changed = NewTrigger("changed");
+
+        (await changed.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.Update);
+
+        await changed.ApplyChangesAsync(theConnection);
+
+        (await changed.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+}

--- a/src/Weasel.MySql/MySqlMigrator.cs
+++ b/src/Weasel.MySql/MySqlMigrator.cs
@@ -163,18 +163,21 @@ public class MySqlMigrator: Migrator
 
     private static async Task executeCommand(DbConnection conn, IMigrationLogger logger, StringWriter writer, CancellationToken ct = default)
     {
-        var sql = writer.ToString();
+        var sql = writer.ToString().Trim();
 
-        // Split on semicolons and execute each statement
-        var statements = sql.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
-
-        foreach (var statement in statements)
+        if (sql.IsEmpty())
         {
-            var trimmed = statement.Trim();
-            if (trimmed.IsEmpty()) continue;
+            return;
+        }
 
+        // One command for the whole delta. This used to split on semicolons and execute the pieces,
+        // which shreds any body that contains one -- a trigger's BEGIN ... END block, a stored
+        // procedure, a string literal with a semicolon in it. MySqlConnector executes several
+        // semicolon-separated statements from a single command, so the split bought nothing and
+        // cost correctness (weasel#452).
+        {
             var cmd = conn.CreateCommand();
-            cmd.CommandText = trimmed;
+            cmd.CommandText = sql;
             logger.SchemaChange(cmd.CommandText);
 
             try

--- a/src/Weasel.MySql/SchemaObjectsExtensions.cs
+++ b/src/Weasel.MySql/SchemaObjectsExtensions.cs
@@ -25,18 +25,18 @@ public static class SchemaObjectsExtensions
         var writer = new StringWriter();
         schemaObject.WriteCreateStatement(new MySqlMigrator(), writer);
 
-        var sql = writer.ToString();
+        // One command for the whole statement. The comment that used to be here said MySQL does not
+        // support multiple statements by default -- MySqlConnector does, and splitting on semicolons
+        // shreds any body that contains one, such as a trigger's BEGIN ... END block (weasel#452).
+        var sql = writer.ToString().Trim();
 
-        // MySQL doesn't support multiple statements by default, split them
-        var statements = sql.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
-        foreach (var statement in statements)
+        if (sql.Length == 0)
         {
-            var trimmed = statement.Trim();
-            if (string.IsNullOrEmpty(trimmed)) continue;
-
-            await using var cmd = connection.CreateCommand(trimmed);
-            await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+            return;
         }
+
+        await using var cmd = connection.CreateCommand(sql);
+        await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
     }
 
     public static async Task DropAsync(

--- a/src/Weasel.MySql/Triggers/Trigger.cs
+++ b/src/Weasel.MySql/Triggers/Trigger.cs
@@ -1,0 +1,130 @@
+using System.Data.Common;
+using JasperFx.Core;
+using MySqlConnector;
+using Weasel.Core;
+using DbCommandBuilder = Weasel.Core.DbCommandBuilder;
+
+namespace Weasel.MySql.Triggers;
+
+/// <summary>
+///     A MySQL trigger. MySQL stores the action statement verbatim in
+///     <c>information_schema.TRIGGERS.ACTION_STATEMENT</c> — unlike a view, whose definition it
+///     rewrites — so the delta is a whitespace-insensitive comparison of the body.
+/// </summary>
+/// <remarks>
+///     <para>
+///         MySQL triggers fire on exactly one event and are always row-level, so
+///         <see cref="TriggerBase.Events" /> carrying more than one is an error rather than a
+///         silently narrowed trigger, and <see cref="TriggerBase.ForEachRow" /> is not emitted.
+///         There is no <c>WHEN</c> clause; the condition goes inside the body.
+///     </para>
+///     <para>
+///         Creating a trigger needs the <c>TRIGGER</c> privilege, and on a server with binary
+///         logging enabled it also needs <c>SUPER</c> or
+///         <c>log_bin_trust_function_creators</c> — MySQL refuses otherwise with a message about
+///         the SUPER privilege that does not mention triggers at all.
+///     </para>
+/// </remarks>
+public class Trigger: TriggerBase
+{
+    public Trigger(string name, string target, string body)
+        : this(
+            DbObjectName.Parse(MySqlProvider.Instance, name),
+            DbObjectName.Parse(MySqlProvider.Instance, target),
+            body)
+    {
+    }
+
+    public Trigger(DbObjectName identifier, DbObjectName target, string body): base(identifier, target, body)
+    {
+    }
+
+    public override void WriteCreateStatement(Migrator migrator, TextWriter writer)
+    {
+        // No CREATE OR REPLACE TRIGGER on MySQL, so drop first. Both statements go to the server in
+        // one command; MySqlConnector executes them in order.
+        WriteDropStatement(migrator, writer);
+        writer.WriteLine(CreateStatement());
+    }
+
+    /// <summary>
+    ///     The single <c>CREATE TRIGGER</c> statement this trigger renders to. Public because it is
+    ///     what delta comparison and diagnostics both want, the same way a view exposes
+    ///     <c>ToBasicCreateViewSql</c>.
+    /// </summary>
+    public string CreateStatement()
+    {
+        if (Condition.IsNotEmpty())
+        {
+            throw new NotSupportedException(
+                $"MySQL has no WHEN clause on a trigger, but trigger {Identifier} declares one. Put the "
+                + "condition inside the trigger body.");
+        }
+
+        if (Timing == TriggerTiming.InsteadOf)
+        {
+            throw new NotSupportedException(
+                $"MySQL has no INSTEAD OF trigger, but trigger {Identifier} asks for one.");
+        }
+
+        return
+            $"CREATE TRIGGER {QualifiedName(Identifier)} {TimingKeyword()} {SingleEvent("MySQL")} "
+            + $"ON {QualifiedName(Target)} FOR EACH ROW {Body.Trim()}";
+    }
+
+    public override void WriteDropStatement(Migrator rules, TextWriter writer)
+    {
+        writer.WriteLine($"DROP TRIGGER IF EXISTS {QualifiedName(Identifier)};");
+    }
+
+    public override void ConfigureQueryCommand(DbCommandBuilder builder)
+    {
+        var schemaParam = builder.AddParameter(Identifier.Schema).ParameterName;
+        var nameParam = builder.AddParameter(Identifier.Name).ParameterName;
+
+        builder.Append(
+            "SELECT action_statement FROM information_schema.TRIGGERS "
+            + $"WHERE trigger_schema = @{schemaParam} AND trigger_name = @{nameParam}");
+    }
+
+    public override async Task<ISchemaObjectDelta> CreateDeltaAsync(DbDataReader reader, CancellationToken ct = default)
+    {
+        var existing = await readBodyAsync(reader, ct).ConfigureAwait(false);
+
+        if (existing == null)
+        {
+            return new SchemaObjectDelta(this, SchemaPatchDifference.Create);
+        }
+
+        return NormalizeBody(existing) == NormalizeBody(Body)
+            ? new SchemaObjectDelta(this, SchemaPatchDifference.None)
+            : new SchemaObjectDelta(this, SchemaPatchDifference.Update);
+    }
+
+    public async Task<string?> FetchExistingBodyAsync(MySqlConnection conn, CancellationToken ct = default)
+    {
+        var builder = new DbCommandBuilder(conn);
+        ConfigureQueryCommand(builder);
+
+        await using var reader = await conn.ExecuteReaderAsync(builder, ct).ConfigureAwait(false);
+        var body = await readBodyAsync(reader, ct).ConfigureAwait(false);
+        await reader.CloseAsync().ConfigureAwait(false);
+
+        return body;
+    }
+
+    public async Task<bool> ExistsInDatabaseAsync(MySqlConnection conn, CancellationToken ct = default)
+        => await FetchExistingBodyAsync(conn, ct).ConfigureAwait(false) != null;
+
+    private static async Task<string?> readBodyAsync(DbDataReader reader, CancellationToken ct)
+    {
+        if (!await reader.ReadAsync(ct).ConfigureAwait(false)) return null;
+        if (await reader.IsDBNullAsync(0, ct).ConfigureAwait(false)) return null;
+
+        var body = await reader.GetFieldValueAsync<string>(0, ct).ConfigureAwait(false);
+        return string.IsNullOrWhiteSpace(body) ? null : body;
+    }
+
+    private static string QualifiedName(DbObjectName name)
+        => $"{SchemaUtils.QuoteName(name.Schema)}.{SchemaUtils.QuoteName(name.Name)}";
+}

--- a/src/Weasel.Oracle.Tests/Triggers/TriggerTests.cs
+++ b/src/Weasel.Oracle.Tests/Triggers/TriggerTests.cs
@@ -1,0 +1,137 @@
+using Shouldly;
+using Weasel.Core;
+using Weasel.Oracle.Tables;
+using Weasel.Oracle.Triggers;
+using Xunit;
+
+namespace Weasel.Oracle.Tests.Triggers;
+
+/// <summary>
+///     Oracle trigger support (weasel#452). Oracle stores the trigger body verbatim in
+///     <c>all_triggers</c>, so the delta is a whitespace-insensitive comparison — with the usual
+///     Oracle caveat that the column is a LONG and reads back empty unless the command says
+///     otherwise.
+/// </summary>
+[Collection("integration")]
+public class TriggerTests: IntegrationContext
+{
+    private const string SchemaName = "WEASEL";
+
+    public TriggerTests(): base(SchemaName)
+    {
+    }
+
+    private static Table SourceTable()
+    {
+        var table = new Table($"{SchemaName}.trg_orders");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn<string>("note");
+        return table;
+    }
+
+    private static Trigger NewTrigger(string note = "touched") => new(
+        $"{SchemaName}.trg_stamp_note",
+        $"{SchemaName}.trg_orders",
+        $"BEGIN :NEW.note := '{note}'; END;")
+    {
+        Timing = TriggerTiming.Before, Events = TriggerEvents.Insert
+    };
+
+    [Fact]
+    public void the_create_statement_uses_create_or_replace()
+    {
+        var sql = NewTrigger().CreateStatement();
+
+        sql.ShouldContain("CREATE OR REPLACE TRIGGER");
+        sql.ShouldContain("BEFORE INSERT");
+        sql.ShouldContain("FOR EACH ROW");
+    }
+
+    [Fact]
+    public void several_events_render_as_an_or_list()
+    {
+        var trigger = NewTrigger();
+        trigger.Events = TriggerEvents.Delete | TriggerEvents.Insert;
+
+        trigger.CreateStatement().ShouldContain("INSERT OR DELETE");
+    }
+
+    [Fact]
+    public async Task a_trigger_round_trips_and_reports_no_delta()
+    {
+        await ResetSchema();
+        await SourceTable().ApplyChangesAsync(theConnection);
+
+        var trigger = NewTrigger();
+        await trigger.ApplyChangesAsync(theConnection);
+
+        (await trigger.ExistsInDatabaseAsync(theConnection)).ShouldBeTrue();
+        (await trigger.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    /// <summary>
+    ///     <c>all_triggers.trigger_body</c> is a LONG, and ODP.NET reads a LONG back as an empty
+    ///     string unless the command sets <c>InitialLONGFetchSize</c> — the trap weasel#450 hit on
+    ///     <c>all_views.TEXT</c>. Without it a trigger that plainly exists looks absent.
+    /// </summary>
+    [Fact]
+    public async Task the_body_reads_back_rather_than_coming_up_empty()
+    {
+        await ResetSchema();
+        await SourceTable().ApplyChangesAsync(theConnection);
+        await NewTrigger().ApplyChangesAsync(theConnection);
+
+        var body = await NewTrigger().FetchExistingBodyAsync(theConnection);
+
+        body.ShouldNotBeNull();
+        body!.ShouldContain("touched");
+    }
+
+    [Fact]
+    public async Task the_trigger_actually_fires()
+    {
+        await ResetSchema();
+        await SourceTable().ApplyChangesAsync(theConnection);
+        await NewTrigger().ApplyChangesAsync(theConnection);
+
+        await theConnection.CreateCommand($"INSERT INTO {SchemaName}.trg_orders (id) VALUES (1)")
+            .ExecuteNonQueryAsync();
+
+        var note = await theConnection.CreateCommand($"SELECT note FROM {SchemaName}.trg_orders WHERE id = 1")
+            .ExecuteScalarAsync();
+
+        note.ShouldBe("touched");
+    }
+
+    [Fact]
+    public async Task a_changed_body_reports_update_and_applying_it_converges()
+    {
+        await ResetSchema();
+        await SourceTable().ApplyChangesAsync(theConnection);
+        await NewTrigger().ApplyChangesAsync(theConnection);
+
+        var changed = NewTrigger("changed");
+
+        (await changed.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.Update);
+
+        await changed.ApplyChangesAsync(theConnection);
+
+        (await changed.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    /// <summary>
+    ///     Oracle's teardown enumerates object types by hand, and weasel#465 taught it triggers
+    ///     before anything could create one. This is the test that arms that.
+    /// </summary>
+    [Fact]
+    public async Task dropping_the_schema_takes_its_triggers_with_it()
+    {
+        await ResetSchema();
+        await SourceTable().ApplyChangesAsync(theConnection);
+        await NewTrigger().ApplyChangesAsync(theConnection);
+
+        await ResetSchema();
+
+        (await NewTrigger().ExistsInDatabaseAsync(theConnection)).ShouldBeFalse();
+    }
+}

--- a/src/Weasel.Oracle/Triggers/Trigger.cs
+++ b/src/Weasel.Oracle/Triggers/Trigger.cs
@@ -1,0 +1,158 @@
+using System.Data.Common;
+using JasperFx.Core;
+using Oracle.ManagedDataAccess.Client;
+using Weasel.Core;
+using DbCommandBuilder = Weasel.Core.DbCommandBuilder;
+
+namespace Weasel.Oracle.Triggers;
+
+/// <summary>
+///     An Oracle trigger. Oracle stores the trigger body verbatim, so the delta is a
+///     whitespace-insensitive comparison, the same as its views.
+/// </summary>
+/// <remarks>
+///     <c>CREATE OR REPLACE TRIGGER</c> rather than drop-then-create: it is idempotent, it is one
+///     statement, and Oracle's migrator executes one statement per delta.
+/// </remarks>
+public class Trigger: TriggerBase
+{
+    public Trigger(string name, string target, string body)
+        : this(
+            DbObjectName.Parse(OracleProvider.Instance, name),
+            DbObjectName.Parse(OracleProvider.Instance, target),
+            body)
+    {
+    }
+
+    public Trigger(DbObjectName identifier, DbObjectName target, string body): base(identifier, target, body)
+    {
+    }
+
+    public override void WriteCreateStatement(Migrator migrator, TextWriter writer)
+    {
+        writer.WriteLine(CreateStatement());
+    }
+
+    /// <summary>
+    ///     The single <c>CREATE TRIGGER</c> statement this trigger renders to. Public because it is
+    ///     what delta comparison and diagnostics both want, the same way a view exposes
+    ///     <c>ToBasicCreateViewSql</c>.
+    /// </summary>
+    public string CreateStatement()
+    {
+        var scope = ForEachRow ? " FOR EACH ROW" : string.Empty;
+        var condition = Condition.IsNotEmpty() ? $" WHEN ({Condition})" : string.Empty;
+        var body = Body.Trim();
+
+        if (!body.StartsWith("BEGIN", StringComparison.OrdinalIgnoreCase)
+            && !body.StartsWith("DECLARE", StringComparison.OrdinalIgnoreCase))
+        {
+            body = $"BEGIN {body.TrimEnd(';')}; END;";
+        }
+
+        return
+            $"CREATE OR REPLACE TRIGGER {Identifier.QualifiedName} {TimingKeyword()} {EventList(" OR ")} "
+            + $"ON {Target.QualifiedName}{scope}{condition} {body}";
+    }
+
+    public override void WriteDropStatement(Migrator rules, TextWriter writer)
+    {
+        // No DROP TRIGGER IF EXISTS on Oracle, so swallow "trigger does not exist" the way the rest
+        // of the provider does.
+        writer.WriteLine($@"BEGIN
+    EXECUTE IMMEDIATE 'DROP TRIGGER {SchemaUtils.EscapeLiteral(Identifier.QualifiedName)}';
+EXCEPTION
+    WHEN OTHERS THEN IF SQLCODE != -4080 THEN RAISE; END IF;
+END;");
+    }
+
+    public override void ConfigureQueryCommand(DbCommandBuilder builder)
+    {
+        if (builder.Command is OracleCommand oracleCommand)
+        {
+            // all_triggers.trigger_body is a LONG, and ODP.NET reads a LONG back empty by default.
+            oracleCommand.InitialLONGFetchSize = -1;
+        }
+
+        var schemaParam = builder.AddParameter(Identifier.Schema.ToUpperInvariant()).ParameterName;
+        var nameParam = builder.AddParameter(Identifier.Name.ToUpperInvariant()).ParameterName;
+
+        builder.Append(
+            $"SELECT trigger_body FROM all_triggers WHERE owner = :{schemaParam} AND trigger_name = :{nameParam}");
+    }
+
+    public override async Task<ISchemaObjectDelta> CreateDeltaAsync(DbDataReader reader, CancellationToken ct = default)
+    {
+        var existing = await readBodyAsync(reader, ct).ConfigureAwait(false);
+
+        if (existing == null)
+        {
+            return new TriggerDelta(this, SchemaPatchDifference.Create);
+        }
+
+        // all_triggers stores only the body, not the header, so that is what gets compared.
+        var expectedBody = CreateStatement();
+        var index = expectedBody.IndexOf("BEGIN", StringComparison.OrdinalIgnoreCase);
+        if (index < 0) index = expectedBody.IndexOf("DECLARE", StringComparison.OrdinalIgnoreCase);
+
+        var expected = index < 0 ? expectedBody : expectedBody[index..];
+
+        return NormalizeBody(existing) == NormalizeBody(expected)
+            ? new TriggerDelta(this, SchemaPatchDifference.None)
+            : new TriggerDelta(this, SchemaPatchDifference.Update);
+    }
+
+    public async Task<string?> FetchExistingBodyAsync(OracleConnection conn, CancellationToken ct = default)
+    {
+        var builder = new DbCommandBuilder(conn);
+        ConfigureQueryCommand(builder);
+
+        await using var reader = await conn.ExecuteReaderAsync(builder, ct).ConfigureAwait(false);
+        var body = await readBodyAsync(reader, ct).ConfigureAwait(false);
+        await reader.CloseAsync().ConfigureAwait(false);
+
+        return body;
+    }
+
+    public async Task<bool> ExistsInDatabaseAsync(OracleConnection conn, CancellationToken ct = default)
+        => await FetchExistingBodyAsync(conn, ct).ConfigureAwait(false) != null;
+
+    private static async Task<string?> readBodyAsync(DbDataReader reader, CancellationToken ct)
+    {
+        if (!await reader.ReadAsync(ct).ConfigureAwait(false)) return null;
+        if (await reader.IsDBNullAsync(0, ct).ConfigureAwait(false)) return null;
+
+        var body = await reader.GetFieldValueAsync<string>(0, ct).ConfigureAwait(false);
+        return string.IsNullOrWhiteSpace(body) ? null : body;
+    }
+}
+
+/// <summary>
+///     Oracle applies a trigger change with <c>CREATE OR REPLACE TRIGGER</c> alone. The default
+///     <see cref="SchemaObjectDelta" /> writes a DROP first, and Oracle's drop has to be an
+///     anonymous PL/SQL block, so the pair arrives as a block followed by a DDL statement — which
+///     ODP.NET cannot execute as one command, the same trap the Oracle view slice hit.
+/// </summary>
+internal class TriggerDelta: ISchemaObjectDelta
+{
+    private readonly Trigger _trigger;
+
+    public TriggerDelta(Trigger trigger, SchemaPatchDifference difference)
+    {
+        _trigger = trigger;
+        Difference = difference;
+    }
+
+    public ISchemaObject SchemaObject => _trigger;
+
+    public SchemaPatchDifference Difference { get; }
+
+    public void WriteUpdate(Migrator rules, TextWriter writer) => _trigger.WriteCreateStatement(rules, writer);
+
+    public void WriteRollback(Migrator rules, TextWriter writer)
+    {
+    }
+
+    public void WriteRestorationOfPreviousState(Migrator rules, TextWriter writer)
+        => throw new NotSupportedException();
+}

--- a/src/Weasel.Postgresql.Tests/IntegrationContext.cs
+++ b/src/Weasel.Postgresql.Tests/IntegrationContext.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using JasperFx;
 using JasperFx.Core.Reflection;
 using Npgsql;
@@ -29,9 +30,17 @@ public abstract class IntegrationContext: IAsyncLifetime
 
     public string SchemaName { get; }
 
+    /// <summary>
+    ///     Reset the schema under test. Safe to call more than once in a test: Npgsql throws
+    ///     "Connection already open" on a second OpenAsync, which made a second reset look like a
+    ///     product failure rather than a fixture one.
+    /// </summary>
     protected async Task ResetSchema()
     {
-        await theConnection.OpenAsync();
+        if (theConnection.State == ConnectionState.Closed)
+        {
+            await theConnection.OpenAsync();
+        }
 
         await theConnection.ResetSchemaAsync(SchemaName);
     }

--- a/src/Weasel.Postgresql.Tests/Triggers/TriggerTests.cs
+++ b/src/Weasel.Postgresql.Tests/Triggers/TriggerTests.cs
@@ -1,0 +1,123 @@
+using Shouldly;
+using Weasel.Core;
+using Weasel.Postgresql.Functions;
+using Weasel.Postgresql.Tables;
+using Weasel.Postgresql.Triggers;
+using Xunit;
+
+namespace Weasel.Postgresql.Tests.Triggers;
+
+/// <summary>
+///     PostgreSQL trigger support (weasel#452). PostgreSQL is the provider where a trigger has no
+///     body of its own — it names a function to execute — so these also cover the composition with
+///     <see cref="Function" /> that makes that work.
+/// </summary>
+[Collection("triggers")]
+public class TriggerTests: IntegrationContext
+{
+    public TriggerTests(): base("triggers")
+    {
+    }
+
+    private static Table SourceTable()
+    {
+        var table = new Table("triggers.orders");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn<string>("note");
+        return table;
+    }
+
+    private static Function AuditFunction(string note = "touched") => new(
+        new PostgresqlObjectName("triggers", "stamp_note"),
+        $@"CREATE OR REPLACE FUNCTION triggers.stamp_note() RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+    NEW.note := '{note}';
+    RETURN NEW;
+END;
+$$;");
+
+    private static Trigger NewTrigger() => new("triggers.stamp_note_trigger", "triggers.orders", "triggers.stamp_note()")
+    {
+        Timing = TriggerTiming.Before, Events = TriggerEvents.Insert
+    };
+
+    [Fact]
+    public void the_create_statement_executes_a_function_rather_than_a_body()
+    {
+        var sql = NewTrigger().CreateStatement();
+
+        sql.ShouldContain("EXECUTE FUNCTION triggers.stamp_note()");
+        sql.ShouldContain("BEFORE INSERT");
+        sql.ShouldContain("FOR EACH ROW");
+    }
+
+    [Fact]
+    public void several_events_render_as_an_or_list_in_a_stable_order()
+    {
+        var trigger = NewTrigger();
+        trigger.Events = TriggerEvents.Delete | TriggerEvents.Insert;
+
+        trigger.CreateStatement().ShouldContain("INSERT OR DELETE");
+    }
+
+    [Fact]
+    public async Task a_trigger_round_trips_and_reports_no_delta()
+    {
+        await ResetSchema();
+        await SourceTable().ApplyChangesAsync(theConnection);
+        await AuditFunction().ApplyChangesAsync(theConnection);
+
+        var trigger = NewTrigger();
+        await trigger.ApplyChangesAsync(theConnection);
+
+        (await trigger.ExistsInDatabaseAsync(theConnection)).ShouldBeTrue();
+        (await trigger.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task the_trigger_actually_fires()
+    {
+        await ResetSchema();
+        await SourceTable().ApplyChangesAsync(theConnection);
+        await AuditFunction().ApplyChangesAsync(theConnection);
+        await NewTrigger().ApplyChangesAsync(theConnection);
+
+        await theConnection.CreateCommand("insert into triggers.orders (id) values (1)").ExecuteNonQueryAsync();
+
+        var note = await theConnection.CreateCommand("select note from triggers.orders where id = 1")
+            .ExecuteScalarAsync();
+
+        note.ShouldBe("touched");
+    }
+
+    [Fact]
+    public async Task a_changed_trigger_reports_update_and_applying_it_converges()
+    {
+        await ResetSchema();
+        await SourceTable().ApplyChangesAsync(theConnection);
+        await AuditFunction().ApplyChangesAsync(theConnection);
+        await NewTrigger().ApplyChangesAsync(theConnection);
+
+        var changed = NewTrigger();
+        changed.Events = TriggerEvents.Insert | TriggerEvents.Update;
+
+        (await changed.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.Update);
+
+        await changed.ApplyChangesAsync(theConnection);
+
+        (await changed.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task dropping_the_schema_takes_its_triggers_with_it()
+    {
+        await ResetSchema();
+        await SourceTable().ApplyChangesAsync(theConnection);
+        await AuditFunction().ApplyChangesAsync(theConnection);
+        await NewTrigger().ApplyChangesAsync(theConnection);
+
+        await ResetSchema();
+
+        (await NewTrigger().ExistsInDatabaseAsync(theConnection)).ShouldBeFalse();
+    }
+}

--- a/src/Weasel.Postgresql/Triggers/Trigger.cs
+++ b/src/Weasel.Postgresql/Triggers/Trigger.cs
@@ -1,0 +1,138 @@
+using System.Data.Common;
+using JasperFx.Core;
+using Npgsql;
+using Weasel.Core;
+using DbCommandBuilder = Weasel.Core.DbCommandBuilder;
+
+namespace Weasel.Postgresql.Triggers;
+
+/// <summary>
+///     A PostgreSQL trigger.
+/// </summary>
+/// <remarks>
+///     <para>
+///         PostgreSQL is the odd one out: a trigger does not carry a body, it names a function to
+///         execute. So <see cref="TriggerBase.Body" /> here is the function call —
+///         <c>audit_orders()</c> — and the function has to exist, which means a PostgreSQL trigger
+///         composes with <c>Weasel.Postgresql.Functions.Function</c> rather than duplicating it.
+///     </para>
+///     <para>
+///         <c>pg_get_triggerdef</c> hands back the whole <c>CREATE TRIGGER</c> statement in the
+///         server's own rendering, so the delta compares against a canonicalized form of that rather
+///         than against the submitted text.
+///     </para>
+/// </remarks>
+public class Trigger: TriggerBase
+{
+    public Trigger(string name, string target, string functionCall)
+        : this(
+            DbObjectName.Parse(PostgresqlProvider.Instance, name),
+            DbObjectName.Parse(PostgresqlProvider.Instance, target),
+            functionCall)
+    {
+    }
+
+    public Trigger(DbObjectName identifier, DbObjectName target, string functionCall)
+        : base(identifier, target, functionCall)
+    {
+    }
+
+    public override void WriteCreateStatement(Migrator migrator, TextWriter writer)
+    {
+        // No CREATE OR REPLACE TRIGGER before PostgreSQL 14, and Weasel supports older, so drop
+        // first. The drop is guarded, which also makes the create idempotent.
+        WriteDropStatement(migrator, writer);
+        writer.WriteLine(CreateStatement());
+    }
+
+    /// <summary>
+    ///     The single <c>CREATE TRIGGER</c> statement this trigger renders to. Public because it is
+    ///     what delta comparison and diagnostics both want, the same way a view exposes
+    ///     <c>ToBasicCreateViewSql</c>.
+    /// </summary>
+    public string CreateStatement()
+    {
+        var scope = ForEachRow ? "FOR EACH ROW" : "FOR EACH STATEMENT";
+        var condition = Condition.IsNotEmpty() ? $" WHEN ({Condition})" : string.Empty;
+        var call = Body.Trim().TrimEnd(';');
+
+        return
+            $"CREATE TRIGGER {SchemaUtils.QuoteName(Identifier.Name)} {TimingKeyword()} {EventList(" OR ")} "
+            + $"ON {Target} {scope}{condition} EXECUTE FUNCTION {call};";
+    }
+
+    public override void WriteDropStatement(Migrator rules, TextWriter writer)
+    {
+        writer.WriteLine($"DROP TRIGGER IF EXISTS {SchemaUtils.QuoteName(Identifier.Name)} ON {Target};");
+    }
+
+    public override void ConfigureQueryCommand(DbCommandBuilder builder)
+    {
+        var nameParam = builder.AddParameter(Identifier.Name).ParameterName;
+        var tableParam = builder.AddParameter(Target.Name).ParameterName;
+        var schemaParam = builder.AddParameter(Target.Schema).ParameterName;
+
+        builder.Append($@"
+SELECT pg_get_triggerdef(t.oid)
+FROM pg_trigger t
+JOIN pg_class c ON c.oid = t.tgrelid
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE NOT t.tgisinternal
+  AND t.tgname = :{nameParam}
+  AND c.relname = :{tableParam}
+  AND n.nspname = :{schemaParam}");
+    }
+
+    public override async Task<ISchemaObjectDelta> CreateDeltaAsync(DbDataReader reader, CancellationToken ct = default)
+    {
+        var existing = await readDefinitionAsync(reader, ct).ConfigureAwait(false);
+
+        if (existing == null)
+        {
+            return new SchemaObjectDelta(this, SchemaPatchDifference.Create);
+        }
+
+        return Matches(existing)
+            ? new SchemaObjectDelta(this, SchemaPatchDifference.None)
+            : new SchemaObjectDelta(this, SchemaPatchDifference.Update);
+    }
+
+    /// <summary>
+    ///     Compare against <c>pg_get_triggerdef</c>'s rendering, which differs from the submitted
+    ///     text in ways that carry no meaning: it always qualifies the table, always spells the
+    ///     action as <c>EXECUTE FUNCTION</c>, and drops the quoting from names that do not need it.
+    /// </summary>
+    public bool Matches(string definition)
+    {
+        var actual = NormalizeBody(definition);
+        var expected = NormalizeBody(CreateStatement());
+
+        // pg_get_triggerdef renders the table qualified whether or not the caller did, so compare
+        // on the tail after the ON clause plus the leading timing and event list.
+        return actual == expected || actual == NormalizeBody(CreateStatement().Replace($"ON {Target}", $"ON {Target.QualifiedName}"));
+    }
+
+    public async Task<string?> FetchExistingDefinitionAsync(NpgsqlConnection conn, CancellationToken ct = default)
+    {
+        var builder = new DbCommandBuilder(conn);
+        ConfigureQueryCommand(builder);
+
+        await using var reader = await conn.ExecuteReaderAsync(builder, ct).ConfigureAwait(false);
+        var definition = await readDefinitionAsync(reader, ct).ConfigureAwait(false);
+        await reader.CloseAsync().ConfigureAwait(false);
+
+        return definition;
+    }
+
+    public async Task<bool> ExistsInDatabaseAsync(NpgsqlConnection conn, CancellationToken ct = default)
+        => await FetchExistingDefinitionAsync(conn, ct).ConfigureAwait(false) != null;
+
+    private static async Task<string?> readDefinitionAsync(DbDataReader reader, CancellationToken ct)
+    {
+        if (!await reader.ReadAsync(ct).ConfigureAwait(false)) return null;
+        if (await reader.IsDBNullAsync(0, ct).ConfigureAwait(false)) return null;
+
+        var definition = await reader.GetFieldValueAsync<string>(0, ct).ConfigureAwait(false);
+        return string.IsNullOrWhiteSpace(definition) ? null : definition;
+    }
+}

--- a/src/Weasel.SqlServer.Tests/IntegrationContext.cs
+++ b/src/Weasel.SqlServer.Tests/IntegrationContext.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using Microsoft.Data.SqlClient;
 using Weasel.Core;
 using Xunit;
@@ -15,9 +16,17 @@ public abstract class IntegrationContext: IAsyncLifetime
         _schemaName = schemaName;
     }
 
+    /// <summary>
+    ///     Reset the schema under test. Safe to call more than once in a test: SqlClient throws
+    ///     "The connection was not closed" on a second OpenAsync, which made a second reset look
+    ///     like a product failure rather than a fixture one.
+    /// </summary>
     protected async Task ResetSchema()
     {
-        await theConnection.OpenAsync();
+        if (theConnection.State == ConnectionState.Closed)
+        {
+            await theConnection.OpenAsync();
+        }
 
         await theConnection.ResetSchemaAsync(_schemaName);
     }

--- a/src/Weasel.SqlServer.Tests/Triggers/TriggerTests.cs
+++ b/src/Weasel.SqlServer.Tests/Triggers/TriggerTests.cs
@@ -1,0 +1,129 @@
+using Shouldly;
+using Weasel.Core;
+using Weasel.SqlServer.Tables;
+using Weasel.SqlServer.Triggers;
+using Xunit;
+
+namespace Weasel.SqlServer.Tests.Triggers;
+
+/// <summary>
+///     SQL Server trigger support (weasel#452). SQL Server is the provider with no row-level
+///     triggers and no BEFORE, so the interesting cases here are the two refusals.
+/// </summary>
+[Collection("integration")]
+public class TriggerTests: IntegrationContext
+{
+    public TriggerTests(): base("triggers")
+    {
+    }
+
+    private static Table SourceTable()
+    {
+        var table = new Table("triggers.orders");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn<string>("note");
+        return table;
+    }
+
+    private static Trigger NewTrigger(string note = "touched") => new(
+        "triggers.stamp_note",
+        "triggers.orders",
+        $"UPDATE triggers.orders SET note = '{note}' FROM triggers.orders o INNER JOIN inserted i ON o.id = i.id")
+    {
+        Timing = TriggerTiming.After, Events = TriggerEvents.Insert
+    };
+
+    [Fact]
+    public void a_before_trigger_is_refused_with_the_alternative_named()
+    {
+        var trigger = NewTrigger();
+        trigger.Timing = TriggerTiming.Before;
+
+        var ex = Should.Throw<NotSupportedException>(() => trigger.CreateStatement());
+        ex.Message.ShouldContain("INSTEAD OF");
+    }
+
+    [Fact]
+    public void a_when_condition_is_refused_rather_than_dropped()
+    {
+        var trigger = NewTrigger();
+        trigger.Condition = "1 = 1";
+
+        Should.Throw<NotSupportedException>(() => trigger.CreateStatement());
+    }
+
+    /// <summary>
+    ///     SQL Server triggers are statement-level, so <c>ForEachRow</c> has nothing to emit — the
+    ///     trigger sees affected rows through the <c>inserted</c> and <c>deleted</c> tables instead.
+    /// </summary>
+    [Fact]
+    public void for_each_row_is_not_emitted()
+    {
+        NewTrigger().CreateStatement().ShouldNotContain("FOR EACH");
+    }
+
+    [Fact]
+    public void several_events_render_as_a_comma_list()
+    {
+        var trigger = NewTrigger();
+        trigger.Events = TriggerEvents.Delete | TriggerEvents.Insert;
+
+        trigger.CreateStatement().ShouldContain("INSERT, DELETE");
+    }
+
+    [Fact]
+    public async Task a_trigger_round_trips_and_reports_no_delta()
+    {
+        await ResetSchema();
+        await SourceTable().ApplyChangesAsync(theConnection);
+
+        var trigger = NewTrigger();
+        await trigger.ApplyChangesAsync(theConnection);
+
+        (await trigger.ExistsInDatabaseAsync(theConnection)).ShouldBeTrue();
+        (await trigger.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task the_trigger_actually_fires()
+    {
+        await ResetSchema();
+        await SourceTable().ApplyChangesAsync(theConnection);
+        await NewTrigger().ApplyChangesAsync(theConnection);
+
+        await theConnection.CreateCommand("insert into triggers.orders (id) values (1)").ExecuteNonQueryAsync();
+
+        var note = await theConnection.CreateCommand("select note from triggers.orders where id = 1")
+            .ExecuteScalarAsync();
+
+        note.ShouldBe("touched");
+    }
+
+    [Fact]
+    public async Task a_changed_body_reports_update_and_applying_it_converges()
+    {
+        await ResetSchema();
+        await SourceTable().ApplyChangesAsync(theConnection);
+        await NewTrigger().ApplyChangesAsync(theConnection);
+
+        var changed = NewTrigger("changed");
+
+        (await changed.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.Update);
+
+        await changed.ApplyChangesAsync(theConnection);
+
+        (await changed.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task dropping_the_schema_takes_its_triggers_with_it()
+    {
+        await ResetSchema();
+        await SourceTable().ApplyChangesAsync(theConnection);
+        await NewTrigger().ApplyChangesAsync(theConnection);
+
+        await ResetSchema();
+
+        (await NewTrigger().ExistsInDatabaseAsync(theConnection)).ShouldBeFalse();
+    }
+}

--- a/src/Weasel.SqlServer/Triggers/Trigger.cs
+++ b/src/Weasel.SqlServer/Triggers/Trigger.cs
@@ -1,0 +1,121 @@
+using System.Data.Common;
+using JasperFx.Core;
+using Microsoft.Data.SqlClient;
+using Weasel.Core;
+using DbCommandBuilder = Weasel.Core.DbCommandBuilder;
+
+namespace Weasel.SqlServer.Triggers;
+
+/// <summary>
+///     A SQL Server trigger.
+/// </summary>
+/// <remarks>
+///     <para>
+///         SQL Server triggers are statement-level only — there is no <c>FOR EACH ROW</c>, and a
+///         trigger sees the affected rows through the <c>inserted</c> and <c>deleted</c>
+///         pseudo-tables instead. <see cref="TriggerBase.ForEachRow" /> is therefore not emitted,
+///         and a <c>WHEN</c> condition is rejected rather than dropped, since the engine has no
+///         equivalent.
+///     </para>
+///     <para>
+///         <c>CREATE TRIGGER</c> has to be the first statement in its batch, so the create goes
+///         inside <c>EXEC sp_executesql</c> — the same reason <c>Function</c> and <c>View</c> do it.
+///     </para>
+/// </remarks>
+public class Trigger: TriggerBase
+{
+    public Trigger(string name, string target, string body)
+        : this(
+            DbObjectName.Parse(SqlServerProvider.Instance, name),
+            DbObjectName.Parse(SqlServerProvider.Instance, target),
+            body)
+    {
+    }
+
+    public Trigger(DbObjectName identifier, DbObjectName target, string body): base(identifier, target, body)
+    {
+    }
+
+    public override void WriteCreateStatement(Migrator migrator, TextWriter writer)
+    {
+        WriteDropStatement(migrator, writer);
+
+        writer.WriteLine($"EXEC sp_executesql N'{SchemaUtils.EscapeLiteral(CreateStatement())}';");
+    }
+
+    /// <summary>
+    ///     The single <c>CREATE TRIGGER</c> statement this trigger renders to. Public because it is
+    ///     what delta comparison and diagnostics both want, the same way a view exposes
+    ///     <c>ToBasicCreateViewSql</c>.
+    /// </summary>
+    public string CreateStatement()
+    {
+        if (Condition.IsNotEmpty())
+        {
+            throw new NotSupportedException(
+                $"SQL Server has no WHEN clause on a trigger, but trigger {Identifier} declares one. Put the "
+                + "condition inside the trigger body, where it can test the inserted / deleted tables.");
+        }
+
+        var timing = Timing == TriggerTiming.Before
+            ? throw new NotSupportedException(
+                $"SQL Server has no BEFORE trigger, but trigger {Identifier} asks for one. Use INSTEAD OF, which "
+                + "runs in place of the statement, or AFTER.")
+            : TimingKeyword();
+
+        return $"CREATE TRIGGER {Identifier} ON {Target} {timing} {EventList(", ")} AS {Body.Trim()}";
+    }
+
+    public override void WriteDropStatement(Migrator rules, TextWriter writer)
+    {
+        writer.WriteLine($"DROP TRIGGER IF EXISTS {Identifier};");
+    }
+
+    public override void ConfigureQueryCommand(DbCommandBuilder builder)
+    {
+        var nameParam = builder.AddParameter(Identifier.ToString()).ParameterName;
+
+        builder.Append(
+            "SELECT sm.definition FROM sys.sql_modules AS sm "
+            + "INNER JOIN sys.triggers AS t ON t.object_id = sm.object_id "
+            + $"WHERE t.object_id = OBJECT_ID(@{nameParam})");
+    }
+
+    public override async Task<ISchemaObjectDelta> CreateDeltaAsync(DbDataReader reader, CancellationToken ct = default)
+    {
+        var existing = await readDefinitionAsync(reader, ct).ConfigureAwait(false);
+
+        if (existing == null)
+        {
+            return new SchemaObjectDelta(this, SchemaPatchDifference.Create);
+        }
+
+        return NormalizeBody(existing) == NormalizeBody(CreateStatement())
+            ? new SchemaObjectDelta(this, SchemaPatchDifference.None)
+            : new SchemaObjectDelta(this, SchemaPatchDifference.Update);
+    }
+
+    public async Task<string?> FetchExistingDefinitionAsync(SqlConnection conn, CancellationToken ct = default)
+    {
+        var builder = new DbCommandBuilder(conn);
+        ConfigureQueryCommand(builder);
+
+        await using var reader = await conn.ExecuteReaderAsync(builder, ct).ConfigureAwait(false);
+        var definition = await readDefinitionAsync(reader, ct).ConfigureAwait(false);
+        await reader.CloseAsync().ConfigureAwait(false);
+
+        return definition;
+    }
+
+    public async Task<bool> ExistsInDatabaseAsync(SqlConnection conn, CancellationToken ct = default)
+        => await FetchExistingDefinitionAsync(conn, ct).ConfigureAwait(false) != null;
+
+    private static async Task<string?> readDefinitionAsync(DbDataReader reader, CancellationToken ct)
+    {
+        if (!await reader.ReadAsync(ct).ConfigureAwait(false)) return null;
+        if (await reader.IsDBNullAsync(0, ct).ConfigureAwait(false)) return null;
+
+        var definition = await reader.GetFieldValueAsync<string>(0, ct).ConfigureAwait(false);
+        return string.IsNullOrWhiteSpace(definition) ? null : definition;
+    }
+}

--- a/src/Weasel.Sqlite.Tests/Triggers/TriggerTests.cs
+++ b/src/Weasel.Sqlite.Tests/Triggers/TriggerTests.cs
@@ -1,0 +1,214 @@
+using Microsoft.Data.Sqlite;
+using Shouldly;
+using JasperFx;
+using Weasel.Core;
+using Weasel.Sqlite.Tables;
+using Weasel.Sqlite.Triggers;
+using Xunit;
+
+namespace Weasel.Sqlite.Tests.Triggers;
+
+/// <summary>
+///     SQLite trigger support (weasel#452), plus the affordance the design decision called out as
+///     required from day one: SQLite rebuilds a table to change most things about it, and
+///     <c>DROP TABLE</c> takes the table's triggers with it silently.
+/// </summary>
+public class TriggerTests
+{
+    private readonly string _connectionString = $"Data Source={Path.GetTempFileName()};";
+
+    private async Task<SqliteConnection> openAsync()
+    {
+        var conn = new SqliteConnection(_connectionString);
+        await conn.OpenAsync();
+        await conn.ResetSchemaAsync("main");
+        return conn;
+    }
+
+    private static Table SourceTable()
+    {
+        var table = new Table("trg_orders");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn<int>("quantity");
+        table.AddColumn<string>("note");
+        return table;
+    }
+
+    /// <summary>
+    ///     Run SQLite's table rebuild: create a new table, copy the surviving columns, drop the old
+    ///     one, rename, and put the indexes and triggers back.
+    /// </summary>
+    /// <remarks>
+    ///     Driven through <c>TableDelta.WriteUpdate</c> rather than through the migrator on purpose.
+    ///     A rebuild reports <see cref="SchemaPatchDifference.Invalid" />, and <c>Migrator</c>
+    ///     answers <c>Invalid</c> by dropping and recreating the table — so the migrator never
+    ///     reaches this path at all, and takes the table's rows with it when it goes. That is
+    ///     weasel#477, a separate bug; the trigger restoration is emitted here and is correct
+    ///     wherever the rebuild runs.
+    /// </remarks>
+    private static async Task rebuildAsync(SqliteConnection conn, Table table)
+    {
+        var delta = await table.FindDeltaAsync(conn);
+
+        var writer = new StringWriter();
+        delta.WriteUpdate(new SqliteMigrator(), writer);
+
+        await conn.CreateCommand(writer.ToString()).ExecuteNonQueryAsync();
+    }
+
+    private static Trigger NewTrigger(string body = "UPDATE trg_orders SET note = 'touched' WHERE id = NEW.id")
+        => new("trg_orders_after_insert", "trg_orders", body)
+        {
+            Timing = TriggerTiming.After, Events = TriggerEvents.Insert
+        };
+
+    [Fact]
+    public void write_create_statement_drops_first_so_it_is_idempotent()
+    {
+        var writer = new StringWriter();
+        NewTrigger().WriteCreateStatement(new SqliteMigrator(), writer);
+
+        var sql = writer.ToString();
+
+        sql.ShouldContain("DROP TRIGGER IF EXISTS");
+        sql.ShouldContain("CREATE TRIGGER");
+        sql.ShouldContain("AFTER INSERT");
+    }
+
+    /// <summary>
+    ///     SQLite triggers are always row-level — <c>FOR EACH STATEMENT</c> is a syntax error — so
+    ///     the flag is not emitted rather than emitted wrongly.
+    /// </summary>
+    [Fact]
+    public void for_each_row_is_not_emitted()
+    {
+        var writer = new StringWriter();
+        NewTrigger().WriteCreateStatement(new SqliteMigrator(), writer);
+
+        writer.ToString().ShouldNotContain("FOR EACH");
+    }
+
+    [Fact]
+    public void more_than_one_event_is_refused_rather_than_narrowed()
+    {
+        var trigger = NewTrigger();
+        trigger.Events = TriggerEvents.Insert | TriggerEvents.Update;
+
+        var ex = Should.Throw<InvalidOperationException>(() => trigger.CreateStatement());
+        ex.Message.ShouldContain("exactly one event");
+    }
+
+    [Fact]
+    public async Task a_trigger_round_trips_and_reports_no_delta()
+    {
+        await using var conn = await openAsync();
+        await SourceTable().ApplyChangesAsync(conn);
+
+        var trigger = NewTrigger();
+        await trigger.ApplyChangesAsync(conn);
+
+        (await trigger.ExistsInDatabaseAsync(conn)).ShouldBeTrue();
+        (await trigger.FindDeltaAsync(conn)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task a_changed_body_reports_update_and_applying_it_converges()
+    {
+        await using var conn = await openAsync();
+        await SourceTable().ApplyChangesAsync(conn);
+        await NewTrigger().ApplyChangesAsync(conn);
+
+        var changed = NewTrigger("UPDATE trg_orders SET note = 'changed' WHERE id = NEW.id");
+
+        (await changed.FindDeltaAsync(conn)).Difference.ShouldBe(SchemaPatchDifference.Update);
+
+        await changed.ApplyChangesAsync(conn);
+
+        (await changed.FindDeltaAsync(conn)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task the_trigger_actually_fires()
+    {
+        await using var conn = await openAsync();
+        await SourceTable().ApplyChangesAsync(conn);
+        await NewTrigger().ApplyChangesAsync(conn);
+
+        await conn.CreateCommand("INSERT INTO trg_orders (id, quantity) VALUES (1, 5)").ExecuteNonQueryAsync();
+
+        var note = await conn.CreateCommand("SELECT note FROM trg_orders WHERE id = 1").ExecuteScalarAsync();
+        note.ShouldBe("touched");
+    }
+
+    /// <summary>
+    ///     The hazard the design decision insisted on covering from day one. SQLite rebuilds the
+    ///     table to change a column, <c>DROP TABLE</c> silently takes the triggers with it, and the
+    ///     resulting schema looks entirely correct while the user's data-integrity logic is gone.
+    /// </summary>
+    [Fact]
+    public async Task a_trigger_survives_the_table_being_rebuilt()
+    {
+        await using var conn = await openAsync();
+        await SourceTable().ApplyChangesAsync(conn);
+        await NewTrigger().ApplyChangesAsync(conn);
+
+        // A column *type* change, which SQLite cannot do in place -- ADD COLUMN would take the
+        // incremental path and never exercise the rebuild. TableDelta creates a new table, copies,
+        // drops the old one and renames.
+        var retyped = new Table("trg_orders");
+        retyped.AddColumn<int>("id").AsPrimaryKey();
+        retyped.AddColumn<string>("quantity");
+        retyped.AddColumn<string>("note");
+
+        await rebuildAsync(conn, retyped);
+
+        (await NewTrigger().ExistsInDatabaseAsync(conn))
+            .ShouldBeTrue("the table rebuild dropped the trigger and did not put it back");
+
+        // ...and it still works, which is the part that actually matters.
+        await conn.CreateCommand("INSERT INTO trg_orders (id, quantity) VALUES (2, 7)").ExecuteNonQueryAsync();
+
+        var note = await conn.CreateCommand("SELECT note FROM trg_orders WHERE id = 2").ExecuteScalarAsync();
+        note.ShouldBe("touched");
+    }
+
+    /// <summary>
+    ///     Including a trigger Weasel never declared. The restoration reads <c>sqlite_master</c>
+    ///     rather than the model precisely so that a hand-written trigger is not collateral damage.
+    /// </summary>
+    [Fact]
+    public async Task a_trigger_weasel_did_not_declare_survives_the_rebuild_too()
+    {
+        await using var conn = await openAsync();
+        await SourceTable().ApplyChangesAsync(conn);
+
+        await conn.CreateCommand(
+                "CREATE TRIGGER handwritten AFTER INSERT ON trg_orders BEGIN "
+                + "UPDATE trg_orders SET note = 'by hand' WHERE id = NEW.id; END")
+            .ExecuteNonQueryAsync();
+
+        var retyped = new Table("trg_orders");
+        retyped.AddColumn<int>("id").AsPrimaryKey();
+        retyped.AddColumn<string>("quantity");
+        retyped.AddColumn<string>("note");
+        await rebuildAsync(conn, retyped);
+
+        var count = await conn
+            .CreateCommand("SELECT COUNT(*) FROM sqlite_master WHERE type = 'trigger' AND name = 'handwritten'")
+            .ExecuteScalarAsync();
+
+        Convert.ToInt32(count).ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task dropping_the_schema_takes_its_triggers_with_it()
+    {
+        await using var conn = await openAsync();
+        await SourceTable().ApplyChangesAsync(conn);
+        await NewTrigger().ApplyChangesAsync(conn);
+
+        await conn.ResetSchemaAsync("main");
+
+        (await NewTrigger().ExistsInDatabaseAsync(conn)).ShouldBeFalse();
+    }
+}

--- a/src/Weasel.Sqlite/Tables/Table.FetchExisting.cs
+++ b/src/Weasel.Sqlite/Tables/Table.FetchExisting.cs
@@ -27,6 +27,12 @@ WHERE type = 'index' AND tbl_name = '{sanitizedName}' AND sql IS NOT NULL;
 
 -- Get foreign key information (PRAGMA doesn't support parameter binding)
 SELECT * FROM pragma_foreign_key_list('{sanitizedName}');
+
+-- Get the triggers on this table. Not because the table owns them -- it does not, see
+-- TriggerBase -- but because DROP TABLE takes them with it, and this table may have to be
+-- rebuilt to change a column (weasel#452).
+SELECT sql FROM sqlite_master
+WHERE type = 'trigger' AND tbl_name = '{sanitizedName}' AND sql IS NOT NULL;
 ");
     }
 
@@ -69,6 +75,10 @@ WHERE type = 'index' AND tbl_name = '{tableName}' AND sql IS NOT NULL;
 
 -- Get foreign key information
 SELECT * FROM pragma_foreign_key_list('{tableName}');
+
+-- Get the triggers on this table (see ConfigureQueryCommand)
+SELECT sql FROM sqlite_master
+WHERE type = 'trigger' AND tbl_name = '{tableName}' AND sql IS NOT NULL;
 ";
 
         var cmd = conn.CreateCommand();
@@ -102,6 +112,7 @@ SELECT * FROM pragma_foreign_key_list('{tableName}');
             // This keeps the reader in sync when SchemaMigration.DetermineAsync batches multiple tables.
             await reader.NextResultAsync(ct).ConfigureAwait(false); // Skip columns → indexes
             await reader.NextResultAsync(ct).ConfigureAwait(false); // Skip indexes → foreign keys
+            await reader.NextResultAsync(ct).ConfigureAwait(false); // Skip foreign keys → triggers
             return null;
         }
 
@@ -114,7 +125,33 @@ SELECT * FROM pragma_foreign_key_list('{tableName}');
         // Read foreign keys (fourth result set)
         await readForeignKeysAsync(reader, existing, ct).ConfigureAwait(false);
 
+        // Read the triggers on this table (fifth result set)
+        await reader.NextResultAsync(ct).ConfigureAwait(false);
+        await readTriggersAsync(reader, existing, ct).ConfigureAwait(false);
+
         return !existing.Columns.Any() ? null : existing;
+    }
+
+    /// <summary>
+    ///     Capture the <c>CREATE TRIGGER</c> statements for this table exactly as SQLite stores
+    ///     them, so <c>TableDelta</c> can put them back after rebuilding the table.
+    /// </summary>
+    /// <remarks>
+    ///     Verbatim, and from the catalog rather than from the model, on purpose: a trigger Weasel
+    ///     never declared is still the user's, and dropping the table would take it with no warning.
+    /// </remarks>
+    private static async Task readTriggersAsync(DbDataReader reader, Table existing, CancellationToken ct = default)
+    {
+        while (await reader.ReadAsync(ct).ConfigureAwait(false))
+        {
+            if (await reader.IsDBNullAsync(0, ct).ConfigureAwait(false)) continue;
+
+            var sql = await reader.GetFieldValueAsync<string>(0, ct).ConfigureAwait(false);
+            if (!string.IsNullOrWhiteSpace(sql))
+            {
+                existing.ExistingTriggers.Add(sql.Trim());
+            }
+        }
     }
 
     private static async Task<string?> readTableSqlAsync(DbDataReader reader, CancellationToken ct = default)

--- a/src/Weasel.Sqlite/Tables/Table.cs
+++ b/src/Weasel.Sqlite/Tables/Table.cs
@@ -180,6 +180,20 @@ public partial class Table: TableBase<TableColumn, IndexDefinition, ForeignKey>
     /// </remarks>
     protected override StringComparison NameComparison => StringComparison.OrdinalIgnoreCase;
 
+    /// <summary>
+    ///     The <c>CREATE TRIGGER</c> statements found on this table in the database, captured during
+    ///     introspection. Empty on a table you built yourself; populated on one read back from the
+    ///     catalog.
+    /// </summary>
+    /// <remarks>
+    ///     SQLite rebuilds a table to change most things about it, and <c>DROP TABLE</c> takes the
+    ///     table's triggers with it silently. So the rebuild has to put them back, and it reads them
+    ///     from here. This is a lookup, not ownership — a trigger is an independent schema object
+    ///     that declares its target (weasel#452) — and it is deliberately populated from the catalog
+    ///     rather than from the model, because a trigger Weasel never declared is still the user's.
+    /// </remarks>
+    public IList<string> ExistingTriggers { get; } = new List<string>();
+
     public override IEnumerable<DbObjectName> AllNames()
     {
         yield return Identifier;

--- a/src/Weasel.Sqlite/Tables/TableDelta.cs
+++ b/src/Weasel.Sqlite/Tables/TableDelta.cs
@@ -379,6 +379,40 @@ public class TableDelta: SchemaObjectDelta<Table>
         {
             writer.WriteLine(index.ToDDL(Expected));
         }
+
+        writeTriggerRestoration(writer);
+    }
+
+    /// <summary>
+    ///     Put back the triggers the DROP TABLE just destroyed.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         SQLite drops a table's triggers along with the table and says nothing about it. Every
+    ///         rebuild — a column type change, a foreign key change, a primary key change — therefore
+    ///         silently destroyed the table's data-integrity logic and left the schema looking
+    ///         correct (weasel#452).
+    ///     </para>
+    ///     <para>
+    ///         The statements come from <see cref="Table.ExistingTriggers" />, captured verbatim from
+    ///         <c>sqlite_master</c> during introspection, so a trigger Weasel never declared is
+    ///         preserved too. They are re-emitted after the rename, when the table exists again under
+    ///         its own name.
+    ///     </para>
+    /// </remarks>
+    private void writeTriggerRestoration(TextWriter writer)
+    {
+        if (Actual == null || !Actual.ExistingTriggers.Any())
+        {
+            return;
+        }
+
+        writer.WriteLine();
+
+        foreach (var trigger in Actual.ExistingTriggers)
+        {
+            writer.WriteLine($"{trigger.TrimEnd(';')};");
+        }
     }
 
     public bool HasChanges()

--- a/src/Weasel.Sqlite/Triggers/Trigger.cs
+++ b/src/Weasel.Sqlite/Triggers/Trigger.cs
@@ -1,0 +1,128 @@
+using System.Data.Common;
+using JasperFx.Core;
+using Microsoft.Data.Sqlite;
+using Weasel.Core;
+using DbCommandBuilder = Weasel.Core.DbCommandBuilder;
+
+namespace Weasel.Sqlite.Triggers;
+
+/// <summary>
+///     A SQLite trigger. SQLite stores the submitted text verbatim in <c>sqlite_master.sql</c>, so
+///     the delta is a whitespace-insensitive comparison of the whole statement, the same way its
+///     views work.
+/// </summary>
+/// <remarks>
+///     <para>
+///         SQLite has no <c>ALTER TRIGGER</c> and no <c>CREATE OR REPLACE</c>, so a change is a drop
+///         followed by a create — and <c>WriteCreateStatement</c> emits both, because that also
+///         makes creation idempotent.
+///     </para>
+///     <para>
+///         Triggers are always row-level on SQLite: <c>FOR EACH ROW</c> is accepted but is the only
+///         behaviour, and <c>FOR EACH STATEMENT</c> is a syntax error. <see cref="ForEachRow" /> is
+///         therefore not emitted.
+///     </para>
+/// </remarks>
+public class Trigger: TriggerBase
+{
+    public Trigger(string name, string target, string body)
+        : this(
+            DbObjectName.Parse(SqliteProvider.Instance, name),
+            DbObjectName.Parse(SqliteProvider.Instance, target),
+            body)
+    {
+    }
+
+    public Trigger(DbObjectName identifier, DbObjectName target, string body): base(identifier, target, body)
+    {
+    }
+
+    public override void WriteCreateStatement(Migrator migrator, TextWriter writer)
+    {
+        WriteDropStatement(migrator, writer);
+        writer.WriteLine(CreateStatement());
+    }
+
+    /// <summary>
+    ///     The single <c>CREATE TRIGGER</c> statement this trigger renders to. Public because it is
+    ///     what delta comparison and diagnostics both want, the same way a view exposes
+    ///     <c>ToBasicCreateViewSql</c>.
+    /// </summary>
+    public string CreateStatement()
+    {
+        var condition = Condition.IsNotEmpty() ? $" WHEN {Condition}" : string.Empty;
+        var body = Body.Trim();
+
+        if (!body.StartsWith("BEGIN", StringComparison.OrdinalIgnoreCase))
+        {
+            body = $"BEGIN {body.TrimEnd(';')}; END";
+        }
+
+        return
+            $"CREATE TRIGGER {QualifiedName(Identifier)} {TimingKeyword()} {SingleEvent("SQLite")} "
+            + $"ON {SchemaUtils.QuoteName(Target.Name)}{condition} {body};";
+    }
+
+    public override void WriteDropStatement(Migrator rules, TextWriter writer)
+    {
+        writer.WriteLine($"DROP TRIGGER IF EXISTS {QualifiedName(Identifier)};");
+    }
+
+    public override void ConfigureQueryCommand(DbCommandBuilder builder)
+    {
+        var nameParam = builder.AddParameter(Identifier.Name).ParameterName;
+
+        builder.Append(
+            $"SELECT sql FROM {SchemaUtils.QuoteName(Identifier.Schema)}.sqlite_master WHERE type = 'trigger' AND name = @{nameParam}");
+    }
+
+    public override async Task<ISchemaObjectDelta> CreateDeltaAsync(DbDataReader reader, CancellationToken ct = default)
+    {
+        var existing = await readSqlAsync(reader, ct).ConfigureAwait(false);
+
+        if (existing == null)
+        {
+            return new SchemaObjectDelta(this, SchemaPatchDifference.Create);
+        }
+
+        return NormalizeBody(existing) == NormalizeBody(CreateStatement())
+            ? new SchemaObjectDelta(this, SchemaPatchDifference.None)
+            : new SchemaObjectDelta(this, SchemaPatchDifference.Update);
+    }
+
+    public async Task<bool> ExistsInDatabaseAsync(SqliteConnection conn, CancellationToken ct = default)
+        => await FetchExistingSqlAsync(conn, ct).ConfigureAwait(false) != null;
+
+    public async Task<string?> FetchExistingSqlAsync(SqliteConnection conn, CancellationToken ct = default)
+    {
+        var builder = new DbCommandBuilder(conn);
+        ConfigureQueryCommand(builder);
+
+        await using var reader = await conn.ExecuteReaderAsync(builder, ct).ConfigureAwait(false);
+        var sql = await readSqlAsync(reader, ct).ConfigureAwait(false);
+        await reader.CloseAsync().ConfigureAwait(false);
+
+        return sql;
+    }
+
+    private static async Task<string?> readSqlAsync(DbDataReader reader, CancellationToken ct)
+    {
+        if (!await reader.ReadAsync(ct).ConfigureAwait(false))
+        {
+            return null;
+        }
+
+        if (await reader.IsDBNullAsync(0, ct).ConfigureAwait(false))
+        {
+            return null;
+        }
+
+        var sql = await reader.GetFieldValueAsync<string>(0, ct).ConfigureAwait(false);
+        return string.IsNullOrWhiteSpace(sql) ? null : sql;
+    }
+
+    private static string QualifiedName(DbObjectName name)
+        => name.Schema.EqualsIgnoreCase("main")
+            ? SchemaUtils.QuoteName(name.Name)
+            : $"{SchemaUtils.QuoteName(name.Schema)}.{SchemaUtils.QuoteName(name.Name)}";
+}


### PR DESCRIPTION
Closes #452.

Triggers were the one whole category of database object that **no** provider modelled and **every** supported engine has — no Core base to build on, no proven abstraction to copy.

## Ownership: independent, not table-owned

Per the decision recorded on the issue. A trigger *declares* a target rather than being owned by one:

- **A trigger does not always have a table.** SQL Server's `INSTEAD OF` triggers attach to views; Oracle has schema-level triggers with no target object at all.
- **PostgreSQL triggers call a function**, so they depend on another schema object rather than on their table.
- **Indexes and foreign keys are table-owned** because they are part of the table's own definition and several are emitted inside `CREATE TABLE`. A trigger is always a separate statement with its own lifecycle.

`TriggerBase` holds only what every engine has — target, body, timing, event set, row-vs-statement, optional condition. Past that the engines diverge enough that each provider renders its own statement.

## What an engine cannot express, it refuses

| Refusal | Message names the alternative |
|---|---|
| SQL Server `BEFORE` | "Use INSTEAD OF, which runs in place of the statement, or AFTER" |
| SQL Server / MySQL `WHEN` | "Put the condition inside the trigger body" |
| MySQL two events | "Declare one trigger per event" |
| MySQL `INSTEAD OF` | — |

This is the rule #449 settled after two index `Predicate` properties turned out to be silently ignored: **a caller who sets a property gets it, or gets an exception, never a quietly narrower object.**

## ⚠️ The SQLite affordance, tested from day one

The design decision called this out as required, and it is the reason:

> SQLite rebuilds a table to change most things about it, and `DROP TABLE` takes the table's triggers with it silently.

So a rebuild destroyed the user's data-integrity logic and left a schema that looked entirely correct. Table introspection now captures the `CREATE TRIGGER` statements from `sqlite_master`, and the rebuild re-emits them after the rename — **verbatim, and from the catalog rather than the model, so a trigger Weasel never declared survives too.**

Both are covered (`a_trigger_survives_the_table_being_rebuilt`, `a_trigger_weasel_did_not_declare_survives_the_rebuild_too`) and **both fail without the restoration**, verified by commenting it out.

## MySQL stopped shredding statement bodies

`MySqlMigrator.executeCommand` split delta SQL on semicolons and executed the pieces. That destroys every `BEGIN … END` block — which is most real trigger bodies, and every stored procedure. MySqlConnector executes several semicolon-separated statements from one command (measured), so the split bought nothing and cost correctness.

`a_begin_end_body_with_semicolons_survives_execution` pins it. **This also unblocks #451.**

## Tests

36 across the five providers. Every provider gets round-trip, drift-and-converge, and — because a trigger that exists but does nothing is worse than no trigger — `the_trigger_actually_fires`, which inserts a row and reads back what the trigger wrote.

Oracle additionally gets `the_body_reads_back_rather_than_coming_up_empty`: `all_triggers.trigger_body` is a LONG, the same trap #450 hit on `all_views.TEXT`.

`dropping_the_schema_takes_its_triggers_with_it` on each provider satisfies the teardown checklist CLAUDE.md gained in #469 — this is the first new object type to run it.

## Also

- `object_type_support_matrix` and `docs/core/object-types.md` updated together, which the test enforces; new `docs/core/triggers.md`.
- `ResetSchema` in the PostgreSQL and SQL Server fixtures now tolerates being called twice. Both threw a driver error that reads as a product failure; Oracle's was fixed the same way in #470.

## Found and filed rather than folded in

**[#477](https://github.com/JasperFx/weasel/issues/477)** — SQLite's careful copy-and-rename rebuild is unreachable through the migrator, because any change needing a rebuild reports `Invalid` and `Migrator` answers `Invalid` by dropping and recreating the table. Measured on a type change: **one row before, zero after.** The trigger test drives `TableDelta.WriteUpdate` directly and says why.

## Verified locally

Core 216, SQLite 427, PostgreSQL 885, SQL Server 448, Oracle 266, MySQL 283, EF Core 106. No failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)