### PR TITLE
feat(postgresql): build a concurrent index on a partitioned table

### DIFF
--- a/src/Weasel.Postgresql.Tests/Tables/partitioning/concurrent_indexes_on_partitioned_tables.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/partitioning/concurrent_indexes_on_partitioned_tables.cs
@@ -1,0 +1,204 @@
+using JasperFx;
+using Npgsql;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Postgresql.Tables;
+using Xunit;
+
+namespace Weasel.Postgresql.Tests.Tables.partitioning;
+
+/// <summary>
+///     weasel#494. <c>IndexDefinition.IsConcurrent</c> emits <c>CREATE INDEX CONCURRENTLY</c>, which
+///     covers an ordinary table and is refused outright on a partitioned one.
+/// </summary>
+/// <remarks>
+///     <para>
+///         The supported sequence on a partitioned parent is three steps:
+///     </para>
+///     <list type="number">
+///         <item><c>CREATE INDEX ON ONLY parent</c> — metadata only; the parent index is left invalid</item>
+///         <item><c>CREATE INDEX CONCURRENTLY child ON partition</c> — per partition, non-blocking</item>
+///         <item><c>ALTER INDEX parent_idx ATTACH PARTITION child_idx</c> — the parent flips to valid
+///         once every child is attached</item>
+///     </list>
+///     <para>
+///         Step 2 cannot share a command with the others, which is what the
+///         <c>IndexCreationBeginComment</c> markers and the split in <c>PostgresqlMigrator.executeDelta</c>
+///         already exist to arrange.
+///     </para>
+/// </remarks>
+[Collection("concurrent_partition_indexes")]
+public class concurrent_indexes_on_partitioned_tables: IntegrationContext
+{
+    public concurrent_indexes_on_partitioned_tables(): base("concurrent_partition_indexes")
+    {
+    }
+
+    public override async ValueTask InitializeAsync()
+    {
+        await ResetSchema();
+    }
+
+    private Table BuildTable(bool withConcurrentIndex)
+    {
+        var table = new Table(new PostgresqlObjectName(SchemaName, "partitioned_docs"));
+        table.AddColumn<Guid>("id").AsPrimaryKey();
+        table.AddColumn<string>("tenant_id").AsPrimaryKey().NotNull()
+            .PartitionByListValues()
+            .AddPartition("one", "one")
+            .AddPartition("two", "two");
+        table.AddColumn<string>("body");
+
+        if (withConcurrentIndex)
+        {
+            var index = new IndexDefinition("idx_partitioned_docs_body") { IsConcurrent = true };
+            index.AgainstColumns("body");
+            table.Indexes.Add(index);
+        }
+
+        return table;
+    }
+
+    /// <summary>
+    ///     The parent index only becomes valid once every partition's index is attached, so this is
+    ///     the assertion that the whole three-step sequence ran and not merely the first step.
+    /// </summary>
+    private async Task<bool> ParentIndexIsValidAsync()
+    {
+        var result = await theConnection.CreateCommand(
+                "select i.indisvalid from pg_index i "
+                + "join pg_class c on c.oid = i.indexrelid "
+                + "join pg_namespace n on n.oid = c.relnamespace "
+                + $"where n.nspname = '{SchemaName}' and c.relname = 'idx_partitioned_docs_body'")
+            .ExecuteScalarAsync();
+
+        result.ShouldNotBeNull("the parent index was never created");
+        return (bool)result!;
+    }
+
+    private async Task<int> AttachedChildIndexCountAsync()
+    {
+        var result = await theConnection.CreateCommand(
+                "select count(*) from pg_inherits h "
+                + "join pg_class parent on parent.oid = h.inhparent "
+                + "join pg_namespace n on n.oid = parent.relnamespace "
+                + $"where n.nspname = '{SchemaName}' and parent.relname = 'idx_partitioned_docs_body'")
+            .ExecuteScalarAsync();
+
+        return Convert.ToInt32(result);
+    }
+
+    [Fact]
+    public async Task a_concurrent_index_can_be_created_on_a_partitioned_table()
+    {
+        var table = BuildTable(withConcurrentIndex: true);
+
+        // Pre-fix this threw 0A000: "cannot create index on partitioned table ... concurrently".
+        await new PostgresqlMigrator().ApplyAllAsync(theConnection,
+            await SchemaMigration.DetermineAsync(theConnection, table), AutoCreate.CreateOrUpdate);
+
+        // Every partition, the default one included -- an index that skipped it would leave the
+        // parent invalid forever.
+        var expected = table.Partitioning!.PartitionTableNames(table).Count();
+        expected.ShouldBe(3, "two named partitions plus the default");
+
+        (await AttachedChildIndexCountAsync()).ShouldBe(expected, "one attached index per partition");
+        (await ParentIndexIsValidAsync()).ShouldBeTrue("the parent index is still invalid");
+    }
+
+    /// <summary>
+    ///     The case the issue is actually about: the table already exists with data in it, and the
+    ///     index is added afterwards without taking a write outage.
+    /// </summary>
+    [Fact]
+    public async Task a_concurrent_index_can_be_added_to_an_existing_partitioned_table()
+    {
+        await new PostgresqlMigrator().ApplyAllAsync(theConnection,
+            await SchemaMigration.DetermineAsync(theConnection, BuildTable(withConcurrentIndex: false)),
+            AutoCreate.CreateOrUpdate);
+
+        await theConnection.CreateCommand(
+                $"insert into {SchemaName}.partitioned_docs (id, tenant_id, body) values (gen_random_uuid(), 'one', 'x')")
+            .ExecuteNonQueryAsync();
+
+        var withIndex = BuildTable(withConcurrentIndex: true);
+        var migration = await SchemaMigration.DetermineAsync(theConnection, withIndex);
+        migration.Difference.ShouldBe(SchemaPatchDifference.Update);
+
+        await new PostgresqlMigrator().ApplyAllAsync(theConnection, migration, AutoCreate.CreateOrUpdate);
+
+        (await AttachedChildIndexCountAsync()).ShouldBe(withIndex.Partitioning!.PartitionTableNames(withIndex).Count());
+        (await ParentIndexIsValidAsync()).ShouldBeTrue();
+    }
+
+    /// <summary>
+    ///     And it has to converge: a second check reports nothing to do, rather than trying to build
+    ///     the index again on every run.
+    /// </summary>
+    [Fact]
+    public async Task the_migration_converges()
+    {
+        var table = BuildTable(withConcurrentIndex: true);
+
+        await new PostgresqlMigrator().ApplyAllAsync(theConnection,
+            await SchemaMigration.DetermineAsync(theConnection, table), AutoCreate.CreateOrUpdate);
+
+        (await SchemaMigration.DetermineAsync(theConnection, BuildTable(withConcurrentIndex: true)))
+            .Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    /// <summary>
+    ///     Changing the index has to rebuild it, which means dropping the parent first. A partitioned
+    ///     index cannot be dropped CONCURRENTLY — PostgreSQL refuses — so the drop this path emits has
+    ///     to know the difference.
+    /// </summary>
+    [Fact]
+    public async Task a_changed_concurrent_index_is_rebuilt()
+    {
+        await new PostgresqlMigrator().ApplyAllAsync(theConnection,
+            await SchemaMigration.DetermineAsync(theConnection, BuildTable(withConcurrentIndex: true)),
+            AutoCreate.CreateOrUpdate);
+
+        // Same index name, different columns: a rebuild rather than an addition.
+        var changed = BuildTable(withConcurrentIndex: false);
+        var index = new IndexDefinition("idx_partitioned_docs_body") { IsConcurrent = true };
+        index.AgainstColumns("body", "tenant_id");
+        changed.Indexes.Add(index);
+
+        var migration = await SchemaMigration.DetermineAsync(theConnection, changed);
+        migration.Difference.ShouldBe(SchemaPatchDifference.Update);
+
+        await new PostgresqlMigrator().ApplyAllAsync(theConnection, migration, AutoCreate.CreateOrUpdate);
+
+        (await AttachedChildIndexCountAsync()).ShouldBe(changed.Partitioning!.PartitionTableNames(changed).Count());
+        (await ParentIndexIsValidAsync()).ShouldBeTrue();
+
+        (await SchemaMigration.DetermineAsync(theConnection, changed)).Difference
+            .ShouldBe(SchemaPatchDifference.None);
+    }
+
+    /// <summary>
+    ///     An ordinary table is untouched by any of this — it still gets the single
+    ///     <c>CREATE INDEX CONCURRENTLY</c> it has always got.
+    /// </summary>
+    [Fact]
+    public async Task an_unpartitioned_table_still_gets_a_plain_concurrent_index()
+    {
+        var table = new Table(new PostgresqlObjectName(SchemaName, "plain"));
+        table.AddColumn<Guid>("id").AsPrimaryKey();
+        table.AddColumn<string>("body");
+
+        var index = new IndexDefinition("idx_plain_body") { IsConcurrent = true };
+        index.AgainstColumns("body");
+        table.Indexes.Add(index);
+
+        table.ToCreateSql(new PostgresqlMigrator()).ShouldContain("CONCURRENTLY");
+        table.ToCreateSql(new PostgresqlMigrator()).ShouldNotContain("ATTACH PARTITION");
+
+        await new PostgresqlMigrator().ApplyAllAsync(theConnection,
+            await SchemaMigration.DetermineAsync(theConnection, table), AutoCreate.CreateOrUpdate);
+
+        (await SchemaMigration.DetermineAsync(theConnection, table)).Difference
+            .ShouldBe(SchemaPatchDifference.None);
+    }
+}

--- a/src/Weasel.Postgresql.Tests/Tables/partitioning/managed_range_partitions.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/partitioning/managed_range_partitions.cs
@@ -287,7 +287,11 @@ public class managed_range_partitions: IntegrationContext
                 from pg_inherits i
                 join pg_class c on c.oid = i.inhrelid
                 join pg_class p on p.oid = i.inhparent
-                where p.relname = 'events'
+                join pg_namespace n on n.oid = p.relnamespace
+                -- Schema-qualified deliberately: 'events' is a name another fixture can easily take,
+                -- and without this the partitions of an unrelated table in another schema show up here
+                -- as extra rows and fail an assertion that has nothing to do with them.
+                where n.nspname = 'managed_ranges' and p.relname = 'events'
                 order by c.relname
                 """)
             .ExecuteReaderAsync();

--- a/src/Weasel.Postgresql/Tables/IndexDefinition.cs
+++ b/src/Weasel.Postgresql/Tables/IndexDefinition.cs
@@ -223,6 +223,29 @@ public class IndexDefinition: ITableIndex
             builder.AppendLine(IndexCreationBeginComment);
         }
 
+        builder.Append(createStatement(parent, QuotedName, parent.Identifier.ToString(), IsConcurrent, onlyParent: false));
+
+        if (IsConcurrent)
+        {
+            builder.AppendLine();
+            builder.Append(IndexCreationEndComment);
+        }
+
+        return builder.ToString();
+    }
+
+    /// <summary>
+    ///     One <c>CREATE INDEX</c> statement, with the name, the target table, the concurrency and the
+    ///     <c>ONLY</c> qualifier supplied rather than taken from this definition.
+    /// </summary>
+    /// <remarks>
+    ///     The last three vary only for a concurrent index on a partitioned table, which is built as
+    ///     three statements per partition rather than one — see <see cref="ToCreateSql" />.
+    /// </remarks>
+    private string createStatement(Table parent, string indexName, string table, bool concurrently, bool onlyParent)
+    {
+        var builder = new StringBuilder();
+
         builder.Append("CREATE ");
 
         if (IsUnique)
@@ -232,15 +255,21 @@ public class IndexDefinition: ITableIndex
 
         builder.Append("INDEX ");
 
-        if (IsConcurrent)
+        if (concurrently)
         {
             builder.Append("CONCURRENTLY ");
         }
 
-        builder.Append(QuotedName);
+        builder.Append(indexName);
 
         builder.Append(" ON ");
-        builder.Append(parent.Identifier);
+
+        if (onlyParent)
+        {
+            builder.Append("ONLY ");
+        }
+
+        builder.Append(table);
         builder.Append(" USING ");
         builder.Append(Method == IndexMethod.custom ? CustomMethod : Method);
         builder.Append(" ");
@@ -295,14 +324,90 @@ public class IndexDefinition: ITableIndex
 
 
         builder.Append(";");
-        if (IsConcurrent)
-        {
-            builder.AppendLine();
-            builder.Append(IndexCreationEndComment);
-        }
-
 
         return builder.ToString();
+    }
+
+    /// <summary>
+    ///     The DDL the migration path should execute to build this index. Usually one statement, and
+    ///     identical to <see cref="ToDDL" />.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         A concurrent index on a partitioned table is the exception. PostgreSQL refuses
+    ///         <c>CREATE INDEX CONCURRENTLY</c> on a partitioned parent outright — "cannot create index
+    ///         on partitioned table ... concurrently" — so <see cref="IsConcurrent" /> could not be
+    ///         honoured there at all, and adding an index to a partitioned table meant an
+    ///         <c>ACCESS EXCLUSIVE</c> lock for the whole build: a write outage rather than a
+    ///         migration (weasel#494).
+    ///     </para>
+    ///     <para>
+    ///         The supported sequence is three steps. <c>CREATE INDEX ON ONLY parent</c> registers the
+    ///         parent index as metadata and leaves it <em>invalid</em>; each partition then gets its own
+    ///         index built concurrently; and each is attached with
+    ///         <c>ALTER INDEX ... ATTACH PARTITION</c>. The parent flips to valid by itself once the
+    ///         last child is attached, which is why a half-finished run is visible rather than silent.
+    ///     </para>
+    ///     <para>
+    ///         Kept separate from <see cref="ToDDL" /> deliberately: that is also the canonical form the
+    ///         delta compares against <c>pg_get_indexdef</c>, which returns a single statement. Folding
+    ///         this sequence into it would make every such index report drift on every run.
+    ///     </para>
+    /// </remarks>
+    public string ToCreateSql(Table parent)
+        => IsConcurrent && parent.Partitioning != null
+            ? toPartitionedConcurrentDDL(parent)
+            : ToDDL(parent);
+
+    private string toPartitionedConcurrentDDL(Table parent)
+    {
+        var builder = new StringBuilder();
+        var schema = parent.Identifier.Schema;
+
+        // Metadata only, and deliberately not concurrent: nothing is scanned, so nothing is blocked.
+        builder.AppendLine(createStatement(parent, QuotedName, parent.Identifier.ToString(),
+            concurrently: false, onlyParent: true));
+
+        foreach (var partition in parent.Partitioning!.PartitionTableNames(parent))
+        {
+            var childName = ChildIndexName(parent, partition);
+            var quotedChild = SchemaUtils.QuoteName(childName);
+
+            // The markers put this statement in a command of its own. CREATE INDEX CONCURRENTLY
+            // cannot run inside a transaction block, and PostgresqlMigrator.executeDelta splits the
+            // script on exactly this boundary.
+            builder.AppendLine(IndexCreationBeginComment);
+            builder.AppendLine(createStatement(parent, quotedChild,
+                $"{schema}.{SchemaUtils.QuoteName(partition)}", concurrently: true, onlyParent: false));
+            builder.AppendLine(IndexCreationEndComment);
+
+            builder.AppendLine($"ALTER INDEX {schema}.{QuotedName} ATTACH PARTITION {schema}.{quotedChild};");
+        }
+
+        return builder.ToString();
+    }
+
+    /// <summary>
+    ///     The name of the index built on one partition, before it is attached to this one.
+    /// </summary>
+    /// <remarks>
+    ///     Deterministic, so a run that died partway through names the same child index on the next
+    ///     attempt rather than building a second one beside it. Deliberately not truncated when it runs
+    ///     long: <c>AssertValidIdentifier</c> refuses an over-length identifier rather than silently
+    ///     renaming the object, which is the rule weasel#468 settled.
+    /// </remarks>
+    internal string ChildIndexName(Table parent, string partitionTableName)
+    {
+        // Partition tables are named "{parent}_{suffix}", so trimming the parent off keeps the child
+        // index at "{index}_{suffix}" rather than repeating the table name inside it. The fallback
+        // covers a partition name that does not follow the convention.
+        var prefix = parent.Identifier.Name.ToLowerInvariant() + "_";
+
+        var suffix = partitionTableName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
+            ? partitionTableName.Substring(prefix.Length)
+            : partitionTableName;
+
+        return $"{Name}_{suffix}";
     }
 
     /// <summary>

--- a/src/Weasel.Postgresql/Tables/Table.cs
+++ b/src/Weasel.Postgresql/Tables/Table.cs
@@ -139,16 +139,20 @@ public partial class Table: TableBase<TableColumn, IndexDefinition, ForeignKey>,
             writer.WriteLine(foreignKey.ToDDL(this));
         }
 
-        foreach (var index in Indexes)
-        {
-            writer.WriteLine();
-            writer.WriteLine(index.ToDDL(this));
-        }
-
         if (Partitioning != null)
         {
             writer.WriteLine();
             Partitioning.WriteCreateStatement(writer, this);
+        }
+
+        // After the partitions, not before them. A concurrent index on a partitioned table is built
+        // per partition and then attached, so the partitions have to exist first (weasel#494). For
+        // every other index the order is immaterial -- an index created on a partitioned parent
+        // propagates to partitions added later either way.
+        foreach (var index in Indexes)
+        {
+            writer.WriteLine();
+            writer.WriteLine(index.ToCreateSql(this));
         }
     }
 

--- a/src/Weasel.Postgresql/Tables/TableDelta.cs
+++ b/src/Weasel.Postgresql/Tables/TableDelta.cs
@@ -158,10 +158,10 @@ public class TableDelta: SchemaObjectDelta<Table>, ISchemaObjectDeltaWithPostPro
         writeCheckConstraintUpdates(writer);
 
         // Missing indexes
-        foreach (var indexDefinition in Indexes.Missing) writer.WriteLine(indexDefinition.ToDDL(Expected));
+        foreach (var indexDefinition in Indexes.Missing) writer.WriteLine(indexDefinition.ToCreateSql(Expected));
 
         // Different indexes
-        foreach (var change in Indexes.Different) writer.WriteLine(change.Expected.ToDDL(Expected));
+        foreach (var change in Indexes.Different) writer.WriteLine(change.Expected.ToCreateSql(Expected));
 
         // Need to make Primary key changes before dropping extra columns
         writePrimaryKeyChanges(writer);
@@ -368,13 +368,13 @@ public class TableDelta: SchemaObjectDelta<Table>, ISchemaObjectDeltaWithPostPro
         foreach (var indexDefinition in Indexes.Missing) writer.WriteDropIndex(Expected, indexDefinition);
 
         // Extra indexes
-        foreach (var extra in Indexes.Extras) writer.WriteLine(extra.ToDDL(Actual!));
+        foreach (var extra in Indexes.Extras) writer.WriteLine(extra.ToCreateSql(Actual!));
 
         // Different indexes
         foreach (var change in Indexes.Different)
         {
             writer.WriteDropIndex(Actual!, change.Expected);
-            writer.WriteLine(change.Actual.ToDDL(Actual!));
+            writer.WriteLine(change.Actual.ToCreateSql(Actual!));
         }
     }
 


### PR DESCRIPTION
Closes #494.

## The gap

`IndexDefinition.IsConcurrent` emits `CREATE INDEX CONCURRENTLY`, which covers an ordinary table
and is refused outright on a partitioned one:

```
0A000: cannot create index on partitioned table "partitioned_docs" concurrently
```

So `IsConcurrent` could not be honoured there at all, and adding an index to a partitioned table
meant an `ACCESS EXCLUSIVE` lock held for the whole build — a write outage rather than a
migration. Under per-tenant event partitioning there was no flag that avoided it.

## Less was missing than the issue suggests

Two of the three pieces were already built:

- The issue calls the non-transactional requirement "the interesting part". It was already
  solved — `IndexCreationBeginComment`/`EndComment` and the split in
  `PostgresqlMigrator.executeDelta` already put a concurrent index in a command of its own, which
  is exactly what `CREATE INDEX CONCURRENTLY` needs since it cannot run inside a transaction block.
- `IPartitionStrategy.PartitionTableNames` already enumerates the children.

What was genuinely missing was the `ON ONLY` rendering and an `ALTER INDEX ... ATTACH PARTITION`
statement, plus the sequencing.

## The change

`ToDDL`'s body is parameterized into `createStatement(parent, name, table, concurrently, onlyParent)`,
and a new `ToCreateSql` emits either the single statement or, for a concurrent index on a
partitioned table, the three-step sequence:

```sql
CREATE INDEX idx ON ONLY schema.parent USING btree (body);      -- metadata only, left invalid
--WEASEL_INDEX_CREATION_BEGIN
CREATE INDEX CONCURRENTLY idx_one ON schema.parent_one USING btree (body);
--WEASEL_INDEX_CREATION_END
ALTER INDEX schema.idx ATTACH PARTITION schema.idx_one;
-- ...repeated per partition
```

**`ToCreateSql` is a new path rather than a change to `ToDDL`, deliberately.** `ToDDL` is also the
canonical form the delta compares against `pg_get_indexdef`, which returns a single statement.
Folding the sequence into it would make every such index report drift on every run — the failure
mode #499 just got fixed.

Index creation in `Table.WriteCreateStatement` moves **after** the partitions are written, since
the per-partition indexes need the partitions to exist. For every other index the order is
immaterial: an index on a partitioned parent propagates to partitions added later either way.

Child indexes are named `{index}_{suffix}`, deterministically, so a run that died partway names
the same child on the next attempt rather than building a second one beside it. Not truncated when
long — `AssertValidIdentifier` refuses an over-length name rather than silently renaming, which is
the rule #468 settled.

## Tests

`concurrent_indexes_on_partitioned_tables`, five cases. **Verified red first** — the three
partitioned cases fail without the product change, with the production error
`0A000: cannot create index on partitioned table ... concurrently`, while the unpartitioned
control passes.

The assertions go through `pg_index.indisvalid` and the count of attached children rather than
merely checking the statements ran, because **the parent index is created invalid by step one and
flips to valid on its own only once the last child is attached**. Asserting validity is what
proves the whole sequence completed. The partition count is read from
`PartitionTableNames` rather than hardcoded, so it stays right as default-partition behaviour
changes — my first draft asserted 2 and the correct answer was 3.

Covered: creation on a new partitioned table; adding to an existing partitioned table with rows in
it (the case the issue is about); convergence to `None` on a second check; rebuild when the index
definition changes; and an ordinary table still getting a plain single-statement concurrent index.

All six suites on `net9.0` against PostgreSQL 15.3, Azure SQL Edge, MySQL 8.0 and Oracle Free 23:

| Suite | Result |
|---|---|
| Weasel.Core.Tests | 267 passed |
| Weasel.Postgresql.Tests | 923 passed, 3 skipped |
| Weasel.SqlServer.Tests | 493 passed, 8 skipped |
| Weasel.Sqlite.Tests | 432 passed |
| Weasel.MySql.Tests | 295 passed |
| Weasel.Oracle.Tests | 313 passed |

## One unrelated test fix, included because I tripped it

`managed_range_partitions`' `partitionTableNames()` matched `p.relname = 'events'` with **no schema
filter**, so it collected the partitions of any table named `events` in any schema in the database.
My new fixture used that name and two of its assertions failed on rows that had nothing to do with
them. Schema-qualified now, with a comment saying why, so the next fixture does not have to
rediscover it.

## Noted, not fixed

Weasel does not read `pg_index.indisvalid`, so an **invalid index reports `None`** — I confirmed
it: marking an index invalid and re-running the delta returns `SchemaPatchDifference.None`. This is
pre-existing (an ordinary `CREATE INDEX CONCURRENTLY` that fails leaves the same state), but this
feature makes it more reachable, since a partial run is now a state a migration can produce.
Fixing it touches the shared index introspection query and the comparison semantics for every
Postgres index, which is a wider blast radius than this feature — so it is filed separately rather
than bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)