### PR TITLE
fix: hold the name the catalog reports, not the one the caller delimited

### DIFF
--- a/src/Weasel.Core.Tests/object_name_normalization_conformance.cs
+++ b/src/Weasel.Core.Tests/object_name_normalization_conformance.cs
@@ -1,0 +1,174 @@
+using Shouldly;
+using Weasel.Core;
+using Weasel.MySql;
+using Weasel.Oracle;
+using Weasel.Postgresql;
+using Weasel.SqlServer;
+using Weasel.Sqlite;
+using Xunit;
+
+namespace Weasel.Core.Tests;
+
+/// <summary>
+///     A name can reach the model already delimited, and the model has to hold the spelling the
+///     database will report rather than the spelling the caller wrote.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <see cref="identifier_rules_conformance" /> pins the string layer, and that layer is
+///         correct: every provider delimits and undelimits without losing a name. What was missing is
+///         one level up. <c>QualifiedNameParser</c> splits a qualified name on <c>.</c> and keeps the
+///         parts exactly as written, so <c>DbObjectName.Parse(provider, "\"MySchema\".things")</c>
+///         handed back a schema still carrying its quotes, and nothing normalized it afterwards.
+///     </para>
+///     <para>
+///         Every provider's <c>ConfigureQueryCommand</c> binds <c>Identifier.Schema</c> straight into
+///         an introspection query against a catalog that holds the bare name. The delimited spelling
+///         never matched, introspection came back empty, the object read as absent, and the delta was
+///         <c>Create</c> on every run — emitted as <c>CREATE TABLE IF NOT EXISTS</c>, which succeeds
+///         and does nothing. So the object was created once and then never migrated again, with every
+///         later change silently discarded (weasel#499).
+///     </para>
+///     <para>
+///         <see cref="IdentifierRules.Undelimit" />'s own remarks already prescribe the fix — "A
+///         provider normalizes names through this as they arrive so that what the model holds is what
+///         the database will report." These tests are that sentence, made enforceable for all five.
+///     </para>
+///     <para>
+///         Stated through <see cref="IdentifierRules.SameObject" /> rather than string equality,
+///         exactly as the sibling suite states its invariants, because Oracle folds: there,
+///         <c>myschema</c> and <c>MYSCHEMA</c> are one object, and the contract has to hold for a
+///         folding dialect without weakening into case-insensitivity for the preserving ones.
+///     </para>
+///     <para>
+///         Pure string and model logic: no connection, no container.
+///     </para>
+/// </remarks>
+public class object_name_normalization_conformance
+{
+    public static TheoryData<string, IDatabaseProvider, IdentifierRules> Providers =>
+        new()
+        {
+            { "SqlServer", SqlServerProvider.Instance, SqlServerIdentifierRules.Instance },
+            { "MySql", MySqlProvider.Instance, MySqlIdentifierRules.Instance },
+            { "Sqlite", SqliteProvider.Instance, SqliteIdentifierRules.Instance },
+            { "Postgresql", PostgresqlProvider.Instance, PostgresqlIdentifierRules.General },
+            { "Oracle", OracleProvider.Instance, OracleIdentifierRules.Instance }
+        };
+
+    /// <summary>
+    ///     Names a caller had to delimit themselves. Weasel emitted most identifiers bare until 9.25,
+    ///     so writing the delimiters by hand was the only way to use one of these at all — which is
+    ///     precisely why they are the names most likely to arrive delimited.
+    /// </summary>
+    public static readonly string[] NamesACallerWouldDelimit =
+    [
+        "MixedCase",
+        "order date",
+        "Table",
+        "order-date",
+        "2ndPlace"
+    ];
+
+    /// <summary>
+    ///     The core of weasel#499: what the model holds has to be what the catalog will report, so
+    ///     that binding it into an introspection query finds the object.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(Providers))]
+    public void a_name_that_arrives_delimited_is_held_as_the_catalog_reports_it(
+        string provider, IDatabaseProvider databaseProvider, IdentifierRules rules)
+    {
+        foreach (var name in NamesACallerWouldDelimit)
+        {
+            var delimited = rules.Quote(name);
+
+            if (!rules.IsDelimited(delimited))
+            {
+                // The dialect writes this one bare, so there is no delimited spelling to normalize.
+                continue;
+            }
+
+            var parsed = databaseProvider.Parse(delimited, delimited);
+
+            rules.IsDelimited(parsed.Schema).ShouldBeFalse(
+                $"{provider} left the schema of '{name}' holding its delimiters: '{parsed.Schema}'");
+            rules.IsDelimited(parsed.Name).ShouldBeFalse(
+                $"{provider} left the name of '{name}' holding its delimiters: '{parsed.Name}'");
+
+            rules.SameObject(parsed.Schema, rules.Undelimit(delimited)).ShouldBeTrue(
+                $"{provider} changed which schema '{name}' refers to: got '{parsed.Schema}'");
+            rules.SameObject(parsed.Name, rules.Undelimit(delimited)).ShouldBeTrue(
+                $"{provider} changed which object '{name}' refers to: got '{parsed.Name}'");
+        }
+    }
+
+    /// <summary>
+    ///     Normalizing on the way in must not change the DDL. Whatever the model ends up holding, the
+    ///     qualified name written into a statement still has to resolve to the object the caller
+    ///     named — delimited again where the dialect needs it.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(Providers))]
+    public void normalizing_does_not_change_which_object_the_ddl_names(
+        string provider, IDatabaseProvider databaseProvider, IdentifierRules rules)
+    {
+        foreach (var name in NamesACallerWouldDelimit)
+        {
+            var delimited = rules.Quote(name);
+
+            if (!rules.IsDelimited(delimited))
+            {
+                continue;
+            }
+
+            var emitted = databaseProvider.ToQualifiedName(databaseProvider.Parse(delimited, delimited).Schema);
+            var resolved = rules.IsDelimited(emitted) ? rules.Undelimit(emitted) : rules.Undelimit(rules.Quote(emitted));
+
+            rules.SameObject(resolved, rules.Undelimit(delimited)).ShouldBeTrue(
+                $"{provider} renamed '{name}' by normalizing it: DDL says '{emitted}'");
+        }
+    }
+
+    /// <summary>
+    ///     A name that arrives bare is already the catalog spelling and must be left exactly as it is.
+    ///     The normalization is only ever allowed to strip delimiters the caller supplied.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(Providers))]
+    public void a_bare_name_is_untouched(
+        string provider, IDatabaseProvider databaseProvider, IdentifierRules rules)
+    {
+        foreach (var name in new[] { "orders", "_internal", "things" })
+        {
+            var parsed = databaseProvider.Parse(name, name);
+
+            parsed.Schema.ShouldBe(name, $"{provider} altered the bare schema '{name}'");
+            parsed.Name.ShouldBe(name, $"{provider} altered the bare name '{name}'");
+        }
+    }
+
+    /// <summary>
+    ///     The pass-through in <see cref="IdentifierRules.Quote" /> is deliberately narrow: a name
+    ///     that merely starts and ends with the delimiters, but carries a loose close character, is
+    ///     not delimited and must not be stripped. Stripping it would hand DDL back out of an
+    ///     identifier.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(Providers))]
+    public void a_name_carrying_ddl_is_not_treated_as_delimited(
+        string provider, IDatabaseProvider databaseProvider, IdentifierRules rules)
+    {
+        foreach (var injection in new[]
+                 {
+                     "[ix] ON t(id); DROP TABLE victim; --]",
+                     "\"ix\" ON t(id); DROP TABLE victim; --\"",
+                     "`ix` ON t(id); DROP TABLE victim; --`"
+                 })
+        {
+            var parsed = databaseProvider.Parse(injection, injection);
+
+            parsed.Name.ShouldBe(injection, $"{provider} stripped delimiters off '{injection}'");
+        }
+    }
+}

--- a/src/Weasel.MySql/MySqlObjectName.cs
+++ b/src/Weasel.MySql/MySqlObjectName.cs
@@ -10,8 +10,16 @@ public class MySqlObjectName: DbObjectName
         ? SchemaUtils.QuoteName(Name)
         : $"{SchemaUtils.QuoteName(Schema)}.{SchemaUtils.QuoteName(Name)}";
 
+    /// <summary>
+    ///     A name can arrive already delimited -- <c>QualifiedNameParser</c> keeps the parts of a
+    ///     qualified name exactly as written, and Weasel emitted most identifiers bare until 9.25, so
+    ///     delimiting one by hand was the only way to use it. The model has to hold the spelling the
+    ///     catalog reports, because that is what introspection binds; holding the delimited spelling
+    ///     matched nothing, so the object read as absent and was recreated on every run (weasel#499).
+    /// </summary>
     public MySqlObjectName(string schema, string name)
-        : base(schema, name, ComputeQualifiedName(schema, name))
+        : base(SchemaUtils.Unquote(schema), SchemaUtils.Unquote(name),
+            ComputeQualifiedName(SchemaUtils.Unquote(schema), SchemaUtils.Unquote(name)))
     {
     }
 

--- a/src/Weasel.Oracle/OracleObjectName.cs
+++ b/src/Weasel.Oracle/OracleObjectName.cs
@@ -7,8 +7,17 @@ public class OracleObjectName: DbObjectName
 {
     protected override string QuotedQualifiedName => $"{SchemaUtils.QuoteName(Schema)}.{SchemaUtils.QuoteName(Name)}";
 
+    /// <summary>
+    ///     A name can arrive already delimited -- <c>QualifiedNameParser</c> keeps the parts of a
+    ///     qualified name exactly as written, and Weasel emitted most identifiers bare until 9.25, so
+    ///     delimiting one by hand was the only way to use it. The model has to hold the spelling the
+    ///     catalog reports, because that is what introspection binds; holding the delimited spelling
+    ///     matched nothing, so the object read as absent and was recreated on every run (weasel#499).
+    /// </summary>
     public OracleObjectName(string schema, string name)
-        : base(schema, name, OracleProvider.Instance.As<IDatabaseProvider>().ToQualifiedName(schema, name))
+        : base(SchemaUtils.Unquote(schema), SchemaUtils.Unquote(name),
+            OracleProvider.Instance.As<IDatabaseProvider>()
+                .ToQualifiedName(SchemaUtils.Unquote(schema), SchemaUtils.Unquote(name)))
     {
     }
 

--- a/src/Weasel.Postgresql.Tests/delimited_schema_name_round_trip.cs
+++ b/src/Weasel.Postgresql.Tests/delimited_schema_name_round_trip.cs
@@ -1,0 +1,105 @@
+using JasperFx;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Postgresql.Tables;
+using Xunit;
+
+namespace Weasel.Postgresql.Tests;
+
+/// <summary>
+///     weasel#499. A table whose schema arrived delimited was created once and then never migrated
+///     again.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <c>QualifiedNameParser</c> keeps the parts of a qualified name exactly as written, so
+///         <c>"RoundTripMixed".things</c> reached the model with its quotes on. <c>ConfigureQueryCommand</c>
+///         binds <c>Identifier.Schema</c> against <c>information_schema</c>, which holds the bare name,
+///         so introspection came back empty and the table read as absent.
+///     </para>
+///     <para>
+///         The delta was therefore <c>Create</c> on every run, and <c>Create</c> is emitted as
+///         <c>CREATE TABLE IF NOT EXISTS</c> — which succeeds against the table that is already there
+///         and does nothing. Every later column, index or constraint change was discarded with no
+///         error and no warning, and <c>ApplyAllAsync</c> returned normally. That silence is what
+///         makes this worth an integration test rather than a unit one: the unit-level contract is in
+///         <c>object_name_normalization_conformance</c>, but only a real database shows the change
+///         going missing.
+///     </para>
+/// </remarks>
+[Collection("delimited_round_trip")]
+public class delimited_schema_name_round_trip: IntegrationContext
+{
+    public delimited_schema_name_round_trip(): base("delimited_round_trip")
+    {
+    }
+
+    private static Table Build(bool withSecondColumn)
+    {
+        var table = new Table(DbObjectName.Parse(PostgresqlProvider.Instance, "\"RoundTripMixed\".things"));
+        table.AddColumn<int>("id").AsPrimaryKey();
+        if (withSecondColumn)
+        {
+            table.AddColumn<string>("added_later").AllowNulls();
+        }
+
+        return table;
+    }
+
+    private async Task DropTheSchemaAsync()
+    {
+        await theConnection.CreateCommand("DROP SCHEMA IF EXISTS \"RoundTripMixed\" CASCADE;").ExecuteNonQueryAsync();
+    }
+
+    /// <summary>
+    ///     The model has to hold what the catalog reports, which is the bare name.
+    /// </summary>
+    [Fact]
+    public void the_schema_is_held_without_its_delimiters()
+    {
+        Build(false).Identifier.Schema.ShouldBe("RoundTripMixed");
+    }
+
+    [Fact]
+    public async Task a_second_check_reports_nothing_to_do()
+    {
+        await theConnection.OpenAsync();
+        await DropTheSchemaAsync();
+
+        var first = await SchemaMigration.DetermineAsync(theConnection, Build(false));
+        first.Difference.ShouldBe(SchemaPatchDifference.Create);
+
+        await new PostgresqlMigrator().ApplyAllAsync(theConnection, first, AutoCreate.CreateOrUpdate);
+
+        // Pre-fix this was Create again, forever.
+        var second = await SchemaMigration.DetermineAsync(theConnection, Build(false));
+        second.Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    /// <summary>
+    ///     The one that matters: a change made after the table exists has to reach the database.
+    /// </summary>
+    [Fact]
+    public async Task a_later_change_is_applied_rather_than_silently_discarded()
+    {
+        await theConnection.OpenAsync();
+        await DropTheSchemaAsync();
+
+        await new PostgresqlMigrator().ApplyAllAsync(theConnection,
+            await SchemaMigration.DetermineAsync(theConnection, Build(false)), AutoCreate.CreateOrUpdate);
+
+        var migration = await SchemaMigration.DetermineAsync(theConnection, Build(true));
+
+        // Pre-fix: Create, written as CREATE TABLE IF NOT EXISTS, which did nothing at all.
+        migration.Difference.ShouldBe(SchemaPatchDifference.Update);
+
+        await new PostgresqlMigrator().ApplyAllAsync(theConnection, migration, AutoCreate.CreateOrUpdate);
+
+        var count = await theConnection.CreateCommand(
+                "select count(*) from information_schema.columns where table_schema = 'RoundTripMixed' "
+                + "and table_name = 'things' and column_name = 'added_later'")
+            .ExecuteScalarAsync();
+
+        Convert.ToInt32(count).ShouldBe(1, "the added column never reached the database");
+    }
+}

--- a/src/Weasel.Postgresql.Tests/least_privilege_schema_creation.cs
+++ b/src/Weasel.Postgresql.Tests/least_privilege_schema_creation.cs
@@ -77,11 +77,17 @@ public class least_privilege_schema_creation: IntegrationContext
     [Fact]
     public void a_quoted_schema_name_is_checked_by_the_name_the_catalog_holds()
     {
-        var schema = DbObjectName.Parse(PostgresqlProvider.Instance, "\"MixedCase\".things").Schema;
-        schema.ShouldBe("\"MixedCase\"", "the parser hands the schema back with its quotes");
-
+        // This used to assert that DbObjectName.Parse hands the schema back with its quotes, as the
+        // precondition that made the guard's own unquoting necessary. weasel#499 moved that
+        // normalization upstream into the provider ObjectName constructors, so a name reaching the
+        // migrator through Parse now arrives bare and the precondition no longer holds -- see
+        // object_name_normalization_conformance for the contract that replaced it.
+        //
+        // The guard keeps its own unquoting and this test keeps testing it, because
+        // WriteSchemaCreationSql is public and takes bare strings: a caller can still hand it a
+        // delimited name without going through Parse at all.
         var writer = new StringWriter();
-        new PostgresqlMigrator().WriteSchemaCreationSql([schema], writer);
+        new PostgresqlMigrator().WriteSchemaCreationSql(["\"MixedCase\""], writer);
         var sql = writer.ToString();
 
         sql.ShouldContain("nspname = 'MixedCase'");

--- a/src/Weasel.Postgresql/PostgresqlObjectName.cs
+++ b/src/Weasel.Postgresql/PostgresqlObjectName.cs
@@ -21,8 +21,16 @@ public class PostgresqlObjectName: DbObjectName
     {
     }
 
+    /// <summary>
+    ///     A name can arrive already delimited -- <c>QualifiedNameParser</c> keeps the parts of a
+    ///     qualified name exactly as written, and Weasel emitted most identifiers bare until 9.25, so
+    ///     delimiting one by hand was the only way to use it. The model has to hold the spelling the
+    ///     catalog reports, because that is what introspection binds; holding the delimited spelling
+    ///     matched nothing, so the object read as absent and was recreated on every run (weasel#499).
+    /// </summary>
     public PostgresqlObjectName(string schema, string name, SchemaUtils.IdentifierUsage usage)
-        : base(schema, name, PostgresqlProvider.Instance.ToQualifiedName(schema, name))
+        : base(SchemaUtils.Unquote(schema), SchemaUtils.Unquote(name),
+            PostgresqlProvider.Instance.ToQualifiedName(SchemaUtils.Unquote(schema), SchemaUtils.Unquote(name)))
     {
         _usage = usage;
     }
@@ -33,9 +41,13 @@ public class PostgresqlObjectName: DbObjectName
     {
     }
 
+    /// <remarks>
+    ///     The schema and name are normalized for the same reason as the constructor above; the
+    ///     qualified name is taken as the caller gave it, since it is already the rendered form.
+    /// </remarks>
     public PostgresqlObjectName(string schema, string name, string qualifiedName,
         SchemaUtils.IdentifierUsage usage)
-        : base(schema, name, qualifiedName)
+        : base(SchemaUtils.Unquote(schema), SchemaUtils.Unquote(name), qualifiedName)
     {
         _usage = usage;
     }

--- a/src/Weasel.SqlServer.Tests/delimited_schema_name_round_trip.cs
+++ b/src/Weasel.SqlServer.Tests/delimited_schema_name_round_trip.cs
@@ -1,0 +1,86 @@
+using JasperFx;
+using Shouldly;
+using Weasel.Core;
+using Weasel.SqlServer.Tables;
+using Xunit;
+
+namespace Weasel.SqlServer.Tests;
+
+/// <summary>
+///     weasel#499 on SQL Server, where the same root cause surfaces loudly instead of silently.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <c>SqlServerMigrator.CreateSchemaStatementFor</c> guards on
+///         <c>sys.schemas where name = @schema</c>. A bracketed spelling misses that guard the same
+///         way it misses <c>information_schema</c>, so the migration attempted <c>CREATE SCHEMA</c>
+///         for a schema that had been there all along and the whole script died with
+///         <c>There is already an object named 'x' in the database</c>.
+///     </para>
+///     <para>
+///         This is the SQL Server twin of the PostgreSQL guard bugs in weasel#495 and weasel#498 —
+///         same shape, same cause, and it falls out of normalizing the name on the way into the model.
+///     </para>
+/// </remarks>
+public class delimited_schema_name_round_trip: IntegrationContext
+{
+    public delimited_schema_name_round_trip(): base("bracketed")
+    {
+    }
+
+    private static Table Build(bool withSecondColumn)
+    {
+        var table = new Table(DbObjectName.Parse(SqlServerProvider.Instance, "[bracketed].things"));
+        table.AddColumn<int>("id").AsPrimaryKey();
+        if (withSecondColumn)
+        {
+            table.AddColumn<string>("added_later").AllowNulls();
+        }
+
+        return table;
+    }
+
+    [Fact]
+    public void the_schema_is_held_without_its_brackets()
+    {
+        Build(false).Identifier.Schema.ShouldBe("bracketed");
+    }
+
+    /// <summary>
+    ///     With the schema already present, the migration must not try to create it again.
+    /// </summary>
+    [Fact]
+    public async Task an_existing_schema_is_not_created_a_second_time()
+    {
+        await ResetSchema();
+
+        // Pre-fix this threw SqlException "There is already an object named 'bracketed' in the
+        // database" on the CREATE SCHEMA that opens the script.
+        await new SqlServerMigrator().ApplyAllAsync(theConnection,
+            await SchemaMigration.DetermineAsync(theConnection, Build(false)), AutoCreate.CreateOrUpdate);
+
+        (await SchemaMigration.DetermineAsync(theConnection, Build(false)))
+            .Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task a_later_change_is_applied_rather_than_silently_discarded()
+    {
+        await ResetSchema();
+
+        await new SqlServerMigrator().ApplyAllAsync(theConnection,
+            await SchemaMigration.DetermineAsync(theConnection, Build(false)), AutoCreate.CreateOrUpdate);
+
+        var migration = await SchemaMigration.DetermineAsync(theConnection, Build(true));
+        migration.Difference.ShouldBe(SchemaPatchDifference.Update);
+
+        await new SqlServerMigrator().ApplyAllAsync(theConnection, migration, AutoCreate.CreateOrUpdate);
+
+        var count = await theConnection.CreateCommand(
+                "select count(*) from information_schema.columns where table_schema = 'bracketed' "
+                + "and table_name = 'things' and column_name = 'added_later'")
+            .ExecuteScalarAsync();
+
+        Convert.ToInt32(count).ShouldBe(1, "the added column never reached the database");
+    }
+}

--- a/src/Weasel.SqlServer/SqlServerObjectName.cs
+++ b/src/Weasel.SqlServer/SqlServerObjectName.cs
@@ -7,8 +7,17 @@ public class SqlServerObjectName: DbObjectName
 {
     protected override string QuotedQualifiedName => $"{SchemaUtils.QuoteName(Schema)}.{SchemaUtils.QuoteName(Name)}";
 
+    /// <summary>
+    ///     A name can arrive already delimited -- <c>QualifiedNameParser</c> keeps the parts of a
+    ///     qualified name exactly as written, and Weasel emitted most identifiers bare until 9.25, so
+    ///     delimiting one by hand was the only way to use it. The model has to hold the spelling the
+    ///     catalog reports, because that is what introspection binds; holding the delimited spelling
+    ///     matched nothing, so the object read as absent and was recreated on every run (weasel#499).
+    /// </summary>
     public SqlServerObjectName(string schema, string name)
-        : base(schema, name, SqlServerProvider.Instance.As<IDatabaseProvider>().ToQualifiedName(schema, name))
+        : base(SchemaUtils.Unbracket(schema), SchemaUtils.Unbracket(name),
+            SqlServerProvider.Instance.As<IDatabaseProvider>()
+                .ToQualifiedName(SchemaUtils.Unbracket(schema), SchemaUtils.Unbracket(name)))
     {
     }
 

--- a/src/Weasel.Sqlite/SqliteObjectName.cs
+++ b/src/Weasel.Sqlite/SqliteObjectName.cs
@@ -10,8 +10,16 @@ public class SqliteObjectName: DbObjectName
             ? SchemaUtils.QuoteName(Name)
             : $"{SchemaUtils.QuoteName(Schema)}.{SchemaUtils.QuoteName(Name)}";
 
+    /// <summary>
+    ///     A name can arrive already delimited -- <c>QualifiedNameParser</c> keeps the parts of a
+    ///     qualified name exactly as written, and Weasel emitted most identifiers bare until 9.25, so
+    ///     delimiting one by hand was the only way to use it. The model has to hold the spelling the
+    ///     catalog reports, because that is what introspection binds; holding the delimited spelling
+    ///     matched nothing, so the object read as absent and was recreated on every run (weasel#499).
+    /// </summary>
     public SqliteObjectName(string schema, string name)
-        : base(schema, name, BuildQualifiedName(schema, name))
+        : base(SchemaUtils.Unquote(schema), SchemaUtils.Unquote(name),
+            BuildQualifiedName(SchemaUtils.Unquote(schema), SchemaUtils.Unquote(name)))
     {
     }
 


### PR DESCRIPTION
Closes #499.

## The bug

A name can reach the model already delimited — `QualifiedNameParser` splits a qualified name on
`.` and keeps the parts exactly as written, and Weasel emitted most identifiers bare until 9.25,
so delimiting one by hand was the only way to use it at all. Nothing normalized it afterwards,
and every provider's `ConfigureQueryCommand` binds `Identifier.Schema` straight into an
introspection query against a catalog that holds the **bare** name.

The delimited spelling never matched, so introspection came back empty, the object read as
absent, and the delta was `Create` on every run — written as `CREATE TABLE IF NOT EXISTS`, which
succeeds against the table that is already there and does nothing.

**The object was created once and then never migrated again.** Measured on PostgreSQL 15.3,
identical models differing only in whether the schema name arrived delimited:

```
--- declared as "RoundTripMixed".things ---
delta after adding a column = Create
added_later present in the database? NO  <-- change silently lost

--- declared as zzdrift_bare.things ---
delta after adding a column = Update
added_later present in the database? YES
```

No error, no warning, `ApplyAllAsync` returns normally. On SQL Server the same root cause
surfaces loudly instead: `CreateSchemaStatementFor` guards on `sys.schemas` by name, a bracketed
spelling misses that guard, and the migration dies with `There is already an object named
'bracketed' in the database` — the twin of the PostgreSQL guard bugs #495 and #498 fixed.

## The change

`IdentifierRules.Undelimit`'s own remarks already prescribed it:

> A provider normalizes names through this as they arrive so that what the model holds is what
> the database will report.

Each provider's `ObjectName` constructor now does that. It is the one seam every `Parse` routes
through, so it catches direct construction as well. **Emission is untouched** — `ToQualifiedName`
re-delimits from the bare name, so the DDL is unchanged.

Patching each `ConfigureQueryCommand` instead was the alternative and is worse: dozens of sites
across five providers and every object type, where missing one reintroduces the bug silently.

### On Oracle

This was the part I expected to sink the approach, since `"myschema"` and bare `myschema` (which
folds to `MYSCHEMA`) are different objects in most readings. It resolves cleanly:
`OracleIdentifierRules.SameObject` is case-insensitive, so under Oracle's own equivalence rule
unquoting cannot rename an object. The conformance suite is therefore stated through `SameObject`
rather than string equality — the same way `identifier_rules_conformance` states its invariants,
and for the same reason.

## Tests

**`object_name_normalization_conformance`** — a new suite alongside `identifier_rules_conformance`,
pure string and model logic, no container. It pins four properties for all five providers: a
delimited name is held as the catalog reports it; normalizing does not change which object the
DDL names; a bare name is untouched; and a name carrying DDL is *not* treated as delimited, so
the narrow pass-through in `Quote` stays narrow.

**Verified red first.** Before the change: 5 failed / 15 passed — every provider failing the core
assertion, and the other three properties already holding, which is what gave the fix a floor to
land on. After: 20/20.

**`delimited_schema_name_round_trip`** on PostgreSQL and SQL Server — the end-to-end symptom the
unit suite cannot show: create, add a column, apply, and assert the column actually reached the
database. All three PostgreSQL cases fail without the product change.

One existing test — `a_quoted_schema_name_is_checked_by_the_name_the_catalog_holds`, from #498 —
asserted the old behaviour as its *precondition*. It has been rewritten with a note saying why
rather than quietly flipped; the guard it covers is still reachable, since
`WriteSchemaCreationSql` is public and takes bare strings.

All six suites on `net9.0`, against PostgreSQL 15.3, Azure SQL Edge, MySQL 8.0 and Oracle Free 23:

| Suite | Result |
|---|---|
| Weasel.Core.Tests | 267 passed |
| Weasel.Postgresql.Tests | 918 passed, 3 skipped |
| Weasel.SqlServer.Tests | 493 passed, 8 skipped |
| Weasel.Sqlite.Tests | 432 passed |
| Weasel.MySql.Tests | 295 passed |
| Weasel.Oracle.Tests | 313 passed |

## Compatibility

`DbObjectName.Schema` and `.Name` change observable value for a name that arrived delimited —
they now hold the bare spelling. That is the point of the fix, but it is a behaviour change worth
a note in the release notes, and worth a look downstream in Marten and Wolverine for anything
comparing those properties against a delimited literal. Names that arrive bare are byte-identical,
and so is all emitted DDL.

## Follow-up, not included

`QualifiedNameParser` splits on a bare `.`, so a *delimited name containing a dot* still
mis-parses — `"my.schema".t` yields three parts and throws. Fixing it means teaching the parser
about delimiters, which needs `IdentifierRules` reachable from `IDatabaseProvider`; that is a
public interface addition and a separate decision. Filing it on its own rather than smuggling it
in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)