### PR TITLE
fix(postgresql): read indexes in a schema whose name starts with "pg"

### DIFF
--- a/src/Weasel.Postgresql.Tests/Tables/indexes_in_a_pg_prefixed_schema.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/indexes_in_a_pg_prefixed_schema.cs
@@ -1,0 +1,99 @@
+using JasperFx;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Postgresql.Tables;
+using Xunit;
+
+namespace Weasel.Postgresql.Tests.Tables;
+
+/// <summary>
+///     weasel#504. The index introspection query carried <c>NOT nspname LIKE 'pg%'</c> alongside the
+///     <c>nspname = :schema</c> it was already filtered by.
+/// </summary>
+/// <remarks>
+///     <para>
+///         The intent was to skip <c>pg_catalog</c> and <c>pg_toast</c>, but it is a bare prefix match
+///         applied to the user's own schema, so any schema named <c>pgcontrol</c>, <c>pgqueues</c>,
+///         <c>pgdata</c> — anything starting with those two letters — had <em>no index read back at
+///         all</em>.
+///     </para>
+///     <para>
+///         What makes it hard to spot from the outside is that the primary key still arrives: the
+///         <c>isPrimary</c> branch in <c>readIndexesAsync</c> returns before the table-name check. The
+///         table looks correct and only its non-PK indexes are missing.
+///     </para>
+///     <para>
+///         With <c>actual.Indexes</c> empty, <c>ItemDelta</c> calls every declared index
+///         <c>Missing</c> rather than <c>Different</c>, so the patch is a bare <c>create index</c> with
+///         no preceding drop. The second startup gets <c>42P07: relation already exists</c>, and since
+///         a delta runs as one command that first failure aborts everything ordered after it. The
+///         schema never converges, so <c>db-assert</c> can never pass either.
+///     </para>
+///     <para>
+///         Found in Wolverine, whose control queue storage uses a <c>pgcontrol</c> schema
+///         (JasperFx/wolverine#3997).
+///     </para>
+/// </remarks>
+[Collection("pg_prefixed")]
+public class indexes_in_a_pg_prefixed_schema: IntegrationContext
+{
+    // The reporter's schema name. Legal: PostgreSQL reserves the "pg_" prefix, not "pg".
+    public indexes_in_a_pg_prefixed_schema(): base("pg3997")
+    {
+    }
+
+    public override ValueTask InitializeAsync() => new(ResetSchema());
+
+    private Table BuildTable()
+    {
+        var table = new Table(new PostgresqlObjectName(SchemaName, "docs"));
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn<string>("body");
+
+        var index = new IndexDefinition("idx_docs_body");
+        index.AgainstColumns("body");
+        table.Indexes.Add(index);
+
+        return table;
+    }
+
+    [Fact]
+    public async Task the_index_is_read_back_from_the_database()
+    {
+        await new PostgresqlMigrator().ApplyAllAsync(theConnection,
+            await SchemaMigration.DetermineAsync(theConnection, BuildTable()), AutoCreate.CreateOrUpdate);
+
+        var existing = await BuildTable().FetchExistingAsync(theConnection);
+
+        existing.ShouldNotBeNull();
+        existing!.Indexes.Select(x => x.Name).ShouldContain("idx_docs_body");
+    }
+
+    /// <summary>
+    ///     The symptom as an operator meets it: the migration never settles.
+    /// </summary>
+    [Fact]
+    public async Task the_migration_converges()
+    {
+        await new PostgresqlMigrator().ApplyAllAsync(theConnection,
+            await SchemaMigration.DetermineAsync(theConnection, BuildTable()), AutoCreate.CreateOrUpdate);
+
+        (await SchemaMigration.DetermineAsync(theConnection, BuildTable()))
+            .Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    /// <summary>
+    ///     And the failure that made it visible: applying the same configuration a second time
+    ///     re-issued <c>create index</c> and PostgreSQL answered <c>42P07</c>, taking the rest of the
+    ///     migration down with it.
+    /// </summary>
+    [Fact]
+    public async Task applying_twice_does_not_throw()
+    {
+        await new PostgresqlMigrator().ApplyAllAsync(theConnection,
+            await SchemaMigration.DetermineAsync(theConnection, BuildTable()), AutoCreate.CreateOrUpdate);
+
+        await new PostgresqlMigrator().ApplyAllAsync(theConnection,
+            await SchemaMigration.DetermineAsync(theConnection, BuildTable()), AutoCreate.CreateOrUpdate);
+    }
+}

--- a/src/Weasel.Postgresql/Tables/Table.FetchExisting.cs
+++ b/src/Weasel.Postgresql/Tables/Table.FetchExisting.cs
@@ -63,8 +63,14 @@ FROM (
       JOIN pg_namespace AS NS ON i.relnamespace = NS.OID
       JOIN pg_roles AS R ON i.relowner = r.oid
     WHERE
-      nspname = :{schemaParam} AND
-      NOT nspname LIKE 'pg%'
+      -- Only the schema that was asked for. There used to be a NOT nspname LIKE 'pg%' beside this,
+      -- meant to skip pg_catalog and pg_toast, but the line above already pins the query to one
+      -- schema so it could never have excluded anything else -- except a user schema that happens
+      -- to start with those two letters, which it excluded completely. pgcontrol, pgqueues, pgdata:
+      -- every index in them read back as absent, every declared index was then reported Missing
+      -- rather than Different, and the resulting bare CREATE INDEX failed with 42P07 on the second
+      -- run and took the rest of the migration with it (weasel#504).
+      nspname = :{schemaParam}
 ) ind
 WHERE
       ind.table_name = :{nameParam} OR


### PR DESCRIPTION
Closes #504.

## The bug

The index introspection query carried `NOT nspname LIKE 'pg%'` beside the `nspname = :schema` it
was already filtered by:

```sql
WHERE
  nspname = :schema AND
  NOT nspname LIKE 'pg%'
```

The equality above it already pins the query to a single schema, so **the exclusion could never
have kept anything out** — except a user schema that happens to start with those two letters,
which it excluded completely.

For `pgcontrol`, `pgqueues`, `pgdata` and anything else so named, no index was read back at all.
The primary key still arrived, because the `isPrimary` branch in `readIndexesAsync` returns before
the table-name check — which is what makes it hard to spot from the outside: the table looks
correct and only its non-PK indexes are missing.

With `actual.Indexes` empty, `ItemDelta` called every declared index `Missing` rather than
`Different`, so the patch was a bare `create index` with no preceding drop. First startup created
the table and its indexes; the second answered `42P07`, and since a delta executes as one command
that failure aborted everything ordered after it.

## The change

The clause is deleted rather than corrected. `nspname = :schema` is the whole filter this query
needs, and any replacement — `NOT IN ('pg_catalog', 'pg_toast', ...)` or `NOT LIKE 'pg\_%'` —
would be equally redundant while leaving a smaller version of the same trap. The comment in its
place records why it is not coming back.

## Tests

`indexes_in_a_pg_prefixed_schema`, in the reporter's own `pg3997` schema. **All three verified to
fail before the change**, and `applying_twice_does_not_throw` fails with the production error
verbatim:

```
Npgsql.PostgresException : 42P07: relation "idx_docs_body" already exists
```

- `the_index_is_read_back_from_the_database` — the root cause, directly.
- `the_migration_converges` — the symptom an operator meets: a schema difference that never settles,
  so `db-assert` can never pass.
- `applying_twice_does_not_throw` — the failure that surfaced it in Wolverine.

`Weasel.Postgresql.Tests` on `net9.0` against PostgreSQL 15.3: **926 passed, 0 failed, 3 skipped.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)