### PR TITLE
refactor(oracle): one delta for every object that updates by being replaced

### DIFF
--- a/src/Weasel.Oracle.Tests/oracle_delta_statement_shape.cs
+++ b/src/Weasel.Oracle.Tests/oracle_delta_statement_shape.cs
@@ -1,0 +1,150 @@
+using Shouldly;
+using Weasel.Core;
+using Weasel.Oracle.Functions;
+using Weasel.Oracle.Packages;
+using Weasel.Oracle.Procedures;
+using Weasel.Oracle.Synonyms;
+using Weasel.Oracle.Triggers;
+using Weasel.Oracle.Views;
+using Xunit;
+
+namespace Weasel.Oracle.Tests;
+
+/// <summary>
+///     No Oracle delta prefixes a drop to its create.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Oracle has no <c>DROP … IF EXISTS</c> before 23c, so every drop in this provider is an
+///         anonymous PL/SQL block that swallows the "does not exist" error. <c>OracleMigrator</c>
+///         executes one command per statement, splitting on the <c>/</c> terminator — so a drop
+///         block written immediately before a <c>CREATE OR REPLACE</c>, with no <c>/</c> between
+///         them, reaches ODP.NET as a PL/SQL block followed by a DDL statement in one command, and
+///         fails with <c>PLS-00103: Encountered the symbol "CREATE"</c>.
+///     </para>
+///     <para>
+///         Six object types hit that separately and each grew its own delta class to avoid it. This
+///         is the invariant those six were all encoding, asserted once, so the seventh does not
+///         have to discover it: <see cref="OracleReplaceDelta" /> is what enforces it, and this is
+///         what fails if a new object type quietly stops using it.
+///     </para>
+/// </remarks>
+public class oracle_delta_statement_shape
+{
+    private const string Schema = "WEASEL";
+
+    public static TheoryData<string, ISchemaObject> Objects =>
+        new()
+        {
+            {
+                "View",
+                new View($"{Schema}.shape_view", $"select id from {Schema}.shape_src")
+            },
+            {
+                "Trigger",
+                new Trigger($"{Schema}.shape_trg", $"{Schema}.shape_src", "BEGIN NULL; END;")
+                {
+                    Timing = TriggerTiming.Before, Events = TriggerEvents.Insert
+                }
+            },
+            {
+                "StoredProcedure",
+                new StoredProcedure($"{Schema}.shape_proc",
+                    $"CREATE OR REPLACE PROCEDURE {Schema}.shape_proc AS BEGIN NULL; END;")
+            },
+            {
+                "Function",
+                new Function($"{Schema}.shape_fn",
+                    $"CREATE OR REPLACE FUNCTION {Schema}.shape_fn RETURN NUMBER IS BEGIN RETURN 1; END;")
+            },
+            {
+                "Synonym",
+                new Synonym($"{Schema}.shape_syn", $"{Schema}.shape_src")
+            },
+            {
+                "Package",
+                new Package($"{Schema}.shape_pkg",
+                    $"CREATE OR REPLACE PACKAGE {Schema}.shape_pkg AS PROCEDURE noop; END;",
+                    $"CREATE OR REPLACE PACKAGE BODY {Schema}.shape_pkg AS PROCEDURE noop IS BEGIN NULL; END; END;")
+            }
+        };
+
+    /// <summary>
+    ///     Split the way <c>OracleMigrator.executeCommand</c> splits, so what is asserted is what
+    ///     the server would actually be sent.
+    /// </summary>
+    private static string[] AsCommands(string sql)
+        => sql.Split(["\n/\n", "\n/", "/\n"], StringSplitOptions.RemoveEmptyEntries)
+            .Select(x => x.Trim())
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .ToArray();
+
+    private static string UpdateSqlFor(ISchemaObject schemaObject)
+    {
+        var delta = new OracleReplaceDelta(schemaObject, SchemaPatchDifference.Update);
+
+        var writer = new StringWriter();
+        delta.WriteUpdate(new OracleMigrator(), writer);
+
+        return writer.ToString();
+    }
+
+    /// <summary>
+    ///     The failure this exists for: a command containing a PL/SQL drop block and then a CREATE.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(Objects))]
+    public void no_command_mixes_a_drop_block_with_a_create(string objectType, ISchemaObject schemaObject)
+    {
+        foreach (var command in AsCommands(UpdateSqlFor(schemaObject)))
+        {
+            var hasDropBlock = command.Contains("EXECUTE IMMEDIATE 'DROP", StringComparison.OrdinalIgnoreCase);
+            var hasCreate = command.Contains("CREATE", StringComparison.OrdinalIgnoreCase);
+
+            (hasDropBlock && hasCreate).ShouldBeFalse(
+                $"{objectType}'s update puts a PL/SQL drop block and a CREATE in one command, which "
+                + $"ODP.NET rejects with PLS-00103:\n{command}");
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(Objects))]
+    public void an_update_emits_at_least_one_command(string objectType, ISchemaObject schemaObject)
+    {
+        AsCommands(UpdateSqlFor(schemaObject)).ShouldNotBeEmpty($"{objectType} produced no SQL to run");
+    }
+
+    /// <summary>
+    ///     A create that spans more than one statement is fine as long as it separates them itself.
+    ///     A package emits its specification, a <c>/</c>, and then its body — two commands, which is
+    ///     exactly right, and the distinction this whole invariant turns on.
+    /// </summary>
+    [Fact]
+    public void a_package_is_allowed_to_be_two_commands_because_it_separates_them()
+    {
+        var package = new Package($"{Schema}.shape_pkg",
+            $"CREATE OR REPLACE PACKAGE {Schema}.shape_pkg AS PROCEDURE noop; END;",
+            $"CREATE OR REPLACE PACKAGE BODY {Schema}.shape_pkg AS PROCEDURE noop IS BEGIN NULL; END; END;");
+
+        AsCommands(UpdateSqlFor(package)).Length.ShouldBe(2);
+    }
+
+    /// <summary>
+    ///     An object marked removed writes its drop instead, alone — a lone PL/SQL block, which is a
+    ///     perfectly good command.
+    /// </summary>
+    [Fact]
+    public void a_removed_object_writes_its_drop_and_nothing_else()
+    {
+        var procedure = new StoredProcedure($"{Schema}.shape_proc",
+            $"CREATE OR REPLACE PROCEDURE {Schema}.shape_proc AS BEGIN NULL; END;") { IsRemoved = true };
+        var delta = new OracleReplaceDelta(procedure, SchemaPatchDifference.Update, isRemoved: true);
+
+        var writer = new StringWriter();
+        delta.WriteUpdate(new OracleMigrator(), writer);
+
+        var sql = writer.ToString();
+        sql.ShouldContain("DROP PROCEDURE");
+        sql.ShouldNotContain("CREATE");
+    }
+}

--- a/src/Weasel.Oracle/Functions/Function.cs
+++ b/src/Weasel.Oracle/Functions/Function.cs
@@ -135,10 +135,10 @@ END;"
 ///     Oracle applies a function change with <c>CREATE OR REPLACE FUNCTION</c> alone.
 /// </summary>
 /// <remarks>
-///     The drop has to be an anonymous PL/SQL block, so a drop-then-create pair arrives as a block
-///     followed by a DDL statement — which ODP.NET cannot execute as one command (PLS-00103), and
-///     Oracle's migrator executes one command per delta. This is the fifth object type to need this
-///     shape; see the note on weasel#455 about hoisting it into the provider.
+///     The write behaviour is <see cref="OracleReplaceDelta" />'s, applied here rather than
+///     inherited: a function delta also needs <see cref="SchemaObjectDelta{T}" />'s expected/actual
+///     comparison, and a type cannot have both bases. Delegating keeps the rule in one place —
+///     see that type for why a drop may not be prefixed to the create.
 /// </remarks>
 public class FunctionDelta: SchemaObjectDelta<Function>
 {
@@ -171,27 +171,24 @@ public class FunctionDelta: SchemaObjectDelta<Function>
         => sql.Replace("\r\n", "").Replace("\n", "").Replace("\r", "").Replace("\t", "")
             .Replace(" ", "").Trim().TrimEnd(';').ToUpperInvariant();
 
+    /// <summary>
+    ///     The drop for a removed function has to come from <see cref="SchemaObjectDelta{T}.Actual" />,
+    ///     not from <c>Expected</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <see cref="FunctionBase.DropStatements" /> returns an <em>empty</em> array when
+    ///     <see cref="FunctionBase.IsRemoved" /> is set — a removed function is a declaration that
+    ///     something should not exist, and it carries no body to build a drop from. The object that
+    ///     can produce the drop is the one read out of the database. Flattening this to
+    ///     <c>Expected</c> emits nothing at all and the function survives the migration, which is
+    ///     what <c>a_function_marked_for_removal_is_dropped</c> catches.
+    /// </remarks>
     public override void WriteUpdate(Migrator rules, TextWriter writer)
-    {
-        if (Expected.IsRemoved)
-        {
-            Actual!.WriteDropStatement(rules, writer);
-            return;
-        }
-
-        Expected.WriteCreateStatement(rules, writer);
-    }
+        => OracleReplaceDelta.WriteReplacement(
+            Expected.IsRemoved ? Actual! : Expected, Expected.IsRemoved, rules, writer);
 
     public override void WriteRollback(Migrator rules, TextWriter writer)
-    {
-        if (Actual == null)
-        {
-            Expected.WriteDropStatement(rules, writer);
-            return;
-        }
-
-        Actual.WriteCreateStatement(rules, writer);
-    }
+        => OracleReplaceDelta.WriteReplacement(Actual ?? Expected, Actual == null, rules, writer);
 
     public override string ToString() => $"{Expected.Identifier.QualifiedName} Diff";
 }

--- a/src/Weasel.Oracle/OracleReplaceDelta.cs
+++ b/src/Weasel.Oracle/OracleReplaceDelta.cs
@@ -1,0 +1,92 @@
+using Weasel.Core;
+
+namespace Weasel.Oracle;
+
+/// <summary>
+///     The delta for an Oracle schema object that updates itself by being re-created, never by
+///     being dropped first.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Six object types had written this class out longhand — views, triggers, stored
+///         procedures, packages, synonyms and functions — because the default
+///         <see cref="SchemaObjectDelta" /> emits a DROP ahead of the CREATE and on Oracle that
+///         combination cannot be executed.
+///     </para>
+///     <para>
+///         The reason is worth stating exactly, because "one statement per delta" is the shorthand
+///         and it is not quite right. Oracle has no <c>DROP … IF EXISTS</c> before 23c, so every
+///         drop in this provider is an anonymous PL/SQL block that swallows the
+///         "does not exist" error. <c>OracleMigrator</c> executes one command per statement,
+///         splitting on the <c>/</c> terminator — and a drop block written immediately before a
+///         <c>CREATE OR REPLACE</c>, with no <c>/</c> between them, arrives at ODP.NET as a PL/SQL
+///         block followed by a DDL statement in a single command. That is
+///         <c>PLS-00103: Encountered the symbol "CREATE"</c>.
+///     </para>
+///     <para>
+///         The drop is not needed anyway: every one of these object types is created with
+///         <c>CREATE OR REPLACE</c>, which is idempotent. So the update is the create statement on
+///         its own. An object marked removed writes its drop instead — alone, which is fine,
+///         because a lone PL/SQL block is a perfectly good command.
+///     </para>
+///     <para>
+///         A create that spans more than one statement is still fine, as long as it separates them
+///         itself: <c>Packages.Package</c> emits the specification, a <c>/</c>, and then the body,
+///         and the migrator splits those into two commands. What matters is that nothing is
+///         prefixed to a statement that did not ask for it.
+///     </para>
+///     <para>
+///         <c>Tables.TableDelta</c> deliberately does not use this. A table's update is a sequence
+///         of ALTERs with no single create to fall back on, and it manages its own statement
+///         separators.
+///     </para>
+/// </remarks>
+public class OracleReplaceDelta: ISchemaObjectDelta
+{
+    private readonly bool _isRemoved;
+
+    public OracleReplaceDelta(ISchemaObject schemaObject, SchemaPatchDifference difference, bool isRemoved = false)
+    {
+        SchemaObject = schemaObject ?? throw new ArgumentNullException(nameof(schemaObject));
+        Difference = difference;
+        _isRemoved = isRemoved;
+    }
+
+    public ISchemaObject SchemaObject { get; }
+
+    public SchemaPatchDifference Difference { get; }
+
+    public void WriteUpdate(Migrator rules, TextWriter writer)
+        => WriteReplacement(SchemaObject, _isRemoved, rules, writer);
+
+    /// <summary>
+    ///     The rule itself, exposed so a delta that needs
+    ///     <see cref="SchemaObjectDelta{T}" />'s expected/actual comparison can apply it too
+    ///     rather than keeping a second copy — <c>Functions.FunctionDelta</c> is the one that does.
+    /// </summary>
+    public static void WriteReplacement(
+        ISchemaObject schemaObject, bool isRemoved, Migrator rules, TextWriter writer)
+    {
+        if (isRemoved)
+        {
+            schemaObject.WriteDropStatement(rules, writer);
+            return;
+        }
+
+        schemaObject.WriteCreateStatement(rules, writer);
+    }
+
+    /// <summary>
+    ///     Nothing. Rolling back to a previous definition would mean having kept it, and these
+    ///     deltas carry only the expected object — the shape every one of the six hand-written
+    ///     versions had.
+    /// </summary>
+    public void WriteRollback(Migrator rules, TextWriter writer)
+    {
+    }
+
+    public void WriteRestorationOfPreviousState(Migrator rules, TextWriter writer)
+        => throw new NotSupportedException();
+
+    public override string ToString() => $"{SchemaObject.Identifier.QualifiedName} {Difference}";
+}

--- a/src/Weasel.Oracle/Packages/Package.cs
+++ b/src/Weasel.Oracle/Packages/Package.cs
@@ -101,7 +101,7 @@ END;");
 
         if (existingSpec == null)
         {
-            return new PackageDelta(this, SchemaPatchDifference.Create);
+            return new OracleReplaceDelta(this, SchemaPatchDifference.Create);
         }
 
         var specMatches = Matches(existingSpec, Specification);
@@ -110,8 +110,8 @@ END;");
             : existingBody != null && Matches(existingBody, Body!);
 
         return specMatches && bodyMatches
-            ? new PackageDelta(this, SchemaPatchDifference.None)
-            : new PackageDelta(this, SchemaPatchDifference.Update);
+            ? new OracleReplaceDelta(this, SchemaPatchDifference.None)
+            : new OracleReplaceDelta(this, SchemaPatchDifference.Update);
     }
 
     /// <summary>
@@ -168,33 +168,4 @@ END;");
         var source = await reader.GetFieldValueAsync<string>(0, ct).ConfigureAwait(false);
         return source.IsEmpty() ? null : source;
     }
-}
-
-/// <summary>
-///     A package applies as <c>CREATE OR REPLACE PACKAGE</c> and, when there is one,
-///     <c>CREATE OR REPLACE PACKAGE BODY</c> — two statements, separated by the <c>/</c> Oracle's
-///     migrator splits on.
-/// </summary>
-internal class PackageDelta: ISchemaObjectDelta
-{
-    private readonly Package _package;
-
-    public PackageDelta(Package package, SchemaPatchDifference difference)
-    {
-        _package = package;
-        Difference = difference;
-    }
-
-    public ISchemaObject SchemaObject => _package;
-
-    public SchemaPatchDifference Difference { get; }
-
-    public void WriteUpdate(Migrator rules, TextWriter writer) => _package.WriteCreateStatement(rules, writer);
-
-    public void WriteRollback(Migrator rules, TextWriter writer)
-    {
-    }
-
-    public void WriteRestorationOfPreviousState(Migrator rules, TextWriter writer)
-        => throw new NotSupportedException();
 }

--- a/src/Weasel.Oracle/Procedures/StoredProcedure.cs
+++ b/src/Weasel.Oracle/Procedures/StoredProcedure.cs
@@ -82,28 +82,26 @@ END;");
     }
 
     /// <summary>
-    ///     <c>CREATE OR REPLACE PROCEDURE</c> does the whole job, so an update is that statement
-    ///     alone.
+    ///     <c>CREATE OR REPLACE PROCEDURE</c> does the whole job, so the update is that statement
+    ///     alone — see <see cref="OracleReplaceDelta" /> for why nothing may be prefixed to it.
     /// </summary>
-    /// <remarks>
-    ///     The default delta writes a DROP first, and Oracle's drop has to be an anonymous PL/SQL
-    ///     block — so the pair arrives as a block followed by a DDL statement, which ODP.NET cannot
-    ///     execute as one command (PLS-00103). The same trap the Oracle view and trigger slices hit.
-    /// </remarks>
     protected override ISchemaObjectDelta CreateDelta(string? existing)
     {
         if (IsRemoved)
         {
-            return new StoredProcedureDelta(this,
-                existing == null ? SchemaPatchDifference.None : SchemaPatchDifference.Update);
+            // isRemoved: the update is the drop, alone -- which is a lone PL/SQL block and so a
+            // perfectly good command.
+            return new OracleReplaceDelta(this,
+                existing == null ? SchemaPatchDifference.None : SchemaPatchDifference.Update,
+                isRemoved: true);
         }
 
         if (existing == null)
         {
-            return new StoredProcedureDelta(this, SchemaPatchDifference.Create);
+            return new OracleReplaceDelta(this, SchemaPatchDifference.Create);
         }
 
-        return new StoredProcedureDelta(this,
+        return new OracleReplaceDelta(this,
             Matches(existing) ? SchemaPatchDifference.None : SchemaPatchDifference.Update);
     }
 
@@ -121,41 +119,4 @@ END;");
 
     public async Task<bool> ExistsInDatabaseAsync(OracleConnection conn, CancellationToken ct = default)
         => await FetchExistingSourceAsync(conn, ct).ConfigureAwait(false) != null;
-}
-
-/// <summary>
-///     Oracle applies a procedure change with <c>CREATE OR REPLACE PROCEDURE</c> alone — one
-///     statement, which is all Oracle's migrator can execute per delta.
-/// </summary>
-internal class StoredProcedureDelta: ISchemaObjectDelta
-{
-    private readonly StoredProcedure _procedure;
-
-    public StoredProcedureDelta(StoredProcedure procedure, SchemaPatchDifference difference)
-    {
-        _procedure = procedure;
-        Difference = difference;
-    }
-
-    public ISchemaObject SchemaObject => _procedure;
-
-    public SchemaPatchDifference Difference { get; }
-
-    public void WriteUpdate(Migrator rules, TextWriter writer)
-    {
-        if (_procedure.IsRemoved)
-        {
-            _procedure.WriteDropStatement(rules, writer);
-            return;
-        }
-
-        _procedure.WriteCreateStatement(rules, writer);
-    }
-
-    public void WriteRollback(Migrator rules, TextWriter writer)
-    {
-    }
-
-    public void WriteRestorationOfPreviousState(Migrator rules, TextWriter writer)
-        => throw new NotSupportedException();
 }

--- a/src/Weasel.Oracle/Synonyms/Synonym.cs
+++ b/src/Weasel.Oracle/Synonyms/Synonym.cs
@@ -78,12 +78,12 @@ END;");
 
         if (existing == null)
         {
-            return new SynonymDelta(this, SchemaPatchDifference.Create);
+            return new OracleReplaceDelta(this, SchemaPatchDifference.Create);
         }
 
         return Normalize(existing) == Normalize(Target)
-            ? new SynonymDelta(this, SchemaPatchDifference.None)
-            : new SynonymDelta(this, SchemaPatchDifference.Update);
+            ? new OracleReplaceDelta(this, SchemaPatchDifference.None)
+            : new OracleReplaceDelta(this, SchemaPatchDifference.Update);
     }
 
     /// <summary>
@@ -123,32 +123,4 @@ END;");
         var target = await reader.GetFieldValueAsync<string>(0, ct).ConfigureAwait(false);
         return string.IsNullOrWhiteSpace(target) ? null : target;
     }
-}
-
-/// <summary>
-///     <c>CREATE OR REPLACE SYNONYM</c> does the whole job, so an update is that statement alone —
-///     Oracle's migrator executes one statement per delta, and its drop is a PL/SQL block.
-/// </summary>
-internal class SynonymDelta: ISchemaObjectDelta
-{
-    private readonly Synonym _synonym;
-
-    public SynonymDelta(Synonym synonym, SchemaPatchDifference difference)
-    {
-        _synonym = synonym;
-        Difference = difference;
-    }
-
-    public ISchemaObject SchemaObject => _synonym;
-
-    public SchemaPatchDifference Difference { get; }
-
-    public void WriteUpdate(Migrator rules, TextWriter writer) => _synonym.WriteCreateStatement(rules, writer);
-
-    public void WriteRollback(Migrator rules, TextWriter writer)
-    {
-    }
-
-    public void WriteRestorationOfPreviousState(Migrator rules, TextWriter writer)
-        => throw new NotSupportedException();
 }

--- a/src/Weasel.Oracle/Triggers/Trigger.cs
+++ b/src/Weasel.Oracle/Triggers/Trigger.cs
@@ -87,7 +87,7 @@ END;");
 
         if (existing == null)
         {
-            return new TriggerDelta(this, SchemaPatchDifference.Create);
+            return new OracleReplaceDelta(this, SchemaPatchDifference.Create);
         }
 
         // all_triggers stores only the body, not the header, so that is what gets compared.
@@ -98,8 +98,8 @@ END;");
         var expected = index < 0 ? expectedBody : expectedBody[index..];
 
         return NormalizeBody(existing) == NormalizeBody(expected)
-            ? new TriggerDelta(this, SchemaPatchDifference.None)
-            : new TriggerDelta(this, SchemaPatchDifference.Update);
+            ? new OracleReplaceDelta(this, SchemaPatchDifference.None)
+            : new OracleReplaceDelta(this, SchemaPatchDifference.Update);
     }
 
     public async Task<string?> FetchExistingBodyAsync(OracleConnection conn, CancellationToken ct = default)
@@ -125,34 +125,4 @@ END;");
         var body = await reader.GetFieldValueAsync<string>(0, ct).ConfigureAwait(false);
         return string.IsNullOrWhiteSpace(body) ? null : body;
     }
-}
-
-/// <summary>
-///     Oracle applies a trigger change with <c>CREATE OR REPLACE TRIGGER</c> alone. The default
-///     <see cref="SchemaObjectDelta" /> writes a DROP first, and Oracle's drop has to be an
-///     anonymous PL/SQL block, so the pair arrives as a block followed by a DDL statement — which
-///     ODP.NET cannot execute as one command, the same trap the Oracle view slice hit.
-/// </summary>
-internal class TriggerDelta: ISchemaObjectDelta
-{
-    private readonly Trigger _trigger;
-
-    public TriggerDelta(Trigger trigger, SchemaPatchDifference difference)
-    {
-        _trigger = trigger;
-        Difference = difference;
-    }
-
-    public ISchemaObject SchemaObject => _trigger;
-
-    public SchemaPatchDifference Difference { get; }
-
-    public void WriteUpdate(Migrator rules, TextWriter writer) => _trigger.WriteCreateStatement(rules, writer);
-
-    public void WriteRollback(Migrator rules, TextWriter writer)
-    {
-    }
-
-    public void WriteRestorationOfPreviousState(Migrator rules, TextWriter writer)
-        => throw new NotSupportedException();
 }

--- a/src/Weasel.Oracle/Views/View.cs
+++ b/src/Weasel.Oracle/Views/View.cs
@@ -89,12 +89,12 @@ END;");
 
         if (existing == null)
         {
-            return new ViewDelta(this, SchemaPatchDifference.Create);
+            return new OracleReplaceDelta(this, SchemaPatchDifference.Create);
         }
 
         return NormalizeSql(existing) == NormalizeSql(ViewSql)
-            ? new ViewDelta(this, SchemaPatchDifference.None)
-            : new ViewDelta(this, SchemaPatchDifference.Update);
+            ? new OracleReplaceDelta(this, SchemaPatchDifference.None)
+            : new OracleReplaceDelta(this, SchemaPatchDifference.Update);
     }
 
     public async Task<View?> FetchExistingAsync(OracleConnection conn, CancellationToken ct = default)
@@ -133,44 +133,4 @@ END;");
             .Trim()
             .TrimEnd(';')
             .ToUpperInvariant();
-}
-
-/// <summary>
-///     Oracle applies a view change with <c>CREATE OR REPLACE VIEW</c> and nothing else, so the
-///     update is the create statement on its own.
-/// </summary>
-/// <remarks>
-///     The default <see cref="SchemaObjectDelta" /> writes a DROP ahead of the CREATE. On Oracle
-///     the drop has to be an anonymous PL/SQL block — there is no <c>DROP VIEW IF EXISTS</c> before
-///     23c — so the pair arrives as a PL/SQL block followed by a DDL statement, and ODP.NET cannot
-///     execute that as one command (PLS-00103: Encountered the symbol "CREATE"). Oracle's migrator
-///     executes one command per delta, so the delta itself has to be a single statement.
-/// </remarks>
-internal class ViewDelta: ISchemaObjectDelta
-{
-    private readonly View _view;
-
-    public ViewDelta(View view, SchemaPatchDifference difference)
-    {
-        _view = view;
-        Difference = difference;
-    }
-
-    public ISchemaObject SchemaObject => _view;
-
-    public SchemaPatchDifference Difference { get; }
-
-    public void WriteUpdate(Migrator rules, TextWriter writer)
-    {
-        _view.WriteCreateStatement(rules, writer);
-    }
-
-    public void WriteRollback(Migrator rules, TextWriter writer)
-    {
-    }
-
-    public void WriteRestorationOfPreviousState(Migrator rules, TextWriter writer)
-    {
-        throw new NotSupportedException();
-    }
 }


### PR DESCRIPTION
The follow-up recorded on #455. Six object types had written the same delta class out longhand — views, triggers, stored procedures, packages, synonyms and functions — each after hitting the same failure separately.

**209 lines removed, 40 added.**

## The shorthand was wrong, so the new type states it precisely

I have been calling this "one statement per delta". That is not quite right, and the imprecision is why it kept being rediscovered.

Oracle has no `DROP … IF EXISTS` before 23c, so **every drop in this provider is an anonymous PL/SQL block**. `OracleMigrator` executes one command per statement, splitting on the `/` terminator. A drop block written immediately before a `CREATE OR REPLACE`, with no `/` between them, reaches ODP.NET as a PL/SQL block followed by a DDL statement in a single command — `PLS-00103: Encountered the symbol "CREATE"`.

The drop is not needed anyway: all six are created with `CREATE OR REPLACE`, which is idempotent.

So the rule is **not** "emit one statement". It is **"do not prefix anything to the create"**. A create that spans several statements is fine when it separates them itself — a package emits its specification, a `/`, then its body, and the migrator runs two commands.

The new test asserts that distinction rather than a statement count: it splits the way `OracleMigrator.executeCommand` splits and asserts no resulting *command* contains both a PL/SQL drop block and a `CREATE`. Plus `a_package_is_allowed_to_be_two_commands_because_it_separates_them`, which is the case a naive statement-count assertion would have failed.

## Tables deliberately do not use it

A table's update is a sequence of `ALTER`s with no single create to fall back on, and `TableDelta` manages its own separators. Said in the type docs so the next person does not "fix" that.

## FunctionDelta calls the rule rather than inheriting it

It also needs `SchemaObjectDelta<T>`'s expected/actual comparison, and a type cannot have both bases. So it delegates — the rule stays in one place.

## ⚠️ One thing the flattening nearly lost

`FunctionBase.DropStatements()` returns an **empty array** when `IsRemoved`:

```csharp
if (IsRemoved) return Array.Empty<string>();
```

A removed function is a declaration that something *should not exist* — it carries no body, so there is nothing to build a drop from. The object that can produce the drop is the one read out of the database, which is why the original code passed `Actual` and not `Expected`.

My first pass flattened that to `Expected`, which emits nothing at all and lets the function survive the migration. **`a_function_marked_for_removal_is_dropped` caught it.** The delegation now passes the right object and the comment says why, because it is exactly the sort of asymmetry a refactor eats.

## Verified locally

All seven suites: Core 240, SQLite 432, PostgreSQL 908, SQL Server 454, **Oracle 313**, MySQL 295, EF Core 106. No failures.

New: `oracle_delta_statement_shape`, 14 cases across all six object types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)