### PR TITLE
fix(sqlite): rebuild the table instead of throwing its rows away

### DIFF
--- a/docs/core/triggers.md
+++ b/docs/core/triggers.md
@@ -33,9 +33,7 @@ forces you to register them together. Views and functions already behave this wa
 ::: warning SQLite rebuilds a table by dropping it
 `DROP TABLE` takes the table's triggers with it and says nothing. Weasel's SQLite table rebuild
 captures the triggers from `sqlite_master` first and re-emits them afterwards — including triggers
-Weasel never declared, because a hand-written trigger is still yours. Note that the rebuild path
-itself is currently unreachable through the migrator; see
-[#477](https://github.com/JasperFx/weasel/issues/477).
+Weasel never declared, because a hand-written trigger is still yours.
 :::
 
 ## What each engine accepts

--- a/src/Weasel.Core/ISchemaObject.cs
+++ b/src/Weasel.Core/ISchemaObject.cs
@@ -42,6 +42,40 @@ public interface ISchemaObjectWithPostProcessing : ISchemaObject
 ///     (weasel#448). Before that, a table's identifier, index names and foreign key names were
 ///     checked and everything else went straight into the DDL unexamined.
 /// </remarks>
+/// <summary>
+///     A delta that reports <see cref="SchemaPatchDifference.Invalid" /> because the change cannot
+///     be made in place, but which knows how to make it anyway without losing the data.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <c>Invalid</c> means "I cannot express this as an ALTER", and the default answer to it
+///         is to drop the object and create it again. For a table that answer throws away every row
+///         — which is right when there is no alternative, and catastrophic when there is.
+///     </para>
+///     <para>
+///         SQLite is where there is one. It cannot change a column's type, add a foreign key or
+///         change a primary key with <c>ALTER TABLE</c>, so every such change is <c>Invalid</c> —
+///         and its <c>TableDelta</c> has always known how to do it properly: create a new table,
+///         copy the surviving columns across, drop the old one, rename, and put the indexes and
+///         triggers back. Nothing called it, so a column type change silently emptied the table
+///         (weasel#477).
+///     </para>
+///     <para>
+///         Implementing this does not make the change safe enough to apply under
+///         <c>AutoCreate.CreateOrUpdate</c>. It is still destructive in the sense that matters for
+///         permission — a column being removed takes its data with it — so it still requires
+///         <c>AutoCreate.All</c>. What changes is only what <c>All</c> then does.
+///     </para>
+/// </remarks>
+public interface ISchemaObjectDeltaWithRebuild : ISchemaObjectDelta
+{
+    /// <summary>
+    ///     Whether <see cref="ISchemaObjectDelta.WriteUpdate" /> can carry out this change without
+    ///     discarding the object's data. When false the caller falls back to drop-and-create.
+    /// </summary>
+    bool CanRebuildInPlace { get; }
+}
+
 public interface ISchemaObjectWithLocalIdentifiers : ISchemaObject
 {
     /// <summary>

--- a/src/Weasel.Core/Migrator.cs
+++ b/src/Weasel.Core/Migrator.cs
@@ -219,6 +219,15 @@ public abstract class
                 return true;
 
             case SchemaPatchDifference.Invalid:
+                if (delta is ISchemaObjectDeltaWithRebuild { CanRebuildInPlace: true })
+                {
+                    // The delta cannot express the change as an ALTER, but it can make it without
+                    // discarding the data. Dropping and recreating would be a silent data loss
+                    // (weasel#477).
+                    delta.WriteUpdate(this, writer);
+                    return true;
+                }
+
                 delta.SchemaObject.WriteDropStatement(this, writer);
                 delta.SchemaObject.WriteCreateStatement(this, writer);
                 return true;

--- a/src/Weasel.Core/SchemaMigration.cs
+++ b/src/Weasel.Core/SchemaMigration.cs
@@ -156,6 +156,15 @@ public class SchemaMigration
                     break;
 
                 case SchemaPatchDifference.Invalid:
+                    if (delta is ISchemaObjectDeltaWithRebuild { CanRebuildInPlace: true })
+                    {
+                        // The delta cannot express the change as an ALTER, but it can make it
+                        // without discarding the data. Dropping and recreating would be a silent
+                        // data loss (weasel#477).
+                        delta.WriteUpdate(rules, writer);
+                        break;
+                    }
+
                     delta.SchemaObject.WriteDropStatement(rules, writer);
                     delta.SchemaObject.WriteCreateStatement(rules, writer);
                     break;

--- a/src/Weasel.Sqlite.Tests/Tables/rebuild_preserves_data.cs
+++ b/src/Weasel.Sqlite.Tests/Tables/rebuild_preserves_data.cs
@@ -1,0 +1,155 @@
+using JasperFx;
+using Microsoft.Data.Sqlite;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Sqlite.Tables;
+using Xunit;
+
+namespace Weasel.Sqlite.Tests.Tables;
+
+/// <summary>
+///     weasel#477: SQLite's table rebuild was unreachable through the migrator, so a change that
+///     needed one dropped the table and everything in it.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <c>TableDelta</c> has always had the careful path — create a new table,
+///         <c>INSERT INTO … SELECT</c> the surviving columns, drop the old one, rename, put the
+///         indexes and triggers back. But it reports <see cref="SchemaPatchDifference.Invalid" />
+///         for exactly the changes that need it, and <c>Migrator</c> answered <c>Invalid</c> by
+///         dropping and recreating the table. Measured before the fix: one row before a column type
+///         change, zero after, and a schema that looked entirely correct.
+///     </para>
+///     <para>
+///         These go through the migrator deliberately. Driving <c>TableDelta.WriteUpdate</c>
+///         directly always worked, which is exactly why the bug survived.
+///     </para>
+/// </remarks>
+public class rebuild_preserves_data
+{
+    private readonly string _connectionString = $"Data Source={Path.GetTempFileName()};";
+
+    private async Task<SqliteConnection> openAsync()
+    {
+        var conn = new SqliteConnection(_connectionString);
+        await conn.OpenAsync();
+        await conn.ResetSchemaAsync("main");
+        return conn;
+    }
+
+    /// <summary>
+    ///     Through the migrator, with <see cref="AutoCreate.All" /> — a rebuild still reports
+    ///     <c>Invalid</c> and still needs <c>All</c>, because a change that removes a column really
+    ///     does take that column's data. What weasel#477 changed is only what <c>All</c> then does.
+    /// </summary>
+    private static async Task applyAsync(SqliteConnection conn, Table table)
+    {
+        var migration = await SchemaMigration.DetermineAsync(conn, CancellationToken.None, table);
+        await new SqliteMigrator().ApplyAllAsync(conn, migration, AutoCreate.All);
+    }
+
+    private static Table OrdersTable(string quantityType = "INTEGER")
+    {
+        var table = new Table("rb_orders");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn("quantity", quantityType);
+        table.AddColumn<string>("note");
+        return table;
+    }
+
+    [Fact]
+    public async Task a_column_type_change_keeps_the_rows()
+    {
+        await using var conn = await openAsync();
+        await applyAsync(conn, OrdersTable());
+
+        await conn.CreateCommand("INSERT INTO rb_orders (id, quantity, note) VALUES (1, 5, 'first')")
+            .ExecuteNonQueryAsync();
+        await conn.CreateCommand("INSERT INTO rb_orders (id, quantity, note) VALUES (2, 9, 'second')")
+            .ExecuteNonQueryAsync();
+
+        await applyAsync(conn, OrdersTable("TEXT"));
+
+        var count = await conn.CreateCommand("SELECT COUNT(*) FROM rb_orders").ExecuteScalarAsync();
+        Convert.ToInt32(count).ShouldBe(2, "the rebuild dropped the table instead of copying it");
+
+        var note = await conn.CreateCommand("SELECT note FROM rb_orders WHERE id = 2").ExecuteScalarAsync();
+        note.ShouldBe("second");
+    }
+
+    [Fact]
+    public async Task the_change_the_rebuild_was_for_actually_takes_effect()
+    {
+        await using var conn = await openAsync();
+        await applyAsync(conn, OrdersTable());
+        await applyAsync(conn, OrdersTable("TEXT"));
+
+        var expected = OrdersTable("TEXT");
+        var delta = await expected.FindDeltaAsync(conn);
+
+        delta.Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    /// <summary>
+    ///     A primary key change is the other route into the rebuild, and the one where copying is
+    ///     least obviously safe — so it gets its own case rather than riding on the type change.
+    /// </summary>
+    [Fact]
+    public async Task a_primary_key_change_keeps_the_rows()
+    {
+        await using var conn = await openAsync();
+        await applyAsync(conn, OrdersTable());
+
+        await conn.CreateCommand("INSERT INTO rb_orders (id, quantity, note) VALUES (1, 5, 'kept')")
+            .ExecuteNonQueryAsync();
+
+        var repointed = new Table("rb_orders");
+        repointed.AddColumn<int>("id");
+        repointed.AddColumn("quantity", "INTEGER");
+        repointed.AddColumn<string>("note").AsPrimaryKey();
+
+        await applyAsync(conn, repointed);
+
+        var note = await conn.CreateCommand("SELECT note FROM rb_orders").ExecuteScalarAsync();
+        note.ShouldBe("kept");
+    }
+
+    /// <summary>
+    ///     Indexes are recreated by the rebuild, and were before this — but the rebuild running at
+    ///     all is new, so nothing had proven it end to end through the migrator.
+    /// </summary>
+    [Fact]
+    public async Task indexes_come_back_after_the_rebuild()
+    {
+        await using var conn = await openAsync();
+
+        var original = OrdersTable();
+        original.Indexes.Add(new IndexDefinition("rb_orders_note_idx") { Columns = ["note"] });
+        await applyAsync(conn, original);
+
+        var retyped = OrdersTable("TEXT");
+        retyped.Indexes.Add(new IndexDefinition("rb_orders_note_idx") { Columns = ["note"] });
+        await applyAsync(conn, retyped);
+
+        var count = await conn
+            .CreateCommand("SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = 'rb_orders_note_idx'")
+            .ExecuteScalarAsync();
+
+        Convert.ToInt32(count).ShouldBe(1);
+    }
+
+    /// <summary>
+    ///     A table that does not exist yet has nothing to preserve, so the ordinary create path is
+    ///     the right one and <c>CanRebuildInPlace</c> says so.
+    /// </summary>
+    [Fact]
+    public async Task a_table_that_does_not_exist_yet_is_not_a_rebuild()
+    {
+        await using var conn = await openAsync();
+
+        var delta = await OrdersTable().FindDeltaAsync(conn);
+
+        delta.Difference.ShouldBe(SchemaPatchDifference.Create);
+        delta.CanRebuildInPlace.ShouldBeFalse();
+    }
+}

--- a/src/Weasel.Sqlite.Tests/Triggers/TriggerTests.cs
+++ b/src/Weasel.Sqlite.Tests/Triggers/TriggerTests.cs
@@ -35,25 +35,20 @@ public class TriggerTests
     }
 
     /// <summary>
-    ///     Run SQLite's table rebuild: create a new table, copy the surviving columns, drop the old
-    ///     one, rename, and put the indexes and triggers back.
+    ///     Run SQLite's table rebuild through the migrator: create a new table, copy the surviving
+    ///     columns, drop the old one, rename, and put the indexes and triggers back.
     /// </summary>
     /// <remarks>
-    ///     Driven through <c>TableDelta.WriteUpdate</c> rather than through the migrator on purpose.
-    ///     A rebuild reports <see cref="SchemaPatchDifference.Invalid" />, and <c>Migrator</c>
-    ///     answers <c>Invalid</c> by dropping and recreating the table — so the migrator never
-    ///     reaches this path at all, and takes the table's rows with it when it goes. That is
-    ///     weasel#477, a separate bug; the trigger restoration is emitted here and is correct
-    ///     wherever the rebuild runs.
+    ///     A rebuild reports <see cref="SchemaPatchDifference.Invalid" /> and so needs
+    ///     <see cref="AutoCreate.All" />. It used to need more than that: the migrator answered
+    ///     <c>Invalid</c> by dropping and recreating the table, so the rebuild — and this trigger
+    ///     restoration with it — never ran at all. weasel#477 fixed that, and these now exercise the
+    ///     path a caller actually takes.
     /// </remarks>
     private static async Task rebuildAsync(SqliteConnection conn, Table table)
     {
-        var delta = await table.FindDeltaAsync(conn);
-
-        var writer = new StringWriter();
-        delta.WriteUpdate(new SqliteMigrator(), writer);
-
-        await conn.CreateCommand(writer.ToString()).ExecuteNonQueryAsync();
+        var migration = await SchemaMigration.DetermineAsync(conn, CancellationToken.None, table);
+        await new SqliteMigrator().ApplyAllAsync(conn, migration, AutoCreate.All);
     }
 
     private static Trigger NewTrigger(string body = "UPDATE trg_orders SET note = 'touched' WHERE id = NEW.id")

--- a/src/Weasel.Sqlite/Tables/TableDelta.cs
+++ b/src/Weasel.Sqlite/Tables/TableDelta.cs
@@ -7,7 +7,7 @@ namespace Weasel.Sqlite.Tables;
 /// Represents the differences between an expected table schema and the actual table in the database.
 /// SQLite has limited ALTER TABLE support, so many changes require table recreation.
 /// </summary>
-public class TableDelta: SchemaObjectDelta<Table>
+public class TableDelta: SchemaObjectDelta<Table>, ISchemaObjectDeltaWithRebuild
 {
     public TableDelta(Table expected, Table? actual): base(expected, actual)
     {
@@ -24,6 +24,24 @@ public class TableDelta: SchemaObjectDelta<Table>
     public IReadOnlyList<Change<TableColumn>> RenamedColumns => _renamedColumns;
 
     private readonly List<Change<TableColumn>> _renamedColumns = new();
+
+    /// <summary>
+    ///     SQLite cannot change a column's type, add or drop a foreign key, or change a primary key
+    ///     with <c>ALTER TABLE</c>, so every such change reports
+    ///     <see cref="SchemaPatchDifference.Invalid" /> — but <see cref="writeTableRecreation" />
+    ///     has always known how to make it properly: new table, copy the surviving columns across,
+    ///     drop the old one, rename, put the indexes and triggers back.
+    /// </summary>
+    /// <remarks>
+    ///     Nothing called it. <c>Migrator</c> answered <c>Invalid</c> by dropping and recreating the
+    ///     table, so a column type change emptied it and left a schema that looked correct — one row
+    ///     before, none after (weasel#477). This is what tells the migrator to use the rebuild.
+    ///     <para>
+    ///     False when there is no existing table to copy from, because then there is nothing to
+    ///     preserve and the ordinary create path is right.
+    ///     </para>
+    /// </remarks>
+    public bool CanRebuildInPlace => Actual != null;
 
     public SchemaPatchDifference PrimaryKeyDifference { get; private set; }
     public bool RequiresTableRecreation { get; private set; }


### PR DESCRIPTION
Closes #477.

## The bug

SQLite's `TableDelta` has always had the careful path — create a new table, `INSERT INTO … SELECT` the surviving columns, drop the old one, rename, put the indexes and (since #452) the triggers back. **Nothing ever called it.**

A change needing a rebuild reports `Invalid`, because SQLite genuinely cannot express it as an `ALTER`. Both places that dispatch on `Invalid` — `Migrator.WriteUpdate` and `SchemaMigration.WriteAllUpdates` — answered it by dropping the schema object and creating it again. So what actually ran was `DROP TABLE` followed by `CREATE TABLE`.

Measured on a column type change:

```
difference: Invalid
rows before: 1
rows after:  0
```

And the schema afterwards is correct, so nothing looks wrong.

## The distinction `Invalid` was missing

`Invalid` conflates two different things:

- **"I cannot express this change."** Drop-and-create is the only answer available.
- **"I cannot express this change *as an `ALTER`*."** There is an alternative sitting right there, and drop-and-create is a data loss.

`ISchemaObjectDeltaWithRebuild` is that distinction:

```csharp
public interface ISchemaObjectDeltaWithRebuild : ISchemaObjectDelta
{
    bool CanRebuildInPlace { get; }
}
```

Added as an interface rather than a new `SchemaPatchDifference` value **because the enum is public and consumers switch on it** — Marten among them. A delta that implements it and answers true gets its own `WriteUpdate` called; everything else falls back exactly as before.

SQLite's `TableDelta` answers true whenever there is an existing table to copy from — false on a create, where there is nothing to preserve.

## It does not relax the permission

A rebuild still reports `Invalid` and still requires `AutoCreate.All`, because a change that *removes* a column really does take that column's data with it. **What changed is only what `All` then does.**

## The other four providers need nothing

Audited per the issue's last checkbox. They report `Invalid` for a column that cannot be altered or added (`CanAlter` / `CanAdd`), or a partition strategy change. In each case there is no non-destructive path to offer, so drop-and-create stays the correct answer.

SQLite was the only provider that had a rebuild and did not use it.

## Tests

`Weasel.Sqlite.Tests/Tables/rebuild_preserves_data.cs` — five tests, all **through the migrator**, which is the point: driving `TableDelta.WriteUpdate` by hand always worked, and that is exactly why the bug survived this long.

- `a_column_type_change_keeps_the_rows` — two rows in, two rows out, contents intact
- `a_primary_key_change_keeps_the_rows` — the other route into a rebuild, and the one where copying is least obviously safe
- `the_change_the_rebuild_was_for_actually_takes_effect` — preserving the data is not enough if the migration silently did nothing
- `indexes_come_back_after_the_rebuild`
- `a_table_that_does_not_exist_yet_is_not_a_rebuild`

**The two data tests fail on `master`**, verified by forcing `CanRebuildInPlace` to false.

## Also

The trigger tests from #452 now drive the rebuild through the migrator instead of calling `TableDelta.WriteUpdate` directly, and `docs/core/triggers.md` drops the caveat that pointed here. The two features compose: a rebuild now preserves the rows *and* the triggers, on the path a caller actually takes.

## Verified locally

Core 216, SQLite 432, PostgreSQL 885, SQL Server 448, Oracle 266, MySQL 283, EF Core 106. No failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)