### PR TITLE
fix(sqlserver): drop the default constraint that blocks dropping its column

### DIFF
--- a/src/Weasel.SqlServer.Tests/Tables/dropping_a_column_with_a_default.cs
+++ b/src/Weasel.SqlServer.Tests/Tables/dropping_a_column_with_a_default.cs
@@ -1,0 +1,155 @@
+using JasperFx;
+using Shouldly;
+using Weasel.Core;
+using Weasel.SqlServer.Tables;
+using Xunit;
+
+namespace Weasel.SqlServer.Tests.Tables;
+
+/// <summary>
+///     weasel#505. SQL Server refuses <c>ALTER TABLE ... DROP COLUMN</c> while a default constraint
+///     still references the column.
+/// </summary>
+/// <remarks>
+///     <para>
+///         So a column declared with <c>DefaultValue(...)</c> could be added by a migration but never
+///         removed by one — the patch was generated, it just always failed:
+///     </para>
+///     <code>
+///     The object 'DF__orders__stamp__384F51F2' is dependent on column 'stamp'.
+///     ALTER TABLE DROP COLUMN stamp failed because one or more objects access this column.
+///     </code>
+///     <para>
+///         PostgreSQL drops a column and its default together, so this is SQL-Server-only. The awkward
+///         part is that SQL Server names the constraint itself when the DDL does not
+///         (<c>DF__table__col__hash</c>), so the drop cannot be written statically — it has to look the
+///         name up at run time.
+///     </para>
+///     <para>
+///         Reported from Wolverine, where <c>DurabilitySettings.OutboxStaleTime</c> adds a defaulted
+///         timestamp column to the envelope tables: turning the option back off left a database that
+///         could never be migrated forward again (JasperFx/wolverine#3997).
+///     </para>
+/// </remarks>
+public class dropping_a_column_with_a_default: IntegrationContext
+{
+    // The fixture keeps its schema name private, so hold it here rather than reaching for it.
+    private const string Schema = "dropdefault";
+
+    public dropping_a_column_with_a_default(): base(Schema)
+    {
+    }
+
+    private Table BuildTable(bool withDefaultedColumn, bool withSecondDefaultedColumn = false)
+    {
+        var table = new Table(new SqlServerObjectName(Schema, "orders"));
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn<string>("name").AllowNulls();
+
+        if (withDefaultedColumn)
+        {
+            table.AddColumn<DateTime>("stamp").DefaultValueByExpression("GETUTCDATE()");
+        }
+
+        if (withSecondDefaultedColumn)
+        {
+            table.AddColumn<DateTime>("stamp2").DefaultValueByExpression("GETUTCDATE()");
+        }
+
+        return table;
+    }
+
+    private async Task<int> ColumnCountAsync(string column)
+    {
+        var result = await theConnection.CreateCommand(
+                "select count(*) from information_schema.columns "
+                + $"where table_schema = '{Schema}' and table_name = 'orders' and column_name = '{column}'")
+            .ExecuteScalarAsync();
+
+        return Convert.ToInt32(result);
+    }
+
+    private async Task<int> DefaultConstraintCountAsync()
+    {
+        var result = await theConnection.CreateCommand(
+                "select count(*) from sys.default_constraints dc "
+                + $"where dc.parent_object_id = object_id('{Schema}.orders')")
+            .ExecuteScalarAsync();
+
+        return Convert.ToInt32(result);
+    }
+
+    [Fact]
+    public async Task the_defaulted_column_can_be_dropped()
+    {
+        await ResetSchema();
+
+        await new SqlServerMigrator().ApplyAllAsync(theConnection,
+            await SchemaMigration.DetermineAsync(theConnection, BuildTable(withDefaultedColumn: true)),
+            AutoCreate.CreateOrUpdate);
+
+        (await ColumnCountAsync("stamp")).ShouldBe(1);
+
+        var without = BuildTable(withDefaultedColumn: false);
+        var migration = await SchemaMigration.DetermineAsync(theConnection, without);
+        migration.Difference.ShouldBe(SchemaPatchDifference.Update);
+
+        // Pre-fix this threw: "The object 'DF__orders__stamp__...' is dependent on column 'stamp'."
+        await new SqlServerMigrator().ApplyAllAsync(theConnection, migration, AutoCreate.CreateOrUpdate);
+
+        (await ColumnCountAsync("stamp")).ShouldBe(0);
+
+        // The constraint goes with it rather than being orphaned.
+        (await DefaultConstraintCountAsync()).ShouldBe(0);
+
+        (await SchemaMigration.DetermineAsync(theConnection, without)).Difference
+            .ShouldBe(SchemaPatchDifference.None);
+    }
+
+    /// <summary>
+    ///     Two defaulted columns dropped in one migration. A SQL Server delta is executed as a single
+    ///     command per table, so a lookup that declared a variable at batch scope would fail here with
+    ///     "The variable name '@...' has already been declared."
+    /// </summary>
+    [Fact]
+    public async Task two_defaulted_columns_can_be_dropped_in_one_migration()
+    {
+        await ResetSchema();
+
+        await new SqlServerMigrator().ApplyAllAsync(theConnection,
+            await SchemaMigration.DetermineAsync(theConnection,
+                BuildTable(withDefaultedColumn: true, withSecondDefaultedColumn: true)),
+            AutoCreate.CreateOrUpdate);
+
+        (await DefaultConstraintCountAsync()).ShouldBe(2);
+
+        var without = BuildTable(withDefaultedColumn: false);
+        await new SqlServerMigrator().ApplyAllAsync(theConnection,
+            await SchemaMigration.DetermineAsync(theConnection, without), AutoCreate.CreateOrUpdate);
+
+        (await ColumnCountAsync("stamp")).ShouldBe(0);
+        (await ColumnCountAsync("stamp2")).ShouldBe(0);
+        (await DefaultConstraintCountAsync()).ShouldBe(0);
+    }
+
+    /// <summary>
+    ///     A column with no default still drops, and the lookup finding nothing is not an error.
+    /// </summary>
+    [Fact]
+    public async Task an_undefaulted_column_still_drops()
+    {
+        await ResetSchema();
+
+        await new SqlServerMigrator().ApplyAllAsync(theConnection,
+            await SchemaMigration.DetermineAsync(theConnection, BuildTable(withDefaultedColumn: false)),
+            AutoCreate.CreateOrUpdate);
+
+        var without = new Table(new SqlServerObjectName(Schema, "orders"));
+        without.AddColumn<int>("id").AsPrimaryKey();
+
+        await new SqlServerMigrator().ApplyAllAsync(theConnection,
+            await SchemaMigration.DetermineAsync(theConnection, without), AutoCreate.CreateOrUpdate);
+
+        (await ColumnCountAsync("name")).ShouldBe(0);
+    }
+}

--- a/src/Weasel.SqlServer/Tables/TableColumn.cs
+++ b/src/Weasel.SqlServer/Tables/TableColumn.cs
@@ -225,9 +225,52 @@ public class TableColumn: ITableColumn
         return $"alter table {table.Identifier} alter column {ToDeclaration()};";
     }
 
+    /// <summary>
+    ///     Drop the column, and the default constraint that would otherwise block it.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         SQL Server refuses <c>DROP COLUMN</c> while a default constraint references the column —
+    ///         "The object 'DF__orders__stamp__2FEFE172' is dependent on column 'stamp'." So a column
+    ///         declared with a default could be added by a migration but never removed by one: the patch
+    ///         was generated, it just always failed (weasel#505). PostgreSQL drops the two together,
+    ///         which is why this is SQL-Server-only.
+    ///     </para>
+    ///     <para>
+    ///         The constraint cannot be named statically. SQL Server invents one when the DDL does not
+    ///         supply it — <c>DF__table__column__hash</c>, where the hash is per-object — so the name has
+    ///         to be read out of <c>sys.default_constraints</c> at run time.
+    ///     </para>
+    ///     <para>
+    ///         The lookup is wrapped in its own <c>EXEC</c> so that <c>@constraint</c> is scoped to a
+    ///         nested batch. <c>DECLARE</c> in T-SQL is scoped to the batch and not to a <c>BEGIN/END</c>
+    ///         block, and <c>SqlServerMigrator.executeDelta</c> sends one command per table — so a table
+    ///         dropping two defaulted columns would otherwise fail with "The variable name '@constraint'
+    ///         has already been declared."
+    ///     </para>
+    ///     <para>
+    ///         Only the default is handled. A check constraint or an index over the column blocks the
+    ///         drop the same way, but Weasel emits a default for any column that declares one, which
+    ///         makes it the case that arises on its own.
+    ///     </para>
+    /// </remarks>
     public string DropColumnSql(Table table)
     {
-        return $"alter table {table.Identifier} drop column {QuotedName};";
+        // Written as the SQL it should be when it runs, then escaped once to embed in the EXEC.
+        var inner = $"""
+                     declare @constraint sysname;
+                     select @constraint = dc.name
+                     from sys.default_constraints dc
+                     inner join sys.columns c
+                         on c.object_id = dc.parent_object_id and c.column_id = dc.parent_column_id
+                     where dc.parent_object_id = object_id('{SchemaUtils.EscapeLiteral(table.Identifier.QualifiedName)}')
+                       and c.name = '{SchemaUtils.EscapeLiteral(Name)}';
+                     if @constraint is not null
+                         exec('alter table {table.Identifier} drop constraint [' + @constraint + ']');
+                     alter table {table.Identifier} drop column {QuotedName};
+                     """;
+
+        return $"EXEC(N'{inner.Replace("'", "''")}');";
     }
 
 


### PR DESCRIPTION
Closes #505.

## The bug

`TableColumn.DropColumnSql` rendered the drop on its own:

```csharp
return $"alter table {table.Identifier} drop column {QuotedName};";
```

SQL Server refuses that while a default constraint references the column:

```
The object 'DF__orders__stamp__2FEFE172' is dependent on column 'stamp'.
ALTER TABLE DROP COLUMN stamp failed because one or more objects access this column.
```

So a column declared with `DefaultValue(...)` could be **added** by a migration but never
**removed** by one — the patch was generated, it just always failed. PostgreSQL drops a column and
its default together, which is why this is SQL-Server-only.

## The change

The constraint cannot be named statically: SQL Server invents one when the DDL does not supply it
(`DF__table__column__hash`, hash per object), so the name is read out of `sys.default_constraints`
at run time and dropped only if it is there.

**The lookup is wrapped in its own `EXEC`**, which is the part worth reviewing. `DECLARE` in T-SQL
is scoped to the *batch*, not to a `BEGIN/END` block, and `SqlServerMigrator.executeDelta` sends
one command per table — so a table dropping two defaulted columns in one migration would fail with
`The variable name '@constraint' has already been declared.` The nested `EXEC` gives each drop its
own batch. There is a test for exactly that case, because it is the one a reviewer would otherwise
have to spot by reading.

The inner SQL is written as the statement it should be when it runs, then escaped once for
embedding, rather than being written with the escaping baked in — the two-level quoting is hard
enough to read without it.

## Scope

Only the default is handled. A check constraint or an index over the column blocks the drop the
same way, but Weasel emits a default for any column that declares one, which makes it the case
that arises on its own rather than by hand. Noted in the code comment rather than left implicit.

## Tests

`dropping_a_column_with_a_default`. **Both defaulted cases verified to fail before the change**,
with the production error verbatim; the undefaulted control passed throughout.

- `the_defaulted_column_can_be_dropped` — the reported bug. Also asserts the constraint is gone
  rather than orphaned, and that a second check reports `None`.
- `two_defaulted_columns_can_be_dropped_in_one_migration` — the batch-scope hazard above.
- `an_undefaulted_column_still_drops` — the lookup finding nothing is not an error.

`Weasel.SqlServer.Tests` on `net9.0` against Azure SQL Edge: **496 passed, 0 failed, 8 skipped.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)