### PR TITLE
fix: split a qualified name on the delimiters, not on every dot

### DIFF
--- a/src/Weasel.Core.Tests/object_name_normalization_conformance.cs
+++ b/src/Weasel.Core.Tests/object_name_normalization_conformance.cs
@@ -149,6 +149,62 @@ public class object_name_normalization_conformance
     }
 
     /// <summary>
+    ///     A dot inside a delimited identifier is an ordinary character on every provider here, so a
+    ///     qualified name has to be split on the delimiters rather than on every dot.
+    /// </summary>
+    /// <remarks>
+    ///     <c>QualifiedNameParser</c> used to call <c>qualifiedName.Split('.')</c> and throw when that
+    ///     produced anything other than two parts, so a legal name simply could not be modelled:
+    ///     <c>"my.schema".things</c>, <c>[my.table]</c>, and the <c>PK_dbo.__MigrationHistory</c> that
+    ///     EF6 gives its own history table — already in this suite's sibling as a hostile name
+    ///     (weasel#501).
+    /// </remarks>
+    [Theory]
+    [MemberData(nameof(Providers))]
+    public void a_dot_inside_a_delimited_identifier_is_not_a_separator(
+        string provider, IDatabaseProvider databaseProvider, IdentifierRules rules)
+    {
+        var schema = rules.Delimit("my.schema");
+        var name = rules.Delimit("my.table");
+
+        var parsed = databaseProvider.Parse($"{schema}.{name}");
+
+        rules.SameObject(parsed.Schema, "my.schema").ShouldBeTrue(
+            $"{provider} mis-split the schema: got '{parsed.Schema}'");
+        rules.SameObject(parsed.Name, "my.table").ShouldBeTrue(
+            $"{provider} mis-split the name: got '{parsed.Name}'");
+    }
+
+    /// <summary>
+    ///     And an undelimited qualified name still splits the way it always has.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(Providers))]
+    public void an_ordinary_qualified_name_still_splits_on_the_dot(
+        string provider, IDatabaseProvider databaseProvider, IdentifierRules rules)
+    {
+        var parsed = databaseProvider.Parse("things.orders");
+
+        parsed.Schema.ShouldBe("things", $"{provider} mis-split an ordinary schema");
+        parsed.Name.ShouldBe("orders", $"{provider} mis-split an ordinary name");
+    }
+
+    /// <summary>
+    ///     A bare name still takes the provider's default schema rather than being treated as qualified.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(Providers))]
+    public void a_bare_name_takes_the_default_schema(
+        string provider, IDatabaseProvider databaseProvider, IdentifierRules rules)
+    {
+        var parsed = databaseProvider.Parse("orders");
+
+        parsed.Name.ShouldBe("orders", $"{provider} altered a bare name");
+        parsed.Schema.ShouldBe(databaseProvider.DefaultDatabaseSchemaName,
+            $"{provider} did not default the schema");
+    }
+
+    /// <summary>
     ///     The pass-through in <see cref="IdentifierRules.Quote" /> is deliberately narrow: a name
     ///     that merely starts and ends with the delimiters, but carries a loose close character, is
     ///     not delimited and must not be stripped. Stripping it would hand DDL back out of an

--- a/src/Weasel.Core/DatabaseProvider.cs
+++ b/src/Weasel.Core/DatabaseProvider.cs
@@ -22,6 +22,16 @@ public interface IDatabaseProvider
     string ToQualifiedName(string schemaName, string objectName) =>
         $"{ToQualifiedName(schemaName)}.{ToQualifiedName(objectName)}";
 
+    /// <summary>
+    ///     This dialect's identifier rules, when it has them. Used to split a qualified name on the
+    ///     dots that separate identifiers rather than on every dot (weasel#501).
+    /// </summary>
+    /// <remarks>
+    ///     Defaulted rather than required so that an implementation outside Weasel keeps compiling and
+    ///     keeps its current splitting. Every provider in the box supplies its own.
+    /// </remarks>
+    IdentifierRules? Rules => null;
+
     public DbObjectName Parse(string qualifiedName)
     {
         var parts = QualifiedNameParser.Parse(this, qualifiedName);
@@ -355,6 +365,18 @@ public abstract class DatabaseProvider<TCommand, TParameter, TParameterType>
     {
         return AddNamedParameter(command, name, value, BoolParameterType);
     }
+
+    /// <summary>
+    ///     This dialect's identifier rules. Declared here as well as on <see cref="IDatabaseProvider" />
+    ///     so that a derived provider can supply it.
+    /// </summary>
+    /// <remarks>
+    ///     A default interface member alone would not do. The interface mapping is fixed at the class
+    ///     that implements the interface -- this one -- so a <c>Rules</c> declared on a derived provider
+    ///     would never be reached and every provider would silently keep the default. Virtual, and
+    ///     null by default, so an implementation outside Weasel keeps compiling.
+    /// </remarks>
+    public virtual IdentifierRules? Rules => null;
 
     public DbObjectName Parse(string qualifiedName)
     {

--- a/src/Weasel.Core/IdentifierRules.cs
+++ b/src/Weasel.Core/IdentifierRules.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using JasperFx.Core;
 
 namespace Weasel.Core;
@@ -149,6 +150,80 @@ public abstract class IdentifierRules
         => IsDelimited(name)
             ? name.Substring(1, name.Length - 2).Replace($"{Close}{Close}", Close.ToString())
             : name;
+
+    /// <summary>
+    ///     Split a qualified name into its parts, on the dots that actually separate identifiers.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         A dot inside a delimited identifier is an ordinary character on every dialect Weasel
+    ///         supports, so <c>"my.schema".things</c> is two parts and not three. Splitting on every dot
+    ///         made such a name unparseable -- and it is not exotic:
+    ///         <c>PK_dbo.__MigrationHistory</c> is the key EF6 gives its own history table
+    ///         (weasel#501).
+    ///     </para>
+    ///     <para>
+    ///         Delimiters are returned as they were written. Undelimiting is the caller's job, and the
+    ///         provider ObjectName constructors already do it (weasel#499).
+    ///     </para>
+    /// </remarks>
+    public string[] SplitQualifiedName(string qualifiedName)
+    {
+        if (qualifiedName.IsEmpty())
+        {
+            return [qualifiedName];
+        }
+
+        var parts = new List<string>();
+        var current = new StringBuilder();
+        var delimited = false;
+
+        for (var i = 0; i < qualifiedName.Length; i++)
+        {
+            var c = qualifiedName[i];
+
+            if (delimited)
+            {
+                if (c == Close)
+                {
+                    // A doubled close character is an escaped one, not the end of the identifier.
+                    if (i + 1 < qualifiedName.Length && qualifiedName[i + 1] == Close)
+                    {
+                        current.Append(c).Append(c);
+                        i++;
+                        continue;
+                    }
+
+                    delimited = false;
+                }
+
+                current.Append(c);
+                continue;
+            }
+
+            // Open is checked before Close, which matters for the dialects where they are the same
+            // character: the delimited flag above is what decides which one it is.
+            if (c == Open)
+            {
+                delimited = true;
+                current.Append(c);
+                continue;
+            }
+
+            if (c == '.')
+            {
+                parts.Add(current.ToString());
+                current.Clear();
+                continue;
+            }
+
+            current.Append(c);
+        }
+
+        parts.Add(current.ToString());
+
+        return parts.ToArray();
+    }
 
     /// <summary>
     ///     Escape a value being written into a SQL string literal, by doubling its single quotes.

--- a/src/Weasel.Core/Names/QualifiedNameParser.cs
+++ b/src/Weasel.Core/Names/QualifiedNameParser.cs
@@ -2,9 +2,15 @@ namespace Weasel.Core.Names;
 
 public static class QualifiedNameParser
 {
+    /// <remarks>
+    ///     Split through the dialect's identifier rules where they are available, because a dot inside
+    ///     a delimited identifier is an ordinary character and not a separator -- <c>"my.schema".things</c>
+    ///     is two parts, and splitting on every dot made such a name unparseable (weasel#501). A
+    ///     provider that supplies no rules falls back to the plain split it always had.
+    /// </remarks>
     public static string[] Parse(IDatabaseProvider databaseProvider, string qualifiedName)
     {
-        var parts = qualifiedName.Split('.');
+        var parts = databaseProvider.Rules?.SplitQualifiedName(qualifiedName) ?? qualifiedName.Split('.');
         if (parts.Length == 1)
         {
             return new[] { databaseProvider.DefaultDatabaseSchemaName, qualifiedName };

--- a/src/Weasel.MySql/MySqlProvider.cs
+++ b/src/Weasel.MySql/MySqlProvider.cs
@@ -54,6 +54,9 @@ public class MySqlProvider: DatabaseProvider<MySqlCommand, MySqlParameter, MySql
     public override string ToQualifiedName(string objectName) =>
         string.IsNullOrEmpty(objectName) ? objectName : $"{SchemaUtils.QuoteName(objectName)}";
 
+    /// <inheritdoc />
+    public override IdentifierRules Rules => MySqlIdentifierRules.Instance;
+
     public override DbObjectName Parse(string schemaName, string objectName) =>
         new MySqlObjectName(schemaName, objectName);
 

--- a/src/Weasel.Oracle/OracleProvider.cs
+++ b/src/Weasel.Oracle/OracleProvider.cs
@@ -51,6 +51,9 @@ public class OracleProvider: DatabaseProvider<OracleCommand, OracleParameter, Or
         return Type.EmptyTypes;
     }
 
+    /// <inheritdoc />
+    public override IdentifierRules Rules => OracleIdentifierRules.Instance;
+
     public override DbObjectName Parse(string schemaName, string objectName) =>
         new OracleObjectName(schemaName, objectName);
 

--- a/src/Weasel.Postgresql/PostgresqlProvider.cs
+++ b/src/Weasel.Postgresql/PostgresqlProvider.cs
@@ -383,6 +383,9 @@ public class PostgresqlProvider: DatabaseProvider<NpgsqlCommand, NpgsqlParameter
         return SchemaUtils.QuoteName(objectName);
     }
 
+    /// <inheritdoc />
+    public override IdentifierRules Rules => PostgresqlIdentifierRules.General;
+
     public override DbObjectName Parse(string schemaName, string objectName) =>
         new PostgresqlObjectName(schemaName, objectName, ToQualifiedName(schemaName, objectName));
 

--- a/src/Weasel.SqlServer/SqlServerProvider.cs
+++ b/src/Weasel.SqlServer/SqlServerProvider.cs
@@ -53,6 +53,9 @@ public class SqlServerProvider: DatabaseProvider<SqlCommand, SqlParameter, SqlDb
         return Type.EmptyTypes;
     }
 
+    /// <inheritdoc />
+    public override IdentifierRules Rules => SqlServerIdentifierRules.Instance;
+
     public override DbObjectName Parse(string schemaName, string objectName) =>
         new SqlServerObjectName(schemaName, objectName);
 

--- a/src/Weasel.Sqlite/SqliteProvider.cs
+++ b/src/Weasel.Sqlite/SqliteProvider.cs
@@ -212,6 +212,9 @@ public class SqliteProvider: DatabaseProvider<SqliteCommand, SqliteParameter, Sq
         parameter.SqliteType = dbType;
     }
 
+    /// <inheritdoc />
+    public override IdentifierRules Rules => SqliteIdentifierRules.Instance;
+
     public override DbObjectName Parse(string schemaName, string objectName) =>
         new SqliteObjectName(schemaName, objectName);
 


### PR DESCRIPTION
Closes #501.

## The bug

`QualifiedNameParser` called `qualifiedName.Split('.')` and threw when that produced anything other
than two parts. A dot inside a delimited identifier is an ordinary character on every provider
Weasel supports, so a legal name simply could not be modelled:

- `"my.schema".things` — PostgreSQL
- `[my.table]` — SQL Server, where `PK_dbo.__MigrationHistory` is the key EF6 gives its own history
  table, a shape already listed as hostile in `identifier_rules_conformance`
- `` `my.table` `` — MySQL

## The change

The split moves onto `IdentifierRules`, where the delimiters already live, and honours a doubled
close character as an escaped one rather than the end of the identifier. Delimiters come back as
written — undelimiting is the ObjectName constructors' job as of #500.

Providers expose their rules through a new `Rules` property.

### The part worth reviewing

`Rules` is declared on the abstract `DatabaseProvider` **as well as** on `IDatabaseProvider`. A
default interface member alone does not work here, and it fails silently: the interface mapping is
fixed at the class that implements the interface, so a `Rules` declared on a derived provider is
never reached and every provider quietly keeps the default. I had it that way first and the
conformance suite stayed red on all five providers with the implementation apparently in place.

It is `virtual` and null by default, so an implementation outside Weasel keeps compiling and keeps
its current splitting rather than being broken by a new abstract member.

## Tests

Three cases added to `object_name_normalization_conformance` — the suite #500 introduced, which the
issue itself suggested extending, since the harness and the provider table were already there.

**Verified red first:** the dotted case failed on all five providers before the change (5 failed /
30 passed), and the two guard cases passed throughout — so the fix had a floor to land on.

- `a_dot_inside_a_delimited_identifier_is_not_a_separator` — the bug, per provider.
- `an_ordinary_qualified_name_still_splits_on_the_dot` — the common path is untouched.
- `a_bare_name_takes_the_default_schema` — an unqualified name is still not treated as qualified.

All seven suites on `net9.0`, against PostgreSQL 15.3, Azure SQL Edge, MySQL 8.0 and Oracle Free 23:

| Suite | Result |
|---|---|
| Weasel.Core.Tests | 282 passed |
| Weasel.Postgresql.Tests | 926 passed, 3 skipped |
| Weasel.SqlServer.Tests | 496 passed, 8 skipped |
| Weasel.Sqlite.Tests | 432 passed |
| Weasel.MySql.Tests | 295 passed |
| Weasel.Oracle.Tests | 313 passed |
| Weasel.EntityFrameworkCore.Tests | 106 passed, 1 skipped |

🤖 Generated with [Claude Code](https://claude.com/claude-code)