### PR TITLE
Sqlserver canonicalization and introspection batching

### DIFF
--- a/src/Weasel.Core.Tests/introspection_batching.cs
+++ b/src/Weasel.Core.Tests/introspection_batching.cs
@@ -1,0 +1,93 @@
+using Shouldly;
+using Weasel.Core;
+using Xunit;
+
+namespace Weasel.Core.Tests;
+
+/// <summary>
+///     Introspection queries are grouped so that no single command binds more parameters than the
+///     driver accepts. SQL Server refuses a request carrying more than 2100, and a table's query
+///     binds two, so a database of more than 1050 tables had every object's query put into one
+///     command and rejected outright, before any comparison happened.
+/// </summary>
+public class introspection_batching
+{
+    private static ISchemaObject[] objects(int count)
+        => Enumerable.Range(0, count).Select(i => (ISchemaObject)new FakeSchemaObject(i)).ToArray();
+
+    private static IReadOnlyList<ISchemaObject[]> batch(int count, int costEach, int budget)
+        => SchemaMigration.BatchByParameterBudget(objects(count), _ => costEach, budget).ToList();
+
+    [Fact]
+    public void no_batch_exceeds_the_budget()
+    {
+        var batches = batch(1100, 2, 2000);
+
+        batches.ShouldAllBe(b => b.Length * 2 <= 2000);
+    }
+
+    [Fact]
+    public void every_object_lands_in_exactly_one_batch_in_order()
+    {
+        var all = objects(1100);
+
+        var flattened = SchemaMigration.BatchByParameterBudget(all, _ => 2, 2000)
+            .SelectMany(x => x).ToArray();
+
+        flattened.ShouldBe(all);
+    }
+
+    [Fact]
+    public void a_set_that_fits_is_left_as_one_batch()
+    {
+        batch(500, 2, 2000).Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void an_object_costing_more_than_the_whole_budget_gets_its_own_batch()
+    {
+        // The guard against yielding an empty batch forever. Such an object cannot be made to fit,
+        // so it is sent on its own and the driver decides.
+        var batches = SchemaMigration.BatchByParameterBudget(objects(3), _ => 5000, 2000);
+
+        batches.Select(x => x.Length).ShouldBe(new[] { 1, 1, 1 });
+    }
+
+    [Fact]
+    public void an_object_that_binds_nothing_never_forces_a_split()
+    {
+        // SQLite interpolates rather than binding, so every object prices at zero.
+        batch(10_000, 0, 2000).Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void a_dialect_that_does_not_answer_falls_back_to_the_default_budget()
+    {
+        // A Migrator test double reports 0 for MaxParametersPerCommand. Taking that literally would
+        // send every object in its own command.
+        batch(500, 2, 0).Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void no_objects_is_no_batches()
+    {
+        SchemaMigration.BatchByParameterBudget([], _ => 2, 2000).ShouldBeEmpty();
+    }
+
+    private class FakeSchemaObject(int index): ISchemaObject
+    {
+        public DbObjectName Identifier { get; } = new("dbo", $"thing{index}");
+
+        public void WriteCreateStatement(Migrator migrator, TextWriter writer) => throw new NotSupportedException();
+        public void WriteDropStatement(Migrator rules, TextWriter writer) => throw new NotSupportedException();
+        public void ConfigureQueryCommand(DbCommandBuilder builder) => throw new NotSupportedException();
+
+        public Task<ISchemaObjectDelta> CreateDeltaAsync(System.Data.Common.DbDataReader reader,
+            CancellationToken ct = default) => throw new NotSupportedException();
+
+        public IEnumerable<DbObjectName> AllNames()
+        {
+            yield return Identifier;
+        }
+    }
+}

--- a/src/Weasel.Core/Migrations/DatabaseBase.cs
+++ b/src/Weasel.Core/Migrations/DatabaseBase.cs
@@ -140,7 +140,7 @@ public abstract class DatabaseBase<TConnection>: IDatabase<TConnection>, IDataba
 
         await initializeSchema(conn, ct).ConfigureAwait(false);
 
-        var migration = await SchemaMigration.DetermineAsync(conn, Migrator.CreateCommandBuilder(conn), ct, group.Objects).ConfigureAwait(false);
+        var migration = await SchemaMigration.DetermineAsync(conn, Migrator, ct, group.Objects).ConfigureAwait(false);
 
         await conn.CloseAsync().ConfigureAwait(false);
 
@@ -260,7 +260,7 @@ public abstract class DatabaseBase<TConnection>: IDatabase<TConnection>, IDataba
         await conn.OpenAsync(ct).ConfigureAwait(false);
         await initializeSchema(conn, ct).ConfigureAwait(false);
 
-        var result = await SchemaMigration.DetermineAsync(conn, Migrator.CreateCommandBuilder(conn), ct, objects).ConfigureAwait(false);
+        var result = await SchemaMigration.DetermineAsync(conn, Migrator, ct, objects).ConfigureAwait(false);
         await conn.CloseAsync().ConfigureAwait(false);
         return result;
     }
@@ -405,7 +405,7 @@ public abstract class DatabaseBase<TConnection>: IDatabase<TConnection>, IDataba
                 }
 
                 await initializeSchema(conn, ct).ConfigureAwait(false);
-                var patch = await SchemaMigration.DetermineAsync(conn, Migrator.CreateCommandBuilder(conn), ct, objects).ConfigureAwait(false);
+                var patch = await SchemaMigration.DetermineAsync(conn, Migrator, ct, objects).ConfigureAwait(false);
 
                 if (patch.Difference != SchemaPatchDifference.None)
                 {
@@ -611,7 +611,7 @@ public abstract class DatabaseBase<TConnection>: IDatabase<TConnection>, IDataba
         await conn.OpenAsync(ct).ConfigureAwait(false);
         await initializeSchema(conn, ct).ConfigureAwait(false);
 
-        var migration = await SchemaMigration.DetermineAsync(conn, Migrator.CreateCommandBuilder(conn), ct, schemaObjects).ConfigureAwait(false);
+        var migration = await SchemaMigration.DetermineAsync(conn, Migrator, ct, schemaObjects).ConfigureAwait(false);
 
         if (migration.Difference == SchemaPatchDifference.None)
         {

--- a/src/Weasel.Core/Migrator.cs
+++ b/src/Weasel.Core/Migrator.cs
@@ -296,6 +296,18 @@ public abstract class
     /// </remarks>
     public virtual DbCommandBuilder CreateCommandBuilder(DbConnection conn) => new(conn);
 
+    /// <summary>
+    ///     The most parameters this dialect will accept in one command. Schema introspection batches
+    ///     every object's query together, so this caps how many objects can be inspected per round
+    ///     trip.
+    /// </summary>
+    /// <remarks>
+    ///     The default suits the providers whose ceiling is PostgreSQL's 65535, set below it to leave
+    ///     headroom rather than to work around a lower limit. SQL Server's ceiling is 2100 and is
+    ///     overridden there.
+    /// </remarks>
+    public virtual int MaxParametersPerCommand => 60000;
+
     public abstract void AssertValidIdentifier(string name);
 
     /// <summary>

--- a/src/Weasel.Core/SchemaMigration.cs
+++ b/src/Weasel.Core/SchemaMigration.cs
@@ -43,6 +43,13 @@ public class SchemaMigration
     public SchemaPatchDifference Difference { get; } = SchemaPatchDifference.None;
 
     /// <summary>
+    ///     The budget assumed for a <see cref="Migrator" /> that reports no limit of its own. SQL
+    ///     Server's hard limit of 2100 is the tightest of the five, so it is what an unknown provider
+    ///     is assumed to have.
+    /// </summary>
+    public const int DefaultParameterBudget = 2000;
+
+    /// <summary>
     ///     Create a SchemaMigration for the supplied connection and array of schema
     ///     objects
     /// </summary>
@@ -62,6 +69,11 @@ public class SchemaMigration
     /// <param name="conn"></param>
     /// <param name="schemaObjects"></param>
     /// <returns></returns>
+    /// <remarks>
+    ///     One command, as it has always been. Without a <see cref="Migrator" /> there is no way to
+    ///     know the provider's parameter limit, and guessing at one would change how many round trips
+    ///     every existing caller makes. Pass the migrator, or an explicit budget, to batch.
+    /// </remarks>
     public static Task<SchemaMigration> DetermineAsync(
         DbConnection conn,
         CancellationToken ct,
@@ -69,15 +81,55 @@ public class SchemaMigration
     ) => DetermineAsync(conn, new DbCommandBuilder(conn), ct, schemaObjects);
 
     /// <summary>
+    ///     Create a SchemaMigration, batching the introspection queries so that no single command
+    ///     binds more than <paramref name="parameterBudget" /> parameters.
+    /// </summary>
+    /// <param name="parameterBudget">
+    ///     The most parameters one introspection command may carry. Use
+    ///     <see cref="Migrator.MaxParametersPerCommand" /> when a migrator is available.
+    /// </param>
+    public static Task<SchemaMigration> DetermineAsync(
+        DbConnection conn,
+        CancellationToken ct,
+        int parameterBudget,
+        params ISchemaObject[] schemaObjects
+    ) => determineBatchedAsync(conn, () => new DbCommandBuilder(conn), parameterBudget, ct, schemaObjects);
+
+    /// <summary>
+    ///     Create a SchemaMigration using the dialect's own command builder and parameter limit.
+    /// </summary>
+    /// <remarks>
+    ///     This is what the migration path uses. It is the only overload that gets both halves
+    ///     right at once: the builder from <see cref="Migrator.CreateCommandBuilder" />, which is
+    ///     what lets Oracle chain a reader across split statements, and the batching limit from
+    ///     <see cref="Migrator.MaxParametersPerCommand" />, so a database with more objects than one
+    ///     command can bind is inspected over several round trips instead of failing.
+    /// </remarks>
+    public static Task<SchemaMigration> DetermineAsync(
+        DbConnection conn,
+        Migrator migrator,
+        CancellationToken ct,
+        params ISchemaObject[] schemaObjects
+    ) => determineBatchedAsync(conn, () => migrator.CreateCommandBuilder(conn),
+        migrator.MaxParametersPerCommand, ct, schemaObjects);
+
+    /// <summary>
     ///     Create a SchemaMigration using a command builder the caller supplies.
     /// </summary>
     /// <remarks>
-    ///     Only Oracle needs this: ODP.NET will not execute several statements from a single
-    ///     command, so <c>OracleDbCommandBuilder</c> splits the batch and the reader chains across
-    ///     the pieces. Without it every Oracle schema object was limited to one introspection query,
-    ///     which is why index, foreign key and primary key drift was invisible to the whole
-    ///     migration path (weasel#474). Callers reach it through
-    ///     <see cref="Migrator.CreateCommandBuilder" />.
+    ///     <para>
+    ///         Only Oracle needs this: ODP.NET will not execute several statements from a single
+    ///         command, so <c>OracleDbCommandBuilder</c> splits the batch and the reader chains across
+    ///         the pieces. Without it every Oracle schema object was limited to one introspection query,
+    ///         which is why index, foreign key and primary key drift was invisible to the whole
+    ///         migration path (weasel#474). Callers reach it through
+    ///         <see cref="Migrator.CreateCommandBuilder" />.
+    ///     </para>
+    ///     <para>
+    ///         One builder is one command, so this overload cannot batch — every object's parameters
+    ///         land in the builder that was handed in. Pass the <see cref="Migrator" /> instead when
+    ///         the object count is unbounded.
+    ///     </para>
     /// </remarks>
     public static async Task<SchemaMigration> DetermineAsync(
         DbConnection conn,
@@ -93,6 +145,108 @@ public class SchemaMigration
             return new SchemaMigration(deltas);
         }
 
+        await determineBatchAsync(conn, builder, schemaObjects, deltas, ct).ConfigureAwait(false);
+
+        postProcess(deltas);
+
+        return new SchemaMigration(deltas);
+    }
+
+    private static async Task<SchemaMigration> determineBatchedAsync(
+        DbConnection conn,
+        Func<DbCommandBuilder> newBuilder,
+        int parameterBudget,
+        CancellationToken ct,
+        ISchemaObject[] schemaObjects
+    )
+    {
+        var deltas = new List<ISchemaObjectDelta>();
+
+        if (!schemaObjects.Any())
+        {
+            return new SchemaMigration(deltas);
+        }
+
+        // Priced against a throwaway builder, which costs no round trip: the parameter count an
+        // object binds is a property of its query, not of the builder it is handed.
+        int cost(ISchemaObject schemaObject)
+        {
+            var probe = new DbCommandBuilder(conn);
+            schemaObject.ConfigureQueryCommand(probe);
+            using var command = probe.Command;
+            return command.Parameters.Count;
+        }
+
+        foreach (var batch in BatchByParameterBudget(schemaObjects, cost, parameterBudget))
+        {
+            await determineBatchAsync(conn, newBuilder(), batch, deltas, ct).ConfigureAwait(false);
+        }
+
+        // Once over the complete delta set rather than per batch, so a delta can still look across
+        // objects that landed in different batches.
+        postProcess(deltas);
+
+        return new SchemaMigration(deltas);
+    }
+
+    /// <summary>
+    ///     Group the objects into batches whose combined parameter count stays within the budget.
+    /// </summary>
+    /// <remarks>
+    ///     Every provider but Oracle concatenates a whole batch into one command, so a large enough
+    ///     database binds more parameters than the driver will accept. SQL Server refuses a request
+    ///     carrying more than 2100, and a table's query binds two, so past about a thousand tables
+    ///     migration failed outright with "The incoming request has too many parameters" before any
+    ///     comparison happened.
+    /// </remarks>
+    /// <param name="parameterCost">
+    ///     What one object binds. Separate from the batching itself so the arithmetic can be
+    ///     exercised without a database.
+    /// </param>
+    internal static IEnumerable<ISchemaObject[]> BatchByParameterBudget(
+        ISchemaObject[] schemaObjects,
+        Func<ISchemaObject, int> parameterCost,
+        int parameterBudget
+    )
+    {
+        // A Migrator subclass that does not answer -- a test double, most often -- would otherwise
+        // put every object in a batch of its own and turn one round trip into hundreds.
+        var budget = parameterBudget > 0 ? parameterBudget : DefaultParameterBudget;
+
+        var current = new List<ISchemaObject>();
+        var used = 0;
+
+        foreach (var schemaObject in schemaObjects)
+        {
+            var cost = parameterCost(schemaObject);
+
+            // current.Count is what keeps an object costing more than the entire budget from
+            // yielding an empty batch forever; it goes into a batch of its own instead.
+            if (current.Count > 0 && used + cost > budget)
+            {
+                yield return current.ToArray();
+                current.Clear();
+                used = 0;
+            }
+
+            current.Add(schemaObject);
+            used += cost;
+        }
+
+        if (current.Count > 0)
+        {
+            yield return current.ToArray();
+        }
+    }
+
+    private static async Task determineBatchAsync(
+        DbConnection conn,
+        DbCommandBuilder builder,
+        ISchemaObject[] schemaObjects,
+        List<ISchemaObjectDelta> deltas,
+        CancellationToken ct
+    )
+    {
         for (var i = 0; i < schemaObjects.Length; i++)
         {
             // Between objects, not before the first: a builder that splits on this boundary would
@@ -121,13 +275,14 @@ public class SchemaMigration
         {
             // It's aggravating, but there's an issue w/ postgresql's metadata query on partitions that can throw here
         }
+    }
 
+    private static void postProcess(List<ISchemaObjectDelta> deltas)
+    {
         foreach (var postProcessing in deltas.OfType<ISchemaObjectDeltaWithPostProcessing>().ToArray())
         {
             postProcessing.PostProcess(deltas);
         }
-
-        return new SchemaMigration(deltas);
     }
 
 

--- a/src/Weasel.SqlServer.Tests/CanonicalizationTests.cs
+++ b/src/Weasel.SqlServer.Tests/CanonicalizationTests.cs
@@ -1,0 +1,68 @@
+using Shouldly;
+using Xunit;
+
+namespace Weasel.SqlServer.Tests;
+
+/// <summary>
+///     <see cref="Canonicalization.CanonicizeSql" /> reconciles a declared T-SQL function body with
+///     what <c>sys.sql_modules</c> stores.
+/// </summary>
+public class CanonicalizationTests
+{
+    [Theory]
+    [InlineData("CREATE OR ALTER FUNCTION dbo.f()")]
+    [InlineData("Create Or Alter Function dbo.f()")]
+    [InlineData("CREATE OR ALTER\r\nFUNCTION dbo.f()")]
+    [InlineData("CREATE FUNCTION dbo.f()")]
+    public void the_preamble_reduces_to_what_the_catalog_returns(string declared)
+    {
+        // OR ALTER is blanked in place, so the catalog holds CREATE + 3 spaces + FUNCTION. Every
+        // spelling of the preamble has to meet it there.
+        declared.CanonicizeSql().ShouldBe("CREATE   FUNCTION dbo.f()".CanonicizeSql(), StringCompareShould.IgnoreCase);
+    }
+
+    [Fact]
+    public void the_declared_casing_is_kept()
+    {
+        "create   function dbo.f()".CanonicizeSql().ShouldBe("create function dbo.f()");
+    }
+
+    [Fact]
+    public void surrounding_whitespace_and_a_trailing_semicolon_are_trimmed()
+    {
+        "  select 1;  ".CanonicizeSql().ShouldBe("select 1");
+    }
+
+    [Fact]
+    public void whitespace_inside_a_string_literal_is_left_alone()
+    {
+        // Collapsing it would change the value the function returns, and fold this body together
+        // with one that returns something different.
+        "select 'foo       bar'".CanonicizeSql().ShouldBe("select 'foo       bar'");
+    }
+
+    [Fact]
+    public void whitespace_inside_a_delimited_identifier_is_left_alone()
+    {
+        // [unit  price] and [unit price] are two different columns.
+        "select [unit  price] from t".CanonicizeSql().ShouldBe("select [unit  price] from t");
+    }
+
+    [Fact]
+    public void line_endings_are_normalized()
+    {
+        // One source file, CRLF on one machine and LF on another, both applying to one database.
+        "CREATE FUNCTION dbo.f()\r\nAS\r\nBEGIN\r\n    return 1;\r\nEND".CanonicizeSql()
+            .ShouldBe("CREATE FUNCTION dbo.f()\nAS\nBEGIN\n    return 1;\nEND");
+    }
+
+    [Fact]
+    public void nothing_else_is_normalized()
+    {
+        // Indentation and internal spacing are compared as written, so reformatting a body is a
+        // change. It costs one drop and recreate of the function, after which it stays clean.
+        const string sql = "CREATE FUNCTION dbo.f()\nAS\nBEGIN\n\treturn 'a  b';\nEND";
+
+        sql.CanonicizeSql().ShouldBe(sql);
+    }
+}

--- a/src/Weasel.SqlServer.Tests/Functions/round_trip_fidelity.cs
+++ b/src/Weasel.SqlServer.Tests/Functions/round_trip_fidelity.cs
@@ -1,0 +1,74 @@
+using Shouldly;
+using Weasel.Core;
+using Weasel.SqlServer.Functions;
+using Xunit;
+
+namespace Weasel.SqlServer.Tests.Functions;
+
+/// <summary>
+///     Whatever Weasel writes, Weasel must read back as unchanged. Any shape SQL Server reformats on
+///     the way into <c>sys.sql_modules</c> shows up here as a phantom delta.
+/// </summary>
+[Collection("functions")]
+public class round_trip_fidelity: IntegrationContext
+{
+    public round_trip_fidelity(): base("functions")
+    {
+    }
+
+    public static TheoryData<string, string> Bodies() => new()
+    {
+        { "crlf line endings", "CREATE OR ALTER FUNCTION functions.rt()\r\nRETURNS int AS\r\nBEGIN\r\n    return 1;\r\nEND;" },
+        { "lf line endings", "CREATE OR ALTER FUNCTION functions.rt()\nRETURNS int AS\nBEGIN\n    return 1;\nEND;" },
+        { "crlf applied, lf compared", "CREATE OR ALTER FUNCTION functions.rt()\r\nRETURNS int AS\r\nBEGIN\r\n    return 1;\r\nEND;" },
+        { "tab indentation", "CREATE OR ALTER FUNCTION functions.rt()\nRETURNS int AS\nBEGIN\n\treturn 1;\nEND;" },
+        { "no OR ALTER", "CREATE FUNCTION functions.rt()\nRETURNS int AS\nBEGIN\n    return 1;\nEND;" },
+        { "OR ALTER split over lines", "CREATE OR ALTER\nFUNCTION functions.rt()\nRETURNS int AS\nBEGIN\n    return 1;\nEND;" },
+        { "lower case keywords", "create or alter function functions.rt()\nreturns int as\nbegin\n    return 1;\nend;" },
+        { "leading blank lines", "\n\n\nCREATE OR ALTER FUNCTION functions.rt()\nRETURNS int AS\nBEGIN\n    return 1;\nEND;" },
+        { "blank lines inside", "CREATE OR ALTER FUNCTION functions.rt()\nRETURNS int AS\nBEGIN\n\n\n    return 1;\n\nEND;" },
+        { "trailing spaces on lines", "CREATE OR ALTER FUNCTION functions.rt()   \nRETURNS int AS   \nBEGIN   \n    return 1;   \nEND;" },
+        { "line comment with an apostrophe", "CREATE OR ALTER FUNCTION functions.rt()\nRETURNS int AS\nBEGIN\n    -- it's fine\n    return 1;\nEND;" },
+        { "block comment", "CREATE OR ALTER FUNCTION functions.rt()\nRETURNS int AS\nBEGIN\n    /* a  spaced   comment */\n    return 1;\nEND;" },
+        { "string literal with runs of spaces", "CREATE OR ALTER FUNCTION functions.rt()\nRETURNS varchar(50) AS\nBEGIN\n    return 'foo       bar';\nEND;" },
+        { "doubled quotes in a literal", "CREATE OR ALTER FUNCTION functions.rt()\nRETURNS varchar(50) AS\nBEGIN\n    return 'it''s   here';\nEND;" },
+        { "bracketed identifier with a space", "CREATE OR ALTER FUNCTION functions.rt()\nRETURNS int AS\nBEGIN\n    declare @t table ([unit  price] int);\n    return 1;\nEND;" },
+        { "unicode literal", "CREATE OR ALTER FUNCTION functions.rt()\nRETURNS nvarchar(50) AS\nBEGIN\n    return N'naïve — ☕';\nEND;" },
+        { "semicolon spacing", "CREATE OR ALTER FUNCTION functions.rt()\nRETURNS int AS\nBEGIN\n    return 1 ;\nEND;" },
+        { "mixed case OR ALTER", "Create Or Alter Function functions.rt()\nRETURNS int AS\nBEGIN\n    return 1;\nEND;" },
+        { "the words OR ALTER inside a literal", "CREATE OR ALTER FUNCTION functions.rt()\nRETURNS varchar(50) AS\nBEGIN\n    return 'use CREATE OR ALTER FUNCTION here';\nEND;" },
+        { "extra spaces between keywords", "CREATE OR ALTER FUNCTION    functions.rt()\nRETURNS     int AS\nBEGIN\n    return    1;\nEND;" }
+    };
+
+    [Theory]
+    [MemberData(nameof(Bodies))]
+    public async Task weasel_reads_back_what_it_wrote(string description, string body)
+    {
+        await ResetSchema();
+
+        var function = new Function(new SqlServerObjectName("functions", "rt"), body);
+        await function.ApplyChangesAsync(theConnection);
+
+        var delta = await function.FindDeltaAsync(theConnection);
+
+        delta.Difference.ShouldBe(SchemaPatchDifference.None, description);
+    }
+
+    /// <summary>
+    ///     The same source file is CRLF on one machine and LF on another. If that were a difference,
+    ///     two environments pointed at one database would recreate the function past each other
+    ///     forever instead of converging.
+    /// </summary>
+    [Fact]
+    public async Task line_endings_do_not_decide_whether_a_body_changed()
+    {
+        await ResetSchema();
+
+        const string lf = "CREATE OR ALTER FUNCTION functions.rt()\nRETURNS int AS\nBEGIN\n    return 1;\nEND;";
+        await new Function(new SqlServerObjectName("functions", "rt"), lf).ApplyChangesAsync(theConnection);
+
+        var crlf = new Function(new SqlServerObjectName("functions", "rt"), lf.Replace("\n", "\r\n"));
+
+        (await crlf.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+}

--- a/src/Weasel.SqlServer.Tests/SqlServerProviderTests.cs
+++ b/src/Weasel.SqlServer.Tests/SqlServerProviderTests.cs
@@ -31,26 +31,6 @@ public class SqlServerProviderTests
     }
 
     [Fact]
-    public void canonicizesql_supports_tabs_as_whitespace()
-    {
-        var noTabsCanonized =
-            "\r\nDECLARE\r\n  final_version uuid;\r\nBEGIN\r\nINSERT INTO table(\"data\", \"mt_dotnet_type\", \"id\", \"mt_version\", mt_last_modified) VALUES (doc, docDotNetType, docId, docVersion, transaction_timestamp())\r\n  ON CONFLICT ON CONSTRAINT pk_table\r\n  DO UPDATE SET \"data\" = doc, \"mt_dotnet_type\" = docDotNetType, \"mt_version\" = docVersion, mt_last_modified = transaction_timestamp();\r\n\r\n  SELECT mt_version FROM table into final_version WHERE id = docId;\r\n  RETURN final_version;\r\nEND;\r\n"
-                .CanonicizeSql();
-        var tabsCanonized =
-            "\r\nDECLARE\r\n\tfinal_version uuid;\r\nBEGIN\r\n\tINSERT INTO table(\"data\", \"mt_dotnet_type\", \"id\", \"mt_version\", mt_last_modified)\r\n\tVALUES (doc, docDotNetType, docId, docVersion, transaction_timestamp())\r\n\t\tON CONFLICT ON CONSTRAINT pk_table\r\n\t\t\tDO UPDATE SET \"data\" = doc, \"mt_dotnet_type\" = docDotNetType, \"mt_version\" = docVersion, mt_last_modified = transaction_timestamp();\r\n\r\n\tSELECT mt_version FROM table into final_version WHERE id = docId;\r\n\r\n\tRETURN final_version;\r\nEND;\r\n"
-                .CanonicizeSql();
-        noTabsCanonized.ShouldBe(tabsCanonized);
-    }
-
-    [Fact]
-    public void replaces_multiple_spaces_with_new_string()
-    {
-        var inputString = "Darth        Maroon the   First";
-        var expectedString = "Darth Maroon the First";
-        inputString.ReplaceMultiSpace(" ").ShouldBe(expectedString);
-    }
-
-    [Fact]
     public void execute_to_parameter_type_with_open_generics()
     {
         SqlServerProvider.Instance.RegisterMapping(typeof(WithOpenGeneric<>), "VarChar", SqlDbType.VarChar);

--- a/src/Weasel.SqlServer.Tests/introspection_batching.cs
+++ b/src/Weasel.SqlServer.Tests/introspection_batching.cs
@@ -1,0 +1,128 @@
+using System.Data.Common;
+using DbCommandBuilder = Weasel.Core.DbCommandBuilder;
+using Microsoft.Data.SqlClient;
+using Shouldly;
+using Weasel.Core;
+using Weasel.SqlServer.Tables;
+using Xunit;
+
+namespace Weasel.SqlServer.Tests;
+
+/// <summary>
+///     SQL Server refuses a request carrying more than 2100 parameters. A Table's introspection
+///     query binds two, so a database of more than 1050 of them put every object's query into one
+///     command and had it rejected outright, before any comparison happened.
+/// </summary>
+public class introspection_batching: IntegrationContext
+{
+    public introspection_batching(): base("batching")
+    {
+    }
+
+    private static ISchemaObject[] tables(int count)
+        => Enumerable.Range(0, count).Select(i =>
+        {
+            var table = new Table($"batching.thing{i}");
+            table.AddColumn<int>("id").AsPrimaryKey();
+            table.AddColumn<string>("name").AllowNulls();
+            return (ISchemaObject)table;
+        }).ToArray();
+
+    /// <summary>
+    ///     Binds <paramref name="parameterCount" /> parameters against a trivial query, so that the
+    ///     server's limit is reached in one round trip rather than by building a thousand tables.
+    /// </summary>
+    private sealed class BindsManyParameters(int parameterCount): ISchemaObject
+    {
+        public DbObjectName Identifier { get; } = new("batching", "wide");
+
+        public void ConfigureQueryCommand(DbCommandBuilder builder)
+        {
+            for (var i = 0; i < parameterCount; i++) builder.AddParameter(i);
+            builder.Append("select 1;");
+        }
+
+        public async Task<ISchemaObjectDelta> CreateDeltaAsync(DbDataReader reader, CancellationToken ct = default)
+        {
+            await reader.ReadAsync(ct);
+            return new SchemaObjectDelta(this, SchemaPatchDifference.None);
+        }
+
+        public void WriteCreateStatement(Migrator migrator, TextWriter writer) => throw new NotSupportedException();
+        public void WriteDropStatement(Migrator rules, TextWriter writer) => throw new NotSupportedException();
+
+        public IEnumerable<DbObjectName> AllNames()
+        {
+            yield return Identifier;
+        }
+    }
+
+    private static ISchemaObject[] wideObjects() =>
+        Enumerable.Range(0, 6).Select(_ => (ISchemaObject)new BindsManyParameters(400)).ToArray();
+
+    [Fact]
+    public async Task one_command_for_everything_is_rejected_by_the_server()
+    {
+        // 2400 parameters in a single command. This is what the migration path did for every object
+        // it had, and it is the overload that still does not batch, because the caller supplies the
+        // one builder it can use.
+        await ResetSchema();
+
+        var tooMany = await Should.ThrowAsync<SqlException>(async () =>
+            await SchemaMigration.DetermineAsync(
+                theConnection, new DbCommandBuilder(theConnection), default, wideObjects()));
+
+        // By number, not message text: SQL Server localizes the text.
+        tooMany.Number.ShouldBe(8003);
+    }
+
+    [Fact]
+    public async Task the_same_objects_go_through_once_the_batch_respects_the_limit()
+    {
+        await ResetSchema();
+
+        var migration = await SchemaMigration.DetermineAsync(
+            theConnection, new SqlServerMigrator(), default, wideObjects());
+
+        migration.Deltas.Count.ShouldBe(6);
+    }
+
+    [Fact]
+    public async Task every_object_is_reported_when_the_batch_has_to_split()
+    {
+        await ResetSchema();
+
+        // Two parameters per table, so this is one table per batch.
+        var migration = await SchemaMigration.DetermineAsync(theConnection, default, 2, tables(10));
+
+        migration.Deltas.Count.ShouldBe(10);
+        migration.Difference.ShouldBe(SchemaPatchDifference.Create);
+    }
+
+    [Fact]
+    public async Task splitting_reports_what_a_single_batch_reports()
+    {
+        await ResetSchema();
+
+        // Create half of them, so the run has a mix of Create and None to get wrong.
+        foreach (var table in tables(10).Take(5))
+        {
+            await CreateSchemaObjectInDatabase(table);
+        }
+
+        var single = await SchemaMigration.DetermineAsync(theConnection, default, int.MaxValue, tables(10));
+        var split = await SchemaMigration.DetermineAsync(theConnection, default, 4, tables(10));
+
+        split.Difference.ShouldBe(single.Difference);
+        split.Deltas.Select(x => x.Difference).ShouldBe(single.Deltas.Select(x => x.Difference));
+    }
+
+    [Fact]
+    public void each_dialect_supplies_its_own_limit()
+    {
+        // SQL Server's 2100 is the tightest of the five; the base default suits the rest and is not
+        // dragged down to it.
+        new SqlServerMigrator().MaxParametersPerCommand.ShouldBe(2000);
+        SchemaMigration.DefaultParameterBudget.ShouldBe(2000);
+    }
+}

--- a/src/Weasel.SqlServer/Canonicalization.cs
+++ b/src/Weasel.SqlServer/Canonicalization.cs
@@ -4,34 +4,31 @@ namespace Weasel.SqlServer;
 
 internal static class Canonicalization
 {
-    public static string ReplaceMultiSpace(this string str, string newStr)
-    {
-        var regex = new Regex("\\s+");
-        return regex.Replace(str, newStr);
-    }
+    /// <summary>
+    ///     The <c>CREATE [OR ALTER] FUNCTION</c> preamble, which is the one part of a body the
+    ///     catalog does not return as written: SQL Server blanks <c>OR ALTER</c> in place rather than
+    ///     removing it, so <c>CREATE OR ALTER FUNCTION</c> is stored as <c>CREATE</c>, three spaces,
+    ///     <c>FUNCTION</c>.
+    /// </summary>
+    private static readonly Regex CreatePreamble =
+        new(@"\b(CREATE)\s+(?:OR\s+ALTER\s+)?(FUNCTION)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-
+    /// <summary>
+    ///     Normalize a T-SQL function body for comparison against what <c>sys.sql_modules</c> stores.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Line endings are normalized because the same source file is CRLF on one machine and
+    ///         LF on another, and both apply against the same database. Left alone they never
+    ///         converge: each side recreates the function and the other sees drift again.
+    ///     </para>
+    ///     <para>
+    ///         Otherwise only the preamble, which is the only thing the catalog rewrites. It cannot
+    ///         be matched by position — <c>Function.Body()</c> wraps the body in
+    ///         <c>EXEC sp_executesql</c> — so a body that spells those same keywords inside a string
+    ///         literal is rewritten there too.
+    ///     </para>
+    /// </remarks>
     public static string CanonicizeSql(this string sql)
-    {
-        var replaced = sql
-            .Trim()
-            .Replace('\n', ' ')
-            .Replace('\r', ' ')
-            .Replace('\t', ' ')
-            .ReplaceMultiSpace(" ")
-            .Replace(" ;", ";")
-            .Replace("SECURITY INVOKER", "")
-            .Replace("  ", " ")
-            .Replace("LANGUAGE plpgsql AS $function$", "")
-            .Replace("$$ LANGUAGE plpgsql", "$function$")
-            .Replace("AS $$ DECLARE", "DECLARE")
-            .Replace("character varying", "varchar")
-            .Replace("Boolean", "boolean")
-            .Replace("bool,", "boolean,")
-            .Replace("int[]", "integer[]")
-            .Replace("numeric", "decimal")
-            .TrimEnd(';').TrimEnd();
-
-        return replaced;
-    }
+        => CreatePreamble.Replace(sql.Trim().Replace("\r\n", "\n"), "$1 $2").TrimEnd(';').TrimEnd();
 }

--- a/src/Weasel.SqlServer/Functions/FunctionDelta.cs
+++ b/src/Weasel.SqlServer/Functions/FunctionDelta.cs
@@ -20,8 +20,10 @@ public class FunctionDelta: SchemaObjectDelta<Function>
             return SchemaPatchDifference.Create;
         }
 
-        var expectedSql = expected.Body().Replace(" OR ALTER", "").CanonicizeSql();
-        var actualSql = actual.Body().Replace(" OR ALTER", "").CanonicizeSql();
+        // CanonicizeSql handles the OR ALTER preamble. Stripping it here as well was a blind
+        // replace over the whole body, so it also hit the words in a literal or a comment.
+        var expectedSql = expected.Body().CanonicizeSql();
+        var actualSql = actual.Body().CanonicizeSql();
         if (!expectedSql.Equals(actualSql, StringComparison.OrdinalIgnoreCase))
         {
             return SchemaPatchDifference.Update;

--- a/src/Weasel.SqlServer/SqlServerMigrator.cs
+++ b/src/Weasel.SqlServer/SqlServerMigrator.cs
@@ -152,6 +152,13 @@ $$;
     public int MaxIdentifierLength { get; set; } = 128;
 
     /// <summary>
+    ///     SQL Server refuses any request carrying more than 2100 parameters. The budget sits under
+    ///     that rather than on it: undershooting only costs a round trip, while reaching it costs the
+    ///     whole migration.
+    /// </summary>
+    public override int MaxParametersPerCommand => 2000;
+
+    /// <summary>
     ///     Validates a database object name before it is written into DDL. See
     ///     <see cref="IdentifierValidation" /> for why each rule is here; this method had no body at all
     ///     before weasel#416.


### PR DESCRIPTION
Accommodate the SQL Server 2100 parameter limit so we don't break on many schema objects and remove some PostgreSQL specific things from SQL Server canonization.