### PR TITLE
fix: refuse a check constraint rather than silently dropping it

### DIFF
--- a/docs/core/object-types.md
+++ b/docs/core/object-types.md
@@ -10,6 +10,7 @@ Three symbols, and the distinction between the last two matters:
 | --- | --- |
 | ✓ | Weasel models it: `WriteCreateStatement`, delta detection, and teardown |
 | ✗ | The engine has it, Weasel does not model it yet — an open issue, not a decision |
+| refused | The engine has it, Weasel does not model it yet, and says so by throwing rather than accepting it silently |
 | — | Not a concept in this engine, so there is nothing to model |
 
 ## The matrix
@@ -19,7 +20,7 @@ Three symbols, and the distinction between the last two matters:
 | Table | ✓ | ✓ | ✓ | ✓ | ✓ |
 | Index | ✓ | ✓ | ✓ | ✓ | ✓ |
 | Foreign key | ✓ | ✓ | ✓ | ✓ | ✓ (inline only) |
-| Check constraint | ✓ | ✓ | ✗ | ✗ | ✗ |
+| Check constraint | ✓ | ✓ | refused | refused | refused |
 | Primary key | ✓ | ✓ | ✓ | ✓ | ✓ |
 | Sequence | ✓ | ✓ | ✓ | — (obsolete emulation) | — |
 | View | ✓ | ✓ | ✓ | ✓ | ✓ |
@@ -37,7 +38,7 @@ Three symbols, and the distinction between the last two matters:
 
 - **Triggers** are modelled as independent schema objects that declare a target rather than as something a table owns, which is why they are a row here and not part of the table row. A trigger does not always have a table — SQL Server's `INSTEAD OF` triggers attach to views — and PostgreSQL's call a function, so they compose with `Function` rather than carrying their own body. See [Triggers](/core/triggers).
 - **Functions and stored procedures** are on all four engines that have them. SQLite has neither as a schema object — its functions are registered per connection.
-- **Check constraints are the one remaining gap** — [#488](https://github.com/JasperFx/weasel/issues/488). `TableBase.CheckConstraints` accepts them on all five providers, but only PostgreSQL and SQL Server emit them; on Oracle, MySQL and SQLite the constraint is held in the model and silently left out of the DDL.
+- **Check constraints are refused on Oracle, MySQL and SQLite** — [#488](https://github.com/JasperFx/weasel/issues/488). All three engines have them; Weasel does not emit them there yet. Until it does, `AddCheckConstraint` and the `CheckConstraints` collection both throw, rather than accepting a constraint that would be silently left out of the DDL. That is the rule from [#449](https://github.com/JasperFx/weasel/issues/449): a caller gets what they set, or an exception, never a quietly narrower object.
 - **Oracle packages** model the specification and the body as one object with two parts, because that is what they are: `all_source` lists them separately, they compile separately, and a body can be invalid while its spec is fine. A spec-only package — shared constants and types — is legal and supported.
 - **PostgreSQL user-defined types** cover enums, domains and composites through one class, because the catalog makes no distinction between them and neither does anything Weasel does with them.
 - **PostgreSQL materialized views already work**, through `Weasel.Postgresql.Views.MaterializedView`, which is `View` with a different `ViewType` and an optional access method. That row was ✗ in the first draft of this page and the check below caught it on its first run, which is the argument for the check.

--- a/src/Weasel.Core.Tests/check_constraint_conformance.cs
+++ b/src/Weasel.Core.Tests/check_constraint_conformance.cs
@@ -1,0 +1,140 @@
+using Shouldly;
+using Weasel.Core;
+using Xunit;
+
+namespace Weasel.Core.Tests;
+
+/// <summary>
+///     A check constraint is either emitted or refused — never accepted and then left out of the
+///     DDL (weasel#488).
+/// </summary>
+/// <remarks>
+///     <para>
+///         <c>TableBase.CheckConstraints</c> is on the shared base, so every provider's
+///         <c>Table</c> accepted one. Only PostgreSQL and SQL Server ever wrote it into
+///         <c>CREATE TABLE</c>. On the other three the constraint sat in the model, never reached
+///         the database, and was never compared during delta detection either — so a caller got a
+///         table without the constraint they asked for and nothing said so.
+///     </para>
+///     <para>
+///         This is the rule weasel#449 settled for the index predicates that did the same thing,
+///         applied to the one place it had been missed. It was missed because the property lives on
+///         <c>TableBase</c> rather than on each provider's own type, so there was no per-provider
+///         surface to audit — which is the argument for testing it here, across all five at once.
+///     </para>
+/// </remarks>
+public class check_constraint_conformance
+{
+    public static TheoryData<string, Func<ITable>, bool> Providers =>
+        new()
+        {
+            { "SqlServer", () => new SqlServer.Tables.Table("dbo.orders"), true },
+            { "Postgresql", () => new Postgresql.Tables.Table("public.orders"), true },
+            { "MySql", () => new MySql.Tables.Table("weasel_testing.orders"), false },
+            { "Oracle", () => new Oracle.Tables.Table("WEASEL.ORDERS"), false },
+            { "Sqlite", () => new Sqlite.Tables.Table("orders"), false }
+        };
+
+    private static ITable OrdersTable(Func<ITable> factory)
+    {
+        var table = factory();
+        table.AddPrimaryKeyColumn("id", typeof(int));
+        table.AddColumn("quantity", typeof(int));
+        return table;
+    }
+
+    [Theory]
+    [MemberData(nameof(Providers))]
+    public void a_check_constraint_is_kept_or_refused_but_never_ignored(
+        string provider, Func<ITable> factory, bool emits)
+    {
+        var table = OrdersTable(factory);
+
+        if (emits)
+        {
+            table.AddCheckConstraint("ck_orders_qty", "quantity > 0");
+            table.CheckConstraints.ShouldHaveSingleItem();
+            return;
+        }
+
+        Should.Throw<NotSupportedException>(() => table.AddCheckConstraint("ck_orders_qty", "quantity > 0"));
+        table.CheckConstraints.ShouldBeEmpty();
+    }
+
+    /// <summary>
+    ///     Adding to the collection directly is the more common spelling, and used to be the way
+    ///     round the refusal — so the collection refuses too, not only
+    ///     <see cref="ITable.AddCheckConstraint" />.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(Providers))]
+    public void adding_to_the_collection_directly_is_refused_the_same_way(
+        string provider, Func<ITable> factory, bool emits)
+    {
+        if (emits) return;
+
+        var table = OrdersTable(factory);
+        var collection = CheckConstraintsOf(table);
+
+        Should.Throw<NotSupportedException>(
+            () => collection.Add(new TableCheckConstraint("ck_orders_qty", "quantity > 0")));
+    }
+
+    /// <summary>
+    ///     The message has to say which provider, that the engine supports it, and where to look —
+    ///     otherwise it reads as "you cannot do this" rather than "Weasel does not do this yet".
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(Providers))]
+    public void the_refusal_explains_itself(string provider, Func<ITable> factory, bool emits)
+    {
+        if (emits) return;
+
+        var table = OrdersTable(factory);
+
+        var ex = Should.Throw<NotSupportedException>(
+            () => table.AddCheckConstraint("ck_orders_qty", "quantity > 0"));
+
+        ex.Message.ShouldContain("ck_orders_qty");
+        ex.Message.ShouldContain("weasel#488");
+    }
+
+    /// <summary>
+    ///     A provider that does emit them keeps working exactly as before — the constraint reaches
+    ///     the generated DDL.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(Providers))]
+    public void a_provider_that_emits_them_still_writes_it_into_the_ddl(
+        string provider, Func<ITable> factory, bool emits)
+    {
+        if (!emits) return;
+
+        var table = OrdersTable(factory);
+        table.AddCheckConstraint("ck_orders_qty", "quantity > 0");
+
+        var writer = new StringWriter();
+        table.WriteCreateStatement(MigratorFor(provider), writer);
+
+        writer.ToString().ShouldContain("ck_orders_qty");
+    }
+
+    private static IList<TableCheckConstraint> CheckConstraintsOf(ITable table)
+        => table switch
+        {
+            SqlServer.Tables.Table t => t.CheckConstraints,
+            Postgresql.Tables.Table t => t.CheckConstraints,
+            MySql.Tables.Table t => t.CheckConstraints,
+            Oracle.Tables.Table t => t.CheckConstraints,
+            Sqlite.Tables.Table t => t.CheckConstraints,
+            _ => throw new ArgumentOutOfRangeException(nameof(table))
+        };
+
+    private static Migrator MigratorFor(string provider)
+        => provider switch
+        {
+            "SqlServer" => new SqlServer.SqlServerMigrator { Formatting = SqlFormatting.Concise },
+            "Postgresql" => new Postgresql.PostgresqlMigrator { Formatting = SqlFormatting.Concise },
+            _ => throw new ArgumentOutOfRangeException(nameof(provider), provider, null)
+        };
+}

--- a/src/Weasel.Core.Tests/table_identifier_coverage_conformance.cs
+++ b/src/Weasel.Core.Tests/table_identifier_coverage_conformance.cs
@@ -31,14 +31,20 @@ namespace Weasel.Core.Tests;
 /// </remarks>
 public class table_identifier_coverage_conformance
 {
-    public static TheoryData<string, Func<ITable>> Providers =>
+    /// <summary>
+    ///     The third value is whether the provider emits check constraints. Oracle, MySQL and
+    ///     SQLite refuse them rather than accepting one they will not write (weasel#488), so there
+    ///     is no check constraint name for them to validate — the absence is correct rather than a
+    ///     coverage gap, and saying so here keeps it visible.
+    /// </summary>
+    public static TheoryData<string, Func<ITable>, bool> Providers =>
         new()
         {
-            { "SqlServer", () => new SqlServer.Tables.Table("dbo.people") },
-            { "MySql", () => new MySql.Tables.Table("weasel_testing.people") },
-            { "Sqlite", () => new Sqlite.Tables.Table("people") },
-            { "Postgresql", () => new Postgresql.Tables.Table("public.people") },
-            { "Oracle", () => new Oracle.Tables.Table("WEASEL.PEOPLE") }
+            { "SqlServer", () => new SqlServer.Tables.Table("dbo.people"), true },
+            { "MySql", () => new MySql.Tables.Table("weasel_testing.people"), false },
+            { "Sqlite", () => new Sqlite.Tables.Table("people"), false },
+            { "Postgresql", () => new Postgresql.Tables.Table("public.people"), true },
+            { "Oracle", () => new Oracle.Tables.Table("WEASEL.PEOPLE"), false }
         };
 
     /// <summary>
@@ -46,7 +52,8 @@ public class table_identifier_coverage_conformance
     ///     over a named column, an ordinary column, an index, a foreign key, and a check
     ///     constraint. Built through <see cref="ITable" /> so it is the same table on all five.
     /// </summary>
-    private static ITable BuildFullyDressedTable(Func<ITable> factory, out string[] expected)
+    private static ITable BuildFullyDressedTable(Func<ITable> factory, bool emitsCheckConstraints,
+        out string[] expected)
     {
         var table = factory();
 
@@ -57,19 +64,25 @@ public class table_identifier_coverage_conformance
         table.PrimaryKeyName = "pk_people_id";
         table.AddIndex("idx_people_email", ["email"]);
         table.AddForeignKey("fk_people_state", table.Identifier, ["state_id"], ["id"]);
-        table.AddCheckConstraint("ck_people_email_present", "email is not null");
 
-        expected =
-        [
+        var names = new List<string>
+        {
             table.Identifier.Name,
             "id",
             "email",
             "state_id",
             "pk_people_id",
             "idx_people_email",
-            "fk_people_state",
-            "ck_people_email_present"
-        ];
+            "fk_people_state"
+        };
+
+        if (emitsCheckConstraints)
+        {
+            table.AddCheckConstraint("ck_people_email_present", "email is not null");
+            names.Add("ck_people_email_present");
+        }
+
+        expected = names.ToArray();
 
         return table;
     }
@@ -86,9 +99,10 @@ public class table_identifier_coverage_conformance
 
     [Theory]
     [MemberData(nameof(Providers))]
-    public void every_name_the_table_writes_is_reachable_by_validation(string provider, Func<ITable> factory)
+    public void every_name_the_table_writes_is_reachable_by_validation(
+        string provider, Func<ITable> factory, bool emitsCheckConstraints)
     {
-        var table = BuildFullyDressedTable(factory, out var expected);
+        var table = BuildFullyDressedTable(factory, emitsCheckConstraints, out var expected);
         var validated = EveryValidatedName(table).ToArray();
 
         foreach (var name in expected)
@@ -106,9 +120,10 @@ public class table_identifier_coverage_conformance
     /// </summary>
     [Theory]
     [MemberData(nameof(Providers))]
-    public void all_names_carries_the_table_its_indexes_and_its_foreign_keys(string provider, Func<ITable> factory)
+    public void all_names_carries_the_table_its_indexes_and_its_foreign_keys(
+        string provider, Func<ITable> factory, bool emitsCheckConstraints)
     {
-        var table = BuildFullyDressedTable(factory, out _);
+        var table = BuildFullyDressedTable(factory, emitsCheckConstraints, out _);
         var names = table.AllNames().Select(x => x.Name).ToArray();
 
         names.ShouldContain(x => string.Equals(x, table.Identifier.Name, StringComparison.OrdinalIgnoreCase),
@@ -121,17 +136,22 @@ public class table_identifier_coverage_conformance
 
     [Theory]
     [MemberData(nameof(Providers))]
-    public void local_identifiers_carry_the_names_that_are_not_objects(string provider, Func<ITable> factory)
+    public void local_identifiers_carry_the_names_that_are_not_objects(
+        string provider, Func<ITable> factory, bool emitsCheckConstraints)
     {
-        var table = BuildFullyDressedTable(factory, out _);
+        var table = BuildFullyDressedTable(factory, emitsCheckConstraints, out _);
         var locals = ((ISchemaObjectWithLocalIdentifiers)table).LocalIdentifiers().ToArray();
 
         locals.ShouldContain(x => string.Equals(x, "email", StringComparison.OrdinalIgnoreCase),
             $"{provider} omits a column name");
         locals.ShouldContain(x => string.Equals(x, "pk_people_id", StringComparison.OrdinalIgnoreCase),
             $"{provider} omits the primary key constraint name");
-        locals.ShouldContain(x => string.Equals(x, "ck_people_email_present", StringComparison.OrdinalIgnoreCase),
-            $"{provider} omits a check constraint name");
+
+        if (emitsCheckConstraints)
+        {
+            locals.ShouldContain(x => string.Equals(x, "ck_people_email_present", StringComparison.OrdinalIgnoreCase),
+                $"{provider} omits a check constraint name");
+        }
     }
 
     /// <summary>
@@ -142,7 +162,8 @@ public class table_identifier_coverage_conformance
     /// </summary>
     [Theory]
     [MemberData(nameof(Providers))]
-    public void a_table_without_a_primary_key_offers_no_primary_key_name(string provider, Func<ITable> factory)
+    public void a_table_without_a_primary_key_offers_no_primary_key_name(
+        string provider, Func<ITable> factory, bool emitsCheckConstraints)
     {
         var table = factory();
         table.AddColumn("email", typeof(string));

--- a/src/Weasel.Core/TableBase.cs
+++ b/src/Weasel.Core/TableBase.cs
@@ -76,13 +76,38 @@ public abstract class TableBase<TColumn, TIndex, TForeignKey>: SchemaObjectBase,
     public IList<TForeignKey> ForeignKeys { get; } = new List<TForeignKey>();
     public IList<TIndex> Indexes { get; } = new List<TIndex>();
 
+    private IList<TableCheckConstraint>? _checkConstraints;
+
     /// <summary>
-    ///     Named table-level CHECK constraints. Emitted in CREATE TABLE and
-    ///     compared during delta detection by the providers that support it
-    ///     (PostgreSQL, SQL Server); see <see cref="TableCheckConstraint" /> for
-    ///     the conservative comparison semantics.
+    ///     Named table-level CHECK constraints. Emitted in CREATE TABLE and compared during delta
+    ///     detection by the providers that support it (PostgreSQL, SQL Server); see
+    ///     <see cref="TableCheckConstraint" /> for the conservative comparison semantics.
     /// </summary>
-    public IList<TableCheckConstraint> CheckConstraints { get; } = new List<TableCheckConstraint>();
+    /// <remarks>
+    ///     On a provider that does not emit them this collection refuses everything added to it
+    ///     rather than holding a constraint that will never reach the database (weasel#488). See
+    ///     <see cref="SupportsCheckConstraints" />.
+    /// </remarks>
+    public IList<TableCheckConstraint> CheckConstraints
+        => _checkConstraints ??= SupportsCheckConstraints
+            ? new List<TableCheckConstraint>()
+            : new UnsupportedCheckConstraints(ProviderName);
+
+    /// <summary>
+    ///     Whether this provider writes check constraints into its DDL and compares them.
+    ///     PostgreSQL and SQL Server do; Oracle, MySQL and SQLite do not yet (weasel#488), and
+    ///     override this to <c>false</c> so that asking for one is refused rather than ignored.
+    /// </summary>
+    /// <remarks>
+    ///     Read lazily rather than in the constructor, so an override is never called before the
+    ///     subclass is built.
+    /// </remarks>
+    protected virtual bool SupportsCheckConstraints => true;
+
+    /// <summary>
+    ///     The provider's name, for the message a refused check constraint carries.
+    /// </summary>
+    protected virtual string ProviderName => GetType().Namespace?.Split('.').ElementAtOrDefault(1) ?? "this provider";
 
     /// <summary>
     ///     Names of indexes that this table intentionally ignores during delta
@@ -277,7 +302,10 @@ public abstract class TableBase<TColumn, TIndex, TForeignKey>: SchemaObjectBase,
     TableCheckConstraint ITable.AddCheckConstraint(string name, string expression)
     {
         var constraint = new TableCheckConstraint(name, expression);
+
+        // Throws on a provider that will not emit it -- see UnsupportedCheckConstraints.
         CheckConstraints.Add(constraint);
+
         return constraint;
     }
 

--- a/src/Weasel.Core/UnsupportedCheckConstraints.cs
+++ b/src/Weasel.Core/UnsupportedCheckConstraints.cs
@@ -1,0 +1,82 @@
+using System.Collections;
+
+namespace Weasel.Core;
+
+/// <summary>
+///     The <see cref="TableBase{TColumn,TIndex,TForeignKey}.CheckConstraints" /> collection for a
+///     provider that will not emit them: it refuses everything added to it and stays empty.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Check constraints live on <c>TableBase</c>, so every provider's <c>Table</c> accepted
+///         one — and only PostgreSQL and SQL Server ever wrote it into the DDL. On the other three
+///         the constraint sat in the model, never reached <c>CREATE TABLE</c>, and was never
+///         compared during delta detection either, so nothing reported the difference. A caller got
+///         a table without the constraint they asked for and no way to notice (weasel#488).
+///     </para>
+///     <para>
+///         Refusing is the rule weasel#449 settled for the index predicates that did the same
+///         thing: a caller who sets a property gets it, or gets an exception, never a quietly
+///         narrower object. The collection refuses rather than only
+///         <see cref="ITable.AddCheckConstraint" /> throwing, because
+///         <see cref="TableBase{TColumn,TIndex,TForeignKey}.CheckConstraints" /> is a public
+///         <see cref="IList{T}" /> and adding to it directly is the more common spelling.
+///     </para>
+/// </remarks>
+internal sealed class UnsupportedCheckConstraints: IList<TableCheckConstraint>
+{
+    private readonly string _provider;
+
+    public UnsupportedCheckConstraints(string provider)
+    {
+        _provider = provider;
+    }
+
+    private NotSupportedException Refuse(TableCheckConstraint? constraint = null)
+    {
+        var named = constraint == null ? "a check constraint" : $"check constraint '{constraint.Name}'";
+
+        return new NotSupportedException(
+            $"Weasel does not emit check constraints on {_provider}, so {named} would be accepted and "
+            + "then silently left out of the generated DDL. The engine supports them — Weasel does not "
+            + "model them here yet; see weasel#488. Until it does, declare the constraint in SQL you run "
+            + "yourself, or move the rule into a trigger.");
+    }
+
+    public void Add(TableCheckConstraint item) => throw Refuse(item);
+
+    public void Insert(int index, TableCheckConstraint item) => throw Refuse(item);
+
+    public TableCheckConstraint this[int index]
+    {
+        get => throw new ArgumentOutOfRangeException(nameof(index));
+        set => throw Refuse(value);
+    }
+
+    // Everything below is the behaviour of an empty, immutable list. Nothing can have been added,
+    // so nothing can be found, removed or enumerated.
+
+    public int Count => 0;
+    public bool IsReadOnly => true;
+
+    public void Clear()
+    {
+    }
+
+    public bool Contains(TableCheckConstraint item) => false;
+
+    public void CopyTo(TableCheckConstraint[] array, int arrayIndex)
+    {
+    }
+
+    public bool Remove(TableCheckConstraint item) => false;
+
+    public void RemoveAt(int index) => throw new ArgumentOutOfRangeException(nameof(index));
+
+    public int IndexOf(TableCheckConstraint item) => -1;
+
+    public IEnumerator<TableCheckConstraint> GetEnumerator()
+        => Enumerable.Empty<TableCheckConstraint>().GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/src/Weasel.MySql/Tables/Table.cs
+++ b/src/Weasel.MySql/Tables/Table.cs
@@ -255,6 +255,15 @@ public partial class Table: TableBase<TableColumn, IndexDefinition, ForeignKey>
         writer.WriteLine($"DROP TABLE IF EXISTS {Identifier.QualifiedName};");
     }
 
+    /// <summary>
+    ///     MySql has check constraints; Weasel does not emit them here yet (weasel#488). False so
+    ///     that asking for one throws rather than being accepted and silently dropped.
+    /// </summary>
+    protected override bool SupportsCheckConstraints => false;
+
+    /// <inheritdoc />
+    protected override string ProviderName => "MySQL";
+
     public override IEnumerable<DbObjectName> AllNames()
     {
         yield return Identifier;

--- a/src/Weasel.Oracle/Tables/Table.cs
+++ b/src/Weasel.Oracle/Tables/Table.cs
@@ -212,6 +212,15 @@ END;
     /// <inheritdoc />
     protected override string NormalizeIdentifier(string name) => SchemaUtils.Unquote(name);
 
+    /// <summary>
+    ///     Oracle has check constraints; Weasel does not emit them here yet (weasel#488). False so
+    ///     that asking for one throws rather than being accepted and silently dropped.
+    /// </summary>
+    protected override bool SupportsCheckConstraints => false;
+
+    /// <inheritdoc />
+    protected override string ProviderName => "Oracle";
+
     public override IEnumerable<DbObjectName> AllNames()
     {
         yield return Identifier;

--- a/src/Weasel.Sqlite.Tests/migration_path_identifier_validation.cs
+++ b/src/Weasel.Sqlite.Tests/migration_path_identifier_validation.cs
@@ -67,19 +67,30 @@ public class migration_path_identifier_validation
         ex.Message.ShouldContain("pk\"broken");
     }
 
+    /// <summary>
+    ///     This used to assert that a check constraint with a delimiter in its name was rejected by
+    ///     the migration path. SQLite no longer gets that far: weasel#488 made the constraint itself
+    ///     refused, because Weasel does not emit check constraints on SQLite and accepting one meant
+    ///     silently leaving it out of the DDL.
+    /// </summary>
+    /// <remarks>
+    ///     The name validation it used to cover is not lost — it is on
+    ///     <c>Weasel.Core.Tests.table_identifier_coverage_conformance</c>, which runs against every
+    ///     provider that emits check constraints. What is asserted here now is the refusal, and
+    ///     that it happens up front rather than at migration time, which is the whole point of it.
+    /// </remarks>
     [Fact]
-    public async Task a_check_constraint_name_is_rejected()
+    public void a_check_constraint_is_refused_because_sqlite_would_not_emit_it()
     {
         var db = NewDatabase();
         var table = db.AddTable(new DbObjectName("main", "mpiv_check"));
         table.AddPrimaryKeyColumn("id", typeof(int));
         table.AddColumn("qty", typeof(int));
-        table.AddCheckConstraint("ck\"broken", "qty > 0");
 
-        var ex = await Should.ThrowAsync<InvalidOperationException>(
-            () => db.ApplyAllConfiguredChangesToDatabaseAsync());
+        var ex = Should.Throw<NotSupportedException>(
+            () => table.AddCheckConstraint("ck_qty_positive", "qty > 0"));
 
-        ex.Message.ShouldContain("ck\"broken");
+        ex.Message.ShouldContain("weasel#488");
     }
 
     /// <summary>

--- a/src/Weasel.Sqlite/Tables/Table.cs
+++ b/src/Weasel.Sqlite/Tables/Table.cs
@@ -194,6 +194,15 @@ public partial class Table: TableBase<TableColumn, IndexDefinition, ForeignKey>
     /// </remarks>
     public IList<string> ExistingTriggers { get; } = new List<string>();
 
+    /// <summary>
+    ///     Sqlite has check constraints; Weasel does not emit them here yet (weasel#488). False so
+    ///     that asking for one throws rather than being accepted and silently dropped.
+    /// </summary>
+    protected override bool SupportsCheckConstraints => false;
+
+    /// <inheritdoc />
+    protected override string ProviderName => "SQLite";
+
     public override IEnumerable<DbObjectName> AllNames()
     {
         yield return Identifier;


### PR DESCRIPTION
Closes #488, taking the **throw** option — matching what #449 did for the ignored index predicates.

## The bug

`TableBase.CheckConstraints` is on the shared base, so every provider's `Table` accepted one. **Only PostgreSQL and SQL Server ever wrote it into `CREATE TABLE`** — `CheckConstraintDeclaration` exists in those two and nowhere else.

On Oracle, MySQL and SQLite the constraint sat in the model, never reached the database, and was never compared during delta detection either. A caller got a table without the constraint they asked for and no way to notice.

It was missed at the time because the property lives on `TableBase` rather than on each provider's own type, so there was no per-provider surface to audit — which is also the argument for the new test living in `Weasel.Core.Tests` across all five at once.

## The collection refuses, not just the method

`CheckConstraints` is a public `IList<TableCheckConstraint>`, and adding to it directly is the more common spelling:

```csharp
table.CheckConstraints.Add(new TableCheckConstraint("ck", "qty > 0"));   // the usual way
table.AddCheckConstraint("ck", "qty > 0");                               // via ITable
```

Throwing from `AddCheckConstraint` alone would have left the first one silent. `UnsupportedCheckConstraints` throws on every mutation and behaves as an empty list otherwise.

`SupportsCheckConstraints` is read **lazily** rather than in the constructor, so an override is never called before the subclass is built.

## The message

```
Weasel does not emit check constraints on Oracle, so check constraint 'ck_orders_qty' would be
accepted and then silently left out of the generated DDL. The engine supports them — Weasel does
not model them here yet; see weasel#488. Until it does, declare the constraint in SQL you run
yourself, or move the rule into a trigger.
```

It says the engine supports it and *Weasel* does not model it yet, because "you cannot do this" would be a different and wrong claim.

## Two existing tests asserted the old behaviour

Rewritten, not deleted:

- **`table_identifier_coverage_conformance`** built a fully dressed table with a check constraint on all five providers. It now carries a per-provider capability flag, so the absence of a check constraint name to validate reads as a capability in the source rather than as a missing assertion.
- **`migration_path_identifier_validation.a_check_constraint_name_is_rejected`** (SQLite) covered validation of a name that can no longer be set at all. Rewritten to assert the refusal and renamed to say so, with a note recording that the name validation it used to cover still runs in Core against the providers that emit them.

## Docs

The matrix row goes from ✗ to `refused`, and the legend gains that symbol — the distinction between "not modelled, and you will find out" and "not modelled, and you will not" is the whole point of this change.

## Verified locally

All seven suites: Core 240, SQLite 432, PostgreSQL 908, SQL Server 454, Oracle 299, MySQL 295, EF Core 106. No failures.

New: `check_constraint_conformance`, 20 cases across five providers — kept-or-refused, the direct-collection path, the message content, and that a provider which does emit them still writes it into the DDL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)