### PR TITLE
Local identifiers are checked for safety, not for length (#485, #486)

### DIFF
--- a/src/Weasel.Core/Migrations/DatabaseBase.cs
+++ b/src/Weasel.Core/Migrations/DatabaseBase.cs
@@ -563,7 +563,7 @@ public abstract class DatabaseBase<TConnection>: IDatabase<TConnection>, IDataba
             {
                 foreach (var name in withLocals.LocalIdentifiers())
                 {
-                    Migrator.AssertValidIdentifier(name);
+                    Migrator.AssertValidLocalIdentifier(name);
                 }
             }
         }

--- a/src/Weasel.Core/Migrator.cs
+++ b/src/Weasel.Core/Migrator.cs
@@ -299,6 +299,24 @@ public abstract class
     public abstract void AssertValidIdentifier(string name);
 
     /// <summary>
+    ///     Assert that a name this dialect will write into DDL but which is not a database object in
+    ///     its own right — a column, a primary key constraint, a check constraint — is safe to emit.
+    /// </summary>
+    /// <remarks>
+    ///     Same safety rules as <see cref="AssertValidIdentifier" />, without the length limit. A
+    ///     local identifier is only ever emitted inside its own table's DDL and never addressed by
+    ///     name afterwards, and <see cref="TableBase{TColumn,TIndex,TForeignKey}.TruncatedNameIdentifier" />
+    ///     already reconciles a truncated one against the catalog — so refusing to create it would
+    ///     reject schemas the delta comparison is built to handle (weasel#485).
+    ///     <para>
+    ///     The default defers to <see cref="AssertValidIdentifier" /> so an out-of-tree provider that
+    ///     has not considered the distinction keeps the stricter behaviour. Every in-tree provider
+    ///     overrides it.
+    ///     </para>
+    /// </remarks>
+    public virtual void AssertValidLocalIdentifier(string name) => AssertValidIdentifier(name);
+
+    /// <summary>
     ///     True when <paramref name="columnName" /> refers to an engine-managed
     ///     system / pseudo column that must never be emitted as a real column in
     ///     generated DDL (the engine rejects <c>CREATE TABLE</c> with such a name).

--- a/src/Weasel.MySql/MySqlMigrator.cs
+++ b/src/Weasel.MySql/MySqlMigrator.cs
@@ -130,16 +130,31 @@ public class MySqlMigrator: Migrator
     /// <exception cref="ArgumentException">The name cannot be safely written into DDL.</exception>
     public override void AssertValidIdentifier(string name)
     {
-        var problem = IdentifierValidation.FindProblem(name, UnsafeIdentifierCharacters);
-        if (problem != null)
-        {
-            throw new ArgumentException($"MySQL identifier '{name}' is not valid because {problem}.");
-        }
+        AssertValidLocalIdentifier(name);
 
         if (name.Length > MaxIdentifierLength)
         {
             throw new ArgumentException(
                 $"MySQL identifier '{name}' exceeds the {MaxIdentifierLength} character limit.");
+        }
+    }
+
+    /// <summary>
+    ///     The safety half of <see cref="AssertValidIdentifier" />, without the length limit.
+    /// </summary>
+    /// <remarks>
+    ///     A column, primary key or check constraint name is only ever emitted inside its own
+    ///     table's DDL and is never addressed by name afterwards, and the delta comparison already
+    ///     reads both sides through TruncatedNameIdentifier so a name MySQL truncated still
+    ///     matches. Refusing to create one would reject schemas the rest of Weasel handles
+    ///     (weasel#485). The safety rules still apply in full.
+    /// </remarks>
+    public override void AssertValidLocalIdentifier(string name)
+    {
+        var problem = IdentifierValidation.FindProblem(name, UnsafeIdentifierCharacters);
+        if (problem != null)
+        {
+            throw new ArgumentException($"MySQL identifier '{name}' is not valid because {problem}.");
         }
     }
 

--- a/src/Weasel.Oracle/OracleMigrator.cs
+++ b/src/Weasel.Oracle/OracleMigrator.cs
@@ -154,16 +154,31 @@ END;");
 
     public override void AssertValidIdentifier(string name)
     {
-        var problem = IdentifierValidation.FindProblem(name, UnsafeIdentifierCharacters);
-        if (problem != null)
-        {
-            throw new InvalidOperationException($"Oracle identifier '{name}' is not valid because {problem}.");
-        }
+        AssertValidLocalIdentifier(name);
 
         if (name.Length > MaxIdentifierLength)
         {
             throw new InvalidOperationException(
                 $"Oracle identifiers cannot exceed {MaxIdentifierLength} characters. '{name}' is {name.Length} characters.");
+        }
+    }
+
+    /// <summary>
+    ///     The safety half of <see cref="AssertValidIdentifier" />, without the length limit.
+    /// </summary>
+    /// <remarks>
+    ///     A column, primary key or check constraint name is only ever emitted inside its own
+    ///     table's DDL and is never addressed by name afterwards, and the delta comparison already
+    ///     reads both sides through TruncatedNameIdentifier so a name Oracle truncated still
+    ///     matches. Refusing to create one would reject schemas the rest of Weasel handles
+    ///     (weasel#485). The safety rules still apply in full.
+    /// </remarks>
+    public override void AssertValidLocalIdentifier(string name)
+    {
+        var problem = IdentifierValidation.FindProblem(name, UnsafeIdentifierCharacters);
+        if (problem != null)
+        {
+            throw new InvalidOperationException($"Oracle identifier '{name}' is not valid because {problem}.");
         }
     }
 

--- a/src/Weasel.Postgresql.Tests/PostgresqlMigratorTests.cs
+++ b/src/Weasel.Postgresql.Tests/PostgresqlMigratorTests.cs
@@ -227,4 +227,44 @@ public class PostgresqlMigratorTests
         await using var connection = new NpgsqlConnection(ConnectionSource.ConnectionString);
         await migrator.EnsureDatabaseExistsAsync(connection);
     }
+
+    [Fact]
+    public void an_over_length_local_identifier_is_allowed_where_an_object_name_is_not()
+    {
+        // weasel#485. An object name the database truncates becomes unaddressable and drifts on every
+        // check, so it stays a hard failure. A column, primary key or check constraint name is only ever
+        // emitted inside its own table's DDL, and TableDelta already compares both sides through
+        // TruncatedNameIdentifier precisely so a truncated one matches -- refusing to create it would
+        // reject a schema the rest of Weasel is built to handle.
+        var migrator = new PostgresqlMigrator();
+        var tooLong = new string('a', migrator.NameDataLength + 10);
+
+        Should.Throw<PostgresqlIdentifierTooLongException>(() => migrator.AssertValidIdentifier(tooLong));
+        Should.NotThrow(() => migrator.AssertValidLocalIdentifier(tooLong));
+    }
+
+    [Theory]
+    [InlineData("has\"quote")]
+    [InlineData("has;semicolon")]
+    [InlineData("has'apostrophe")]
+    [InlineData(" leading")]
+    [InlineData("trailing ")]
+    [InlineData("with\nbreak")]
+    public void the_safety_rules_still_apply_in_full_to_a_local_identifier(string name)
+    {
+        // The length limit is the only thing that is relaxed. Anything that could escape the statement
+        // it is written into is rejected wherever it appears.
+        var migrator = new PostgresqlMigrator();
+
+        Should.Throw<PostgresqlIdentifierInvalidException>(() => migrator.AssertValidLocalIdentifier(name));
+    }
+
+    [Fact]
+    public void an_ordinary_local_identifier_passes()
+    {
+        var migrator = new PostgresqlMigrator();
+
+        Should.NotThrow(() => migrator.AssertValidLocalIdentifier("unit price"));
+        Should.NotThrow(() => migrator.AssertValidLocalIdentifier("pkey_mt_doc_thing_id"));
+    }
 }

--- a/src/Weasel.Postgresql/PostgresqlMigrator.cs
+++ b/src/Weasel.Postgresql/PostgresqlMigrator.cs
@@ -354,11 +354,7 @@ $$;
     /// </remarks>
     public override void AssertValidIdentifier(string name)
     {
-        var problem = IdentifierValidation.FindProblem(name, UnsafeIdentifierCharacters);
-        if (problem != null)
-        {
-            throw new PostgresqlIdentifierInvalidException(name, problem);
-        }
+        AssertValidLocalIdentifier(name);
 
         if (name.Length < NameDataLength)
         {
@@ -366,6 +362,25 @@ $$;
         }
 
         throw new PostgresqlIdentifierTooLongException(NameDataLength, name);
+    }
+
+    /// <summary>
+    ///     The safety half of <see cref="AssertValidIdentifier" />, without the length limit.
+    /// </summary>
+    /// <remarks>
+    ///     A column, primary key or check constraint name is only ever emitted inside its own
+    ///     table's DDL and is never addressed by name afterwards, and the delta comparison already
+    ///     reads both sides through TruncatedNameIdentifier so a name PostgreSQL truncated still
+    ///     matches. Refusing to create one would reject schemas the rest of Weasel handles
+    ///     (weasel#485). The safety rules still apply in full.
+    /// </remarks>
+    public override void AssertValidLocalIdentifier(string name)
+    {
+        var problem = IdentifierValidation.FindProblem(name, UnsafeIdentifierCharacters);
+        if (problem != null)
+        {
+            throw new PostgresqlIdentifierInvalidException(name, problem);
+        }
     }
 
     public override async Task EnsureDatabaseExistsAsync(DbConnection connection, CancellationToken ct = default)

--- a/src/Weasel.SqlServer/SqlServerMigrator.cs
+++ b/src/Weasel.SqlServer/SqlServerMigrator.cs
@@ -159,17 +159,32 @@ $$;
     /// <exception cref="InvalidOperationException">The name cannot be safely written into DDL.</exception>
     public override void AssertValidIdentifier(string name)
     {
-        var problem = IdentifierValidation.FindProblem(name, UnsafeIdentifierCharacters);
-        if (problem != null)
-        {
-            throw new InvalidOperationException(
-                $"SQL Server identifier '{name}' is not valid because {problem}.");
-        }
+        AssertValidLocalIdentifier(name);
 
         if (name.Length > MaxIdentifierLength)
         {
             throw new InvalidOperationException(
                 $"SQL Server identifiers cannot exceed {MaxIdentifierLength} characters. '{name}' is {name.Length} characters.");
+        }
+    }
+
+    /// <summary>
+    ///     The safety half of <see cref="AssertValidIdentifier" />, without the length limit.
+    /// </summary>
+    /// <remarks>
+    ///     A column, primary key or check constraint name is only ever emitted inside its own
+    ///     table's DDL and is never addressed by name afterwards, and the delta comparison already
+    ///     reads both sides through TruncatedNameIdentifier so a name SQL Server truncated still
+    ///     matches. Refusing to create one would reject schemas the rest of Weasel handles
+    ///     (weasel#485). The safety rules still apply in full.
+    /// </remarks>
+    public override void AssertValidLocalIdentifier(string name)
+    {
+        var problem = IdentifierValidation.FindProblem(name, UnsafeIdentifierCharacters);
+        if (problem != null)
+        {
+            throw new InvalidOperationException(
+                $"SQL Server identifier '{name}' is not valid because {problem}.");
         }
     }
 

--- a/src/Weasel.Sqlite/SqliteMigrator.cs
+++ b/src/Weasel.Sqlite/SqliteMigrator.cs
@@ -110,16 +110,31 @@ public class SqliteMigrator: Migrator
     /// <exception cref="InvalidOperationException">The name cannot be safely written into DDL.</exception>
     public override void AssertValidIdentifier(string name)
     {
-        var problem = IdentifierValidation.FindProblem(name, UnsafeIdentifierCharacters);
-        if (problem != null)
-        {
-            throw new InvalidOperationException($"SQLite identifier '{name}' is not valid because {problem}.");
-        }
+        AssertValidLocalIdentifier(name);
 
         if (name.Length > MaxIdentifierLength)
         {
             throw new InvalidOperationException(
                 $"SQLite identifier '{name}' is too long ({name.Length} characters). Maximum recommended length is {MaxIdentifierLength}.");
+        }
+    }
+
+    /// <summary>
+    ///     The safety half of <see cref="AssertValidIdentifier" />, without the length limit.
+    /// </summary>
+    /// <remarks>
+    ///     A column, primary key or check constraint name is only ever emitted inside its own
+    ///     table's DDL and is never addressed by name afterwards, and the delta comparison already
+    ///     reads both sides through TruncatedNameIdentifier so a name SQLite truncated still
+    ///     matches. Refusing to create one would reject schemas the rest of Weasel handles
+    ///     (weasel#485). The safety rules still apply in full.
+    /// </remarks>
+    public override void AssertValidLocalIdentifier(string name)
+    {
+        var problem = IdentifierValidation.FindProblem(name, UnsafeIdentifierCharacters);
+        if (problem != null)
+        {
+            throw new InvalidOperationException($"SQLite identifier '{name}' is not valid because {problem}.");
         }
     }
 


### PR DESCRIPTION
Fixes #485. Also fixes #486 — same root cause; see below.

## The regression

9.25 added `ISchemaObjectWithLocalIdentifiers` (#468) so the migration path validates the names a table writes that are not database objects of their own — columns, the primary key constraint, check constraints. It ran them through the provider's `AssertValidIdentifier`, which also enforces the length limit. Schemas that applied cleanly on 9.24 now throw.

## Why the length rule does not belong there

The two kinds of name fail differently:

- An **object** name the database truncates becomes unaddressable, and the model never matches the catalog again — it drifts on every check. Worth refusing.
- A **local** identifier is only ever emitted inside its own table's DDL and never addressed by name afterwards. And `TableDelta` already compares both `PrimaryKeyName` and the primary key column list through `TruncatedNameIdentifier`, *precisely* so a truncated one still matches.

So Weasel already handles truncated local identifiers downstream, and 9.25 started refusing to create them upstream. Those two positions cannot both be right.

## The change

`Migrator.AssertValidLocalIdentifier` — same safety rules, no length limit. A quote, a semicolon, a line break, leading or trailing whitespace are still rejected wherever they appear; only the length rule is dropped. The base implementation defers to `AssertValidIdentifier`, so an out-of-tree provider keeps the stricter behaviour until it opts in. All five in-tree providers override it, and each `AssertValidIdentifier` is now expressed as "safe, and also fits".

## #486 is the same bug

Filed separately because it presented as a `23505` on `pk_mt_event_progression` during a per-tenant async daemon catch-up — an error naming a table with nothing to do with identifiers.

The actual chain: a Marten projection whose aggregate is a nested test class produces the document table `mt_doc_bug_4679_catch_up_per_tenant_23505_tripdistance`, and under conjoined tenancy its primary key is `(tenant_id, id)`, so the constraint name is

```
pkey_mt_doc_bug_4679_catch_up_per_tenant_23505_tripdistance_tenant_id_id   (72 chars)
```

That rejection aborted the projection's schema application. The daemon then ran against storage that had never been created and failed downstream. **The loud failure and the quiet one are one rejection**, which is the part worth keeping in mind: this does not only throw where you can see it.

## Verification

- `Weasel.Core.Tests` 220/0, `Weasel.Postgresql.Tests` 908/0 — plus 8 new tests in `PostgresqlMigratorTests` pinning that an over-length local identifier is allowed where an object name is not, and that every safety rule still applies in full to a local identifier.
- Against Marten, built from this branch and consumed as a local package: both regressions go from failing to passing, and the partitioned pair was run three times to be sure it was not a race. Unmodified `master` fails the same tests 3/3, so the fix is doing the work rather than the rebuild.
- Full Marten suites on the fix: `EventSourcingTests` 1940/0, `TenantPartitionedEventsTests` 243/0.

## Release notes

`docs/release-9-25.md` says a conventional lowercase schema is byte-identical to 9.24. That was not true for either of these, and both schemas are entirely conventional — the names are just long. Worth a line if this ships as 9.25.1 rather than being folded into a re-cut 9.25.0.