### PR TITLE
Only attempt CREATE SCHEMA when the schema is actually missing

### DIFF
--- a/docs/core/schema-migrations.md
+++ b/docs/core/schema-migrations.md
@@ -147,6 +147,18 @@ Each database provider has a `Migrator` subclass that knows how to format SQL fo
 - `OracleMigrator` -- Oracle-specific DDL formatting
 - `SqliteMigrator` -- simplified DDL without schema creation SQL (SQLite schemas are fixed)
 
+### Privileges needed to apply a migration
+
+A migration only needs the privilege to create what is actually missing. Both the PostgreSQL and SQL Server
+migrators check whether a schema exists before attempting to create it, so applying a delta into a schema
+that is already there does not require a database-level create privilege -- only the privileges the objects
+in the delta need.
+
+This matters because a schema-level grant is the usual way to let an application manage its own tables while
+a separate migration role owns everything else. On PostgreSQL, `GRANT USAGE, CREATE ON SCHEMA my_schema TO
+my_app` is enough for that application to apply its own migrations, and it needs no `CREATE` on the database.
+Creating the schema in the first place does, so a role without it has to be given the schema up front.
+
 The `Migrator` is used internally by `WriteCreateStatement()`, `WriteDropStatement()`, and `WriteUpdate()` on every schema object and delta.
 
 ## Putting It Together

--- a/src/Weasel.Postgresql.Tests/least_privilege_schema_creation.cs
+++ b/src/Weasel.Postgresql.Tests/least_privilege_schema_creation.cs
@@ -1,0 +1,149 @@
+using System.Threading.Tasks;
+using JasperFx;
+using Npgsql;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Postgresql.Tables;
+using Xunit;
+
+namespace Weasel.Postgresql.Tests;
+
+/// <summary>
+///     A migration that touches an existing schema must not require <c>CREATE</c> on the database.
+///     <para>
+///     <see cref="SchemaMigration.Schemas" /> is every schema any delta mentions, not the schemas that are
+///     missing, so <c>PostgresqlMigrator.executeDelta</c> re-emits schema creation on every migration that
+///     touches one - including a migration whose only work is adding a table to a schema that has been there
+///     for months. PostgreSQL checks <c>CREATE</c> on the <em>database</em> before it evaluates
+///     <c>CREATE SCHEMA</c>'s own <c>IF NOT EXISTS</c>, so on a least-privilege role that statement fails
+///     with <c>42501 permission denied for database</c> even though there is nothing for it to do - and it is
+///     the first statement in the script, so every table in the migration goes with it.
+///     </para>
+///     <para>
+///     That role is not exotic. Granting an application <c>USAGE, CREATE</c> on one schema, and nothing on
+///     the database, is the standard way to let it manage its own tables while a migration role owns
+///     everything else; it is what Wolverine's PostgreSQL envelope storage documents. Before this fix such an
+///     application could not start against a database that already had its schema.
+///     </para>
+///     <para>
+///     <see cref="Weasel.SqlServer.SqlServerMigrator.CreateSchemaStatementFor" /> has always guarded on
+///     <c>sys.schemas</c> for the same reason. These tests pin the PostgreSQL side to the same behaviour.
+///     </para>
+/// </summary>
+[Collection("least_privilege")]
+public class least_privilege_schema_creation: IntegrationContext
+{
+    private const string RoleName = "weasel_least_privilege";
+
+    public least_privilege_schema_creation(): base("least_privilege")
+    {
+    }
+
+    [Fact]
+    public void schema_creation_is_guarded_by_an_existence_check()
+    {
+        var writer = new StringWriter();
+
+        new PostgresqlMigrator().WriteSchemaCreationSql(["one"], writer);
+
+        var sql = writer.ToString();
+
+        sql.ShouldContain("IF NOT EXISTS (SELECT 1 FROM pg_catalog.pg_namespace WHERE nspname = 'one')");
+
+        // The concurrency handling from #282 has to survive the guard: the pre-check is not a substitute for
+        // it, because two sessions can still both pass the check and race on the catalog insert.
+        sql.ShouldContain("WHEN duplicate_schema THEN NULL;");
+        sql.ShouldContain("WHEN unique_violation THEN NULL;");
+    }
+
+    [Fact]
+    public void schema_name_is_escaped_into_the_existence_check()
+    {
+        var writer = new StringWriter();
+
+        new PostgresqlMigrator().WriteSchemaCreationSql(["it's"], writer);
+
+        writer.ToString().ShouldContain("nspname = 'it''s'");
+    }
+
+    /// <summary>
+    ///     The regression itself, against a real role. Applying a table into a schema that already exists has
+    ///     to succeed for a role that was granted the schema and nothing else.
+    /// </summary>
+    [Fact]
+    public async Task can_apply_a_delta_to_an_existing_schema_without_create_on_the_database()
+    {
+        await ResetSchema();
+        await GrantSchemaToLeastPrivilegeRoleAsync();
+
+        var table = new Table(new PostgresqlObjectName(SchemaName, "documents"));
+        table.AddColumn<int>("id").AsPrimaryKey();
+
+        await using var conn = new NpgsqlConnection(LeastPrivilegeConnectionString());
+        await conn.OpenAsync();
+
+        var migration = await SchemaMigration.DetermineAsync(conn, table);
+        migration.Difference.ShouldBe(SchemaPatchDifference.Create);
+
+        // Pre-fix this threw 42501 on the CREATE SCHEMA that opens the script, and the table was never
+        // created even though the role holds CREATE on the schema it belongs to.
+        await new PostgresqlMigrator().ApplyAllAsync(conn, migration, AutoCreate.CreateOrUpdate);
+
+        (await SchemaMigration.DetermineAsync(conn, table)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    /// <summary>
+    ///     The other half: a genuinely missing schema still needs <c>CREATE</c> on the database, and the
+    ///     failure has to stay a failure rather than being swallowed by the guard.
+    /// </summary>
+    [Fact]
+    public async Task still_fails_when_the_schema_is_missing_and_the_role_cannot_create_one()
+    {
+        await ResetSchema();
+        await GrantSchemaToLeastPrivilegeRoleAsync();
+
+        var table = new Table(new PostgresqlObjectName("least_privilege_absent", "documents"));
+        table.AddColumn<int>("id").AsPrimaryKey();
+
+        await using var conn = new NpgsqlConnection(LeastPrivilegeConnectionString());
+        await conn.OpenAsync();
+
+        var migration = await SchemaMigration.DetermineAsync(conn, table);
+
+        var exception = await Should.ThrowAsync<PostgresException>(
+            () => new PostgresqlMigrator().ApplyAllAsync(conn, migration, AutoCreate.CreateOrUpdate));
+
+        exception.SqlState.ShouldBe(PostgresErrorCodes.InsufficientPrivilege);
+    }
+
+    private static string LeastPrivilegeConnectionString() =>
+        new NpgsqlConnectionStringBuilder(ConnectionSource.ConnectionString)
+        {
+            Username = RoleName,
+            Password = RoleName
+        }.ConnectionString;
+
+    /// <remarks>
+    ///     A role is cluster-wide rather than per database, so this tolerates one left behind by an earlier
+    ///     run. <c>least_privilege_absent</c> is dropped so the negative test above has a schema that is
+    ///     genuinely missing.
+    /// </remarks>
+    private async Task GrantSchemaToLeastPrivilegeRoleAsync()
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+
+        await conn.CreateCommand(
+                $"""
+                 DO $$
+                 BEGIN
+                     IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '{RoleName}') THEN
+                         CREATE ROLE {RoleName} LOGIN PASSWORD '{RoleName}';
+                     END IF;
+                 END $$;
+                 DROP SCHEMA IF EXISTS least_privilege_absent CASCADE;
+                 GRANT USAGE, CREATE ON SCHEMA {SchemaName} TO {RoleName};
+                 """)
+            .ExecuteNonQueryAsync();
+    }
+}

--- a/src/Weasel.Postgresql/PostgresqlMigrator.cs
+++ b/src/Weasel.Postgresql/PostgresqlMigrator.cs
@@ -94,20 +94,36 @@ $$;
 
     private static void WriteSql(string databaseSchemaName, TextWriter writer)
     {
-        // Neither the "IF NOT EXISTS(information_schema.schemata) THEN EXECUTE 'CREATE SCHEMA'"
-        // pattern nor PostgreSQL's own "CREATE SCHEMA IF NOT EXISTS" is concurrent-safe — both
-        // can have two sessions pass the existence check then race on the insert into pg_namespace,
-        // surfacing as "23505 duplicate key value violates unique constraint pg_namespace_nspname_index"
-        // / "42P06 schema X already exists". Wrap the create in a sub-block that swallows those two
-        // race exceptions specifically; any other error still propagates.
+        // Two independent hazards, and each guard here covers exactly one of them. Neither replaces the
+        // other, so removing either reintroduces a real failure.
+        //
+        // The outer IF NOT EXISTS is about PERMISSIONS, not existence. PostgreSQL checks CREATE on the
+        // *database* before it evaluates CREATE SCHEMA's own IF NOT EXISTS, so a role holding CREATE on the
+        // schema but not on the database - the documented way to let an application own its own tables while
+        // a migration role owns the schema - is refused with "42501 permission denied for database" even
+        // when the schema is already there. Since every delta that touches a schema re-emits this statement,
+        // that aborts the whole migration script, every table in it included, with nothing to do. Reading
+        // pg_catalog.pg_namespace first costs one catalog lookup and asks for no privilege the caller has no
+        // reason to hold. Weasel.SqlServer has always guarded this way - see
+        // SqlServerMigrator.CreateSchemaStatementFor - and this brings PostgreSQL into line with it.
+        // pg_namespace rather than information_schema.schemata deliberately: the latter is filtered by the
+        // caller's privileges on the schema, and a schema it cannot see is exactly one it must not try to
+        // create.
+        //
+        // The inner EXCEPTION block is about CONCURRENCY (#282) and is still required. No existence check,
+        // this one or PostgreSQL's own, is concurrent-safe: two sessions can both pass it and then race on
+        // the insert into pg_namespace, surfacing as "23505 duplicate key value violates unique constraint
+        // pg_namespace_nspname_index" / "42P06 schema X already exists". Any other error still propagates.
         writer.WriteLine(
             $"""
-                   BEGIN
-                     EXECUTE 'CREATE SCHEMA IF NOT EXISTS {PostgresqlProvider.Instance.ToQualifiedName(databaseSchemaName)}';
-                   EXCEPTION
-                     WHEN duplicate_schema THEN NULL;
-                     WHEN unique_violation THEN NULL;
-                   END;
+                   IF NOT EXISTS (SELECT 1 FROM pg_catalog.pg_namespace WHERE nspname = '{SchemaUtils.EscapeLiteral(databaseSchemaName)}') THEN
+                     BEGIN
+                       EXECUTE 'CREATE SCHEMA IF NOT EXISTS {PostgresqlProvider.Instance.ToQualifiedName(databaseSchemaName)}';
+                     EXCEPTION
+                       WHEN duplicate_schema THEN NULL;
+                       WHEN unique_violation THEN NULL;
+                     END;
+                   END IF;
 
              """);
     }


### PR DESCRIPTION
## The problem

PostgreSQL checks `CREATE` on the **database** before it evaluates `CREATE SCHEMA`'s own `IF NOT EXISTS`. So a role holding `CREATE` on a schema but not on the database is refused with `42501 permission denied for database` even when the schema is already there and the statement has nothing to do:

```
postgres=> DO $$
BEGIN
  BEGIN
    EXECUTE 'CREATE SCHEMA IF NOT EXISTS wv';   -- wv already exists
  EXCEPTION
    WHEN duplicate_schema THEN NULL;
    WHEN unique_violation THEN NULL;
  END;
END $$;
ERROR:  permission denied for database postgres
CONTEXT:  SQL statement "CREATE SCHEMA IF NOT EXISTS wv"
```

That role held exactly `GRANT USAGE, CREATE ON SCHEMA wv`.

This is not an edge case for a migrator, because `SchemaMigration.Schemas` is *every schema any delta mentions* rather than the schemas that are missing:

```csharp
Schemas = _deltas.SelectMany(x => x.SchemaObject.AllNames())
    .Select(x => x.Schema)
    .Where(x => x != "public")
    .Distinct().ToArray();
```

and `PostgresqlMigrator.executeDelta` emits creation for all of them whenever there is any delta at all. So a migration whose only work is adding one table to a schema that has existed for months still re-emits `CREATE SCHEMA` — and since that block is the *first* statement in the script, the whole migration aborts with nothing applied.

Granting an application `USAGE, CREATE` on one schema and nothing on the database is the standard way to let it manage its own tables while a separate migration role owns everything else. Before this change, such an application could not apply a migration at all once its schema existed.

## How we hit it

Wolverine's PostgreSQL envelope storage builds its tables on the *application's* connection at startup (`AutoBuildMessageStorageOnStartup`). We granted the application role `USAGE, CREATE` on the three Wolverine schemas and pre-created the schemas in our own migration run, which is exactly the arrangement above. Every host then failed to start:

```
[ERR] Error executing Wolverine Envelope Storage database migration: DO $$ ... CREATE SCHEMA IF NOT EXISTS wolverine ...
Npgsql.PostgresException 42501: permission denied for database prosecco
    Where: SQL statement "CREATE SCHEMA IF NOT EXISTS wolverine"
...
Npgsql.PostgresException 42P01: relation "wolverine.wolverine_nodes" does not exist
    at Wolverine.Runtime.Agents.NodeAgentController.StartSoloModeAsync()
```

The schemas existed. The tables did not, because statement one killed the script.

## The change

An existence pre-check before the create, which is what `SqlServerMigrator.CreateSchemaStatementFor` has always done on `sys.schemas` — so this brings PostgreSQL into line rather than introducing a new behaviour:

```sql
IF NOT EXISTS (SELECT 1 FROM pg_catalog.pg_namespace WHERE nspname = 'one') THEN
  BEGIN
    EXECUTE 'CREATE SCHEMA IF NOT EXISTS one';
  EXCEPTION
    WHEN duplicate_schema THEN NULL;
    WHEN unique_violation THEN NULL;
  END;
END IF;
```

Two details I want to flag explicitly, because both look removable and are not:

- **The `EXCEPTION` block from #282 stays, and is still required.** An existence check is not concurrent-safe — two sessions can both pass it and then race on the insert into `pg_namespace`. The pre-check is about *privileges*; the handlers are about *concurrency*. The comment in the diff now says which guard covers which hazard, so neither reads as redundant to the next reader.
- **`pg_catalog.pg_namespace`, not `information_schema.schemata`.** The latter is filtered by the caller's privileges on the schema, and a schema the caller cannot see is precisely one it must not try to create.

Behaviour when the schema is genuinely missing is unchanged: creating it still requires `CREATE` on the database, and a role without that still gets `42501`.

## Tests

`src/Weasel.Postgresql.Tests/least_privilege_schema_creation.cs`:

- the emitted SQL carries the existence check, **and** still carries both `#282` exception handlers
- the schema name is escaped into the check (`it's` → `nspname = 'it''s'`)
- **the regression**, against a real role granted `USAGE, CREATE` on one schema and nothing else: applying a new table into an existing schema succeeds, and a second `DetermineAsync` reports `SchemaPatchDifference.None`
- the negative case: the same role applying into a *missing* schema still fails with `InsufficientPrivilege`

Verified against the pre-fix code — the regression test fails with exactly the production error:

```
Failed ... can_apply_a_delta_to_an_existing_schema_without_create_on_the_database
   Npgsql.PostgresException : 42501: permission denied for database marten_testing
```

Full `Weasel.Postgresql.Tests` suite on `net10.0` against PostgreSQL 16: **912 passed, 0 failed, 3 skipped**. (The `net9.0` leg does not run here — that runtime is not installed on this machine.)

## Not included

MySQL (`CREATE DATABASE IF NOT EXISTS`) and Oracle plausibly have the same shape, but I have no environment to verify either, and shipping an unverified change to them seemed worse than leaving them out. Happy to follow up if you think they are worth the same treatment.

I have also added a short "Privileges needed to apply a migration" note to `docs/core/schema-migrations.md`, since the privilege contract is the thing a least-privilege setup actually needs to know. Drop that commit hunk if you would rather document it differently.
