### PR TITLE
feat: stored procedures on PostgreSQL, MySQL and Oracle

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -61,7 +61,8 @@ export default withMermaid(
             { text: 'Provider Trait Matrix', link: '/core/provider-trait-matrix' },
             { text: 'Object Type Support', link: '/core/object-types' },
             { text: 'Identifiers & Quoting', link: '/core/identifiers' },
-            { text: 'Triggers', link: '/core/triggers' }
+            { text: 'Triggers', link: '/core/triggers' },
+            { text: 'Stored Procedures', link: '/core/procedures' }
           ]
         },
         {

--- a/docs/core/object-types.md
+++ b/docs/core/object-types.md
@@ -25,7 +25,7 @@ Three symbols, and the distinction between the last two matters:
 | View | ✓ | ✓ | ✓ | ✓ | ✓ |
 | Materialized view | ✓ | — | ✗ | — | — |
 | Function | ✓ | ✓ | ✗ | ✗ | connection-scoped |
-| Stored procedure | ✗ | ✓ | ✗ | ✗ | — |
+| Stored procedure | ✓ | ✓ | ✓ | ✓ | — |
 | Trigger | ✓ | ✓ | ✓ | ✓ | ✓ |
 | Package | — | — | ✗ | — | — |
 | Synonym | — | ✗ | ✗ | — | — |
@@ -36,7 +36,7 @@ Three symbols, and the distinction between the last two matters:
 ### Reading the gaps
 
 - **Triggers** are modelled as independent schema objects that declare a target rather than as something a table owns, which is why they are a row here and not part of the table row. A trigger does not always have a table — SQL Server's `INSTEAD OF` triggers attach to views — and PostgreSQL's call a function, so they compose with `Function` rather than carrying their own body. See [Triggers](/core/triggers).
-- **Functions on Oracle and MySQL, and stored procedures on PostgreSQL, MySQL and Oracle**, are [#450](https://github.com/JasperFx/weasel/issues/450) and [#451](https://github.com/JasperFx/weasel/issues/451).
+- **Functions on Oracle and MySQL** are [#450](https://github.com/JasperFx/weasel/issues/450). Stored procedures are on all four engines that have them; SQLite has no such concept.
 - **The long tail** — Oracle packages, materialized views and synonyms, SQL Server synonyms, PostgreSQL user-defined types — is [#453](https://github.com/JasperFx/weasel/issues/453).
 - **PostgreSQL materialized views already work**, through `Weasel.Postgresql.Views.MaterializedView`, which is `View` with a different `ViewType` and an optional access method. That row was ✗ in the first draft of this page and the check below caught it on its first run, which is the argument for the check.
 

--- a/docs/core/procedures.md
+++ b/docs/core/procedures.md
@@ -1,0 +1,75 @@
+# Stored Procedures
+
+Stored procedures work on the four engines that have them. SQLite does not — it has no such
+concept, and `Weasel.Sqlite.Functions` registers connection-scoped functions rather than modelling
+a schema object.
+
+## You supply the whole statement
+
+```csharp
+var procedure = new StoredProcedure("audit.stamp", @"
+CREATE OR REPLACE PROCEDURE audit.stamp(n int) LANGUAGE plpgsql AS $$
+BEGIN
+    INSERT INTO audit.log (note) VALUES ('touched');
+END;
+$$;");
+
+await procedure.ApplyChangesAsync(connection);
+```
+
+The body is the complete `CREATE PROCEDURE …` statement, not just the procedure's contents. That
+is how [functions](/postgresql/functions) already work, and it is what lets you write the
+parameter list, the language clause and whatever option flags your engine supports without Weasel
+modelling any of it.
+
+`StoredProcedureBase` in `Weasel.Core` owns the shared parts: the statement, the removal flag,
+canonicalization for comparison, and the delta shape. Each provider supplies its drop statement,
+its catalog query, and whatever its engine does to the statement on the way in.
+
+## Comparison is against what the catalog actually stores
+
+This is where the engines differ, and where a careless implementation reports drift forever.
+
+| Provider | Compared against | The catalog stores |
+| --- | --- | --- |
+| PostgreSQL | `pg_proc.prosrc` | the body verbatim, between the dollar quotes |
+| SQL Server | `sys.sql_modules.definition` | the statement verbatim |
+| Oracle | `all_source`, joined by line | the source from `PROCEDURE` onward, without the schema qualifier |
+| MySQL | `information_schema.ROUTINES.action_statement` | the body from `BEGIN` onward |
+
+Two of those needed measuring rather than assuming:
+
+**PostgreSQL does not store the header.** `pg_get_functiondef` *renders* it — `(n int, tag text)`
+comes back as `(IN n integer, IN tag text)`, and `$$` becomes `$procedure$`. Comparing against that
+would report a change on every check for any procedure not written in PostgreSQL's own spelling.
+So Weasel compares `prosrc`, and takes your body from between the outermost dollar quotes, which is
+unambiguous by construction.
+
+**Oracle stores neither the `CREATE OR REPLACE` wrapper nor the schema qualifier.** A statement
+reading `CREATE OR REPLACE PROCEDURE WEASEL.sp_stamp IS` comes back as `PROCEDURE\t sp_stamp IS` —
+tab included. Both are stripped before comparing, and any run of whitespace collapses to one space.
+
+::: warning PostgreSQL overloads on the signature
+Changing a procedure's **parameter list** does not change that procedure — PostgreSQL creates a
+second one and leaves the first in place. Weasel reports the new signature as `Create`; the old
+procedure is still there and still yours to drop.
+:::
+
+## Applying a change
+
+| Provider | How |
+| --- | --- |
+| PostgreSQL | `CREATE OR REPLACE PROCEDURE` |
+| Oracle | `CREATE OR REPLACE PROCEDURE` |
+| SQL Server | `CREATE OR ALTER PROCEDURE`, via `WriteCreateOrAlterStatement` |
+| MySQL | drop, then create — it has no replace form |
+
+Oracle's delta emits only the `CREATE OR REPLACE`, because its drop has to be an anonymous PL/SQL
+block and ODP.NET cannot execute a block and a DDL statement as one command.
+
+## MySQL and semicolons
+
+A procedure body is full of them, and MySQL's migrator used to split delta SQL on semicolons and
+execute the fragments — which shredded every `BEGIN … END` block it saw. It no longer splits;
+MySqlConnector executes several statements from one command perfectly well. Fixed in
+[#452](https://github.com/JasperFx/weasel/issues/452) for triggers, which have the same shape.

--- a/src/Weasel.Core.Tests/object_type_support_matrix.cs
+++ b/src/Weasel.Core.Tests/object_type_support_matrix.cs
@@ -48,6 +48,7 @@ public class object_type_support_matrix
         ("Postgresql", "Function", "Weasel.Postgresql.Functions.Function"),
         ("Postgresql", "Extension", "Weasel.Postgresql.Extension"),
         ("Postgresql", "Trigger", "Weasel.Postgresql.Triggers.Trigger"),
+        ("Postgresql", "StoredProcedure", "Weasel.Postgresql.Procedures.StoredProcedure"),
 
         ("SqlServer", "Table", "Weasel.SqlServer.Tables.Table"),
         ("SqlServer", "Sequence", "Weasel.SqlServer.Sequence"),
@@ -61,11 +62,13 @@ public class object_type_support_matrix
         ("Oracle", "Sequence", "Weasel.Oracle.Sequence"),
         ("Oracle", "View", "Weasel.Oracle.Views.View"),
         ("Oracle", "Trigger", "Weasel.Oracle.Triggers.Trigger"),
+        ("Oracle", "StoredProcedure", "Weasel.Oracle.Procedures.StoredProcedure"),
 
         ("MySql", "Table", "Weasel.MySql.Tables.Table"),
         ("MySql", "Sequence", "Weasel.MySql.Sequence"),
         ("MySql", "View", "Weasel.MySql.Views.View"),
         ("MySql", "Trigger", "Weasel.MySql.Triggers.Trigger"),
+        ("MySql", "StoredProcedure", "Weasel.MySql.Procedures.StoredProcedure"),
 
         ("Sqlite", "Table", "Weasel.Sqlite.Tables.Table"),
         ("Sqlite", "View", "Weasel.Sqlite.Views.View"),
@@ -89,9 +92,6 @@ public class object_type_support_matrix
     public static TheoryData<string, string, string> NotSupported =>
         new()
         {
-            { "Postgresql", "Weasel.Postgresql.Procedures.StoredProcedure", "#451" },
-            { "MySql", "Weasel.MySql.Procedures.StoredProcedure", "#451" },
-            { "Oracle", "Weasel.Oracle.Procedures.StoredProcedure", "#451" },
             { "Oracle", "Weasel.Oracle.Functions.Function", "#450" },
             { "Oracle", "Weasel.Oracle.Views.MaterializedView", "#453" },
             { "MySql", "Weasel.MySql.Functions.Function", "#450" }

--- a/src/Weasel.Core/StoredProcedureBase.cs
+++ b/src/Weasel.Core/StoredProcedureBase.cs
@@ -1,0 +1,154 @@
+using System.Data.Common;
+using System.Text.RegularExpressions;
+using JasperFx.Core;
+
+namespace Weasel.Core;
+
+/// <summary>
+///     Cross-provider base for a stored procedure, alongside <see cref="FunctionBase" /> and
+///     <see cref="ViewBase" />.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Lifted from <c>Weasel.SqlServer.Procedures.StoredProcedure</c>, which implemented
+///         <see cref="ISchemaObject" /> directly and so gave a second provider nothing to reuse
+///         (weasel#451). The base came first, with the working implementation refitted onto it, so
+///         the abstraction was validated against something real before three more providers
+///         depended on it.
+///     </para>
+///     <para>
+///         The body is the whole <c>CREATE PROCEDURE …</c> statement rather than just the
+///         procedure's contents. That is how <see cref="FunctionBase" /> already works, and it is
+///         what lets a caller write the parameter list, the language clause and the option flags
+///         their engine supports without Weasel modelling any of it.
+///     </para>
+/// </remarks>
+public abstract class StoredProcedureBase: SchemaObjectBase
+{
+    protected StoredProcedureBase(DbObjectName identifier) : base(identifier)
+    {
+    }
+
+    protected StoredProcedureBase(DbObjectName identifier, string body) : base(identifier)
+    {
+        RawBody = body;
+    }
+
+    /// <summary>
+    ///     The statement the procedure was constructed with, or <c>null</c> when a subclass
+    ///     generates it instead through <see cref="GenerateBody" />.
+    /// </summary>
+    protected string? RawBody { get; }
+
+    /// <summary>
+    ///     True when this procedure has been marked for removal. A removed procedure emits no
+    ///     create statement, and its delta reports the drop.
+    /// </summary>
+    public bool IsRemoved { get; set; }
+
+    public override void WriteCreateStatement(Migrator migrator, TextWriter writer)
+    {
+        if (IsRemoved)
+        {
+            return;
+        }
+
+        writer.WriteLine(BodyText());
+    }
+
+    /// <summary>
+    ///     The create statement as text, whether it came from the constructor or from
+    ///     <see cref="GenerateBody" />.
+    /// </summary>
+    public string BodyText()
+    {
+        if (RawBody.IsNotEmpty())
+        {
+            return RawBody!;
+        }
+
+        var writer = new StringWriter();
+        GenerateBody(writer);
+        return writer.ToString();
+    }
+
+    /// <summary>
+    ///     Subclasses that build their statement rather than being handed one override this.
+    ///     Throwing is the right default: a procedure with neither a body nor a generator has
+    ///     nothing to create.
+    /// </summary>
+    protected virtual void GenerateBody(TextWriter writer)
+        => throw new NotSupportedException(
+            $"Stored procedure {Identifier} was constructed without a body, so a subclass has to "
+            + $"override {nameof(GenerateBody)} to supply one.");
+
+    /// <summary>
+    ///     Normalize the statement for comparison against what the catalog stores: trim every line,
+    ///     drop the blank ones, and collapse runs of spaces. Every engine reformats what it keeps to
+    ///     some degree, and none of those differences change what the procedure does.
+    /// </summary>
+    public string CanonicizeSql() => Canonicize(BodyText());
+
+    public static string Canonicize(string sql)
+        => sql.ReadLines()
+            .Select(x => Whitespace.Replace(x, " ").Trim())
+            .Where(x => x.IsNotEmpty())
+            .Join(Environment.NewLine);
+
+    /// <summary>
+    ///     Any run of whitespace collapses to one space. Oracle stores <c>PROCEDURE\t name</c> with
+    ///     a tab where the caller wrote a space, and none of these engines treat the difference as
+    ///     meaningful.
+    /// </summary>
+    private static readonly Regex Whitespace = new(@"\s+", RegexOptions.Compiled);
+
+    public override async Task<ISchemaObjectDelta> CreateDeltaAsync(
+        DbDataReader reader, CancellationToken ct = default)
+    {
+        var existing = await ReadExistingAsync(reader, ct).ConfigureAwait(false);
+        return CreateDelta(existing);
+    }
+
+    /// <summary>
+    ///     Read the procedure's stored statement out of the catalog query, or <c>null</c> when it
+    ///     does not exist.
+    /// </summary>
+    protected virtual async Task<string?> ReadExistingAsync(DbDataReader reader, CancellationToken ct)
+    {
+        if (!await reader.ReadAsync(ct).ConfigureAwait(false)) return null;
+        if (await reader.IsDBNullAsync(0, ct).ConfigureAwait(false)) return null;
+
+        var body = await reader.GetFieldValueAsync<string>(0, ct).ConfigureAwait(false);
+        return body.IsEmpty() ? null : body;
+    }
+
+    /// <summary>
+    ///     Compare what the catalog holds against what this procedure would create. Subclasses
+    ///     override when the engine rewrites the statement enough that a canonicalized comparison
+    ///     needs help.
+    /// </summary>
+    protected virtual ISchemaObjectDelta CreateDelta(string? existing)
+    {
+        if (IsRemoved)
+        {
+            return new SchemaObjectDelta(this,
+                existing == null ? SchemaPatchDifference.None : SchemaPatchDifference.Update);
+        }
+
+        if (existing == null)
+        {
+            return new SchemaObjectDelta(this, SchemaPatchDifference.Create);
+        }
+
+        return Matches(existing)
+            ? new SchemaObjectDelta(this, SchemaPatchDifference.None)
+            : new SchemaObjectDelta(this, SchemaPatchDifference.Update);
+    }
+
+    /// <summary>
+    ///     Whether the catalog's rendering is this same procedure. Case-insensitive, because SQL
+    ///     keywords are.
+    /// </summary>
+    protected virtual bool Matches(string existing)
+        => Canonicize(existing).Equals(CanonicizeSql(), StringComparison.OrdinalIgnoreCase);
+}

--- a/src/Weasel.MySql.Tests/Procedures/StoredProcedureTests.cs
+++ b/src/Weasel.MySql.Tests/Procedures/StoredProcedureTests.cs
@@ -1,0 +1,121 @@
+using MySqlConnector;
+using Shouldly;
+using Weasel.Core;
+using Weasel.MySql.Procedures;
+using Weasel.MySql.Tables;
+using Xunit;
+
+namespace Weasel.MySql.Tests.Procedures;
+
+/// <summary>
+///     MySQL stored procedure support (weasel#451). MySQL stores a routine's body verbatim in
+///     <c>information_schema.ROUTINES.ROUTINE_DEFINITION</c> — unlike a view definition, which it
+///     rewrites — so comparison is a straight match on the body.
+/// </summary>
+/// <remarks>
+///     A procedure body is the case that made the migrator stop splitting delta SQL on semicolons
+///     in weasel#452: every <c>BEGIN … END</c> block it saw got shredded.
+/// </remarks>
+[Collection("integration")]
+public class StoredProcedureTests: IAsyncLifetime
+{
+    private const string SchemaName = "weasel_testing";
+
+    private MySqlConnection theConnection = default!;
+
+    public async ValueTask InitializeAsync()
+    {
+        var builder = new MySqlConnectionStringBuilder(ConnectionSource.ConnectionString)
+        {
+            UserID = "root", Password = "P@55w0rd", Database = SchemaName
+        };
+
+        theConnection = new MySqlConnection(builder.ConnectionString);
+        await theConnection.OpenAsync();
+        await cleanupAsync();
+
+        var table = new Table($"{SchemaName}.sp_log");
+        table.AddColumn<int>("id").AsPrimaryKey().AutoIncrement();
+        table.AddColumn<string>("note");
+        await table.ApplyChangesAsync(theConnection);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await cleanupAsync();
+        await theConnection.CloseAsync();
+        await theConnection.DisposeAsync();
+    }
+
+    private async Task cleanupAsync()
+    {
+        await theConnection.CreateCommand($"DROP PROCEDURE IF EXISTS `{SchemaName}`.`sp_stamp`")
+            .ExecuteNonQueryAsync();
+        await theConnection.CreateCommand($"DROP TABLE IF EXISTS `{SchemaName}`.`sp_log`")
+            .ExecuteNonQueryAsync();
+    }
+
+    private static StoredProcedure NewProcedure(string note = "touched") => new(
+        $"{SchemaName}.sp_stamp",
+        $@"CREATE PROCEDURE `{SchemaName}`.`sp_stamp`()
+BEGIN
+    INSERT INTO `{SchemaName}`.`sp_log` (note) VALUES ('{note}');
+END");
+
+    [Fact]
+    public void the_body_is_taken_from_the_first_begin()
+    {
+        StoredProcedure.ExtractBody("CREATE PROCEDURE x() BEGIN SELECT 1; END;")
+            .ShouldBe("BEGIN SELECT 1; END");
+    }
+
+    [Fact]
+    public async Task a_procedure_round_trips_and_reports_no_delta()
+    {
+        var procedure = NewProcedure();
+        await procedure.ApplyChangesAsync(theConnection);
+
+        (await procedure.ExistsInDatabaseAsync(theConnection)).ShouldBeTrue();
+        (await procedure.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task an_unchanged_procedure_does_not_report_permanent_drift()
+    {
+        await NewProcedure().ApplyChangesAsync(theConnection);
+
+        (await NewProcedure().FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+        (await NewProcedure().FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    /// <summary>
+    ///     The body contains semicolons, which is the whole point: the migrator used to split delta
+    ///     SQL on them and execute the fragments.
+    /// </summary>
+    [Fact]
+    public async Task the_procedure_actually_runs()
+    {
+        await NewProcedure().ApplyChangesAsync(theConnection);
+
+        await theConnection.CreateCommand($"CALL `{SchemaName}`.`sp_stamp`()").ExecuteNonQueryAsync();
+
+        var note = await theConnection.CreateCommand($"SELECT note FROM `{SchemaName}`.`sp_log` LIMIT 1")
+            .ExecuteScalarAsync();
+
+        note.ShouldBe("touched");
+    }
+
+    [Fact]
+    public async Task a_changed_body_reports_update_and_applying_it_converges()
+    {
+        await NewProcedure().ApplyChangesAsync(theConnection);
+
+        var changed = NewProcedure("changed");
+
+        (await changed.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.Update);
+
+        await changed.ApplyChangesAsync(theConnection);
+
+        (await changed.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+}

--- a/src/Weasel.MySql/Procedures/StoredProcedure.cs
+++ b/src/Weasel.MySql/Procedures/StoredProcedure.cs
@@ -1,0 +1,93 @@
+using JasperFx.Core;
+using MySqlConnector;
+using Weasel.Core;
+using DbCommandBuilder = Weasel.Core.DbCommandBuilder;
+
+namespace Weasel.MySql.Procedures;
+
+/// <summary>
+///     A MySQL stored procedure.
+/// </summary>
+/// <remarks>
+///     <para>
+///         MySQL stores a routine's body verbatim in
+///         <c>information_schema.ROUTINES.ROUTINE_DEFINITION</c> — unlike a view definition, which
+///         it rewrites — so comparison is a straight canonicalized match on the body. The stored
+///         value is the body alone, without the <c>CREATE PROCEDURE …</c> header, so the caller's
+///         statement is trimmed to its <c>BEGIN</c> before comparing.
+///     </para>
+///     <para>
+///         There is no <c>CREATE OR REPLACE PROCEDURE</c>, so a change is a drop followed by a
+///         create. Both go to the server in one command; MySqlConnector executes them in order,
+///         which is what weasel#452 stopped the migrator from breaking by splitting delta SQL on
+///         semicolons.
+///     </para>
+/// </remarks>
+public class StoredProcedure: StoredProcedureBase
+{
+    public StoredProcedure(string name, string body)
+        : this(DbObjectName.Parse(MySqlProvider.Instance, name), body)
+    {
+    }
+
+    public StoredProcedure(DbObjectName identifier, string body): base(identifier, body)
+    {
+    }
+
+    public override void WriteCreateStatement(Migrator migrator, TextWriter writer)
+    {
+        if (IsRemoved)
+        {
+            return;
+        }
+
+        WriteDropStatement(migrator, writer);
+        writer.WriteLine(BodyText());
+    }
+
+    public override void WriteDropStatement(Migrator rules, TextWriter writer)
+    {
+        writer.WriteLine($"DROP PROCEDURE IF EXISTS {QualifiedName()};");
+    }
+
+    public override void ConfigureQueryCommand(DbCommandBuilder builder)
+    {
+        var schemaParam = builder.AddParameter(Identifier.Schema).ParameterName;
+        var nameParam = builder.AddParameter(Identifier.Name).ParameterName;
+
+        builder.Append(
+            "SELECT routine_definition FROM information_schema.ROUTINES "
+            + $"WHERE routine_type = 'PROCEDURE' AND routine_schema = @{schemaParam} AND routine_name = @{nameParam}");
+    }
+
+    /// <inheritdoc />
+    protected override bool Matches(string existing)
+        => Canonicize(existing).Equals(Canonicize(ExtractBody(BodyText())), StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    ///     Everything from the first <c>BEGIN</c>, which is what <c>ROUTINE_DEFINITION</c> stores.
+    /// </summary>
+    internal static string ExtractBody(string statement)
+    {
+        var index = statement.IndexOf("BEGIN", StringComparison.OrdinalIgnoreCase);
+        return index < 0 ? statement : statement[index..].TrimEnd().TrimEnd(';');
+    }
+
+    private string QualifiedName()
+        => $"{SchemaUtils.QuoteName(Identifier.Schema)}.{SchemaUtils.QuoteName(Identifier.Name)}";
+
+    public async Task<string?> FetchExistingBodyAsync(MySqlConnection conn, CancellationToken ct = default)
+    {
+        var builder = new DbCommandBuilder(conn);
+        ConfigureQueryCommand(builder);
+
+        await using var reader = await conn.ExecuteReaderAsync(builder, ct).ConfigureAwait(false);
+        var body = await ReadExistingAsync(reader, ct).ConfigureAwait(false);
+        await reader.CloseAsync().ConfigureAwait(false);
+
+        return body;
+    }
+
+    public async Task<bool> ExistsInDatabaseAsync(MySqlConnection conn, CancellationToken ct = default)
+        => await FetchExistingBodyAsync(conn, ct).ConfigureAwait(false) != null;
+}

--- a/src/Weasel.Oracle.Tests/Procedures/StoredProcedureTests.cs
+++ b/src/Weasel.Oracle.Tests/Procedures/StoredProcedureTests.cs
@@ -1,0 +1,115 @@
+using Shouldly;
+using Weasel.Core;
+using Weasel.Oracle.Procedures;
+using Weasel.Oracle.Tables;
+using Xunit;
+
+namespace Weasel.Oracle.Tests.Procedures;
+
+/// <summary>
+///     Oracle stored procedure support (weasel#451). Oracle keeps the source verbatim in
+///     <c>all_source</c>, one row per line — and without the <c>CREATE OR REPLACE</c> prefix, which
+///     is a wrapper on the statement rather than part of the object.
+/// </summary>
+[Collection("integration")]
+public class StoredProcedureTests: IntegrationContext
+{
+    private const string SchemaName = "WEASEL";
+
+    public StoredProcedureTests(): base(SchemaName)
+    {
+    }
+
+    private static StoredProcedure NewProcedure(string note = "touched") => new(
+        $"{SchemaName}.sp_stamp",
+        $@"CREATE OR REPLACE PROCEDURE {SchemaName}.sp_stamp IS
+BEGIN
+    INSERT INTO {SchemaName}.sp_log (id, note) VALUES (1, '{note}');
+END;");
+
+    private async Task createLogTableAsync()
+    {
+        var table = new Table($"{SchemaName}.sp_log");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn<string>("note");
+        await table.ApplyChangesAsync(theConnection);
+    }
+
+    /// <summary>
+    ///     Oracle stores neither the <c>CREATE OR REPLACE</c> wrapper nor the schema qualifier: the
+    ///     owner is already the <c>all_source</c> row's own column.
+    /// </summary>
+    [Fact]
+    public void the_create_or_replace_prefix_and_the_schema_qualifier_are_stripped()
+    {
+        StoredProcedure.StripCreateOrReplace("CREATE OR REPLACE PROCEDURE WEASEL.x IS BEGIN NULL; END;", "WEASEL")
+            .ShouldStartWith("PROCEDURE x");
+    }
+
+    [Fact]
+    public async Task a_procedure_round_trips_and_reports_no_delta()
+    {
+        await ResetSchema();
+        await createLogTableAsync();
+
+        var procedure = NewProcedure();
+        await procedure.ApplyChangesAsync(theConnection);
+
+        (await procedure.ExistsInDatabaseAsync(theConnection)).ShouldBeTrue();
+        (await procedure.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task an_unchanged_procedure_does_not_report_permanent_drift()
+    {
+        await ResetSchema();
+        await createLogTableAsync();
+        await NewProcedure().ApplyChangesAsync(theConnection);
+
+        (await NewProcedure().FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+        (await NewProcedure().FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task the_procedure_actually_runs()
+    {
+        await ResetSchema();
+        await createLogTableAsync();
+        await NewProcedure().ApplyChangesAsync(theConnection);
+
+        await theConnection.CreateCommand($"BEGIN {SchemaName}.sp_stamp; END;").ExecuteNonQueryAsync();
+
+        var note = await theConnection.CreateCommand($"SELECT note FROM {SchemaName}.sp_log WHERE ROWNUM = 1")
+            .ExecuteScalarAsync();
+
+        note.ShouldBe("touched");
+    }
+
+    [Fact]
+    public async Task a_changed_body_reports_update_and_applying_it_converges()
+    {
+        await ResetSchema();
+        await createLogTableAsync();
+        await NewProcedure().ApplyChangesAsync(theConnection);
+
+        var changed = NewProcedure("changed");
+
+        (await changed.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.Update);
+
+        await changed.ApplyChangesAsync(theConnection);
+
+        (await changed.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task dropping_the_schema_takes_its_procedures_with_it()
+    {
+        await ResetSchema();
+        await createLogTableAsync();
+        await NewProcedure().ApplyChangesAsync(theConnection);
+
+        await ResetSchema();
+
+        (await NewProcedure().ExistsInDatabaseAsync(theConnection)).ShouldBeFalse();
+    }
+}

--- a/src/Weasel.Oracle/Procedures/StoredProcedure.cs
+++ b/src/Weasel.Oracle/Procedures/StoredProcedure.cs
@@ -1,0 +1,161 @@
+using System.Text.RegularExpressions;
+using JasperFx.Core;
+using Oracle.ManagedDataAccess.Client;
+using Weasel.Core;
+using DbCommandBuilder = Weasel.Core.DbCommandBuilder;
+
+namespace Weasel.Oracle.Procedures;
+
+/// <summary>
+///     An Oracle stored procedure.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Oracle keeps the source verbatim, one row per line, in <c>all_source</c> — and without
+///         the <c>CREATE OR REPLACE</c> prefix, which is a wrapper on the statement rather than part
+///         of the object. The caller's statement is stripped of that prefix before comparing.
+///     </para>
+///     <para>
+///         A procedure inside a package is a different object and is not this — see weasel#453.
+///     </para>
+/// </remarks>
+public class StoredProcedure: StoredProcedureBase
+{
+    public StoredProcedure(string name, string body)
+        : this(DbObjectName.Parse(OracleProvider.Instance, name), body)
+    {
+    }
+
+    public StoredProcedure(DbObjectName identifier, string body): base(identifier, body)
+    {
+    }
+
+    public override void WriteDropStatement(Migrator rules, TextWriter writer)
+    {
+        // No DROP PROCEDURE IF EXISTS on Oracle, so swallow "object does not exist" the way the
+        // rest of the provider does.
+        writer.WriteLine($@"BEGIN
+    EXECUTE IMMEDIATE 'DROP PROCEDURE {SchemaUtils.EscapeLiteral(Identifier.QualifiedName)}';
+EXCEPTION
+    WHEN OTHERS THEN IF SQLCODE != -4043 THEN RAISE; END IF;
+END;");
+    }
+
+    public override void ConfigureQueryCommand(DbCommandBuilder builder)
+    {
+        var schemaParam = builder.AddParameter(Identifier.Schema.ToUpperInvariant()).ParameterName;
+        var nameParam = builder.AddParameter(Identifier.Name.ToUpperInvariant()).ParameterName;
+
+        // LISTAGG rather than reading the rows, so this stays one result set like every other
+        // schema object's query.
+        builder.Append(
+            "SELECT LISTAGG(text, '') WITHIN GROUP (ORDER BY line) FROM all_source "
+            + $"WHERE owner = :{schemaParam} AND name = :{nameParam} AND type = 'PROCEDURE'");
+    }
+
+    /// <inheritdoc />
+    protected override bool Matches(string existing)
+        => Canonicize(existing)
+            .Equals(Canonicize(StripCreateOrReplace(BodyText(), Identifier.Schema)),
+                StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    ///     Reduce the caller's statement to what <c>all_source</c> actually stores.
+    /// </summary>
+    /// <remarks>
+    ///     Two things go. The <c>CREATE OR REPLACE</c> is a wrapper on the statement rather than
+    ///     part of the object, so Oracle keeps the source from <c>PROCEDURE</c> onwards. And the
+    ///     schema qualifier goes with it — a procedure's source names it bare, because the owner is
+    ///     already the row's <c>owner</c> column. Measured, not assumed: Oracle stores
+    ///     <c>PROCEDURE\t sp_stamp IS</c> for a statement that said
+    ///     <c>CREATE OR REPLACE PROCEDURE WEASEL.sp_stamp IS</c>.
+    /// </remarks>
+    internal static string StripCreateOrReplace(string statement, string? schema = null)
+    {
+        var index = statement.IndexOf("PROCEDURE", StringComparison.OrdinalIgnoreCase);
+        var source = (index < 0 ? statement : statement[index..]).TrimEnd().TrimEnd('/').TrimEnd();
+
+        return schema.IsEmpty()
+            ? source
+            : Regex.Replace(source, $@"(?<=PROCEDURE\s+){Regex.Escape(schema!)}\s*\.\s*", "",
+                RegexOptions.IgnoreCase);
+    }
+
+    /// <summary>
+    ///     <c>CREATE OR REPLACE PROCEDURE</c> does the whole job, so an update is that statement
+    ///     alone.
+    /// </summary>
+    /// <remarks>
+    ///     The default delta writes a DROP first, and Oracle's drop has to be an anonymous PL/SQL
+    ///     block — so the pair arrives as a block followed by a DDL statement, which ODP.NET cannot
+    ///     execute as one command (PLS-00103). The same trap the Oracle view and trigger slices hit.
+    /// </remarks>
+    protected override ISchemaObjectDelta CreateDelta(string? existing)
+    {
+        if (IsRemoved)
+        {
+            return new StoredProcedureDelta(this,
+                existing == null ? SchemaPatchDifference.None : SchemaPatchDifference.Update);
+        }
+
+        if (existing == null)
+        {
+            return new StoredProcedureDelta(this, SchemaPatchDifference.Create);
+        }
+
+        return new StoredProcedureDelta(this,
+            Matches(existing) ? SchemaPatchDifference.None : SchemaPatchDifference.Update);
+    }
+
+    public async Task<string?> FetchExistingSourceAsync(OracleConnection conn, CancellationToken ct = default)
+    {
+        var builder = new DbCommandBuilder(conn);
+        ConfigureQueryCommand(builder);
+
+        await using var reader = await conn.ExecuteReaderAsync(builder, ct).ConfigureAwait(false);
+        var source = await ReadExistingAsync(reader, ct).ConfigureAwait(false);
+        await reader.CloseAsync().ConfigureAwait(false);
+
+        return source;
+    }
+
+    public async Task<bool> ExistsInDatabaseAsync(OracleConnection conn, CancellationToken ct = default)
+        => await FetchExistingSourceAsync(conn, ct).ConfigureAwait(false) != null;
+}
+
+/// <summary>
+///     Oracle applies a procedure change with <c>CREATE OR REPLACE PROCEDURE</c> alone — one
+///     statement, which is all Oracle's migrator can execute per delta.
+/// </summary>
+internal class StoredProcedureDelta: ISchemaObjectDelta
+{
+    private readonly StoredProcedure _procedure;
+
+    public StoredProcedureDelta(StoredProcedure procedure, SchemaPatchDifference difference)
+    {
+        _procedure = procedure;
+        Difference = difference;
+    }
+
+    public ISchemaObject SchemaObject => _procedure;
+
+    public SchemaPatchDifference Difference { get; }
+
+    public void WriteUpdate(Migrator rules, TextWriter writer)
+    {
+        if (_procedure.IsRemoved)
+        {
+            _procedure.WriteDropStatement(rules, writer);
+            return;
+        }
+
+        _procedure.WriteCreateStatement(rules, writer);
+    }
+
+    public void WriteRollback(Migrator rules, TextWriter writer)
+    {
+    }
+
+    public void WriteRestorationOfPreviousState(Migrator rules, TextWriter writer)
+        => throw new NotSupportedException();
+}

--- a/src/Weasel.Postgresql.Tests/Procedures/StoredProcedureTests.cs
+++ b/src/Weasel.Postgresql.Tests/Procedures/StoredProcedureTests.cs
@@ -1,0 +1,123 @@
+using Shouldly;
+using Weasel.Core;
+using Weasel.Postgresql.Procedures;
+using Xunit;
+
+namespace Weasel.Postgresql.Tests.Procedures;
+
+/// <summary>
+///     PostgreSQL stored procedure support (weasel#451). Real <c>PROCEDURE</c> objects, distinct
+///     from functions: no return value, and they can manage transactions.
+/// </summary>
+[Collection("procedures")]
+public class StoredProcedureTests: IntegrationContext
+{
+    public StoredProcedureTests(): base("procedures")
+    {
+    }
+
+    private static StoredProcedure NewProcedure(string note = "touched") => new(
+        "procedures.stamp",
+        $@"CREATE OR REPLACE PROCEDURE procedures.stamp(n int) LANGUAGE plpgsql AS $$
+BEGIN
+    INSERT INTO procedures.log (note) VALUES ('{note}');
+END;
+$$;");
+
+    private async Task createLogTableAsync()
+    {
+        await theConnection.CreateCommand(
+                "create table procedures.log (id serial primary key, note varchar(100))")
+            .ExecuteNonQueryAsync();
+    }
+
+    /// <summary>
+    ///     The reason comparison uses <c>prosrc</c> rather than <c>pg_get_functiondef</c>: the body
+    ///     comes back verbatim, and dollar quoting makes extracting it from the caller's statement
+    ///     unambiguous.
+    /// </summary>
+    [Fact]
+    public void the_body_is_taken_from_between_the_dollar_quotes()
+    {
+        StoredProcedure.ExtractBody("CREATE PROCEDURE x() AS $$ BEGIN NULL; END; $$;")
+            .Trim().ShouldBe("BEGIN NULL; END;");
+    }
+
+    [Fact]
+    public void a_tagged_dollar_quote_is_handled_too()
+    {
+        StoredProcedure.ExtractBody("CREATE PROCEDURE x() AS $body$ BEGIN NULL; END; $body$;")
+            .Trim().ShouldBe("BEGIN NULL; END;");
+    }
+
+    [Fact]
+    public async Task a_procedure_round_trips_and_reports_no_delta()
+    {
+        await ResetSchema();
+        await createLogTableAsync();
+
+        var procedure = NewProcedure();
+        await procedure.ApplyChangesAsync(theConnection);
+
+        (await procedure.ExistsInDatabaseAsync(theConnection)).ShouldBeTrue();
+        (await procedure.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    /// <summary>
+    ///     Checked twice, because comparing against PostgreSQL's rendered definition rather than the
+    ///     stored body would pass once and then report drift forever.
+    /// </summary>
+    [Fact]
+    public async Task an_unchanged_procedure_does_not_report_permanent_drift()
+    {
+        await ResetSchema();
+        await createLogTableAsync();
+        await NewProcedure().ApplyChangesAsync(theConnection);
+
+        (await NewProcedure().FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+        (await NewProcedure().FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task the_procedure_actually_runs()
+    {
+        await ResetSchema();
+        await createLogTableAsync();
+        await NewProcedure().ApplyChangesAsync(theConnection);
+
+        await theConnection.CreateCommand("call procedures.stamp(1)").ExecuteNonQueryAsync();
+
+        var note = await theConnection.CreateCommand("select note from procedures.log limit 1")
+            .ExecuteScalarAsync();
+
+        note.ShouldBe("touched");
+    }
+
+    [Fact]
+    public async Task a_changed_body_reports_update_and_applying_it_converges()
+    {
+        await ResetSchema();
+        await createLogTableAsync();
+        await NewProcedure().ApplyChangesAsync(theConnection);
+
+        var changed = NewProcedure("changed");
+
+        (await changed.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.Update);
+
+        await changed.ApplyChangesAsync(theConnection);
+
+        (await changed.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task dropping_the_schema_takes_its_procedures_with_it()
+    {
+        await ResetSchema();
+        await createLogTableAsync();
+        await NewProcedure().ApplyChangesAsync(theConnection);
+
+        await ResetSchema();
+
+        (await NewProcedure().ExistsInDatabaseAsync(theConnection)).ShouldBeFalse();
+    }
+}

--- a/src/Weasel.Postgresql/Procedures/StoredProcedure.cs
+++ b/src/Weasel.Postgresql/Procedures/StoredProcedure.cs
@@ -1,0 +1,99 @@
+using JasperFx.Core;
+using Npgsql;
+using Weasel.Core;
+using DbCommandBuilder = Weasel.Core.DbCommandBuilder;
+
+namespace Weasel.Postgresql.Procedures;
+
+/// <summary>
+///     A PostgreSQL stored procedure. Real <c>PROCEDURE</c> objects, which PostgreSQL has had since
+///     v11 and which are distinct from functions: no return value, and they can manage transactions.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Comparison is against <c>pg_proc.prosrc</c>, which holds the body exactly as submitted.
+///         <c>pg_get_functiondef</c> is not used, because PostgreSQL renders the header rather than
+///         storing it — <c>(n int, tag text)</c> comes back as <c>(IN n integer, IN tag text)</c>
+///         and <c>$$</c> becomes <c>$procedure$</c> — so comparing against it reports drift on every
+///         check for any procedure not written in PostgreSQL's own spelling. That is the permanent
+///         drift weasel#445 and weasel#446 were about.
+///     </para>
+///     <para>
+///         The caller's body is taken from between the outermost dollar quotes, which is
+///         unambiguous by construction: that is what dollar quoting is for.
+///     </para>
+///     <para>
+///         <strong>A changed parameter list is not a change to this procedure.</strong> PostgreSQL
+///         overloads on the signature, so <c>CREATE OR REPLACE PROCEDURE</c> with different
+///         parameters creates a second procedure and leaves the first one in place. Weasel reports
+///         the new one as <c>Create</c>; the old one is still yours to drop.
+///     </para>
+/// </remarks>
+public class StoredProcedure: StoredProcedureBase
+{
+    public StoredProcedure(string name, string body)
+        : this(DbObjectName.Parse(PostgresqlProvider.Instance, name), body)
+    {
+    }
+
+    public StoredProcedure(DbObjectName identifier, string body): base(identifier, body)
+    {
+    }
+
+    public override void WriteDropStatement(Migrator rules, TextWriter writer)
+    {
+        // No argument list: PostgreSQL accepts a bare name when it is unambiguous, and Weasel does
+        // not model the signature.
+        writer.WriteLine($"DROP PROCEDURE IF EXISTS {Identifier};");
+    }
+
+    public override void ConfigureQueryCommand(DbCommandBuilder builder)
+    {
+        var nameParam = builder.AddParameter(Identifier.Name).ParameterName;
+        var schemaParam = builder.AddParameter(Identifier.Schema).ParameterName;
+
+        builder.Append($@"
+SELECT p.prosrc
+FROM pg_proc p
+JOIN pg_namespace n ON n.oid = p.pronamespace
+WHERE p.prokind = 'p' AND p.proname = :{nameParam} AND n.nspname = :{schemaParam}");
+    }
+
+    /// <inheritdoc />
+    protected override bool Matches(string existing)
+        => Canonicize(existing).Equals(Canonicize(ExtractBody(BodyText())), StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    ///     The contents between the outermost dollar quotes — <c>$$ … $$</c> or a tagged
+    ///     <c>$name$ … $name$</c> — which is what <c>pg_proc.prosrc</c> holds.
+    /// </summary>
+    internal static string ExtractBody(string statement)
+    {
+        var open = statement.IndexOf('$');
+        if (open < 0) return statement;
+
+        var tagEnd = statement.IndexOf('$', open + 1);
+        if (tagEnd < 0) return statement;
+
+        var tag = statement.Substring(open, tagEnd - open + 1);
+        var bodyStart = tagEnd + 1;
+        var close = statement.IndexOf(tag, bodyStart, StringComparison.Ordinal);
+
+        return close < 0 ? statement[bodyStart..] : statement[bodyStart..close];
+    }
+
+    public async Task<string?> FetchExistingBodyAsync(NpgsqlConnection conn, CancellationToken ct = default)
+    {
+        var builder = new DbCommandBuilder(conn);
+        ConfigureQueryCommand(builder);
+
+        await using var reader = await conn.ExecuteReaderAsync(builder, ct).ConfigureAwait(false);
+        var body = await ReadExistingAsync(reader, ct).ConfigureAwait(false);
+        await reader.CloseAsync().ConfigureAwait(false);
+
+        return body;
+    }
+
+    public async Task<bool> ExistsInDatabaseAsync(NpgsqlConnection conn, CancellationToken ct = default)
+        => await FetchExistingBodyAsync(conn, ct).ConfigureAwait(false) != null;
+}

--- a/src/Weasel.SqlServer/Procedures/StoredProcedure.cs
+++ b/src/Weasel.SqlServer/Procedures/StoredProcedure.cs
@@ -1,4 +1,4 @@
-﻿using System.Data.Common;
+using System.Data.Common;
 using JasperFx.Core;
 using Microsoft.Data.SqlClient;
 using Weasel.Core;
@@ -6,41 +6,32 @@ using DbCommandBuilder = Weasel.Core.DbCommandBuilder;
 
 namespace Weasel.SqlServer.Procedures;
 
-public class StoredProcedure: ISchemaObject
+/// <summary>
+///     A SQL Server stored procedure.
+/// </summary>
+/// <remarks>
+///     This was the only stored procedure implementation in the tree, and it implemented
+///     <see cref="ISchemaObject" /> directly rather than deriving from a shared base — so a second
+///     provider had nothing to reuse. weasel#451 lifted the shared parts into
+///     <see cref="StoredProcedureBase" /> and refitted this onto them, without changing what it
+///     emits or how it compares.
+/// </remarks>
+public class StoredProcedure: StoredProcedureBase
 {
-    private readonly string? _body;
-
-    public StoredProcedure(DbObjectName identifier)
+    public StoredProcedure(DbObjectName identifier): base(identifier)
     {
-        Identifier = identifier;
     }
 
-    public StoredProcedure(DbObjectName identifier, string body)
+    public StoredProcedure(DbObjectName identifier, string body): base(identifier, body)
     {
-        Identifier = identifier;
-        _body = body;
     }
 
-    public bool IsRemoved { get; set; }
-
-    public void WriteCreateStatement(Migrator migrator, TextWriter writer)
-    {
-        if (_body.IsNotEmpty())
-        {
-            writer.WriteLine(_body);
-        }
-        else
-        {
-            generateBody(writer);
-        }
-    }
-
-    public void WriteDropStatement(Migrator rules, TextWriter writer)
+    public override void WriteDropStatement(Migrator rules, TextWriter writer)
     {
         writer.WriteLine($"drop procedure if exists {Identifier};");
     }
 
-    public void ConfigureQueryCommand(DbCommandBuilder builder)
+    public override void ConfigureQueryCommand(DbCommandBuilder builder)
     {
         builder.Append($@"
 select
@@ -54,80 +45,34 @@ where
 ");
     }
 
-    public async Task<ISchemaObjectDelta> CreateDeltaAsync(DbDataReader reader, CancellationToken ct = default)
-    {
-        var existing = await readExistingAsync(reader, ct).ConfigureAwait(false);
-        return new StoredProcedureDelta(this, existing);
-    }
+    /// <inheritdoc />
+    protected override ISchemaObjectDelta CreateDelta(string? existing)
+        => new StoredProcedureDelta(this, existing == null ? null : new StoredProcedure(Identifier, existing));
 
-    public IEnumerable<DbObjectName> AllNames()
-    {
-        yield return Identifier;
-    }
-
-    public DbObjectName Identifier { get; }
-
-    protected virtual string generateBody(TextWriter writer)
-    {
-        throw new NotSupportedException(
-            "This must be implemented in subclasses that do not inject the procedure body");
-    }
-
+    /// <summary>
+    ///     <c>CREATE OR ALTER PROCEDURE</c>, which SQL Server has and the other three providers
+    ///     spell differently or not at all.
+    /// </summary>
     public void WriteCreateOrAlterStatement(Migrator rules, TextWriter writer)
     {
-        var body = _body;
-        if (_body.IsEmpty())
-        {
-            var w = new StringWriter();
-            generateBody(w);
-
-            body = w.ToString();
-        }
-
-        body = body!.Replace("CREATE PROCEDURE", "CREATE OR ALTER PROCEDURE");
-        body = body.Replace("create procedure", "create or alter procedure");
+        var body = BodyText()
+            .Replace("CREATE PROCEDURE", "CREATE OR ALTER PROCEDURE")
+            .Replace("create procedure", "create or alter procedure");
 
         writer.WriteLine(body);
-    }
-
-    private async Task<StoredProcedure?> readExistingAsync(DbDataReader reader, CancellationToken ct = default)
-    {
-        if (await reader.ReadAsync(ct).ConfigureAwait(false))
-        {
-            var body = await reader.GetFieldValueAsync<string>(0, ct).ConfigureAwait(false);
-            return new StoredProcedure(Identifier, body);
-        }
-
-        return null;
-    }
-
-    public string CanonicizeSql()
-    {
-        var body = _body;
-        if (_body.IsEmpty())
-        {
-            var writer = new StringWriter();
-            generateBody(writer);
-
-            body = writer.ToString();
-        }
-
-        return body!.ReadLines().Select(x => x.Trim()).Where(x => x.IsNotEmpty())
-            .Select(x => x.Replace("   ", " ")).Join(Environment.NewLine);
     }
 
     public async Task<StoredProcedure?> FetchExistingAsync(SqlConnection conn, CancellationToken ct = default)
     {
         var builder = new DbCommandBuilder(conn);
-
         ConfigureQueryCommand(builder);
 
         await using var reader = await conn.ExecuteReaderAsync(builder, ct).ConfigureAwait(false);
-        var result = await readExistingAsync(reader, ct).ConfigureAwait(false);
+        var body = await ReadExistingAsync(reader, ct).ConfigureAwait(false);
         await reader.CloseAsync().ConfigureAwait(false);
-        return result;
-    }
 
+        return body == null ? null : new StoredProcedure(Identifier, body);
+    }
 
     public async Task<StoredProcedureDelta> FindDeltaAsync(SqlConnection conn, CancellationToken ct = default)
     {


### PR DESCRIPTION
Closes #451.

## The base first, validated against working code

SQL Server had the only stored procedure implementation in the tree, and it implemented `ISchemaObject` **directly** rather than deriving from a shared base — so a second provider had nothing to reuse, unlike views and functions with `ViewBase` and `FunctionBase`.

`StoredProcedureBase` lands first, with SQL Server refitted onto it before three more providers depend on it. The refit changes nothing it emits or how it compares: **all 448 SQL Server tests pass untouched.**

The body is the whole `CREATE PROCEDURE …` statement rather than the procedure's contents, matching `FunctionBase`. That is what lets a caller write the parameter list, the language clause and whatever option flags their engine has without Weasel modelling any of it.

## Where the work actually was

Comparing against what each catalog stores. It is different in every case, and each one needed measuring:

| Provider | Compared against | What it actually stores |
|---|---|---|
| PostgreSQL | `pg_proc.prosrc` | the body verbatim, between the dollar quotes |
| SQL Server | `sys.sql_modules` | the statement verbatim |
| Oracle | `all_source` | from `PROCEDURE` onward, **without the schema qualifier** |
| MySQL | `ROUTINES.routine_definition` | the body from `BEGIN` onward |

**PostgreSQL does not store the header at all.** `pg_get_functiondef` *renders* it:

```
submitted   CREATE OR REPLACE PROCEDURE probe2.p(n int, tag text) ... AS $$
returned    CREATE OR REPLACE PROCEDURE probe2.p(IN n integer, IN tag text) ... AS $procedure$
```

Comparing against that reports a change on every check for any procedure not written in PostgreSQL's own spelling — the permanent drift #445 and #446 were about. So the comparison is against `prosrc`, with the caller's body taken from between the outermost dollar quotes. **Unambiguous by construction** — which is exactly what the Oracle view slice could not say about parsing for `AS`, and why that idea was rejected there.

**Oracle stores neither the wrapper nor the qualifier.** Measured:

```
submitted   CREATE OR REPLACE PROCEDURE WEASEL.sp_stamp IS
returned    PROCEDURE→ sp_stamp IS          (that is a tab)
```

Both stripped, and canonicalization now collapses any run of whitespace rather than only doubled and tripled spaces.

## ⚠️ PostgreSQL overloads on the signature

Changing a procedure's **parameter list** does not change that procedure — PostgreSQL creates a second one and leaves the first in place. Weasel reports the new signature as `Create`; the old procedure is still there and still the caller's to drop.

Stated on the type and in the docs rather than papered over.

## Also

Oracle gets its own delta so an update emits only the `CREATE OR REPLACE` — its drop has to be an anonymous PL/SQL block, and ODP.NET cannot execute a block and a DDL statement as one command. **Third time that trap has come up**, after views (#470) and triggers (#478).

MySQL procedure bodies are full of semicolons, which is why `the_procedure_actually_runs` matters there specifically: the migrator used to split delta SQL on semicolons until #478 stopped it.

## Tests

24 across the four providers: round trip, **checked twice** for permanent drift, drift-and-converge, teardown, and `the_procedure_actually_runs` — because a procedure that exists but does not work is worse than none. Plus unit cover for each provider's extraction rule.

`object_type_support_matrix` and `docs/core/object-types.md` updated together, which the test enforces; new `docs/core/procedures.md`.

## Verified locally

Core 216, SQLite 432, PostgreSQL 892, SQL Server 448, Oracle 272, MySQL 288, EF Core 106. No failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)