### PR TITLE
feat: the long tail — Oracle packages, materialized views and synonyms; SQL Server synonyms; PostgreSQL UDTs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,6 +195,10 @@ PublishScripts/
 **/[Pp]ackages/*
 # except build/, which is used as an MSBuild target.
 !**/[Pp]ackages/build/
+# ...and except our own source. Weasel.Oracle models Oracle PACKAGE objects, and the natural
+# directory name for them collides with the NuGet restore folder this rule is aimed at. Without
+# this the files are silently untracked and the branch does not compile (weasel#453).
+!src/**/[Pp]ackages/*.cs
 # Uncomment if necessary however generally it will be regenerated when needed
 #!**/[Pp]ackages/repositories.config
 # NuGet v3's project.json files produces more ignorable files

--- a/docs/core/object-types.md
+++ b/docs/core/object-types.md
@@ -21,15 +21,15 @@ Three symbols, and the distinction between the last two matters:
 | Foreign key | ✓ | ✓ | ✓ | ✓ | ✓ (inline only) |
 | Check constraint | ✓ | ✓ | ✗ | ✗ | ✗ |
 | Primary key | ✓ | ✓ | ✓ | ✓ | ✓ |
-| Sequence | ✓ | ✓ | ✓ | table-emulated | table-emulated |
+| Sequence | ✓ | ✓ | ✓ | — (obsolete emulation) | — |
 | View | ✓ | ✓ | ✓ | ✓ | ✓ |
-| Materialized view | ✓ | — | ✗ | — | — |
+| Materialized view | ✓ | — | ✓ | — | — |
 | Function | ✓ | ✓ | ✗ | ✗ | connection-scoped |
 | Stored procedure | ✓ | ✓ | ✓ | ✓ | — |
 | Trigger | ✓ | ✓ | ✓ | ✓ | ✓ |
-| Package | — | — | ✗ | — | — |
-| Synonym | — | ✗ | ✗ | — | — |
-| User-defined type | ✗ | ✓ (table types) | ✗ | — | — |
+| Package | — | — | ✓ | — | — |
+| Synonym | — | ✓ | ✓ | — | — |
+| User-defined type | ✓ (enum/domain/composite) | ✓ (table types) | — | — | — |
 | Extension | ✓ | — | — | — | — |
 | Partitioning | ✓ (hash/range/list) | ✓ (range) | ✓ | ✓ | — |
 
@@ -37,7 +37,8 @@ Three symbols, and the distinction between the last two matters:
 
 - **Triggers** are modelled as independent schema objects that declare a target rather than as something a table owns, which is why they are a row here and not part of the table row. A trigger does not always have a table — SQL Server's `INSTEAD OF` triggers attach to views — and PostgreSQL's call a function, so they compose with `Function` rather than carrying their own body. See [Triggers](/core/triggers).
 - **Functions on Oracle and MySQL** are [#450](https://github.com/JasperFx/weasel/issues/450). Stored procedures are on all four engines that have them; SQLite has no such concept.
-- **The long tail** — Oracle packages, materialized views and synonyms, SQL Server synonyms, PostgreSQL user-defined types — is [#453](https://github.com/JasperFx/weasel/issues/453).
+- **Oracle packages** model the specification and the body as one object with two parts, because that is what they are: `all_source` lists them separately, they compile separately, and a body can be invalid while its spec is fine. A spec-only package — shared constants and types — is legal and supported.
+- **PostgreSQL user-defined types** cover enums, domains and composites through one class, because the catalog makes no distinction between them and neither does anything Weasel does with them.
 - **PostgreSQL materialized views already work**, through `Weasel.Postgresql.Views.MaterializedView`, which is `View` with a different `ViewType` and an optional access method. That row was ✗ in the first draft of this page and the check below caught it on its first run, which is the argument for the check.
 
 ### SQLite functions are a different thing
@@ -49,10 +50,20 @@ them repeatable, not to model a schema object.
 
 ### Sequences on MySQL and SQLite
 
-Neither engine has a native `SEQUENCE`. Both providers emulate one with a table, which is why
-they read `table-emulated` above rather than ✓ or —. The emulation is deliberate and supported:
-what [#453](https://github.com/JasperFx/weasel/issues/453) settled is that Weasel emulates
-*operations* an engine lacks but does not invent *objects* it does not have.
+Neither engine has a native `SEQUENCE` — MySQL never has, at any version; it is MariaDB 10.3 that
+added them.
+
+**`Weasel.MySql.Sequence` is `[Obsolete]`.** It emulates a sequence with a single-row table, and
+nothing can consume it: `current_value` is never read or incremented, there is no next-value
+operation anywhere, and its delta only checks existence. Use `AUTO_INCREMENT`.
+
+That follows the rule [#453](https://github.com/JasperFx/weasel/issues/453) settled: **emulate
+operations, not objects.** SQLite's table recreation around its `ALTER` limits and MySQL's DDL
+ordering around foreign-key backing indexes are fine, because the end state is the object the
+caller declared and the emulation is invisible. An emulated *object* makes `AllObjects()` and
+introspection lie, and the semantics diverge where it matters — a real sequence does not roll back
+and does not serialize writers; a table-backed counter does both. Which is why SQLite does not get
+one either.
 
 ## Teardown has to keep up
 

--- a/src/Weasel.Core.Tests/object_type_support_matrix.cs
+++ b/src/Weasel.Core.Tests/object_type_support_matrix.cs
@@ -49,6 +49,7 @@ public class object_type_support_matrix
         ("Postgresql", "Extension", "Weasel.Postgresql.Extension"),
         ("Postgresql", "Trigger", "Weasel.Postgresql.Triggers.Trigger"),
         ("Postgresql", "StoredProcedure", "Weasel.Postgresql.Procedures.StoredProcedure"),
+        ("Postgresql", "UserDefinedType", "Weasel.Postgresql.Types.UserDefinedType"),
 
         ("SqlServer", "Table", "Weasel.SqlServer.Tables.Table"),
         ("SqlServer", "Sequence", "Weasel.SqlServer.Sequence"),
@@ -57,12 +58,16 @@ public class object_type_support_matrix
         ("SqlServer", "StoredProcedure", "Weasel.SqlServer.Procedures.StoredProcedure"),
         ("SqlServer", "TableType", "Weasel.SqlServer.Tables.TableType"),
         ("SqlServer", "Trigger", "Weasel.SqlServer.Triggers.Trigger"),
+        ("SqlServer", "Synonym", "Weasel.SqlServer.Synonyms.Synonym"),
 
         ("Oracle", "Table", "Weasel.Oracle.Tables.Table"),
         ("Oracle", "Sequence", "Weasel.Oracle.Sequence"),
         ("Oracle", "View", "Weasel.Oracle.Views.View"),
         ("Oracle", "Trigger", "Weasel.Oracle.Triggers.Trigger"),
         ("Oracle", "StoredProcedure", "Weasel.Oracle.Procedures.StoredProcedure"),
+        ("Oracle", "MaterializedView", "Weasel.Oracle.Views.MaterializedView"),
+        ("Oracle", "Synonym", "Weasel.Oracle.Synonyms.Synonym"),
+        ("Oracle", "Package", "Weasel.Oracle.Packages.Package"),
 
         ("MySql", "Table", "Weasel.MySql.Tables.Table"),
         ("MySql", "Sequence", "Weasel.MySql.Sequence"),
@@ -93,7 +98,6 @@ public class object_type_support_matrix
         new()
         {
             { "Oracle", "Weasel.Oracle.Functions.Function", "#450" },
-            { "Oracle", "Weasel.Oracle.Views.MaterializedView", "#453" },
             { "MySql", "Weasel.MySql.Functions.Function", "#450" }
         };
 

--- a/src/Weasel.Core/SchemaObjectBase.cs
+++ b/src/Weasel.Core/SchemaObjectBase.cs
@@ -91,10 +91,26 @@ public abstract class SchemaObjectBase: ISchemaObject
     ///     <c>FindDeltaAsync(NpgsqlConnection, CancellationToken)</c>) that simply forwards
     ///     to this method.
     /// </summary>
-    public async Task<ISchemaObjectDelta> FindDeltaAsync(
+    public Task<ISchemaObjectDelta> FindDeltaAsync(
         DbConnection conn, CancellationToken ct = default)
+        => FindDeltaAsync(conn, CreateCommandBuilder(conn), ct);
+
+    /// <summary>
+    ///     The command builder this object's <see cref="ConfigureQueryCommand" /> should be built
+    ///     against. The neutral one by default; a schema object that registers more than one
+    ///     statement on a provider whose driver executes them one at a time overrides it.
+    /// </summary>
+    /// <remarks>
+    ///     Oracle is the only such provider — ODP.NET will not execute several statements from one
+    ///     command, and <c>OracleDbCommandBuilder</c> splits the batch so the reader can chain
+    ///     across the pieces (weasel#474). Without this hook, an Oracle object registering two
+    ///     queries had them concatenated into one command and failed with ORA-03048.
+    /// </remarks>
+    protected virtual DbCommandBuilder CreateCommandBuilder(DbConnection conn) => new(conn);
+
+    public async Task<ISchemaObjectDelta> FindDeltaAsync(
+        DbConnection conn, DbCommandBuilder builder, CancellationToken ct = default)
     {
-        var builder = new DbCommandBuilder(conn);
         ConfigureQueryCommand(builder);
 
         await using var reader = await conn.ExecuteReaderAsync(builder, ct).ConfigureAwait(false);

--- a/src/Weasel.MySql/Sequence.cs
+++ b/src/Weasel.MySql/Sequence.cs
@@ -3,11 +3,35 @@ using Weasel.Core;
 namespace Weasel.MySql;
 
 /// <summary>
-///     MySQL sequence. Because MySQL 5.x doesn't have native sequences, this is emulated as
-///     a single-row auto-increment table — the underlying database object is therefore a
-///     TABLE, not a SEQUENCE. The fluent surface still mirrors the other providers'
-///     <see cref="SequenceBase" /> for portability of caller code.
+///     A MySQL "sequence", emulated as a single-row auto-increment table. Obsolete: nothing can
+///     consume it.
 /// </summary>
+/// <remarks>
+///     <para>
+///         MySQL has never had <c>CREATE SEQUENCE</c> — the comment that used to say 5.x lacked it
+///         and 8.0 added it was wrong; it is MariaDB 10.3 that has them. So this was always an
+///         emulation, and an incomplete one: <see cref="WriteCreateStatement" /> creates a table
+///         with a <c>current_value</c> column that is never read and never incremented, there is no
+///         next-value operation anywhere in <c>Weasel.MySql</c> or on <see cref="SequenceBase" />,
+///         and <see cref="ConfigureQueryCommand" /> only checks existence, so a change to
+///         <see cref="SequenceBase.StartWith" /> is never detected.
+///     </para>
+///     <para>
+///         The general rule this follows (weasel#453): emulate <em>operations</em> an engine lacks
+///         freely — SQLite's table recreation around its <c>ALTER</c> limits, MySQL's DDL ordering
+///         around foreign-key backing indexes — because the end state is the object the caller
+///         declared and the emulation is invisible. Do not emulate <em>objects</em>: an emulated
+///         object makes <c>AllObjects()</c> and introspection lie, and the semantics diverge where
+///         it matters. A real sequence does not roll back and does not serialize writers; a
+///         table-backed counter does both.
+///     </para>
+///     <para>
+///         Use <c>AUTO_INCREMENT</c> on the column that needs generated values.
+///     </para>
+/// </remarks>
+[Obsolete(
+    "MySQL has no sequences and this emulation cannot be consumed - nothing reads or increments "
+    + "current_value. Use AUTO_INCREMENT on the column instead. See weasel#453.")]
 public class Sequence: SequenceBase
 {
     public Sequence(DbObjectName identifier) : base(identifier, startWith: 1)
@@ -20,16 +44,32 @@ public class Sequence: SequenceBase
     }
 
     /// <summary>
-    ///     Reserved for future use — MySQL's table-based emulation doesn't currently honor
-    ///     a non-1 increment, but the property is here for fluent-API parity and may be
-    ///     wired into the emulation later.
+    ///     Always 1. Setting anything else throws.
     /// </summary>
-    public long IncrementBy { get; set; } = 1;
+    /// <remarks>
+    ///     This used to be settable and documented as "reserved for future use" while being
+    ///     silently ignored, which left a caller with a sequence stepping by one when they asked for
+    ///     ten and nothing to notice it by. Refusing is the same rule weasel#449 applied to the
+    ///     index predicates that did nothing: a caller gets what they set, or an exception.
+    /// </remarks>
+    public long IncrementBy
+    {
+        get => 1;
+        set
+        {
+            if (value != 1)
+            {
+                throw new NotSupportedException(
+                    "MySQL has no sequences, and this table-based emulation does not honour an "
+                    + "increment other than 1. Use AUTO_INCREMENT, whose step is set server-wide by "
+                    + "auto_increment_increment.");
+            }
+        }
+    }
 
     public override void WriteCreateStatement(Migrator migrator, TextWriter writer)
     {
-        // MySQL 8.0+ supports sequences, but older versions don't.
-        // Using a table-based sequence for broader compatibility.
+        // MySQL has no CREATE SEQUENCE at any version, so this is a table.
         var seed = StartWith ?? 1;
         writer.WriteLine($"CREATE TABLE IF NOT EXISTS {Identifier.QualifiedName} (");
         writer.WriteLine("    id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,");

--- a/src/Weasel.Oracle.Tests/Packages/PackageTests.cs
+++ b/src/Weasel.Oracle.Tests/Packages/PackageTests.cs
@@ -1,0 +1,146 @@
+using Shouldly;
+using Weasel.Core;
+using Weasel.Oracle.Packages;
+using Xunit;
+
+namespace Weasel.Oracle.Tests.Packages;
+
+/// <summary>
+///     Oracle packages (weasel#453). The spec and the body are two objects with separate validity,
+///     which is why packages did not fit <c>FunctionBase</c>'s single-body shape.
+/// </summary>
+[Collection("integration")]
+public class PackageTests: IntegrationContext
+{
+    private const string SchemaName = "WEASEL";
+
+    public PackageTests(): base(SchemaName)
+    {
+    }
+
+    private static Package NewPackage(string constant = "one") => new(
+        $"{SchemaName}.pkg_probe",
+        $@"CREATE OR REPLACE PACKAGE {SchemaName}.pkg_probe AS
+    FUNCTION label RETURN VARCHAR2;
+END pkg_probe;",
+        $@"CREATE OR REPLACE PACKAGE BODY {SchemaName}.pkg_probe AS
+    FUNCTION label RETURN VARCHAR2 IS
+    BEGIN
+        RETURN '{constant}';
+    END label;
+END pkg_probe;");
+
+    private static Package SpecOnly() => new(
+        $"{SchemaName}.pkg_constants",
+        $@"CREATE OR REPLACE PACKAGE {SchemaName}.pkg_constants AS
+    max_retries CONSTANT PLS_INTEGER := 3;
+END pkg_constants;");
+
+    [Fact]
+    public void the_create_or_replace_prefix_and_the_schema_qualifier_are_stripped()
+    {
+        Package.Strip("CREATE OR REPLACE PACKAGE WEASEL.p AS END;", "WEASEL")
+            .ShouldStartWith("PACKAGE p");
+    }
+
+    /// <summary>
+    ///     The <c>BODY</c> keyword sits between <c>PACKAGE</c> and the name, so stripping the schema
+    ///     has to survive it.
+    /// </summary>
+    [Fact]
+    public void stripping_a_package_body_keeps_the_body_keyword()
+    {
+        Package.Strip("CREATE OR REPLACE PACKAGE BODY WEASEL.p AS END;", "WEASEL")
+            .ShouldStartWith("PACKAGE BODY p");
+    }
+
+    [Fact]
+    public async Task a_package_round_trips_and_reports_no_delta()
+    {
+        await ResetSchema();
+
+        var package = NewPackage();
+        await package.ApplyChangesAsync(theConnection);
+
+        (await package.ExistsInDatabaseAsync(theConnection)).ShouldBeTrue();
+        (await package.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task an_unchanged_package_does_not_report_permanent_drift()
+    {
+        await ResetSchema();
+        await NewPackage().ApplyChangesAsync(theConnection);
+
+        (await NewPackage().FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+        (await NewPackage().FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task the_package_actually_runs()
+    {
+        await ResetSchema();
+        await NewPackage().ApplyChangesAsync(theConnection);
+
+        var label = await theConnection
+            .CreateCommand($"SELECT {SchemaName}.pkg_probe.label FROM dual")
+            .ExecuteScalarAsync();
+
+        label.ShouldBe("one");
+    }
+
+    /// <summary>
+    ///     A change to the body alone, with the spec untouched — the case a single-body model could
+    ///     not have expressed.
+    /// </summary>
+    [Fact]
+    public async Task a_changed_body_reports_update_and_applying_it_converges()
+    {
+        await ResetSchema();
+        await NewPackage().ApplyChangesAsync(theConnection);
+
+        var changed = NewPackage("two");
+
+        (await changed.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.Update);
+
+        await changed.ApplyChangesAsync(theConnection);
+
+        (await changed.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+
+        var label = await theConnection
+            .CreateCommand($"SELECT {SchemaName}.pkg_probe.label FROM dual")
+            .ExecuteScalarAsync();
+
+        label.ShouldBe("two");
+    }
+
+    /// <summary>
+    ///     A spec with no body is legal Oracle — it is how shared constants and types are declared —
+    ///     so <c>Body</c> is optional rather than required.
+    /// </summary>
+    [Fact]
+    public async Task a_spec_only_package_round_trips()
+    {
+        await ResetSchema();
+
+        var package = SpecOnly();
+        await package.ApplyChangesAsync(theConnection);
+
+        (await package.ExistsInDatabaseAsync(theConnection)).ShouldBeTrue();
+        (await package.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+
+        var (_, body) = await package.FetchExistingAsync(theConnection);
+        body.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task dropping_the_schema_takes_its_packages_with_it()
+    {
+        await ResetSchema();
+        await NewPackage().ApplyChangesAsync(theConnection);
+
+        await ResetSchema();
+
+        (await NewPackage().ExistsInDatabaseAsync(theConnection)).ShouldBeFalse();
+    }
+}

--- a/src/Weasel.Oracle.Tests/Synonyms/SynonymTests.cs
+++ b/src/Weasel.Oracle.Tests/Synonyms/SynonymTests.cs
@@ -1,0 +1,112 @@
+using Shouldly;
+using Weasel.Core;
+using Weasel.Oracle.Synonyms;
+using Weasel.Oracle.Tables;
+using Xunit;
+
+namespace Weasel.Oracle.Tests.Synonyms;
+
+/// <summary>
+///     Oracle private synonyms (weasel#453). Public synonyms are modelled but not covered here —
+///     creating one needs CREATE PUBLIC SYNONYM, which the test user is not granted.
+/// </summary>
+[Collection("integration")]
+public class SynonymTests: IntegrationContext
+{
+    private const string SchemaName = "WEASEL";
+
+    public SynonymTests(): base(SchemaName)
+    {
+    }
+
+    private static Table SourceTable(string name = "syn_orders")
+    {
+        var table = new Table($"{SchemaName}.{name}");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        return table;
+    }
+
+    private static Synonym NewSynonym(string target = "syn_orders")
+        => new($"{SchemaName}.syn_alias", $"{SchemaName}.{target}");
+
+    [Fact]
+    public void an_unqualified_target_is_qualified_with_the_synonym_own_schema()
+    {
+        var synonym = new Synonym($"{SchemaName}.a", "orders");
+
+        synonym.Normalize("orders").ShouldBe($"{SchemaName}.ORDERS");
+    }
+
+    [Fact]
+    public async Task a_synonym_round_trips_and_reports_no_delta()
+    {
+        await ResetSchema();
+        await SourceTable().ApplyChangesAsync(theConnection);
+
+        var synonym = NewSynonym();
+        await synonym.ApplyChangesAsync(theConnection);
+
+        (await synonym.ExistsInDatabaseAsync(theConnection)).ShouldBeTrue();
+        (await synonym.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task an_unchanged_synonym_does_not_report_permanent_drift()
+    {
+        await ResetSchema();
+        await SourceTable().ApplyChangesAsync(theConnection);
+        await NewSynonym().ApplyChangesAsync(theConnection);
+
+        (await NewSynonym().FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+        (await NewSynonym().FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task the_synonym_actually_resolves()
+    {
+        await ResetSchema();
+        await SourceTable().ApplyChangesAsync(theConnection);
+        await NewSynonym().ApplyChangesAsync(theConnection);
+
+        await theConnection.CreateCommand($"INSERT INTO {SchemaName}.syn_orders (id) VALUES (1)")
+            .ExecuteNonQueryAsync();
+
+        var count = await theConnection.CreateCommand($"SELECT COUNT(*) FROM {SchemaName}.syn_alias")
+            .ExecuteScalarAsync();
+
+        Convert.ToInt32(count).ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task a_retargeted_synonym_reports_update_and_applying_it_converges()
+    {
+        await ResetSchema();
+        await SourceTable().ApplyChangesAsync(theConnection);
+        await SourceTable("syn_archive").ApplyChangesAsync(theConnection);
+        await NewSynonym().ApplyChangesAsync(theConnection);
+
+        var retargeted = NewSynonym("syn_archive");
+
+        (await retargeted.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.Update);
+
+        await retargeted.ApplyChangesAsync(theConnection);
+
+        (await retargeted.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    /// <summary>
+    ///     Oracle's teardown learned synonyms in weasel#469, before anything could create one. This
+    ///     is the test that arms it.
+    /// </summary>
+    [Fact]
+    public async Task dropping_the_schema_takes_its_synonyms_with_it()
+    {
+        await ResetSchema();
+        await SourceTable().ApplyChangesAsync(theConnection);
+        await NewSynonym().ApplyChangesAsync(theConnection);
+
+        await ResetSchema();
+
+        (await NewSynonym().ExistsInDatabaseAsync(theConnection)).ShouldBeFalse();
+    }
+}

--- a/src/Weasel.Oracle.Tests/Views/MaterializedViewTests.cs
+++ b/src/Weasel.Oracle.Tests/Views/MaterializedViewTests.cs
@@ -1,0 +1,132 @@
+using Shouldly;
+using Weasel.Core;
+using Weasel.Oracle.Tables;
+using Weasel.Oracle.Views;
+using Xunit;
+
+namespace Weasel.Oracle.Tests.Views;
+
+/// <summary>
+///     Oracle materialized views (weasel#453). Not a subclass of <see cref="View" />, unlike
+///     PostgreSQL's — Oracle's differ in more than the keyword.
+/// </summary>
+[Collection("integration")]
+public class MaterializedViewTests: IntegrationContext
+{
+    private const string SchemaName = "WEASEL";
+
+    public MaterializedViewTests(): base(SchemaName)
+    {
+    }
+
+    private static Table SourceTable()
+    {
+        var table = new Table($"{SchemaName}.mv_src");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn<int>("qty");
+        return table;
+    }
+
+    private static MaterializedView NewView(string sql = null!) => new(
+        $"{SchemaName}.mv_totals",
+        sql ?? $"SELECT id, qty FROM {SchemaName}.mv_src");
+
+    [Fact]
+    public void refresh_mode_and_query_rewrite_are_emitted()
+    {
+        var view = NewView();
+        view.Refresh = MaterializedViewRefresh.OnCommit;
+        view.EnableQueryRewrite = true;
+
+        var writer = new StringWriter();
+        view.WriteCreateStatement(new OracleMigrator(), writer);
+
+        var sql = writer.ToString();
+        sql.ShouldContain("REFRESH ON COMMIT");
+        sql.ShouldContain("ENABLE QUERY REWRITE");
+    }
+
+    [Fact]
+    public async Task a_materialized_view_round_trips_and_reports_no_delta()
+    {
+        await ResetSchema();
+        await SourceTable().ApplyChangesAsync(theConnection);
+
+        var view = NewView();
+        await view.ApplyChangesAsync(theConnection);
+
+        (await view.ExistsInDatabaseAsync(theConnection)).ShouldBeTrue();
+        (await view.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task an_unchanged_view_does_not_report_permanent_drift()
+    {
+        await ResetSchema();
+        await SourceTable().ApplyChangesAsync(theConnection);
+        await NewView().ApplyChangesAsync(theConnection);
+
+        (await NewView().FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+        (await NewView().FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    /// <summary>
+    ///     The point of a materialized view: the rows are stored, not re-evaluated.
+    /// </summary>
+    [Fact]
+    public async Task the_view_holds_rows()
+    {
+        await ResetSchema();
+        await SourceTable().ApplyChangesAsync(theConnection);
+
+        await theConnection.CreateCommand($"INSERT INTO {SchemaName}.mv_src (id, qty) VALUES (1, 5)")
+            .ExecuteNonQueryAsync();
+
+        await NewView().ApplyChangesAsync(theConnection);
+
+        var count = await theConnection.CreateCommand($"SELECT COUNT(*) FROM {SchemaName}.mv_totals")
+            .ExecuteScalarAsync();
+
+        Convert.ToInt32(count).ShouldBe(1);
+    }
+
+    /// <summary>
+    ///     There is no <c>CREATE OR REPLACE MATERIALIZED VIEW</c>, so a changed query is
+    ///     <see cref="SchemaPatchDifference.Invalid" /> — drop and create, which for a materialized
+    ///     view is right: its contents are derived rather than authored.
+    /// </summary>
+    [Fact]
+    public async Task a_changed_query_reports_invalid()
+    {
+        await ResetSchema();
+        await SourceTable().ApplyChangesAsync(theConnection);
+        await NewView().ApplyChangesAsync(theConnection);
+
+        var changed = NewView($"SELECT id FROM {SchemaName}.mv_src");
+
+        (await changed.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.Invalid);
+    }
+
+    /// <summary>
+    ///     Oracle lists a materialized view's container table in <c>all_tables</c> under the same
+    ///     name, and <c>DROP TABLE</c> against it fails — which is why weasel#465's teardown excludes
+    ///     mview containers from its table sweep. This is the test that arms that.
+    /// </summary>
+    [Fact]
+    public async Task dropping_the_schema_takes_the_view_and_its_container_table()
+    {
+        await ResetSchema();
+        await SourceTable().ApplyChangesAsync(theConnection);
+        await NewView().ApplyChangesAsync(theConnection);
+
+        await ResetSchema();
+
+        (await NewView().ExistsInDatabaseAsync(theConnection)).ShouldBeFalse();
+
+        var leftovers = await theConnection
+            .CreateCommand($"SELECT COUNT(*) FROM all_tables WHERE owner = '{SchemaName}'")
+            .ExecuteScalarAsync();
+
+        Convert.ToInt32(leftovers).ShouldBe(0);
+    }
+}

--- a/src/Weasel.Oracle/Packages/Package.cs
+++ b/src/Weasel.Oracle/Packages/Package.cs
@@ -1,0 +1,200 @@
+using System.Data.Common;
+using JasperFx.Core;
+using Oracle.ManagedDataAccess.Client;
+using Weasel.Core;
+using DbCommandBuilder = Weasel.Core.DbCommandBuilder;
+
+namespace Weasel.Oracle.Packages;
+
+/// <summary>
+///     An Oracle package: a specification declaring what the package exposes, and a body
+///     implementing it.
+/// </summary>
+/// <remarks>
+///     <para>
+///         This is why packages did not fit <see cref="FunctionBase" />'s single-body shape
+///         (weasel#453). The spec and the body are <em>two objects</em> — <c>all_source</c> lists
+///         them as <c>PACKAGE</c> and <c>PACKAGE BODY</c>, they compile separately, and each has its
+///         own validity. A body can be invalid while the spec is fine, which is the normal state
+///         after a base table changes, and callers of the package see that as ORA-04063 rather than
+///         as a missing object.
+///     </para>
+///     <para>
+///         So <see cref="Body" /> is optional. A spec-only package is legal Oracle — it is how you
+///         declare shared constants and types — and Weasel models it rather than insisting on
+///         something to implement.
+///     </para>
+///     <para>
+///         Dropping the spec drops the body with it, so there is only one drop statement.
+///     </para>
+/// </remarks>
+public class Package: SchemaObjectBase
+{
+    public Package(string name, string specification, string? body = null)
+        : this(DbObjectName.Parse(OracleProvider.Instance, name), specification, body)
+    {
+    }
+
+    public Package(DbObjectName identifier, string specification, string? body = null): base(identifier)
+    {
+        Specification = specification ?? throw new ArgumentNullException(nameof(specification));
+        Body = body;
+    }
+
+    /// <summary>The <c>CREATE OR REPLACE PACKAGE …</c> statement.</summary>
+    public string Specification { get; }
+
+    /// <summary>
+    ///     The <c>CREATE OR REPLACE PACKAGE BODY …</c> statement, or null for a spec-only package.
+    /// </summary>
+    public string? Body { get; }
+
+    public override void WriteCreateStatement(Migrator migrator, TextWriter writer)
+    {
+        writer.WriteLine(Specification.TrimEnd().TrimEnd('/').TrimEnd());
+
+        if (Body.IsNotEmpty())
+        {
+            // The separator Oracle's migrator splits on: a package spec and a package body are two
+            // statements, and ODP.NET executes one at a time.
+            writer.WriteLine("/");
+            writer.WriteLine(Body!.TrimEnd().TrimEnd('/').TrimEnd());
+        }
+    }
+
+    public override void WriteDropStatement(Migrator rules, TextWriter writer)
+    {
+        // Dropping the spec takes the body with it. ORA-04043: object does not exist.
+        writer.WriteLine($@"BEGIN
+    EXECUTE IMMEDIATE 'DROP PACKAGE {SchemaUtils.EscapeLiteral(Identifier.QualifiedName)}';
+EXCEPTION
+    WHEN OTHERS THEN IF SQLCODE != -4043 THEN RAISE; END IF;
+END;");
+    }
+
+    /// <summary>
+    ///     Two result sets, spec then body — which Oracle can do now that a schema object may
+    ///     register more than one statement (weasel#474).
+    /// </summary>
+    public override void ConfigureQueryCommand(DbCommandBuilder builder)
+    {
+        var schemaParam = builder.AddParameter(Identifier.Schema.ToUpperInvariant()).ParameterName;
+        var nameParam = builder.AddParameter(Identifier.Name.ToUpperInvariant()).ParameterName;
+
+        builder.Append(
+            "SELECT LISTAGG(text, '') WITHIN GROUP (ORDER BY line) FROM all_source "
+            + $"WHERE owner = :{schemaParam} AND name = :{nameParam} AND type = 'PACKAGE'");
+
+        builder.StartNewCommand();
+
+        builder.Append(
+            "SELECT LISTAGG(text, '') WITHIN GROUP (ORDER BY line) FROM all_source "
+            + $"WHERE owner = :{schemaParam} AND name = :{nameParam} AND type = 'PACKAGE BODY'");
+    }
+
+    public override async Task<ISchemaObjectDelta> CreateDeltaAsync(DbDataReader reader, CancellationToken ct = default)
+    {
+        var existingSpec = await readSourceAsync(reader, ct).ConfigureAwait(false);
+
+        await reader.NextResultAsync(ct).ConfigureAwait(false);
+        var existingBody = await readSourceAsync(reader, ct).ConfigureAwait(false);
+
+        if (existingSpec == null)
+        {
+            return new PackageDelta(this, SchemaPatchDifference.Create);
+        }
+
+        var specMatches = Matches(existingSpec, Specification);
+        var bodyMatches = Body.IsEmpty()
+            ? existingBody == null
+            : existingBody != null && Matches(existingBody, Body!);
+
+        return specMatches && bodyMatches
+            ? new PackageDelta(this, SchemaPatchDifference.None)
+            : new PackageDelta(this, SchemaPatchDifference.Update);
+    }
+
+    /// <summary>
+    ///     <c>all_source</c> stores neither the <c>CREATE OR REPLACE</c> wrapper nor the schema
+    ///     qualifier — the owner is already the row's own column — exactly as with a standalone
+    ///     procedure.
+    /// </summary>
+    internal bool Matches(string existing, string expected)
+        => StoredProcedureBase.Canonicize(existing)
+            .Equals(StoredProcedureBase.Canonicize(Strip(expected, Identifier.Schema)),
+                StringComparison.OrdinalIgnoreCase);
+
+    internal static string Strip(string statement, string schema)
+    {
+        var index = statement.IndexOf("PACKAGE", StringComparison.OrdinalIgnoreCase);
+        var source = (index < 0 ? statement : statement[index..]).TrimEnd().TrimEnd('/').TrimEnd();
+
+        return System.Text.RegularExpressions.Regex.Replace(
+            source,
+            $@"(?<=PACKAGE\s)(\s*BODY\s+)?{System.Text.RegularExpressions.Regex.Escape(schema)}\s*\.\s*",
+            m => m.Groups[1].Success ? m.Groups[1].Value : "",
+            System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+    }
+
+    /// <inheritdoc />
+    protected override DbCommandBuilder CreateCommandBuilder(DbConnection conn) => new OracleDbCommandBuilder();
+
+    public async Task<(string? Specification, string? Body)> FetchExistingAsync(
+        OracleConnection conn, CancellationToken ct = default)
+    {
+        // The Oracle builder, not the neutral one: this registers two statements, and ODP.NET
+        // executes one per command. OracleDbCommandBuilder splits on the boundary and the reader
+        // chains across the pieces (weasel#474).
+        var builder = new OracleDbCommandBuilder();
+        ConfigureQueryCommand(builder);
+
+        await using var reader = await conn.ExecuteReaderAsync(builder, ct).ConfigureAwait(false);
+        var spec = await readSourceAsync(reader, ct).ConfigureAwait(false);
+        await reader.NextResultAsync(ct).ConfigureAwait(false);
+        var body = await readSourceAsync(reader, ct).ConfigureAwait(false);
+        await reader.CloseAsync().ConfigureAwait(false);
+
+        return (spec, body);
+    }
+
+    public async Task<bool> ExistsInDatabaseAsync(OracleConnection conn, CancellationToken ct = default)
+        => (await FetchExistingAsync(conn, ct).ConfigureAwait(false)).Specification != null;
+
+    private static async Task<string?> readSourceAsync(DbDataReader reader, CancellationToken ct)
+    {
+        if (!await reader.ReadAsync(ct).ConfigureAwait(false)) return null;
+        if (await reader.IsDBNullAsync(0, ct).ConfigureAwait(false)) return null;
+
+        var source = await reader.GetFieldValueAsync<string>(0, ct).ConfigureAwait(false);
+        return source.IsEmpty() ? null : source;
+    }
+}
+
+/// <summary>
+///     A package applies as <c>CREATE OR REPLACE PACKAGE</c> and, when there is one,
+///     <c>CREATE OR REPLACE PACKAGE BODY</c> — two statements, separated by the <c>/</c> Oracle's
+///     migrator splits on.
+/// </summary>
+internal class PackageDelta: ISchemaObjectDelta
+{
+    private readonly Package _package;
+
+    public PackageDelta(Package package, SchemaPatchDifference difference)
+    {
+        _package = package;
+        Difference = difference;
+    }
+
+    public ISchemaObject SchemaObject => _package;
+
+    public SchemaPatchDifference Difference { get; }
+
+    public void WriteUpdate(Migrator rules, TextWriter writer) => _package.WriteCreateStatement(rules, writer);
+
+    public void WriteRollback(Migrator rules, TextWriter writer)
+    {
+    }
+
+    public void WriteRestorationOfPreviousState(Migrator rules, TextWriter writer)
+        => throw new NotSupportedException();
+}

--- a/src/Weasel.Oracle/Synonyms/Synonym.cs
+++ b/src/Weasel.Oracle/Synonyms/Synonym.cs
@@ -1,0 +1,154 @@
+using System.Data.Common;
+using Oracle.ManagedDataAccess.Client;
+using Weasel.Core;
+using DbCommandBuilder = Weasel.Core.DbCommandBuilder;
+
+namespace Weasel.Oracle.Synonyms;
+
+/// <summary>
+///     An Oracle synonym, private or public.
+/// </summary>
+/// <remarks>
+///     <para>
+///         A public synonym belongs to no schema — it is visible to every user, and
+///         <c>all_synonyms</c> reports its owner as <c>PUBLIC</c>. Set <see cref="IsPublic" /> and
+///         the identifier's schema is ignored, because there is nowhere for it to go.
+///     </para>
+///     <para>
+///         <c>CREATE OR REPLACE SYNONYM</c> exists, so a change is one statement — which is what
+///         Oracle's migrator can execute per delta.
+///     </para>
+/// </remarks>
+public class Synonym: SchemaObjectBase
+{
+    public Synonym(string name, string target)
+        : this(DbObjectName.Parse(OracleProvider.Instance, name), target)
+    {
+    }
+
+    public Synonym(DbObjectName identifier, string target): base(identifier)
+    {
+        Target = target ?? throw new ArgumentNullException(nameof(target));
+    }
+
+    /// <summary>The object this synonym stands for.</summary>
+    public string Target { get; }
+
+    /// <summary>
+    ///     A public synonym, visible to every user and owned by no schema.
+    /// </summary>
+    public bool IsPublic { get; set; }
+
+    public override void WriteCreateStatement(Migrator migrator, TextWriter writer)
+    {
+        var scope = IsPublic ? "PUBLIC " : string.Empty;
+        writer.WriteLine($"CREATE OR REPLACE {scope}SYNONYM {QualifiedName()} FOR {Target}");
+    }
+
+    public override void WriteDropStatement(Migrator rules, TextWriter writer)
+    {
+        var scope = IsPublic ? "PUBLIC " : string.Empty;
+
+        // No DROP SYNONYM IF EXISTS on Oracle. ORA-01434 is a private synonym that is not there,
+        // ORA-01432 a public one.
+        writer.WriteLine($@"BEGIN
+    EXECUTE IMMEDIATE 'DROP {scope}SYNONYM {SchemaUtils.EscapeLiteral(QualifiedName())}';
+EXCEPTION
+    WHEN OTHERS THEN IF SQLCODE NOT IN (-1434, -1432) THEN RAISE; END IF;
+END;");
+    }
+
+    private string QualifiedName()
+        => IsPublic ? SchemaUtils.QuoteName(Identifier.Name) : Identifier.QualifiedName;
+
+    public override void ConfigureQueryCommand(DbCommandBuilder builder)
+    {
+        var ownerParam = builder
+            .AddParameter(IsPublic ? "PUBLIC" : Identifier.Schema.ToUpperInvariant()).ParameterName;
+        var nameParam = builder.AddParameter(Identifier.Name.ToUpperInvariant()).ParameterName;
+
+        builder.Append(
+            "SELECT table_owner || '.' || table_name FROM all_synonyms "
+            + $"WHERE owner = :{ownerParam} AND synonym_name = :{nameParam}");
+    }
+
+    public override async Task<ISchemaObjectDelta> CreateDeltaAsync(DbDataReader reader, CancellationToken ct = default)
+    {
+        var existing = await readTargetAsync(reader, ct).ConfigureAwait(false);
+
+        if (existing == null)
+        {
+            return new SynonymDelta(this, SchemaPatchDifference.Create);
+        }
+
+        return Normalize(existing) == Normalize(Target)
+            ? new SynonymDelta(this, SchemaPatchDifference.None)
+            : new SynonymDelta(this, SchemaPatchDifference.Update);
+    }
+
+    /// <summary>
+    ///     Oracle folds an unquoted name to uppercase and always reports the target fully qualified,
+    ///     so both sides are uppercased and a caller's unqualified target is qualified with this
+    ///     synonym's own schema before comparing.
+    /// </summary>
+    internal string Normalize(string target)
+    {
+        var normalized = target.Replace("\"", "").Trim().ToUpperInvariant();
+
+        return normalized.Contains('.')
+            ? normalized
+            : $"{Identifier.Schema.ToUpperInvariant()}.{normalized}";
+    }
+
+    public async Task<string?> FetchExistingTargetAsync(OracleConnection conn, CancellationToken ct = default)
+    {
+        var builder = new DbCommandBuilder(conn);
+        ConfigureQueryCommand(builder);
+
+        await using var reader = await conn.ExecuteReaderAsync(builder, ct).ConfigureAwait(false);
+        var target = await readTargetAsync(reader, ct).ConfigureAwait(false);
+        await reader.CloseAsync().ConfigureAwait(false);
+
+        return target;
+    }
+
+    public async Task<bool> ExistsInDatabaseAsync(OracleConnection conn, CancellationToken ct = default)
+        => await FetchExistingTargetAsync(conn, ct).ConfigureAwait(false) != null;
+
+    private static async Task<string?> readTargetAsync(DbDataReader reader, CancellationToken ct)
+    {
+        if (!await reader.ReadAsync(ct).ConfigureAwait(false)) return null;
+        if (await reader.IsDBNullAsync(0, ct).ConfigureAwait(false)) return null;
+
+        var target = await reader.GetFieldValueAsync<string>(0, ct).ConfigureAwait(false);
+        return string.IsNullOrWhiteSpace(target) ? null : target;
+    }
+}
+
+/// <summary>
+///     <c>CREATE OR REPLACE SYNONYM</c> does the whole job, so an update is that statement alone —
+///     Oracle's migrator executes one statement per delta, and its drop is a PL/SQL block.
+/// </summary>
+internal class SynonymDelta: ISchemaObjectDelta
+{
+    private readonly Synonym _synonym;
+
+    public SynonymDelta(Synonym synonym, SchemaPatchDifference difference)
+    {
+        _synonym = synonym;
+        Difference = difference;
+    }
+
+    public ISchemaObject SchemaObject => _synonym;
+
+    public SchemaPatchDifference Difference { get; }
+
+    public void WriteUpdate(Migrator rules, TextWriter writer) => _synonym.WriteCreateStatement(rules, writer);
+
+    public void WriteRollback(Migrator rules, TextWriter writer)
+    {
+    }
+
+    public void WriteRestorationOfPreviousState(Migrator rules, TextWriter writer)
+        => throw new NotSupportedException();
+}

--- a/src/Weasel.Oracle/Views/MaterializedView.cs
+++ b/src/Weasel.Oracle/Views/MaterializedView.cs
@@ -1,0 +1,138 @@
+using System.Data.Common;
+using JasperFx.Core;
+using Oracle.ManagedDataAccess.Client;
+using Weasel.Core;
+using DbCommandBuilder = Weasel.Core.DbCommandBuilder;
+
+namespace Weasel.Oracle.Views;
+
+/// <summary>How a materialized view is brought up to date.</summary>
+public enum MaterializedViewRefresh
+{
+    /// <summary>Only when someone asks, through <c>dbms_mview.refresh</c>.</summary>
+    OnDemand,
+
+    /// <summary>At the end of every transaction that changes a base table.</summary>
+    OnCommit
+}
+
+/// <summary>
+///     An Oracle materialized view: a query whose results are stored, and which is refreshed rather
+///     than re-evaluated.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Not a subclass of <see cref="View" />, unlike PostgreSQL's, because Oracle's differ in
+///         more than the keyword. There is no <c>CREATE OR REPLACE MATERIALIZED VIEW</c>, the query
+///         lives in <c>all_mviews</c> rather than <c>all_views</c>, and refresh mode and query
+///         rewrite have no equivalent on a plain view.
+///     </para>
+///     <para>
+///         <strong>The container table shares the view's name.</strong> Oracle lists it in
+///         <c>all_tables</c>, and <c>DROP TABLE</c> against it fails with ORA-12083 — which is why
+///         the teardown in weasel#465 excludes mview containers from its table sweep.
+///     </para>
+/// </remarks>
+public class MaterializedView: SchemaObjectBase
+{
+    public MaterializedView(string name, string viewSql)
+        : this(DbObjectName.Parse(OracleProvider.Instance, name), viewSql)
+    {
+    }
+
+    public MaterializedView(DbObjectName identifier, string viewSql): base(identifier)
+    {
+        ViewSql = viewSql ?? throw new ArgumentNullException(nameof(viewSql));
+    }
+
+    /// <summary>The SELECT whose results are stored.</summary>
+    public string ViewSql { get; }
+
+    public MaterializedViewRefresh Refresh { get; set; } = MaterializedViewRefresh.OnDemand;
+
+    /// <summary>
+    ///     Let the optimizer answer a query against the base tables from this view instead. Off by
+    ///     default, because it changes plans for queries that never mention the view.
+    /// </summary>
+    public bool EnableQueryRewrite { get; set; }
+
+    public override void WriteCreateStatement(Migrator migrator, TextWriter writer)
+    {
+        var refresh = Refresh == MaterializedViewRefresh.OnCommit ? "REFRESH ON COMMIT" : "REFRESH ON DEMAND";
+        var rewrite = EnableQueryRewrite ? " ENABLE QUERY REWRITE" : string.Empty;
+        var body = ViewSql.TrimEnd().TrimEnd(';');
+
+        writer.WriteLine(
+            $"CREATE MATERIALIZED VIEW {Identifier.QualifiedName} {refresh}{rewrite} AS {body}");
+    }
+
+    public override void WriteDropStatement(Migrator rules, TextWriter writer)
+    {
+        // ORA-12003: materialized view does not exist.
+        writer.WriteLine($@"BEGIN
+    EXECUTE IMMEDIATE 'DROP MATERIALIZED VIEW {SchemaUtils.EscapeLiteral(Identifier.QualifiedName)}';
+EXCEPTION
+    WHEN OTHERS THEN IF SQLCODE != -12003 THEN RAISE; END IF;
+END;");
+    }
+
+    public override void ConfigureQueryCommand(DbCommandBuilder builder)
+    {
+        if (builder.Command is OracleCommand oracleCommand)
+        {
+            // all_mviews.query is a LONG, and ODP.NET reads a LONG back empty by default -- the
+            // trap weasel#450 hit on all_views.TEXT.
+            oracleCommand.InitialLONGFetchSize = -1;
+        }
+
+        var schemaParam = builder.AddParameter(Identifier.Schema.ToUpperInvariant()).ParameterName;
+        var nameParam = builder.AddParameter(Identifier.Name.ToUpperInvariant()).ParameterName;
+
+        builder.Append(
+            $"SELECT query FROM all_mviews WHERE owner = :{schemaParam} AND mview_name = :{nameParam}");
+    }
+
+    public override async Task<ISchemaObjectDelta> CreateDeltaAsync(DbDataReader reader, CancellationToken ct = default)
+    {
+        var existing = await readQueryAsync(reader, ct).ConfigureAwait(false);
+
+        if (existing == null)
+        {
+            return new SchemaObjectDelta(this, SchemaPatchDifference.Create);
+        }
+
+        // No CREATE OR REPLACE for a materialized view, so a change is Invalid -- drop and create,
+        // which for a materialized view is exactly right: its contents are derived, not authored.
+        return Normalize(existing) == Normalize(ViewSql)
+            ? new SchemaObjectDelta(this, SchemaPatchDifference.None)
+            : new SchemaObjectDelta(this, SchemaPatchDifference.Invalid);
+    }
+
+    internal static string Normalize(string sql)
+        => sql.Replace("\r\n", "").Replace("\n", "").Replace("\r", "").Replace("\t", "")
+            .Replace(" ", "").Trim().TrimEnd(';').ToUpperInvariant();
+
+    public async Task<string?> FetchExistingQueryAsync(OracleConnection conn, CancellationToken ct = default)
+    {
+        var builder = new DbCommandBuilder(conn);
+        ConfigureQueryCommand(builder);
+
+        await using var reader = await conn.ExecuteReaderAsync(builder, ct).ConfigureAwait(false);
+        var query = await readQueryAsync(reader, ct).ConfigureAwait(false);
+        await reader.CloseAsync().ConfigureAwait(false);
+
+        return query;
+    }
+
+    public async Task<bool> ExistsInDatabaseAsync(OracleConnection conn, CancellationToken ct = default)
+        => await FetchExistingQueryAsync(conn, ct).ConfigureAwait(false) != null;
+
+    private static async Task<string?> readQueryAsync(DbDataReader reader, CancellationToken ct)
+    {
+        if (!await reader.ReadAsync(ct).ConfigureAwait(false)) return null;
+        if (await reader.IsDBNullAsync(0, ct).ConfigureAwait(false)) return null;
+
+        var query = await reader.GetFieldValueAsync<string>(0, ct).ConfigureAwait(false);
+        return query.IsEmpty() ? null : query;
+    }
+}

--- a/src/Weasel.Postgresql.Tests/Types/UserDefinedTypeTests.cs
+++ b/src/Weasel.Postgresql.Tests/Types/UserDefinedTypeTests.cs
@@ -1,0 +1,124 @@
+using Shouldly;
+using Weasel.Core;
+using Weasel.Postgresql.Types;
+using Xunit;
+
+namespace Weasel.Postgresql.Tests.Types;
+
+/// <summary>
+///     PostgreSQL user-defined types — enums, domains and composites (weasel#453). One class for
+///     all three, because they are one object in the catalog and Weasel does the same thing with
+///     each.
+/// </summary>
+[Collection("udts")]
+public class UserDefinedTypeTests: IntegrationContext
+{
+    public UserDefinedTypeTests(): base("udts")
+    {
+    }
+
+    [Fact]
+    public async Task an_enum_round_trips_and_reports_no_delta()
+    {
+        await ResetSchema();
+
+        var type = UserDefinedType.Enum("udts.order_status", "pending", "shipped", "cancelled");
+        await type.ApplyChangesAsync(theConnection);
+
+        (await type.ExistsInDatabaseAsync(theConnection)).ShouldBeTrue();
+        (await type.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task an_enum_does_not_report_permanent_drift()
+    {
+        await ResetSchema();
+
+        var type = UserDefinedType.Enum("udts.order_status", "pending", "shipped");
+        await type.ApplyChangesAsync(theConnection);
+
+        (await type.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+        (await type.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task an_enum_is_usable_as_a_column_type()
+    {
+        await ResetSchema();
+        await UserDefinedType.Enum("udts.order_status", "pending", "shipped").ApplyChangesAsync(theConnection);
+
+        await theConnection.CreateCommand("create table udts.orders (id int primary key, status udts.order_status)")
+            .ExecuteNonQueryAsync();
+        await theConnection.CreateCommand("insert into udts.orders values (1, 'shipped')").ExecuteNonQueryAsync();
+
+        var status = await theConnection.CreateCommand("select status::text from udts.orders").ExecuteScalarAsync();
+        status.ShouldBe("shipped");
+    }
+
+    /// <summary>
+    ///     Changing an enum's labels is not an <c>ALTER</c> anyone can do safely — a column may
+    ///     depend on the type — so it reports <see cref="SchemaPatchDifference.Invalid" /> and asks
+    ///     for a human rather than dropping the type out from under a column.
+    /// </summary>
+    [Fact]
+    public async Task changing_an_enum_reports_invalid_rather_than_dropping_it()
+    {
+        await ResetSchema();
+        await UserDefinedType.Enum("udts.order_status", "pending", "shipped").ApplyChangesAsync(theConnection);
+
+        var changed = UserDefinedType.Enum("udts.order_status", "pending", "shipped", "cancelled");
+
+        (await changed.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.Invalid);
+    }
+
+    [Fact]
+    public async Task a_domain_round_trips_and_reports_no_delta()
+    {
+        await ResetSchema();
+
+        var type = UserDefinedType.Domain("udts.positive_qty", "integer", "VALUE > 0");
+        await type.ApplyChangesAsync(theConnection);
+
+        (await type.ExistsInDatabaseAsync(theConnection)).ShouldBeTrue();
+        (await type.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task a_domain_enforces_its_constraint()
+    {
+        await ResetSchema();
+        await UserDefinedType.Domain("udts.positive_qty", "integer", "VALUE > 0")
+            .ApplyChangesAsync(theConnection);
+
+        await theConnection.CreateCommand("create table udts.items (id int primary key, qty udts.positive_qty)")
+            .ExecuteNonQueryAsync();
+
+        await Should.ThrowAsync<Exception>(async () =>
+            await theConnection.CreateCommand("insert into udts.items values (1, -5)").ExecuteNonQueryAsync());
+    }
+
+    [Fact]
+    public async Task a_composite_round_trips_and_reports_no_delta()
+    {
+        await ResetSchema();
+
+        var type = UserDefinedType.Composite("udts.address", ("street", "varchar(100)"), ("postcode", "varchar(10)"));
+        await type.ApplyChangesAsync(theConnection);
+
+        (await type.ExistsInDatabaseAsync(theConnection)).ShouldBeTrue();
+        (await type.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task dropping_the_schema_takes_its_types_with_it()
+    {
+        await ResetSchema();
+
+        var type = UserDefinedType.Enum("udts.order_status", "pending");
+        await type.ApplyChangesAsync(theConnection);
+
+        await ResetSchema();
+
+        (await type.ExistsInDatabaseAsync(theConnection)).ShouldBeFalse();
+    }
+}

--- a/src/Weasel.Postgresql/Types/UserDefinedType.cs
+++ b/src/Weasel.Postgresql/Types/UserDefinedType.cs
@@ -1,0 +1,178 @@
+using System.Data.Common;
+using JasperFx.Core;
+using Npgsql;
+using Weasel.Core;
+using DbCommandBuilder = Weasel.Core.DbCommandBuilder;
+
+namespace Weasel.Postgresql.Types;
+
+/// <summary>
+///     A PostgreSQL user-defined type: an enum, a domain, or a composite.
+/// </summary>
+/// <remarks>
+///     <para>
+///         The three are one class because they are one object in the catalog — a row in
+///         <c>pg_type</c> — and because what Weasel does with each is the same: create it, notice
+///         when its definition moved, drop it. Modelling them separately would triple the surface to
+///         express a distinction the catalog does not make.
+///     </para>
+///     <para>
+///         <strong>Changing one is not an <c>ALTER</c>.</strong> A domain's constraint can be
+///         altered, an enum can gain a label, but reordering an enum's labels or changing a
+///         composite's fields cannot — and a type in use cannot be dropped at all, because columns
+///         depend on it. So a changed type reports <see cref="SchemaPatchDifference.Invalid" />: it
+///         needs a human, and pretending otherwise would drop a column's type out from under it.
+///     </para>
+/// </remarks>
+public class UserDefinedType: SchemaObjectBase
+{
+    private UserDefinedType(DbObjectName identifier, string kind, string definition): base(identifier)
+    {
+        Kind = kind;
+        Definition = definition;
+    }
+
+    /// <summary><c>ENUM</c>, <c>DOMAIN</c> or <c>COMPOSITE</c>.</summary>
+    public string Kind { get; }
+
+    /// <summary>
+    ///     The type's contents as they will be written and as they come back from the catalog: the
+    ///     label list, the base type and constraint, or the field list.
+    /// </summary>
+    public string Definition { get; }
+
+    /// <summary>
+    ///     An enum type over a fixed set of labels. Marten generates these, so there is an existing
+    ///     consumer.
+    /// </summary>
+    public static UserDefinedType Enum(string name, params string[] labels)
+        => new(DbObjectName.Parse(PostgresqlProvider.Instance, name), "ENUM",
+            labels.Select(x => $"'{IdentifierRules.EscapeLiteral(x)}'").Join(", "));
+
+    /// <summary>
+    ///     A domain: a base type plus an optional constraint, reusable as a column type.
+    /// </summary>
+    public static UserDefinedType Domain(string name, string baseType, string? constraint = null)
+        => new(DbObjectName.Parse(PostgresqlProvider.Instance, name), "DOMAIN",
+            constraint.IsEmpty() ? baseType : $"{baseType} CHECK ({constraint})");
+
+    /// <summary>
+    ///     A composite type: named fields, usable as a column type or a function's return.
+    /// </summary>
+    public static UserDefinedType Composite(string name, params (string Name, string Type)[] fields)
+        => new(DbObjectName.Parse(PostgresqlProvider.Instance, name), "COMPOSITE",
+            fields.Select(x => $"{SchemaUtils.QuoteName(x.Name)} {x.Type}").Join(", "));
+
+    public override void WriteCreateStatement(Migrator migrator, TextWriter writer)
+    {
+        writer.WriteLine(Kind switch
+        {
+            "ENUM" => $"CREATE TYPE {Identifier} AS ENUM ({Definition});",
+            "DOMAIN" => $"CREATE DOMAIN {Identifier} AS {Definition};",
+            _ => $"CREATE TYPE {Identifier} AS ({Definition});"
+        });
+    }
+
+    public override void WriteDropStatement(Migrator rules, TextWriter writer)
+    {
+        // No CASCADE: a type with dependents should refuse to be dropped rather than take the
+        // columns that use it.
+        writer.WriteLine(Kind == "DOMAIN"
+            ? $"DROP DOMAIN IF EXISTS {Identifier};"
+            : $"DROP TYPE IF EXISTS {Identifier};");
+    }
+
+    public override void ConfigureQueryCommand(DbCommandBuilder builder)
+    {
+        var nameParam = builder.AddParameter(Identifier.Name).ParameterName;
+        var schemaParam = builder.AddParameter(Identifier.Schema).ParameterName;
+
+        // One query for all three kinds: the label list for an enum, the base type and constraint
+        // for a domain, the field list for a composite.
+        builder.Append($@"
+SELECT
+    CASE
+        WHEN t.typtype = 'e' THEN (
+            SELECT string_agg(quote_literal(e.enumlabel), ', ' ORDER BY e.enumsortorder)
+            FROM pg_enum e WHERE e.enumtypid = t.oid)
+        WHEN t.typtype = 'd' THEN
+            format_type(t.typbasetype, t.typtypmod) ||
+            COALESCE((SELECT ' ' || pg_get_constraintdef(c.oid)
+                      FROM pg_constraint c WHERE c.contypid = t.oid LIMIT 1), '')
+        ELSE (
+            SELECT string_agg(quote_ident(a.attname) || ' ' || format_type(a.atttypid, a.atttypmod), ', '
+                              ORDER BY a.attnum)
+            FROM pg_attribute a WHERE a.attrelid = t.typrelid AND a.attnum > 0 AND NOT a.attisdropped)
+    END
+FROM pg_type t
+JOIN pg_namespace n ON n.oid = t.typnamespace
+WHERE t.typname = :{nameParam} AND n.nspname = :{schemaParam}
+  AND t.typtype IN ('e', 'd', 'c')");
+    }
+
+    public override async Task<ISchemaObjectDelta> CreateDeltaAsync(DbDataReader reader, CancellationToken ct = default)
+    {
+        var existing = await readDefinitionAsync(reader, ct).ConfigureAwait(false);
+
+        if (existing == null)
+        {
+            return new SchemaObjectDelta(this, SchemaPatchDifference.Create);
+        }
+
+        return Normalize(existing) == Normalize(Definition)
+            ? new SchemaObjectDelta(this, SchemaPatchDifference.None)
+            : new SchemaObjectDelta(this, SchemaPatchDifference.Invalid);
+    }
+
+    /// <summary>
+    ///     PostgreSQL renders what it stores — <c>varchar</c> becomes
+    ///     <c>character varying</c>, a check constraint comes back with its own parenthesization —
+    ///     so the comparison ignores whitespace and case. It is not exact, and a purely cosmetic
+    ///     difference in a domain's constraint can read as a change; reporting that is
+    ///     <see cref="SchemaPatchDifference.Invalid" /> means a human looks at it rather than a
+    ///     migration dropping a type some column depends on.
+    /// </summary>
+    internal static string Normalize(string definition)
+    {
+        // PostgreSQL renders type names by their canonical spelling, so a composite declared with
+        // varchar(100) comes back as character varying(100); route both sides through the provider's
+        // own synonym table rather than keeping a second list here.
+        var canonical = TypeName.Replace(definition, m =>
+            PostgresqlProvider.Instance.ConvertSynonyms(m.Value.ToLowerInvariant()));
+
+        return canonical
+            .Replace(" ", "").Replace("\"", "").Replace("\r", "").Replace("\n", "")
+            // pg_get_constraintdef parenthesizes a domain's check where the caller may not have.
+            .Replace("(", "").Replace(")", "")
+            .Trim().ToUpperInvariant();
+    }
+
+    private static readonly System.Text.RegularExpressions.Regex TypeName =
+        new(@"character varying|timestamp without time zone|timestamp with time zone|double precision",
+            System.Text.RegularExpressions.RegexOptions.IgnoreCase
+            | System.Text.RegularExpressions.RegexOptions.Compiled);
+
+    public async Task<string?> FetchExistingDefinitionAsync(NpgsqlConnection conn, CancellationToken ct = default)
+    {
+        var builder = new DbCommandBuilder(conn);
+        ConfigureQueryCommand(builder);
+
+        await using var reader = await conn.ExecuteReaderAsync(builder, ct).ConfigureAwait(false);
+        var definition = await readDefinitionAsync(reader, ct).ConfigureAwait(false);
+        await reader.CloseAsync().ConfigureAwait(false);
+
+        return definition;
+    }
+
+    public async Task<bool> ExistsInDatabaseAsync(NpgsqlConnection conn, CancellationToken ct = default)
+        => await FetchExistingDefinitionAsync(conn, ct).ConfigureAwait(false) != null;
+
+    private static async Task<string?> readDefinitionAsync(DbDataReader reader, CancellationToken ct)
+    {
+        if (!await reader.ReadAsync(ct).ConfigureAwait(false)) return null;
+        if (await reader.IsDBNullAsync(0, ct).ConfigureAwait(false)) return null;
+
+        var definition = await reader.GetFieldValueAsync<string>(0, ct).ConfigureAwait(false);
+        return definition.IsEmpty() ? null : definition;
+    }
+}

--- a/src/Weasel.SqlServer.Tests/Synonyms/SynonymTests.cs
+++ b/src/Weasel.SqlServer.Tests/Synonyms/SynonymTests.cs
@@ -1,0 +1,110 @@
+using Shouldly;
+using Weasel.Core;
+using Weasel.SqlServer.Synonyms;
+using Weasel.SqlServer.Tables;
+using Xunit;
+
+namespace Weasel.SqlServer.Tests.Synonyms;
+
+/// <summary>
+///     SQL Server synonyms (weasel#453).
+/// </summary>
+[Collection("integration")]
+public class SynonymTests: IntegrationContext
+{
+    public SynonymTests(): base("synonyms")
+    {
+    }
+
+    private static Table SourceTable(string name = "orders")
+    {
+        var table = new Table($"synonyms.{name}");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        return table;
+    }
+
+    private static Synonym NewSynonym(string target = "synonyms.orders")
+        => new("synonyms.order_alias", target);
+
+    /// <summary>
+    ///     <c>sys.synonyms</c> brackets and qualifies the target whatever the caller wrote, so a
+    ///     bare name and a bracketed one have to compare equal or every synonym reports drift.
+    /// </summary>
+    [Fact]
+    public void the_target_comparison_ignores_bracketing()
+    {
+        Synonym.Normalize("[synonyms].[orders]").ShouldBe(Synonym.Normalize("synonyms.orders"));
+    }
+
+    [Fact]
+    public async Task a_synonym_round_trips_and_reports_no_delta()
+    {
+        await ResetSchema();
+        await SourceTable().ApplyChangesAsync(theConnection);
+
+        var synonym = NewSynonym();
+        await synonym.ApplyChangesAsync(theConnection);
+
+        (await synonym.ExistsInDatabaseAsync(theConnection)).ShouldBeTrue();
+        (await synonym.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task an_unchanged_synonym_does_not_report_permanent_drift()
+    {
+        await ResetSchema();
+        await SourceTable().ApplyChangesAsync(theConnection);
+        await NewSynonym().ApplyChangesAsync(theConnection);
+
+        (await NewSynonym().FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+        (await NewSynonym().FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task the_synonym_actually_resolves()
+    {
+        await ResetSchema();
+        await SourceTable().ApplyChangesAsync(theConnection);
+        await NewSynonym().ApplyChangesAsync(theConnection);
+
+        await theConnection.CreateCommand("insert into synonyms.orders (id) values (1)").ExecuteNonQueryAsync();
+
+        var count = await theConnection.CreateCommand("select count(*) from synonyms.order_alias")
+            .ExecuteScalarAsync();
+
+        Convert.ToInt32(count).ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task a_retargeted_synonym_reports_update_and_applying_it_converges()
+    {
+        await ResetSchema();
+        await SourceTable().ApplyChangesAsync(theConnection);
+        await SourceTable("archive").ApplyChangesAsync(theConnection);
+        await NewSynonym().ApplyChangesAsync(theConnection);
+
+        var retargeted = NewSynonym("synonyms.archive");
+
+        (await retargeted.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.Update);
+
+        await retargeted.ApplyChangesAsync(theConnection);
+
+        (await retargeted.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    /// <summary>
+    ///     SQL Server's teardown enumerates object types by hand, so a new one has to be added to it
+    ///     — the rule CLAUDE.md gained in weasel#469, and the trap weasel#464 fell into with views.
+    /// </summary>
+    [Fact]
+    public async Task dropping_the_schema_takes_its_synonyms_with_it()
+    {
+        await ResetSchema();
+        await SourceTable().ApplyChangesAsync(theConnection);
+        await NewSynonym().ApplyChangesAsync(theConnection);
+
+        await ResetSchema();
+
+        (await NewSynonym().ExistsInDatabaseAsync(theConnection)).ShouldBeFalse();
+    }
+}

--- a/src/Weasel.SqlServer/SchemaObjectsExtensions.cs
+++ b/src/Weasel.SqlServer/SchemaObjectsExtensions.cs
@@ -135,6 +135,13 @@ WHERE
                 $"select sequence_name from information_schema.sequences where sequence_schema = '{SchemaUtils.EscapeLiteral(schemaName)}'")
             .FetchListAsync<string>(cancellation: ct).ConfigureAwait(false);
 
+        // Synonyms: weasel#453 made them creatable, and CLAUDE.md's rule is that a new object type
+        // is not done until the enumerating teardowns know about it.
+        var synonyms = await conn
+            .CreateCommand(
+                $"select s.name from sys.synonyms s inner join sys.schemas sch on sch.schema_id = s.schema_id where sch.name = '{SchemaUtils.EscapeLiteral(schemaName)}'")
+            .FetchListAsync<string>(cancellation: ct).ConfigureAwait(false);
+
         var tableTypes = await conn
             .CreateCommand(
                 $"select sys.table_types.name from sys.table_types inner join sys.schemas on sys.table_types.schema_id = sys.schemas.schema_id where sys.schemas.name = '{SchemaUtils.EscapeLiteral(schemaName)}'")
@@ -150,6 +157,7 @@ WHERE
         drops.AddRange(tables.Select(name => $"drop table if exists {SchemaUtils.QuoteName(schemaName)}.{SchemaUtils.QuoteName(name)};"));
         drops.AddRange(sequences.Select(name => $"drop sequence if exists {SchemaUtils.QuoteName(schemaName)}.{SchemaUtils.QuoteName(name)};"));
         drops.AddRange(tableTypes.Select(x => $"DROP TYPE IF EXISTS {SchemaUtils.QuoteName(schemaName)}.{SchemaUtils.QuoteName(x)};"));
+        drops.AddRange(synonyms.Select(name => $"drop synonym if exists {SchemaUtils.QuoteName(schemaName)}.{SchemaUtils.QuoteName(name)};"));
 
 
         foreach (var drop in drops)

--- a/src/Weasel.SqlServer/Synonyms/Synonym.cs
+++ b/src/Weasel.SqlServer/Synonyms/Synonym.cs
@@ -1,0 +1,105 @@
+using System.Data.Common;
+using Microsoft.Data.SqlClient;
+using Weasel.Core;
+using DbCommandBuilder = Weasel.Core.DbCommandBuilder;
+
+namespace Weasel.SqlServer.Synonyms;
+
+/// <summary>
+///     A SQL Server synonym: a second name for an object, possibly in another database or on a
+///     linked server.
+/// </summary>
+/// <remarks>
+///     <para>
+///         The target is stored as text and is deliberately not validated — a synonym may point at
+///         something that does not exist yet, or at a four-part name on a linked server, and SQL
+///         Server accepts both. <c>sys.synonyms.base_object_name</c> hands the name back bracketed
+///         and fully qualified whatever the caller wrote, so comparison normalizes the brackets away
+///         rather than demanding the caller match SQL Server's spelling.
+///     </para>
+///     <para>
+///         There is no <c>ALTER SYNONYM</c>, so a change is a drop and a create.
+///     </para>
+/// </remarks>
+public class Synonym: SchemaObjectBase
+{
+    public Synonym(string name, string target)
+        : this(DbObjectName.Parse(SqlServerProvider.Instance, name), target)
+    {
+    }
+
+    public Synonym(DbObjectName identifier, string target): base(identifier)
+    {
+        Target = target ?? throw new ArgumentNullException(nameof(target));
+    }
+
+    /// <summary>The object this synonym stands for.</summary>
+    public string Target { get; }
+
+    public override void WriteCreateStatement(Migrator migrator, TextWriter writer)
+    {
+        WriteDropStatement(migrator, writer);
+        writer.WriteLine($"CREATE SYNONYM {Identifier} FOR {Target};");
+    }
+
+    public override void WriteDropStatement(Migrator rules, TextWriter writer)
+    {
+        writer.WriteLine($"DROP SYNONYM IF EXISTS {Identifier};");
+    }
+
+    public override void ConfigureQueryCommand(DbCommandBuilder builder)
+    {
+        var nameParam = builder.AddParameter(Identifier.Name).ParameterName;
+        var schemaParam = builder.AddParameter(Identifier.Schema).ParameterName;
+
+        builder.Append(
+            "SELECT s.base_object_name FROM sys.synonyms s "
+            + "INNER JOIN sys.schemas sch ON sch.schema_id = s.schema_id "
+            + $"WHERE s.name = @{nameParam} AND sch.name = @{schemaParam}");
+    }
+
+    public override async Task<ISchemaObjectDelta> CreateDeltaAsync(DbDataReader reader, CancellationToken ct = default)
+    {
+        var existing = await readTargetAsync(reader, ct).ConfigureAwait(false);
+
+        if (existing == null)
+        {
+            return new SchemaObjectDelta(this, SchemaPatchDifference.Create);
+        }
+
+        return Normalize(existing) == Normalize(Target)
+            ? new SchemaObjectDelta(this, SchemaPatchDifference.None)
+            : new SchemaObjectDelta(this, SchemaPatchDifference.Update);
+    }
+
+    /// <summary>
+    ///     <c>sys.synonyms</c> brackets and qualifies the target whatever the caller wrote, so the
+    ///     brackets come off both sides before comparing. Case-insensitive, like SQL Server itself.
+    /// </summary>
+    internal static string Normalize(string target)
+        => target.Replace("[", "").Replace("]", "").Trim().ToUpperInvariant();
+
+    public async Task<string?> FetchExistingTargetAsync(SqlConnection conn, CancellationToken ct = default)
+    {
+        var builder = new DbCommandBuilder(conn);
+        ConfigureQueryCommand(builder);
+
+        await using var reader = await conn.ExecuteReaderAsync(builder, ct).ConfigureAwait(false);
+        var target = await readTargetAsync(reader, ct).ConfigureAwait(false);
+        await reader.CloseAsync().ConfigureAwait(false);
+
+        return target;
+    }
+
+    public async Task<bool> ExistsInDatabaseAsync(SqlConnection conn, CancellationToken ct = default)
+        => await FetchExistingTargetAsync(conn, ct).ConfigureAwait(false) != null;
+
+    private static async Task<string?> readTargetAsync(DbDataReader reader, CancellationToken ct)
+    {
+        if (!await reader.ReadAsync(ct).ConfigureAwait(false)) return null;
+        if (await reader.IsDBNullAsync(0, ct).ConfigureAwait(false)) return null;
+
+        var target = await reader.GetFieldValueAsync<string>(0, ct).ConfigureAwait(false);
+        return string.IsNullOrWhiteSpace(target) ? null : target;
+    }
+}


### PR DESCRIPTION
Closes #453. The last of the object types from the structural survey.

## Oracle packages are the one with a shape of their own

The specification and the body are **two objects**. `all_source` lists them as `PACKAGE` and `PACKAGE BODY`, they compile separately, and a body can be invalid while its spec is fine — the normal state after a base table changes, and what callers see as ORA-04063 rather than as a missing object. That is precisely why they never fitted `FunctionBase`'s single-body shape.

`Body` is **optional**: a spec-only package is legal Oracle and is how shared constants and types get declared. Dropping the spec takes the body with it, so there is one drop statement.

## The rest

| | Notes |
|---|---|
| **Oracle materialized views** | **Not** a subclass of `View`, unlike PostgreSQL's — no `CREATE OR REPLACE`, the query lives in `all_mviews`, and refresh mode and query rewrite have no equivalent on a plain view. A changed query reports `Invalid` rather than `Update`, which for a materialized view is right: its contents are derived, not authored. |
| **PostgreSQL UDTs** | Enums, domains and composites through one class, because the catalog makes no distinction and neither does anything Weasel does with them. A change reports `Invalid` — a column may depend on the type, and dropping it out from under one is worse than asking for a human. |
| **Oracle + SQL Server synonyms** | Straightforward, with one wrinkle each (below). |

Two rendering facts that needed measuring, not assuming:

- **SQL Server's `sys.synonyms` brackets and qualifies the target** whatever the caller wrote, so the comparison normalizes brackets away rather than demanding the caller match SQL Server's spelling.
- **PostgreSQL renders type names canonically** — a composite declared `varchar(100)` comes back `character varying(100)`, and `pg_get_constraintdef` supplies its own `CHECK` and parentheses. Both sides route through `PostgresqlProvider.ConvertSynonyms` rather than keeping a second synonym list here.

## The MySQL sequence decision, as recorded on the issue

`Weasel.MySql.Sequence` is now `[Obsolete]` pointing at `AUTO_INCREMENT`, and **`IncrementBy` throws** rather than silently ignoring the value.

Nothing could consume the object: `current_value` is never read or incremented, there is no next-value operation anywhere in `Weasel.MySql` or on `SequenceBase`, and its delta only checks existence. The code comment claiming MySQL 8.0 added sequences was also wrong — MySQL never had them at any version; MariaDB 10.3 does.

The general rule is now in the docs: **emulate operations, not objects.** An emulated object makes `AllObjects()` and introspection lie, and the semantics diverge where it matters — a real sequence does not roll back and does not serialize writers; a table-backed counter does both.

## Teardown, per the standing rule

SQL Server's teardown learned synonyms — CLAUDE.md's rule from #469 is that a new object type is not done until the enumerating teardowns know about it. Oracle's already knew about all three of its new types; #469 taught it packages, synonyms and materialized views *before* anything could create one, and the `dropping_the_schema_takes_…` tests here are what arm that.

`dropping_the_schema_takes_the_view_and_its_container_table` is the pointed one: Oracle lists a materialized view's container table in `all_tables` under the same name, and `DROP TABLE` against it fails.

## One small Core hook

`SchemaObjectBase.CreateCommandBuilder`, so an object registering more than one query gets a builder that can split them. Oracle packages need it — without it the two statements were concatenated into one command and failed with ORA-03048, the same shape as #474.

## ⚠️ `.gitignore` was silently eating the source

The standard .NET rule `**/[Pp]ackages/*` — meant for the NuGet restore folder — swallowed `src/Weasel.Oracle/Packages/`. The first push went out without `Package.cs` and would not have compiled. Added a negation for `src/**/[Pp]ackages/*.cs` so it cannot happen again.

## Verified locally

Core 220, SQLite 432, PostgreSQL 900, SQL Server 454, Oracle 292, MySQL 288, EF Core 106. No failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)