### PR TITLE
fix(postgresql): treat an invalid index as drift so a failed build is repaired

### DIFF
--- a/src/Weasel.Postgresql.Tests/Tables/an_invalid_index_is_drift.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/an_invalid_index_is_drift.cs
@@ -1,0 +1,120 @@
+using JasperFx;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Postgresql.Tables;
+using Xunit;
+
+namespace Weasel.Postgresql.Tests.Tables;
+
+/// <summary>
+///     weasel#503. An index that exists but is <em>invalid</em> was read back as a perfectly good one,
+///     so the delta reported no drift and the index was never repaired.
+/// </summary>
+/// <remarks>
+///     <para>
+///         The introspection query read <c>indisunique</c> and <c>indisprimary</c> but not
+///         <c>indisvalid</c>, and <c>pg_get_indexdef</c> renders the same definition either way — so
+///         nothing distinguished the two.
+///     </para>
+///     <para>
+///         An invalid index is ignored by the planner. The object exists, <c>\d</c> shows it, Weasel
+///         said the schema matched configuration, and every query that was meant to use it silently did
+///         a sequential scan instead. Nothing surfaced it.
+///     </para>
+///     <para>
+///         PostgreSQL leaves an index in exactly that state when <c>CREATE INDEX CONCURRENTLY</c> fails
+///         partway, which is documented behaviour rather than an edge case. weasel#494 made it more
+///         reachable still: a concurrent index on a partitioned table is built per partition, and the
+///         parent is <em>deliberately</em> invalid until the last child is attached, so an interrupted
+///         run leaves a genuinely half-finished index behind.
+///     </para>
+/// </remarks>
+[Collection("invalid_index")]
+public class an_invalid_index_is_drift: IntegrationContext
+{
+    public an_invalid_index_is_drift(): base("invalid_index")
+    {
+    }
+
+    public override ValueTask InitializeAsync() => new(ResetSchema());
+
+    private Table BuildTable()
+    {
+        var table = new Table(new PostgresqlObjectName(SchemaName, "docs"));
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn<string>("body");
+
+        var index = new IndexDefinition("idx_docs_body");
+        index.AgainstColumns("body");
+        table.Indexes.Add(index);
+
+        return table;
+    }
+
+    /// <summary>
+    ///     Marking the index invalid directly is the only way to reach the state deterministically —
+    ///     making a real concurrent build fail on demand is not something a test can arrange.
+    /// </summary>
+    private Task InvalidateTheIndexAsync() =>
+        theConnection.CreateCommand(
+                $"update pg_index set indisvalid = false where indexrelid = '{SchemaName}.idx_docs_body'::regclass")
+            .ExecuteNonQueryAsync();
+
+    private async Task<bool> IndexIsValidAsync()
+    {
+        var result = await theConnection.CreateCommand(
+                $"select indisvalid from pg_index where indexrelid = '{SchemaName}.idx_docs_body'::regclass")
+            .ExecuteScalarAsync();
+
+        result.ShouldNotBeNull("the index is gone entirely");
+        return (bool)result!;
+    }
+
+    private async Task ApplyAsync() =>
+        await new PostgresqlMigrator().ApplyAllAsync(theConnection,
+            await SchemaMigration.DetermineAsync(theConnection, BuildTable()), AutoCreate.CreateOrUpdate);
+
+    [Fact]
+    public async Task an_invalid_index_is_reported_as_drift()
+    {
+        await ApplyAsync();
+        await InvalidateTheIndexAsync();
+
+        // Pre-fix: None. The index was unusable and Weasel said the schema was correct.
+        (await SchemaMigration.DetermineAsync(theConnection, BuildTable()))
+            .Difference.ShouldBe(SchemaPatchDifference.Update);
+    }
+
+    /// <summary>
+    ///     And the drift has to be repairable. The rebuild goes through <c>ItemDelta.Different</c>,
+    ///     which drops before it creates — a bare <c>create index</c> would fail with <c>42P07</c>
+    ///     against the invalid index still sitting there.
+    /// </summary>
+    [Fact]
+    public async Task applying_the_drift_rebuilds_the_index()
+    {
+        await ApplyAsync();
+        await InvalidateTheIndexAsync();
+
+        (await IndexIsValidAsync()).ShouldBeFalse("the fixture did not reach the state under test");
+
+        await ApplyAsync();
+
+        (await IndexIsValidAsync()).ShouldBeTrue("the index was not rebuilt");
+
+        (await SchemaMigration.DetermineAsync(theConnection, BuildTable()))
+            .Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    /// <summary>
+    ///     A valid index is still no drift — the check must not make every index rebuild on every run.
+    /// </summary>
+    [Fact]
+    public async Task a_valid_index_is_still_no_drift()
+    {
+        await ApplyAsync();
+
+        (await SchemaMigration.DetermineAsync(theConnection, BuildTable()))
+            .Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+}

--- a/src/Weasel.Postgresql/Tables/IndexDefinition.cs
+++ b/src/Weasel.Postgresql/Tables/IndexDefinition.cs
@@ -119,6 +119,18 @@ public class IndexDefinition: ITableIndex
     /// </remarks>
     public bool IsConcurrent { get; set; }
 
+    /// <summary>
+    ///     False when the database holds this index but has marked it invalid. Only ever set while
+    ///     reading an existing table; an index in a Weasel model is valid by construction.
+    /// </summary>
+    /// <remarks>
+    ///     PostgreSQL leaves an index invalid when <c>CREATE INDEX CONCURRENTLY</c> fails partway, and
+    ///     weasel#494 creates one deliberately -- a partitioned parent index is invalid until the last
+    ///     partition's index is attached. Either way the planner ignores it, so an invalid index is a
+    ///     schema that does not do what it says.
+    /// </remarks>
+    internal bool IsValidInDatabase { get; set; } = true;
+
     // Define the columns part of the index definition
     public virtual string[]? Columns { get; set; }
 
@@ -834,6 +846,16 @@ public class IndexDefinition: ITableIndex
     /// <returns></returns>
     public bool Matches(IndexDefinition actual, Table parent)
     {
+        if (!actual.IsValidInDatabase)
+        {
+            // The index exists but PostgreSQL will not use it -- the planner ignores an invalid
+            // index entirely. Reporting a match would leave it unusable forever while every check
+            // said the schema was correct, so this is drift even though the definitions agree. It
+            // routes to ItemDelta.Different, which drops before it creates; a bare CREATE INDEX
+            // would fail with 42P07 against the index still sitting there (weasel#503).
+            return false;
+        }
+
         var expectedExpression = correctedExpression(parent);
 
         if (actual.Mask == expectedExpression)

--- a/src/Weasel.Postgresql/Tables/Table.FetchExisting.cs
+++ b/src/Weasel.Postgresql/Tables/Table.FetchExisting.cs
@@ -54,7 +54,11 @@ FROM (
                ORDER BY k
            ) AS index_keys,
       (idx.indexprs IS NOT NULL) OR (idx.indkey::int[] @> array[0]) AS is_functional,
-      idx.indpred IS NOT NULL AS is_partial
+      idx.indpred IS NOT NULL AS is_partial,
+      -- Appended rather than inserted: readIndexesAsync reads positionally, so a column added
+      -- anywhere above would shift every existing read. pg_get_indexdef renders an invalid index
+      -- exactly like a valid one, so without this nothing distinguished the two (weasel#503).
+      idx.indisvalid           AS is_valid
     FROM pg_index AS idx
       JOIN pg_class AS i
         ON i.oid = idx.indexrelid
@@ -386,12 +390,14 @@ order by column_index;
             var schemaName = await reader.GetFieldValueAsync<string>(1, ct).ConfigureAwait(false);
             var tableName = await reader.GetFieldValueAsync<string>(2, ct).ConfigureAwait(false);
             var ddl = await reader.GetFieldValueAsync<string>(4, ct).ConfigureAwait(false);
+            var isValid = await reader.GetFieldValueAsync<bool>(12, ct).ConfigureAwait(false);
 
 
             if ((Identifier.Schema == schemaName && Identifier.Name == tableName) ||
                 Equals(Identifier, DbObjectName.Parse(PostgresqlProvider.Instance, tableName)))
             {
                 var index = IndexDefinition.Parse(ddl);
+                index.IsValidInDatabase = isValid;
 
                 existing.Indexes.Add(index);
             }


### PR DESCRIPTION
Closes #503.

## The bug

The index introspection query read `indisunique` and `indisprimary` but not **`indisvalid`**, and
`pg_get_indexdef` renders an invalid index exactly like a valid one — so nothing distinguished the
two and the delta reported no drift.

An invalid index is **ignored by the planner**. The object exists, `\d` shows it, Weasel said the
schema matched configuration, and every query that was meant to use it silently did a sequential
scan instead. Nothing surfaced it.

PostgreSQL leaves an index in that state whenever `CREATE INDEX CONCURRENTLY` fails partway, which
is documented behaviour rather than an edge case. #502 made it more reachable still: a concurrent
index on a partitioned table is built per partition and the parent is *deliberately* invalid until
the last child is attached, so an interrupted run leaves a genuinely half-finished index behind.

## The change

Two small pieces:

- `idx.indisvalid` is **appended to the end of the select list**, not inserted. `readIndexesAsync`
  reads positionally, so a column added anywhere above would shift every existing read.
- `Matches` refuses an invalid actual index. That routes it to `ItemDelta.Different` — the path
  that drops before it creates, which matters here: a bare `create index` would fail with `42P07`
  against the invalid index still sitting there. Rebuilding is also what PostgreSQL's own guidance
  prescribes for a failed concurrent build.

`IsValidInDatabase` defaults to true and is only ever set while reading an existing table; an index
in a Weasel model is valid by construction.

## Tests

`an_invalid_index_is_drift`. **Both failing cases verified red first**; the third guards the
obvious way to get this wrong.

- `an_invalid_index_is_reported_as_drift` — the root cause. Pre-fix: `None`.
- `applying_the_drift_rebuilds_the_index` — the repair actually works and then converges, rather
  than reporting drift it cannot fix.
- `a_valid_index_is_still_no_drift` — the check must not make every index rebuild on every run.

Marking the index invalid directly is the only way to reach the state deterministically; making a
real concurrent build fail on demand is not something a test can arrange.

`Weasel.Postgresql.Tests` on `net9.0` against PostgreSQL 15.3: **929 passed, 0 failed, 3 skipped.**

## Other providers

The issue asked whether SQL Server, Oracle and MySQL have an equivalent "exists but unusable"
state — SQL Server's disabled indexes being the obvious candidate. Not investigated here; this PR
is the PostgreSQL half that #502 made urgent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)