### PR TITLE
fix: batch introspection on the public MigrateAsync extensions too

### DIFF
--- a/src/Weasel.Postgresql/SchemaObjectsExtensions.cs
+++ b/src/Weasel.Postgresql/SchemaObjectsExtensions.cs
@@ -271,12 +271,16 @@ public static class SchemaObjectsExtensions
             await conn.OpenAsync(cancellationToken.Value).ConfigureAwait(false);
         }
 
-        var migration = await SchemaMigration.DetermineAsync(conn, cancellationToken.Value, schemaObjects).ConfigureAwait(false);
+        // Through the migrator, so an unbounded array is split into commands the driver will accept.
+        // PostgreSQL's ceiling is 65535 and a table binds five, so this is a great deal harder to reach
+        // than SQL Server's 2100 -- but it is the same path, and it is the same one-line fix.
+        var migrator = new PostgresqlMigrator();
+
+        var migration = await SchemaMigration.DetermineAsync(conn, migrator, cancellationToken.Value, schemaObjects).ConfigureAwait(false);
         if (migration.Difference == SchemaPatchDifference.None) return false;
 
         migration.AssertPatchingIsValid(autoCreate);
 
-        var migrator = new PostgresqlMigrator();
         await migrator.ApplyAllAsync(conn, migration, autoCreate, ct: cancellationToken.Value).ConfigureAwait(false);
 
         return true;

--- a/src/Weasel.SqlServer.Tests/introspection_batching.cs
+++ b/src/Weasel.SqlServer.Tests/introspection_batching.cs
@@ -117,6 +117,40 @@ public class introspection_batching: IntegrationContext
         split.Deltas.Select(x => x.Difference).ShouldBe(single.Deltas.Select(x => x.Difference));
     }
 
+    /// <summary>
+    ///     The public <c>MigrateAsync</c> extension takes an unbounded array and reached the same
+    ///     one-command-for-everything path, so batching the migration path alone left the bug live on
+    ///     the entry point a caller outside Weasel is most likely to hold.
+    /// </summary>
+    [Fact]
+    public async Task the_public_migrate_extension_batches_too()
+    {
+        await ResetSchema();
+
+        // 2400 parameters. Pre-fix this threw SqlException 8003 out of the introspection query,
+        // before any comparison happened. Nothing has drifted, so nothing is migrated.
+        var migrated = await wideObjects().MigrateAsync(theConnection);
+
+        migrated.ShouldBeFalse();
+    }
+
+    /// <summary>
+    ///     And it still applies what it finds. The batching sits in front of the comparison, so a real
+    ///     delta has to survive the split and reach the database.
+    /// </summary>
+    [Fact]
+    public async Task the_public_migrate_extension_still_applies_the_delta_it_finds()
+    {
+        await ResetSchema();
+
+        var expected = tables(3);
+
+        (await expected.MigrateAsync(theConnection)).ShouldBeTrue();
+
+        // Second pass over the same objects: everything is there now, so there is nothing to do.
+        (await expected.MigrateAsync(theConnection)).ShouldBeFalse();
+    }
+
     [Fact]
     public void each_dialect_supplies_its_own_limit()
     {

--- a/src/Weasel.SqlServer/SchemaObjectsExtensions.cs
+++ b/src/Weasel.SqlServer/SchemaObjectsExtensions.cs
@@ -342,12 +342,16 @@ WHERE
             await conn.OpenAsync(cancellationToken.Value).ConfigureAwait(false);
         }
 
-        var migration = await SchemaMigration.DetermineAsync(conn, cancellationToken.Value, schemaObjects).ConfigureAwait(false);
+        // Through the migrator, not the bare connection: this overload takes an unbounded array, and
+        // the one-command-for-everything path binds two parameters per table against a server that
+        // refuses more than 2100 of them. The migrator carries the limit that splits the batch.
+        var migrator = new SqlServerMigrator();
+
+        var migration = await SchemaMigration.DetermineAsync(conn, migrator, cancellationToken.Value, schemaObjects).ConfigureAwait(false);
         if (migration.Difference == SchemaPatchDifference.None) return false;
 
         migration.AssertPatchingIsValid(autoCreate);
 
-        var migrator = new SqlServerMigrator();
         await migrator.ApplyAllAsync(conn, migration, autoCreate, ct: cancellationToken.Value).ConfigureAwait(false);
 
         return true;

--- a/src/Weasel.Sqlite/SchemaObjectsExtensions.cs
+++ b/src/Weasel.Sqlite/SchemaObjectsExtensions.cs
@@ -321,7 +321,13 @@ public static class SchemaObjectsExtensions
             await conn.OpenAsync(cancellationToken.Value).ConfigureAwait(false);
         }
 
-        var migration = await SchemaMigration.DetermineAsync(conn, cancellationToken.Value, schemaObjects)
+        // Through the migrator, for the same reason as the other providers. SQLite interpolates its
+        // introspection queries rather than binding them -- only a trigger binds anything at all -- so
+        // there is nothing here to split today. Routing through the migrator keeps it that way by
+        // construction rather than by the accident of what the current queries happen to bind.
+        var migrator = new SqliteMigrator();
+
+        var migration = await SchemaMigration.DetermineAsync(conn, migrator, cancellationToken.Value, schemaObjects)
             .ConfigureAwait(false);
         if (migration.Difference == SchemaPatchDifference.None)
         {
@@ -330,7 +336,6 @@ public static class SchemaObjectsExtensions
 
         migration.AssertPatchingIsValid(autoCreate);
 
-        var migrator = new SqliteMigrator();
         await migrator.ApplyAllAsync(conn, migration, autoCreate, ct: cancellationToken.Value).ConfigureAwait(false);
 
         return true;


### PR DESCRIPTION
Follow-up to #496, from review of that PR.

## The gap

#496 put the parameter budget on the migration path — `DatabaseBase` — but the provider
extension methods are a separate entry point, and the array-taking overload of
`MigrateAsync` still assembled every object's introspection query into one command:

```csharp
var migration = await SchemaMigration.DetermineAsync(conn, cancellationToken.Value, schemaObjects);
if (migration.Difference == SchemaPatchDifference.None) return false;

migration.AssertPatchingIsValid(autoCreate);

var migrator = new SqlServerMigrator();   // four lines later
```

So the bug #496 fixed stayed live on the surface a caller outside Weasel is most likely to
hold. SQL Server refuses a request carrying more than 2100 parameters and a table's query
binds two, so past about a thousand tables this threw `SqlException` 8003 out of the
introspection query, before any comparison happened. The migrator was already in scope in
every case — it just had to be built before the comparison rather than after it.

## What changed

`MigrateAsync(this ISchemaObject[] …)` on SQL Server, PostgreSQL and SQLite now passes the
migrator to `DetermineAsync`, so those calls get both the dialect's command builder and its
parameter limit.

Only the overloads that take an unbounded array. The single-object overloads bind at most
five parameters between them, so there is nothing there to split, and changing them would
be churn.

PostgreSQL and SQLite are consistency rather than a live bug — PostgreSQL's ceiling is
65535 against five parameters a table, and SQLite interpolates rather than binds — but they
are the same path and the same line, and routing through the migrator means neither depends
on what the current introspection queries happen to bind.

**Oracle is deliberately left out.** `OracleDbCommandBuilder.CompileCommands` hands back one
command per statement, "each carrying only the parameters that its own statement bound", so
its per-command count does not grow with the batch at all. The builder overload there is
also load-bearing for that split (#474), and the comment explaining it is worth more than
the consistency.

## Tests

Two cases added to `Weasel.SqlServer.Tests/introspection_batching.cs`, which is where #496
put the rest of this:

- `the_public_migrate_extension_batches_too` — six objects binding 400 parameters each
  through `MigrateAsync`. **Verified to fail without the product change**, with the
  production error: reverting only `Weasel.SqlServer/SchemaObjectsExtensions.cs` leaves
  6 of 7 passing and this one failing.
- `the_public_migrate_extension_still_applies_the_delta_it_finds` — batching sits in front
  of the comparison, so a real delta still has to survive the split and reach the database;
  a second pass over the same objects reports nothing to do.

Suites run locally on `net9.0` against PostgreSQL 15.3 and Azure SQL Edge:

| Suite | Result |
|---|---|
| Weasel.SqlServer.Tests | 490 passed, 8 skipped |
| Weasel.Postgresql.Tests | 908 passed, 3 skipped |
| Weasel.Sqlite.Tests | 432 passed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)