### PR TITLE
fix(postgresql): check the existence guard against the name the catalog holds

### DIFF
--- a/src/Weasel.Postgresql.Tests/least_privilege_schema_creation.cs
+++ b/src/Weasel.Postgresql.Tests/least_privilege_schema_creation.cs
@@ -67,6 +67,67 @@ public class least_privilege_schema_creation: IntegrationContext
     }
 
     /// <summary>
+    ///     A schema name can reach the migrator already delimited: <see cref="DbObjectName.Parse" /> splits a
+    ///     qualified name on <c>.</c> and keeps the parts exactly as written, and
+    ///     <c>PostgresqlProvider.ToQualifiedName</c> passes a name the caller delimited straight through. The
+    ///     check has to be made against the name <c>pg_namespace</c> holds, which is the bare one - otherwise
+    ///     it asks for <c>nspname = '"MixedCase"'</c>, nothing ever matches, and the guard is permanently
+    ///     false for exactly the names that had to be quoted.
+    /// </summary>
+    [Fact]
+    public void a_quoted_schema_name_is_checked_by_the_name_the_catalog_holds()
+    {
+        var schema = DbObjectName.Parse(PostgresqlProvider.Instance, "\"MixedCase\".things").Schema;
+        schema.ShouldBe("\"MixedCase\"", "the parser hands the schema back with its quotes");
+
+        var writer = new StringWriter();
+        new PostgresqlMigrator().WriteSchemaCreationSql([schema], writer);
+        var sql = writer.ToString();
+
+        sql.ShouldContain("nspname = 'MixedCase'");
+        sql.ShouldNotContain("nspname = '\"MixedCase\"'");
+
+        // The create still emits the delimited form, because that is the name PostgreSQL has to be told
+        // to make. Only the catalog lookup changes.
+        sql.ShouldContain("CREATE SCHEMA IF NOT EXISTS \"MixedCase\"");
+    }
+
+    /// <summary>
+    ///     An interior quote survives the round trip: <c>"it""s"</c> is the delimited spelling of the schema
+    ///     literally named <c>it"s</c>, so the doubling is undone for the lookup and the single quote
+    ///     escaping still applies on top of it.
+    /// </summary>
+    [Fact]
+    public void undoubling_and_literal_escaping_compose()
+    {
+        var writer = new StringWriter();
+
+        new PostgresqlMigrator().WriteSchemaCreationSql(["\"it\"\"s\""], writer);
+
+        writer.ToString().ShouldContain("nspname = 'it\"s'");
+    }
+
+    /// <summary>
+    ///     And the same thing against a real role. A schema whose name had to be quoted is the case the
+    ///     unquoted check got wrong, so it is the case that has to be shown working end to end.
+    /// </summary>
+    [Fact]
+    public async Task a_quoted_schema_name_does_not_reintroduce_the_permission_failure()
+    {
+        await GrantQuotedSchemaToLeastPrivilegeRoleAsync();
+
+        var writer = new StringWriter();
+        new PostgresqlMigrator().WriteSchemaCreationSql(["\"MixedCase\""], writer);
+
+        await using var conn = new NpgsqlConnection(LeastPrivilegeConnectionString());
+        await conn.OpenAsync();
+
+        // Pre-fix the guard never matched, so this reached CREATE SCHEMA and threw
+        // "42501 permission denied for database" on a schema that has been there all along.
+        await conn.CreateCommand(writer.ToString()).ExecuteNonQueryAsync();
+    }
+
+    /// <summary>
     ///     The regression itself, against a real role. Applying a table into a schema that already exists has
     ///     to succeed for a role that was granted the schema and nothing else.
     /// </summary>
@@ -143,6 +204,29 @@ public class least_privilege_schema_creation: IntegrationContext
                  END $$;
                  DROP SCHEMA IF EXISTS least_privilege_absent CASCADE;
                  GRANT USAGE, CREATE ON SCHEMA {SchemaName} TO {RoleName};
+                 """)
+            .ExecuteNonQueryAsync();
+    }
+
+    /// <remarks>
+    ///     Quoted, so PostgreSQL keeps the casing rather than folding it. This is deliberately not the
+    ///     fixture's own schema: the point is a name that cannot be written bare.
+    /// </remarks>
+    private static async Task GrantQuotedSchemaToLeastPrivilegeRoleAsync()
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+
+        await conn.CreateCommand(
+                $"""
+                 DO $$
+                 BEGIN
+                     IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '{RoleName}') THEN
+                         CREATE ROLE {RoleName} LOGIN PASSWORD '{RoleName}';
+                     END IF;
+                 END $$;
+                 CREATE SCHEMA IF NOT EXISTS "MixedCase";
+                 GRANT USAGE, CREATE ON SCHEMA "MixedCase" TO {RoleName};
                  """)
             .ExecuteNonQueryAsync();
     }

--- a/src/Weasel.Postgresql/PostgresqlMigrator.cs
+++ b/src/Weasel.Postgresql/PostgresqlMigrator.cs
@@ -110,13 +110,21 @@ $$;
         // caller's privileges on the schema, and a schema it cannot see is exactly one it must not try to
         // create.
         //
+        // Unquote before escaping, because the check and the create have to agree on what the name
+        // is. ToQualifiedName below passes a name the caller already delimited straight through, and
+        // DbObjectName.Parse hands one back whole -- it splits on '.' and keeps the parts as written --
+        // so a table declared as "MySchema".things arrives here spelled with its quotes. pg_namespace
+        // holds the bare name, so escaping the delimited spelling into the literal asks for
+        // nspname = '"MySchema"', which nothing ever matches: the guard is then permanently false and
+        // the 42501 above comes straight back for exactly the names that had to be quoted.
+        //
         // The inner EXCEPTION block is about CONCURRENCY (#282) and is still required. No existence check,
         // this one or PostgreSQL's own, is concurrent-safe: two sessions can both pass it and then race on
         // the insert into pg_namespace, surfacing as "23505 duplicate key value violates unique constraint
         // pg_namespace_nspname_index" / "42P06 schema X already exists". Any other error still propagates.
         writer.WriteLine(
             $"""
-                   IF NOT EXISTS (SELECT 1 FROM pg_catalog.pg_namespace WHERE nspname = '{SchemaUtils.EscapeLiteral(databaseSchemaName)}') THEN
+                   IF NOT EXISTS (SELECT 1 FROM pg_catalog.pg_namespace WHERE nspname = '{SchemaUtils.EscapeLiteral(SchemaUtils.Unquote(databaseSchemaName))}') THEN
                      BEGIN
                        EXECUTE 'CREATE SCHEMA IF NOT EXISTS {PostgresqlProvider.Instance.ToQualifiedName(databaseSchemaName)}';
                      EXCEPTION


### PR DESCRIPTION
Follow-up to #495, from review of that PR.

## The gap

#495 guards `CREATE SCHEMA` with a `pg_namespace` lookup so a role holding `CREATE` on a
schema but not on the database can still apply a migration into it. The lookup escapes the
schema name into the literal exactly as it arrived — but the create beneath it does not.
`PostgresqlProvider.ToQualifiedName` passes a name the caller already delimited straight
through:

```csharp
if (string.IsNullOrEmpty(objectName) || (objectName.Length >= 2 && objectName[0] == '"' && objectName[^1] == '"'))
    return objectName;
```

And `DbObjectName.Parse` hands one back whole — `QualifiedNameParser` splits on `.` and
keeps the parts as written. So a table declared as `"MySchema".things` reaches the migrator
with its quotes on, and the guard asked for a name that cannot exist:

```sql
IF NOT EXISTS (SELECT 1 FROM pg_catalog.pg_namespace WHERE nspname = '"MixedCase"') THEN
  BEGIN
    EXECUTE 'CREATE SCHEMA IF NOT EXISTS "MixedCase"';
```

`pg_namespace` holds `MixedCase`. Nothing ever matched, so the guard was permanently false
and the `42501 permission denied for database` that #495 fixed came straight back — for
exactly the names that had to be quoted in the first place. Same class of mismatch #446
fixed for SQL Server brackets.

## The change

`SchemaUtils.Unquote` before escaping. It is the existing counterpart to the pass-through in
`Quote`, and its own remarks describe this failure — *"the model holding the delimited
spelling, while the database reports the bare name — so the two never compare equal"*. It
also undoubles an interior quote, so `"it""s"` looks up the schema literally named `it"s`,
with the single-quote literal escaping still applying on top.

The create is untouched and still emits the delimited form, because that is the name
PostgreSQL has to be told to make. Only the catalog lookup changes.

## Tests

Three added to `least_privilege_schema_creation.cs`. **All three verified to fail without the
product change** — reverting only `PostgresqlMigrator.cs` leaves 4 of 7 passing:

- `a_quoted_schema_name_is_checked_by_the_name_the_catalog_holds` — goes through
  `DbObjectName.Parse` so the quoted spelling is reached the way real code reaches it, and
  pins that the create still emits the delimited form.
- `undoubling_and_literal_escaping_compose` — `"it""s"` → `nspname = 'it"s'`.
- `a_quoted_schema_name_does_not_reintroduce_the_permission_failure` — the real one, against
  the least-privilege role from #495 and a schema that has been there all along. Pre-fix it
  throws the production error verbatim:
  `Npgsql.PostgresException : 42501: permission denied for database marten_testing`.

`Weasel.Postgresql.Tests` on `net9.0` against PostgreSQL 15.3: **915 passed, 0 failed, 3 skipped.**

## Noted, not fixed

While confirming the reachable path: a `PostgresqlObjectName` built from a quoted qualified
name keeps the delimited spelling in `.Schema`, and introspection binds that against
`information_schema.columns.table_schema`, which holds the bare name. So such a table would
report `Create` on every check regardless of this fix. That is the broader normalization gap
`IdentifierRules.Undelimit`'s remarks warn about, it is independent of the privilege guard,
and it wants its own issue rather than being smuggled in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)