### PR TITLE
preserve key order, type arguments and identity on read-back, and honour IgnoredIndexes

### DIFF
--- a/src/Weasel.SqlServer.Tests/Tables/column_introspection_fidelity.cs
+++ b/src/Weasel.SqlServer.Tests/Tables/column_introspection_fidelity.cs
@@ -1,0 +1,92 @@
+using Shouldly;
+using Weasel.SqlServer.Tables;
+using Xunit;
+
+namespace Weasel.SqlServer.Tests.Tables;
+
+/// <summary>
+///     information_schema.columns reports length in characters and has no is_identity, so a column
+///     read back through it lost its precision, its scale and the fact that it was an IDENTITY.
+///     Everything that regenerates DDL from a fetched table -- rollback above all -- then emitted a
+///     narrower column than the one in the database.
+/// </summary>
+public class column_introspection_fidelity: IntegrationContext
+{
+    public column_introspection_fidelity(): base("fidelity")
+    {
+    }
+
+    [Theory]
+    [InlineData("decimal(18,2)", "decimal(18,2)")]
+    [InlineData("numeric(9,4)", "numeric(9,4)")]
+    [InlineData("varchar(50)", "varchar(50)")]
+    [InlineData("varchar(max)", "varchar(max)")]
+    [InlineData("nvarchar(50)", "nvarchar(50)")]
+    [InlineData("nvarchar(max)", "nvarchar(max)")]
+    [InlineData("nchar(10)", "nchar(10)")]
+    [InlineData("binary(16)", "binary(16)")]
+    [InlineData("varbinary(max)", "varbinary(max)")]
+    [InlineData("datetime2(3)", "datetime2(3)")]
+    [InlineData("time(4)", "time(4)")]
+    [InlineData("datetimeoffset(7)", "datetimeoffset(7)")]
+    [InlineData("int", "int")]
+    [InlineData("bit", "bit")]
+    [InlineData("uniqueidentifier", "uniqueidentifier")]
+    public async Task a_store_type_round_trips(string declared, string expected)
+    {
+        await ResetSchema();
+
+        await theConnection.CreateCommand(
+                $"create table fidelity.types (id int not null constraint pk_types primary key, value {declared} null)")
+            .ExecuteNonQueryAsync();
+
+        var existing = await new Table("fidelity.types").FetchExistingAsync(theConnection);
+
+        existing!.ColumnFor("value")!.Type.ShouldBe(expected);
+    }
+
+    [Fact]
+    public async Task an_identity_column_is_read_back_as_an_identity()
+    {
+        await ResetSchema();
+
+        await theConnection.CreateCommand(
+                "create table fidelity.ident (id int identity(1,1) not null constraint pk_ident primary key, name varchar(20) null)")
+            .ExecuteNonQueryAsync();
+
+        var existing = await new Table("fidelity.ident").FetchExistingAsync(theConnection);
+
+        existing!.ColumnFor("id")!.IsAutoNumber.ShouldBeTrue();
+        existing.ColumnFor("name")!.IsAutoNumber.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task nullability_and_defaults_still_come_back()
+    {
+        await ResetSchema();
+
+        await theConnection.CreateCommand(
+                "create table fidelity.defaults (id int not null constraint pk_defaults primary key, note varchar(20) null, count int not null constraint df_count default 0)")
+            .ExecuteNonQueryAsync();
+
+        var existing = await new Table("fidelity.defaults").FetchExistingAsync(theConnection);
+
+        existing!.ColumnFor("note")!.AllowNulls.ShouldBeTrue();
+        existing.ColumnFor("count")!.AllowNulls.ShouldBeFalse();
+        existing.ColumnFor("count")!.DefaultExpression.ShouldBe("((0))");
+    }
+
+    [Fact]
+    public async Task columns_keep_their_declared_order()
+    {
+        await ResetSchema();
+
+        await theConnection.CreateCommand(
+                "create table fidelity.ordered (zebra int not null constraint pk_ordered primary key, apple int null, mango int null)")
+            .ExecuteNonQueryAsync();
+
+        var existing = await new Table("fidelity.ordered").FetchExistingAsync(theConnection);
+
+        existing!.Columns.Select(x => x.Name).ShouldBe(["zebra", "apple", "mango"]);
+    }
+}

--- a/src/Weasel.SqlServer.Tests/Tables/composite_key_ordering.cs
+++ b/src/Weasel.SqlServer.Tests/Tables/composite_key_ordering.cs
@@ -1,0 +1,108 @@
+using Shouldly;
+using Weasel.SqlServer.Tables;
+using Xunit;
+
+namespace Weasel.SqlServer.Tests.Tables;
+
+/// <summary>
+///     Column order is part of a composite key's identity: (a, b) and (b, a) are different indexes
+///     with different query plans, and a foreign key's two column lists are positionally paired. The
+///     catalog queries either had no ORDER BY at all or ordered by the wrong column, so all three
+///     kinds could come back reordered.
+/// </summary>
+public class composite_key_ordering: IntegrationContext
+{
+    public composite_key_ordering(): base("ordering")
+    {
+    }
+
+    [Fact]
+    public async Task composite_primary_key_keeps_its_declared_key_order()
+    {
+        await ResetSchema();
+
+        // Column order is a, b, c but the key is declared (c, a).
+        await theConnection.CreateCommand(
+                "create table ordering.composite_pk (a int not null, b int not null, c int not null, constraint pk_composite primary key (c, a))")
+            .ExecuteNonQueryAsync();
+
+        var existing = await new Table("ordering.composite_pk").FetchExistingAsync(theConnection);
+
+        existing!.PrimaryKeyColumns.ShouldBe(["c", "a"]);
+        existing.PrimaryKeyName.ShouldBe("pk_composite");
+    }
+
+    [Fact]
+    public async Task composite_index_keeps_its_key_order()
+    {
+        await ResetSchema();
+
+        // Key order is the reverse of the table's column order, which is what index_column_id
+        // reported and key_ordinal gets right.
+        await theConnection.CreateCommand(
+                "create table ordering.reading (id int not null constraint pk_reading primary key, a int not null, b int not null)")
+            .ExecuteNonQueryAsync();
+        await theConnection.CreateCommand("create index ix_reading on ordering.reading (b, a)")
+            .ExecuteNonQueryAsync();
+
+        var existing = await new Table("ordering.reading").FetchExistingAsync(theConnection);
+
+        existing!.IndexFor("ix_reading")!.Columns.ShouldBe(["b", "a"]);
+    }
+
+    [Fact]
+    public async Task included_columns_are_not_mixed_into_the_key()
+    {
+        await ResetSchema();
+
+        await theConnection.CreateCommand(
+                "create table ordering.covering (id int not null constraint pk_covering primary key, a int not null, b int not null, note varchar(20) null)")
+            .ExecuteNonQueryAsync();
+        await theConnection.CreateCommand("create index ix_covering on ordering.covering (b, a) include (note)")
+            .ExecuteNonQueryAsync();
+
+        var existing = await new Table("ordering.covering").FetchExistingAsync(theConnection);
+
+        var index = existing!.IndexFor("ix_covering")!;
+        index.Columns.ShouldBe(["b", "a"]);
+        index.IncludedColumns.ShouldBe(["note"]);
+    }
+
+    [Fact]
+    public async Task composite_foreign_key_pairs_the_right_columns()
+    {
+        await ResetSchema();
+
+        await theConnection.CreateCommand(
+                "create table ordering.fk_parent (x int not null, y int not null, constraint pk_parent primary key (x, y))")
+            .ExecuteNonQueryAsync();
+
+        // Chosen so that sorting each side independently mispairs them: the child columns sort to
+        // (a, b) while the parent columns stay (x, y), which would claim a -> x. The truth is
+        // b -> x and a -> y.
+        await theConnection.CreateCommand(
+                "create table ordering.fk_child (b int not null, a int not null, constraint fk_child_parent foreign key (b, a) references ordering.fk_parent (x, y))")
+            .ExecuteNonQueryAsync();
+
+        var existing = await new Table("ordering.fk_child").FetchExistingAsync(theConnection);
+
+        var fk = existing!.ForeignKeys.Single();
+        fk.ColumnNames.ShouldBe(["b", "a"]);
+        fk.LinkedNames.ShouldBe(["x", "y"]);
+    }
+
+    [Fact]
+    public async Task a_single_column_key_is_unaffected()
+    {
+        await ResetSchema();
+
+        var table = new Table("ordering.simple");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn<string>("name").AllowNulls();
+        await CreateSchemaObjectInDatabase(table);
+
+        var existing = await table.FetchExistingAsync(theConnection);
+
+        existing!.PrimaryKeyColumns.ShouldBe(["id"]);
+    }
+}

--- a/src/Weasel.SqlServer.Tests/Tables/ignored_indexes.cs
+++ b/src/Weasel.SqlServer.Tests/Tables/ignored_indexes.cs
@@ -1,0 +1,69 @@
+using Shouldly;
+using Weasel.Core;
+using Weasel.SqlServer.Tables;
+using Xunit;
+
+namespace Weasel.SqlServer.Tests.Tables;
+
+/// <summary>
+///     IgnoreIndex is Weasel.Core API honoured by the PostgreSQL and SQLite table deltas. SQL Server
+///     ignored it, so an index the caller asked Weasel to leave alone was reported as an extra and
+///     dropped by the generated patch.
+/// </summary>
+public class ignored_indexes: IntegrationContext
+{
+    public ignored_indexes(): base("ignoring")
+    {
+    }
+
+    private async Task<Table> tableWithAHandTunedIndex()
+    {
+        await ResetSchema();
+
+        await theConnection.CreateCommand(
+                "create table ignoring.docs (id int not null constraint pk_docs primary key, name varchar(50) not null)")
+            .ExecuteNonQueryAsync();
+        await theConnection.CreateCommand("create index ix_hand_tuned on ignoring.docs (name)")
+            .ExecuteNonQueryAsync();
+
+        var table = new Table("ignoring.docs");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn("name", "varchar(50)").NotNull();
+
+        return table;
+    }
+
+    [Fact]
+    public async Task an_ignored_index_is_not_drift()
+    {
+        var table = await tableWithAHandTunedIndex();
+        table.IgnoreIndex("ix_hand_tuned");
+
+        var delta = await table.FindDeltaAsync(theConnection);
+
+        delta.Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task an_ignored_index_is_not_dropped_by_the_patch()
+    {
+        var table = await tableWithAHandTunedIndex();
+        table.IgnoreIndex("ix_hand_tuned");
+
+        var delta = await table.FindDeltaAsync(theConnection);
+        var writer = new StringWriter();
+        delta.WriteUpdate(new SqlServerMigrator(), writer);
+
+        writer.ToString().ShouldNotContain("ix_hand_tuned");
+    }
+
+    [Fact]
+    public async Task an_index_that_is_not_ignored_is_still_drift()
+    {
+        var table = await tableWithAHandTunedIndex();
+
+        var delta = await table.FindDeltaAsync(theConnection);
+
+        delta.Difference.ShouldBe(SchemaPatchDifference.Update);
+    }
+}

--- a/src/Weasel.SqlServer.Tests/Tables/upgrade_causes_no_new_migrations.cs
+++ b/src/Weasel.SqlServer.Tests/Tables/upgrade_causes_no_new_migrations.cs
@@ -1,0 +1,168 @@
+using Shouldly;
+using Weasel.Core;
+using Weasel.SqlServer.Tables;
+using Xunit;
+
+namespace Weasel.SqlServer.Tests.Tables;
+
+/// <summary>
+///     Nobody upgrading should be handed a migration they did not have before.
+/// </summary>
+/// <remarks>
+///     The ordering fixes in this change make Weasel read composite key order faithfully, which is
+///     necessary — but reading it must not turn into <em>comparing</em> it for models that never
+///     expressed an order. Those users would get a primary key drop and recreate (a table rebuild on
+///     a clustered key) or a foreign key drop and recreate with its validation scan, purely from
+///     upgrading. Each test here sets up a database in the state older Weasel would have left it and
+///     declares the model the way a user would have written it. Most assert no delta; the ones named
+///     for opting in, or for a genuinely different constraint, assert that the difference IS still
+///     reported -- a gate that never reports anything would pass every other test here too.
+/// </remarks>
+public class upgrade_causes_no_new_migrations: IntegrationContext
+{
+    public upgrade_causes_no_new_migrations(): base("upgrade")
+    {
+    }
+
+    [Fact]
+    public async Task a_composite_primary_key_in_a_different_order_is_not_a_difference()
+    {
+        await ResetSchema();
+
+        // The database has the key as (c, a). A hand-written table derives its key list from column
+        // order and has no way to say that, so it will offer (a, c).
+        await theConnection.CreateCommand(
+                "create table upgrade.pkorder (a int not null, b int not null, c int not null, constraint pk_pkorder primary key (c, a))")
+            .ExecuteNonQueryAsync();
+
+        var expected = new Table("upgrade.pkorder");
+        expected.AddColumn<int>("a").AsPrimaryKey();
+        expected.AddColumn<int>("b").NotNull();
+        expected.AddColumn<int>("c").AsPrimaryKey();
+        expected.PrimaryKeyName = "pk_pkorder";
+
+        var delta = await expected.FindDeltaAsync(theConnection);
+
+        delta.Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task pinning_the_order_explicitly_does_compare_it()
+    {
+        await ResetSchema();
+        await theConnection.CreateCommand(
+                "create table upgrade.pkpinned (a int not null, b int not null, c int not null, constraint pk_pkpinned primary key (c, a))")
+            .ExecuteNonQueryAsync();
+
+        var expected = new Table("upgrade.pkpinned");
+        expected.AddColumn<int>("a").AsPrimaryKey();
+        expected.AddColumn<int>("b").NotNull();
+        expected.AddColumn<int>("c").AsPrimaryKey();
+        expected.PrimaryKeyName = "pk_pkpinned";
+
+        // Opting in: now the order is part of the contract, and this one is wrong.
+        expected.SetPrimaryKeyOrder(["a", "c"]);
+
+        (await expected.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.Update);
+
+        // ...and stating the true order is clean again.
+        expected.SetPrimaryKeyOrder(["c", "a"]);
+        (await expected.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task a_composite_foreign_key_declared_in_another_order_is_not_a_difference()
+    {
+        await ResetSchema();
+        await theConnection.CreateCommand(
+                "create table upgrade.fkparent (x int not null, y int not null, constraint pk_fkparent primary key (x, y))")
+            .ExecuteNonQueryAsync();
+        // The shape older Weasel would have written, having sorted both sides.
+        await theConnection.CreateCommand(
+                "create table upgrade.fkchild (a int not null, b int not null, constraint pk_fkchild primary key (a, b), constraint fk_ch foreign key (a, b) references upgrade.fkparent (x, y))")
+            .ExecuteNonQueryAsync();
+
+        var expected = new Table("upgrade.fkchild");
+        expected.AddColumn<int>("a").AsPrimaryKey();
+        expected.AddColumn<int>("b").AsPrimaryKey();
+        expected.PrimaryKeyName = "pk_fkchild";
+        // Same pairs, stated in the other order: b->y and a->x. Same constraint.
+        expected.ForeignKeys.Add(new ForeignKey("fk_ch")
+        {
+            LinkedTable = new SqlServerObjectName("upgrade", "fkparent"),
+            ColumnNames = ["b", "a"],
+            LinkedNames = ["y", "x"]
+        });
+
+        var delta = await expected.FindDeltaAsync(theConnection);
+
+        delta.Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task a_foreign_key_pairing_different_columns_is_still_a_difference()
+    {
+        await ResetSchema();
+        await theConnection.CreateCommand(
+                "create table upgrade.p2 (x int not null, y int not null, constraint pk_p2 primary key (x, y))")
+            .ExecuteNonQueryAsync();
+        await theConnection.CreateCommand(
+                "create table upgrade.c2 (a int not null, b int not null, constraint pk_c2 primary key (a, b), constraint fk_c2 foreign key (a, b) references upgrade.p2 (x, y))")
+            .ExecuteNonQueryAsync();
+
+        var expected = new Table("upgrade.c2");
+        expected.AddColumn<int>("a").AsPrimaryKey();
+        expected.AddColumn<int>("b").AsPrimaryKey();
+        expected.PrimaryKeyName = "pk_c2";
+        // a->y and b->x is genuinely a different constraint, and must not be masked by
+        // order-insensitivity.
+        expected.ForeignKeys.Add(new ForeignKey("fk_c2")
+        {
+            LinkedTable = new SqlServerObjectName("upgrade", "p2"),
+            ColumnNames = ["a", "b"],
+            LinkedNames = ["y", "x"]
+        });
+
+        (await expected.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.Update);
+    }
+
+    [Fact]
+    public async Task an_all_descending_index_is_not_a_difference()
+    {
+        await ResetSchema();
+        await theConnection.CreateCommand(
+                "create table upgrade.ad (id int not null constraint pk_ad primary key, a int not null, b int not null)")
+            .ExecuteNonQueryAsync();
+        // Created outside Weasel, every key column descending.
+        await theConnection.CreateCommand("create index ix_ad on upgrade.ad (a desc, b desc)")
+            .ExecuteNonQueryAsync();
+
+        var expected = new Table("upgrade.ad");
+        expected.AddColumn<int>("id").AsPrimaryKey();
+        expected.AddColumn<int>("a").NotNull();
+        expected.AddColumn<int>("b").NotNull();
+        expected.PrimaryKeyName = "pk_ad";
+        // All a hand-written model can say. Comparing the database's per-column truth against it
+        // would drop the index and recreate it as (a, b DESC) -- silently flipping a to ASC.
+        expected.Indexes.Add(new IndexDefinition("ix_ad") { Columns = ["a", "b"], SortOrder = SortOrder.Desc });
+
+        (await expected.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task an_ordinary_table_still_reports_no_delta_against_itself()
+    {
+        await ResetSchema();
+
+        var table = new Table("upgrade.ordinary");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn<string>("name").NotNull();
+        table.AddColumn<decimal>("amount").AllowNulls();
+        table.Indexes.Add(new IndexDefinition("ix_ordinary_name") { Columns = ["name"] });
+        table.CheckConstraints.Add(new TableCheckConstraint("ck_ordinary", "amount is null or amount > 0"));
+
+        await CreateSchemaObjectInDatabase(table);
+
+        (await table.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+}

--- a/src/Weasel.SqlServer/Tables/ForeignKey.cs
+++ b/src/Weasel.SqlServer/Tables/ForeignKey.cs
@@ -78,6 +78,46 @@ public class ForeignKey: ForeignKeyBase
     ///     SQL Server has no ON DELETE RESTRICT — it is written and reported as
     ///     NO ACTION, so the two must compare as equal during delta detection.
     /// </summary>
+    /// <summary>
+    ///     A foreign key pairs its columns positionally, but the pairing -- not the order the pairs
+    ///     are written in -- is what defines the constraint. Now that both sides keep declaration
+    ///     order, comparing the two lists positionally would report drift on a key the caller merely
+    ///     wrote in another order, and "fix" it by dropping and recreating an identical constraint.
+    /// </summary>
+    private bool SamePairs(ForeignKey other)
+    {
+        if (ColumnNames.Length != other.ColumnNames.Length ||
+            LinkedNames.Length != other.LinkedNames.Length ||
+            ColumnNames.Length != LinkedNames.Length)
+        {
+            return false;
+        }
+
+        // ColumnComparer is virtual; hardcoding a comparer would silently change case sensitivity
+        // and ignore a subclass that overrides it.
+        IEnumerable<string> pairs(ForeignKey fk)
+            => fk.ColumnNames.Zip(fk.LinkedNames, (c, l) => $"{c}\u0000{l}")
+                .OrderBy(x => x, ColumnComparer);
+
+        return pairs(this).SequenceEqual(pairs(other), ColumnComparer);
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is not ForeignKey other)
+        {
+            return base.Equals(obj);
+        }
+
+        return base.Equals(obj) || (NameComparer.Equals(Name, other.Name)
+                                    && Equals(LinkedTable, other.LinkedTable)
+                                    && NormalizeCascadeAction(DeleteAction) ==
+                                    NormalizeCascadeAction(other.DeleteAction)
+                                    && NormalizeCascadeAction(UpdateAction) ==
+                                    NormalizeCascadeAction(other.UpdateAction)
+                                    && SamePairs(other));
+    }
+
     protected override Core.CascadeAction NormalizeCascadeAction(Core.CascadeAction action)
         => action == Core.CascadeAction.Restrict ? Core.CascadeAction.NoAction : action;
 

--- a/src/Weasel.SqlServer/Tables/ForeignKey.cs
+++ b/src/Weasel.SqlServer/Tables/ForeignKey.cs
@@ -12,16 +12,21 @@ public class ForeignKey: ForeignKeyBase
     {
     }
 
+    // Declaration order is preserved on both sides. These setters used to sort each side
+    // independently, which made a composite FK whose two sides don't sort into the same relative
+    // order pair the wrong columns together -- ColumnNames[i] must stay matched to LinkedNames[i].
+    // The sort was compensating for the catalog query having no ORDER BY; that query now orders by
+    // constraint_column_id instead. See Table.FetchExisting.cs.
     public override string[] ColumnNames
     {
         get => _columnNames;
-        set => _columnNames = value.Select(SchemaUtils.Unbracket).OrderBy(x => x).ToArray();
+        set => _columnNames = value.Select(SchemaUtils.Unbracket).ToArray();
     }
 
     public override string[] LinkedNames
     {
         get => _linkedNames;
-        set => _linkedNames = value.Select(SchemaUtils.Unbracket).OrderBy(x => x).ToArray();
+        set => _linkedNames = value.Select(SchemaUtils.Unbracket).ToArray();
     }
 
 #pragma warning disable CS0618 // Type or member is obsolete

--- a/src/Weasel.SqlServer/Tables/Table.FetchExisting.cs
+++ b/src/Weasel.SqlServer/Tables/Table.FetchExisting.cs
@@ -13,9 +13,25 @@ public partial class Table
         var nameParam = builder.AddParameter(Identifier.Name).ParameterName;
 
         builder.Append($@"
-select column_name, data_type, character_maximum_length, null as udt_name, column_default, is_nullable
-from information_schema.columns where table_schema = @{schemaParam} and table_name = @{nameParam}
-order by ordinal_position;
+-- Columns come from sys.columns rather than information_schema.columns because the latter exposes
+-- no is_identity, and reports length only in characters -- it cannot express decimal(18,2) or
+-- datetime2(3) at all, so both read back as a bare type name.
+select
+    c.name,
+    tp.name as type_name,
+    c.max_length,
+    c.precision,
+    c.scale,
+    c.is_nullable,
+    c.is_identity,
+    dc.definition as default_definition
+from sys.columns c
+    inner join sys.tables t on t.object_id = c.object_id
+    inner join sys.schemas s on s.schema_id = t.schema_id
+    inner join sys.types tp on tp.user_type_id = c.user_type_id
+    left join sys.default_constraints dc on dc.parent_object_id = c.object_id and dc.parent_column_id = c.column_id
+where s.name = @{schemaParam} and t.name = @{nameParam}
+order by c.column_id;
 
 -- CONSTRAINT_COLUMN_USAGE cannot express key order, so the primary key comes from sys.index_columns
 -- via the backing index: key_ordinal is the declared order, which for a composite key is not
@@ -276,31 +292,53 @@ where s.name = @{schemaParam} and t.name = @{nameParam};
 
     private static async Task<TableColumn> readColumnAsync(DbDataReader reader, CancellationToken ct = default)
     {
-        var column = new TableColumn(
-            await reader.GetFieldValueAsync<string>(0, ct).ConfigureAwait(false),
-            await reader.GetFieldValueAsync<string>(1, ct).ConfigureAwait(false)
-        );
+        var name = await reader.GetFieldValueAsync<string>(0, ct).ConfigureAwait(false);
+        var typeName = await reader.GetFieldValueAsync<string>(1, ct).ConfigureAwait(false);
+        var maxLength = await reader.GetFieldValueAsync<short>(2, ct).ConfigureAwait(false);
+        var precision = await reader.GetFieldValueAsync<byte>(3, ct).ConfigureAwait(false);
+        var scale = await reader.GetFieldValueAsync<byte>(4, ct).ConfigureAwait(false);
 
-        if (column.Type.Equals("user-defined"))
+        var column = new TableColumn(name, FormatStoreType(typeName, maxLength, precision, scale))
         {
-            column.Type = await reader.GetFieldValueAsync<string>(3, ct).ConfigureAwait(false);
-        }
+            AllowNulls = await reader.GetFieldValueAsync<bool>(5, ct).ConfigureAwait(false),
+            IsAutoNumber = await reader.GetFieldValueAsync<bool>(6, ct).ConfigureAwait(false)
+        };
 
-        if (!await reader.IsDBNullAsync(2, ct).ConfigureAwait(false))
+        if (!await reader.IsDBNullAsync(7, ct).ConfigureAwait(false))
         {
-            var length = await reader.GetFieldValueAsync<int>(2, ct).ConfigureAwait(false);
-            // SQL Server returns -1 for MAX length columns (nvarchar(max), varbinary(max), etc.)
-            column.Type = length == -1 ? $"{column.Type}(max)" : $"{column.Type}({length})";
+            column.DefaultExpression = await reader.GetFieldValueAsync<string>(7, ct).ConfigureAwait(false);
         }
-
-        if (!await reader.IsDBNullAsync(4, ct).ConfigureAwait(false))
-        {
-            column.DefaultExpression = await reader.GetFieldValueAsync<string>(4, ct).ConfigureAwait(false);
-        }
-
-        column.AllowNulls = await reader.GetFieldValueAsync<string>(5, ct).ConfigureAwait(false) == "YES";
 
         return column;
+    }
+
+    internal static string FormatStoreType(string typeName, short maxLength, byte precision, byte scale)
+    {
+        switch (typeName.ToLowerInvariant())
+        {
+            case "nchar":
+            case "nvarchar":
+                // Unicode lengths are stored doubled; -1 is the MAX sentinel and must not be halved.
+                return maxLength == -1 ? $"{typeName}(max)" : $"{typeName}({maxLength / 2})";
+
+            case "char":
+            case "varchar":
+            case "binary":
+            case "varbinary":
+                return maxLength == -1 ? $"{typeName}(max)" : $"{typeName}({maxLength})";
+
+            case "decimal":
+            case "numeric":
+                return $"{typeName}({precision},{scale})";
+
+            case "time":
+            case "datetime2":
+            case "datetimeoffset":
+                return $"{typeName}({scale})";
+
+            default:
+                return typeName;
+        }
     }
 
 

--- a/src/Weasel.SqlServer/Tables/Table.FetchExisting.cs
+++ b/src/Weasel.SqlServer/Tables/Table.FetchExisting.cs
@@ -17,15 +17,20 @@ select column_name, data_type, character_maximum_length, null as udt_name, colum
 from information_schema.columns where table_schema = @{schemaParam} and table_name = @{nameParam}
 order by ordinal_position;
 
+-- CONSTRAINT_COLUMN_USAGE cannot express key order, so the primary key comes from sys.index_columns
+-- via the backing index: key_ordinal is the declared order, which for a composite key is not
+-- necessarily the table's column order.
 select
-    COLUMN_NAME,
-    CONSTRAINT_NAME
-from
-    INFORMATION_SCHEMA.CONSTRAINT_COLUMN_USAGE
-where
-    TABLE_SCHEMA = @{schemaParam} and
-    TABLE_NAME = @{nameParam} and
-    CONSTRAINT_NAME in (select constraint_name from INFORMATION_SCHEMA.TABLE_CONSTRAINTS where TABLE_CONSTRAINTS.TABLE_NAME = @{nameParam} and TABLE_CONSTRAINTS.TABLE_SCHEMA = @{schemaParam} and CONSTRAINT_TYPE = 'PRIMARY KEY')
+    c.name as COLUMN_NAME,
+    kc.name as CONSTRAINT_NAME
+from sys.key_constraints kc
+    inner join sys.tables t on t.object_id = kc.parent_object_id
+    inner join sys.schemas s on s.schema_id = t.schema_id
+    inner join sys.indexes i on i.object_id = kc.parent_object_id and i.index_id = kc.unique_index_id
+    inner join sys.index_columns ic on ic.object_id = i.object_id and ic.index_id = i.index_id
+    inner join sys.columns c on c.object_id = ic.object_id and c.column_id = ic.column_id
+where s.name = @{schemaParam} and t.name = @{nameParam} and kc.type = 'PK'
+order by ic.key_ordinal;
 
    select
           parent.name as constraint_name,
@@ -46,7 +51,8 @@ where
        inner join sys.columns cfk on fk.referenced_object_id = cfk.object_id and fk.referenced_column_id = cfk.column_id
    where
         s.name = @{schemaParam} and
-        t.name = @{nameParam};
+        t.name = @{nameParam}
+   order by parent.name, fk.constraint_column_id;
 
 
 
@@ -83,8 +89,14 @@ from
 where
         t.name = @{nameParam} and
         s.name = @{schemaParam}
+-- key_ordinal is the index's key order; index_column_id is just the column's position in the
+-- table. Ordering by the latter silently reorders a composite index -- (ProductId, Id) came back
+-- as (Id, ProductId), which is a different index. Included columns carry key_ordinal 0, so they
+-- are separated out first.
 order by
     ic.index_id,
+    ic.is_included_column,
+    ic.key_ordinal,
     ic.index_column_id;
 
 
@@ -144,6 +156,8 @@ where s.name = @{schemaParam} and t.name = @{nameParam};
         var (pks, primaryKeyName) = await readPrimaryKeysAsync(reader, ct).ConfigureAwait(false);
         foreach (var pkColumn in pks) existing.ColumnFor(pkColumn)!.IsPrimaryKey = true;
         existing.PrimaryKeyName = primaryKeyName;
+        // Declared key order, which for a composite key need not match the table's column order.
+        existing.SetPrimaryKeyOrder(pks);
 
 
         await readForeignKeysAsync(reader, existing, ct).ConfigureAwait(false);

--- a/src/Weasel.SqlServer/Tables/Table.cs
+++ b/src/Weasel.SqlServer/Tables/Table.cs
@@ -33,15 +33,29 @@ public partial class Table: TableBase<TableColumn, IndexDefinition, ForeignKey>
     {
     }
 
+    private IReadOnlyList<string>? _primaryKeyOrder;
+
     /// <inheritdoc />
     /// <remarks>
-    ///     SQL Server derives the primary key column list from
+    ///     For a table declared in code, SQL Server derives the primary key column list from
     ///     <see cref="TableBase{TColumn,TIndex,TForeignKey}.Columns" /> rather
     ///     than storing it separately, so the list refreshes automatically as
-    ///     columns are flagged with <c>IsPrimaryKey</c>.
+    ///     columns are flagged with <c>IsPrimaryKey</c>. A table read back out of the database
+    ///     instead carries its declared key order, which for a composite key need not match the
+    ///     order the columns appear in the table.
     /// </remarks>
     public override IReadOnlyList<string> PrimaryKeyColumns =>
-        _columns.Where(x => x.IsPrimaryKey).Select(x => x.Name).ToList();
+        _primaryKeyOrder ?? _columns.Where(x => x.IsPrimaryKey).Select(x => x.Name).ToList();
+
+    /// <summary>
+    ///     Pin the primary key's column order explicitly, rather than deriving it from column order.
+    ///     Passing an empty list clears the override.
+    /// </summary>
+    public void SetPrimaryKeyOrder(IEnumerable<string> columnNames)
+    {
+        var ordered = columnNames.ToArray();
+        _primaryKeyOrder = ordered.Length == 0 ? null : ordered;
+    }
 
     /// <inheritdoc />
     /// <inheritdoc />

--- a/src/Weasel.SqlServer/Tables/Table.cs
+++ b/src/Weasel.SqlServer/Tables/Table.cs
@@ -45,16 +45,82 @@ public partial class Table: TableBase<TableColumn, IndexDefinition, ForeignKey>
     ///     order the columns appear in the table.
     /// </remarks>
     public override IReadOnlyList<string> PrimaryKeyColumns =>
-        _primaryKeyOrder ?? _columns.Where(x => x.IsPrimaryKey).Select(x => x.Name).ToList();
+        orderedPrimaryKeyColumns();
+
+    public bool HasExplicitPrimaryKeyOrder => _primaryKeyOrder != null;
+
+    private IReadOnlyList<string> orderedPrimaryKeyColumns()
+    {
+        var flagged = _columns.Where(x => x.IsPrimaryKey).Select(x => x.Name).ToList();
+        if (_primaryKeyOrder == null)
+        {
+            return flagged;
+        }
+
+        // The pin ORDERS the flagged set rather than replacing it, so flagging or removing a column
+        // afterwards still takes effect and a pin naming a since-dropped column cannot resurrect it.
+        var pinned = _primaryKeyOrder;
+        return flagged
+            .OrderBy(name =>
+            {
+                for (var i = 0; i < pinned.Count; i++)
+                {
+                    if (pinned[i].EqualsIgnoreCase(name))
+                    {
+                        return i;
+                    }
+                }
+
+                return int.MaxValue;
+            })
+            .ToList();
+    }
 
     /// <summary>
     ///     Pin the primary key's column order explicitly, rather than deriving it from column order.
     ///     Passing an empty list clears the override.
     /// </summary>
+    /// <exception cref="ArgumentException">
+    ///     The list repeats a column, names one that is not part of the primary key, or covers only
+    ///     part of the key. Each produces a migration that drops the existing key and then fails to
+    ///     add the replacement, so they are rejected here rather than at the database.
+    /// </exception>
     public void SetPrimaryKeyOrder(IEnumerable<string> columnNames)
     {
         var ordered = columnNames.ToArray();
-        _primaryKeyOrder = ordered.Length == 0 ? null : ordered;
+        if (ordered.Length == 0)
+        {
+            _primaryKeyOrder = null;
+            return;
+        }
+
+        var duplicates = ordered.GroupBy(x => x, StringComparer.OrdinalIgnoreCase)
+            .Where(g => g.Count() > 1).Select(g => g.Key).ToArray();
+        if (duplicates.Any())
+        {
+            throw new ArgumentException(
+                $"Primary key order for {Identifier} repeats {duplicates.Join(", ")}.", nameof(columnNames));
+        }
+
+        var keyColumns = _columns.Where(x => x.IsPrimaryKey).Select(x => x.Name).ToArray();
+        var unknown = ordered.Where(x => !keyColumns.Contains(x, StringComparer.OrdinalIgnoreCase)).ToArray();
+        if (unknown.Any())
+        {
+            throw new ArgumentException(
+                $"Primary key order for {Identifier} names {unknown.Join(", ")}, which is not part of the key. The key is: {(keyColumns.Any() ? keyColumns.Join(", ") : "(no columns flagged as primary key)")}.",
+                nameof(columnNames));
+        }
+
+        // A partial pin would still opt the table into strict order comparison, silently reordering
+        // the columns it does not name. An order is only meaningful for the whole key.
+        if (ordered.Length != keyColumns.Length)
+        {
+            throw new ArgumentException(
+                $"Primary key order for {Identifier} lists {ordered.Length} of {keyColumns.Length} key columns. Name every column of the key, in order. The key is: {keyColumns.Join(", ")}.",
+                nameof(columnNames));
+        }
+
+        _primaryKeyOrder = ordered;
     }
 
     /// <inheritdoc />

--- a/src/Weasel.SqlServer/Tables/TableDelta.cs
+++ b/src/Weasel.SqlServer/Tables/TableDelta.cs
@@ -16,6 +16,17 @@ public class TableDelta: SchemaObjectDelta<Table>
 
     internal ItemDelta<TableCheckConstraint> CheckConstraints { get; private set; } = null!;
 
+    // The actual key now carries the order the catalog declares, which for a composite key need not
+    // match the order the columns appear in the table -- and a model that flags columns cannot
+    // express any other order. Comparing positionally would report drift on every such table and
+    // "fix" it by reordering the user's key. Order is only compared when it was pinned deliberately.
+    private static bool primaryKeyColumnsMatch(Table expected, Table actual)
+        => expected.HasExplicitPrimaryKeyOrder
+            ? expected.PrimaryKeyColumns.SequenceEqual(actual.PrimaryKeyColumns, StringComparer.Ordinal)
+            : expected.PrimaryKeyColumns.OrderBy(x => x, StringComparer.Ordinal)
+                .SequenceEqual(actual.PrimaryKeyColumns.OrderBy(x => x, StringComparer.Ordinal),
+                    StringComparer.Ordinal);
+
     public SchemaPatchDifference PrimaryKeyDifference { get; private set; }
 
     /// <summary>
@@ -65,7 +76,7 @@ public class TableDelta: SchemaObjectDelta<Table>
         {
             PrimaryKeyDifference = SchemaPatchDifference.Create;
         }
-        else if (!expected.PrimaryKeyColumns.SequenceEqual(actual.PrimaryKeyColumns))
+        else if (!primaryKeyColumnsMatch(expected, actual))
         {
             PrimaryKeyDifference = SchemaPatchDifference.Update;
         }

--- a/src/Weasel.SqlServer/Tables/TableDelta.cs
+++ b/src/Weasel.SqlServer/Tables/TableDelta.cs
@@ -35,7 +35,11 @@ public class TableDelta: SchemaObjectDelta<Table>
 
         Columns = new ItemDelta<TableColumn>(expected.Columns, actual.Columns,
             (e, a) => e.MatchesForDelta(a, expected.DetectColumnDrift));
-        Indexes = new ItemDelta<IndexDefinition>(expected.Indexes, actual.Indexes,
+        // IgnoreIndex is Weasel.Core API and is honoured by the PostgreSQL and SQLite twins; without
+        // this SQL Server put an ignored index in Extras and WriteUpdate dropped it.
+        Indexes = new ItemDelta<IndexDefinition>(
+            expected.Indexes.Where(x => !expected.HasIgnoredIndex(x.Name)),
+            actual.Indexes.Where(x => !expected.HasIgnoredIndex(x.Name)),
             (e, a) => e.Matches(a, Expected));
 
         ForeignKeys = new ItemDelta<ForeignKey>(expected.ForeignKeys, actual.ForeignKeys);


### PR DESCRIPTION
- `IgnoreIndex` did nothing on SQL Server, though PostgreSQL and SQLite honour it — the
  generated patch dropped the index it was meant to protect.
- Composite PK and FK columns came back sorted rather than in key order, so a composite FK
  could pair the wrong columns together.
- `decimal(18,2)` read back as `decimal`; rollback then emitted `(18,0)` and truncated the scale.
- IDENTITY was never read back.
