### PR TITLE
Read an index's key direction per column

### DIFF
--- a/src/Weasel.SqlServer.Tests/Tables/index_column_direction.cs
+++ b/src/Weasel.SqlServer.Tests/Tables/index_column_direction.cs
@@ -1,0 +1,132 @@
+using Shouldly;
+using Weasel.Core;
+using Weasel.SqlServer.Tables;
+using Xunit;
+
+namespace Weasel.SqlServer.Tests.Tables;
+
+/// <summary>
+///     SQL Server sets key direction per column. Weasel could only say "the index is descending",
+///     which appends one trailing DESC and therefore marks the LAST key column -- so an index read
+///     back out of the database as (a DESC, b) was reported as (a, b DESC), a different index, and
+///     a model declaring (a, b DESC) compared equal to it.
+/// </summary>
+public class index_column_direction: IntegrationContext
+{
+    public index_column_direction(): base("dir")
+    {
+    }
+
+    private async Task<Table> tableWithIndex(string name, string createIndex)
+    {
+        await ResetSchema();
+        await theConnection.CreateCommand(
+                $"create table dir.{name} (id int not null constraint pk_{name} primary key, a int not null, b int not null)")
+            .ExecuteNonQueryAsync();
+        await theConnection.CreateCommand(createIndex).ExecuteNonQueryAsync();
+
+        var table = new Table($"dir.{name}");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn<int>("a").NotNull();
+        table.AddColumn<int>("b").NotNull();
+        table.PrimaryKeyName = $"pk_{name}";
+        return table;
+    }
+
+    [Fact]
+    public async Task the_fetched_index_reports_the_direction_the_database_has()
+    {
+        var table = await tableWithIndex("t1", "create index ix_t1 on dir.t1 (a desc, b)");
+
+        var existing = await table.FetchExistingAsync(theConnection);
+        var ddl = existing!.IndexFor("ix_t1")!.ToDDL(existing);
+
+        ddl.ShouldContain("(a DESC, b)");
+    }
+
+    [Fact]
+    public async Task a_model_that_pins_direction_sees_a_differently_directed_index_as_drift()
+    {
+        var table = await tableWithIndex("t2", "create index ix_t2 on dir.t2 (a desc, b)");
+        table.Indexes.Add(new IndexDefinition("ix_t2")
+        {
+            Columns = ["a", "b"], DescendingColumns = { "b" }, CompareColumnDirection = true
+        });
+
+        (await table.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.Update);
+    }
+
+    [Fact]
+    public async Task a_model_that_pins_the_direction_the_database_has_is_not_drift()
+    {
+        var table = await tableWithIndex("t3", "create index ix_t3 on dir.t3 (a desc, b)");
+        table.Indexes.Add(new IndexDefinition("ix_t3")
+        {
+            Columns = ["a", "b"], DescendingColumns = { "a" }, CompareColumnDirection = true
+        });
+
+        (await table.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    /// A model that never stated a direction must not be dragged into comparing one, or every
+    /// existing descending index reports drift the user cannot resolve.
+    [Fact]
+    public async Task a_model_that_says_nothing_about_direction_is_not_drift()
+    {
+        var table = await tableWithIndex("t4", "create index ix_t4 on dir.t4 (a desc, b)");
+        table.Indexes.Add(new IndexDefinition("ix_t4") { Columns = ["a", "b"], SortOrder = SortOrder.Desc });
+
+        (await table.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task an_all_descending_index_is_still_not_drift_for_a_coarse_model()
+    {
+        var table = await tableWithIndex("t5", "create index ix_t5 on dir.t5 (a desc, b desc)");
+        table.Indexes.Add(new IndexDefinition("ix_t5") { Columns = ["a", "b"], SortOrder = SortOrder.Desc });
+
+        (await table.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public void a_stray_descending_column_is_rejected_rather_than_ignored()
+    {
+        var table = new Table("dir.stray");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn<int>("a").NotNull();
+        var index = new IndexDefinition("ix_stray") { Columns = ["a"], DescendingColumns = { "typo" } };
+        table.Indexes.Add(index);
+
+        Should.Throw<InvalidOperationException>(() => index.ToDDL(table))
+            .Message.ShouldContain("typo");
+    }
+
+    [Theory]
+    [InlineData("Order", "[Order]")]
+    [InlineData("[Order]", "Order")]
+    public void a_bracketed_spelling_is_not_mistaken_for_a_stray_column(string keyColumn, string descending)
+    {
+        var table = new Table("dir.br");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn("Order", "int").NotNull();
+        var index = new IndexDefinition("ix_br") { Columns = [keyColumn], DescendingColumns = { descending } };
+        table.Indexes.Add(index);
+
+        index.ToDDL(table).ShouldContain("[Order] DESC");
+    }
+
+    [Fact]
+    public void matches_is_symmetric_for_a_given_setting()
+    {
+        var table = new Table("dir.sym");
+        table.AddColumn<int>("a").NotNull();
+        table.AddColumn<int>("b").NotNull();
+
+        var pinned = new IndexDefinition("ix") { Columns = ["a", "b"], DescendingColumns = { "a" } };
+        var coarse = new IndexDefinition("ix") { Columns = ["a", "b"], SortOrder = SortOrder.Desc };
+
+        pinned.Matches(coarse, table, false).ShouldBe(coarse.Matches(pinned, table, false));
+        pinned.Matches(coarse, table, true).ShouldBe(coarse.Matches(pinned, table, true));
+        pinned.Matches(coarse, table, true).ShouldBeFalse();
+    }
+}

--- a/src/Weasel.SqlServer/Tables/IndexDefinition.cs
+++ b/src/Weasel.SqlServer/Tables/IndexDefinition.cs
@@ -23,6 +23,31 @@ public class IndexDefinition: ITableIndex
 
     public SortOrder SortOrder { get; set; } = SortOrder.Asc;
 
+    /// <summary>
+    ///     Key columns that sort descending, when the index mixes directions.
+    /// </summary>
+    /// <remarks>
+    ///     <see cref="SortOrder" /> applies to the index as a whole and appends a single trailing
+    ///     <c>DESC</c>, which can only describe an index whose last key column is the descending one.
+    ///     SQL Server sets the direction per column, so an index on <c>(a, b DESC, c)</c> has no
+    ///     representation in <see cref="SortOrder" /> at all.
+    /// </remarks>
+    public ISet<string> DescendingColumns { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    ///     Compare per-column key direction as well as the column list. Off by default.
+    /// </summary>
+    /// <remarks>
+    ///     Direction is read from the database faithfully into <see cref="DescendingColumns" />, but
+    ///     comparing it against a model that never stated one would report a difference the user
+    ///     cannot resolve — and the migration "fixing" it would drop the index and recreate it from
+    ///     the coarse rendering, silently flipping columns from DESC to ASC. So the comparison is
+    ///     opt-in, and the opt-in is this flag rather than "is <see cref="DescendingColumns" />
+    ///     populated": inferring intent from a populated collection means one stale or misspelled
+    ///     entry silently turns strict comparison on.
+    /// </remarks>
+    public bool CompareColumnDirection { get; set; }
+
     public bool IsUnique { get; set; }
 
     public string[] Columns
@@ -107,7 +132,14 @@ public class IndexDefinition: ITableIndex
         return this;
     }
 
-    public string ToDDL(Table parent)
+    public string ToDDL(Table parent) => ToDDL(parent, true);
+
+    /// <summary>
+    ///     Render the index, optionally ignoring <see cref="DescendingColumns" /> and falling back to
+    ///     the coarse trailing <c>DESC</c>. The coarse form is what comparison uses unless the model
+    ///     opted into <see cref="CompareColumnDirection" />.
+    /// </summary>
+    internal string ToDDL(Table parent, bool usePerColumnDirection)
     {
         var builder = new StringBuilder();
 
@@ -135,7 +167,7 @@ public class IndexDefinition: ITableIndex
         builder.Append(parent.Identifier);
 
         builder.Append(" ");
-        builder.Append(correctedExpression());
+        builder.Append(correctedExpression(usePerColumnDirection));
 
         // Clause order is fixed by SQL Server's grammar: INCLUDE, then WHERE, then WITH. Emitting
         // them in any other order is a syntax error, which only shows up on an index that uses more
@@ -164,7 +196,7 @@ public class IndexDefinition: ITableIndex
         return builder.ToString();
     }
 
-    private string correctedExpression()
+    private string correctedExpression(bool usePerColumnDirection = true)
     {
         if (!Columns.Any())
         {
@@ -173,39 +205,80 @@ public class IndexDefinition: ITableIndex
 
         // Quoted: a column named "Table" (or any other reserved word) is legal in SQL Server and
         // turns up in real schemas. QuoteName leaves ordinary identifiers untouched.
-        var expression = Columns.Select(SchemaUtils.QuoteName).Join(", ");
+        var quoted = Columns.Select(SchemaUtils.QuoteName).ToArray();
+
+        if (DescendingColumns.Any())
+        {
+            // A name here that is not a key column is always a mistake -- a typo, or a column that
+            // was renamed and left behind. Silently ignoring it would emit an index whose direction
+            // is not what the model says. Compared unbracketed on both sides, since QuoteName passes
+            // through an entry the caller already bracketed.
+            var keys = Columns.Select(SchemaUtils.Unbracket).ToArray();
+            var stray = DescendingColumns
+                .Where(x => !keys.Contains(SchemaUtils.Unbracket(x), StringComparer.OrdinalIgnoreCase))
+                .ToArray();
+            if (stray.Any())
+            {
+                throw new InvalidOperationException(
+                    $"Index {Name} marks {stray.Join(", ")} descending, but {(stray.Length == 1 ? "it is not a key column" : "they are not key columns")} of the index. Key columns are: {Columns.Join(", ")}.");
+            }
+        }
+
+        if (usePerColumnDirection && DescendingColumns.Any())
+        {
+            var descending = DescendingColumns
+                .Select(SchemaUtils.Unbracket).ToHashSet(StringComparer.OrdinalIgnoreCase);
+            var perColumn = Columns
+                .Select((c, i) => descending.Contains(SchemaUtils.Unbracket(c)) ? $"{quoted[i]} DESC" : quoted[i])
+                .Join(", ");
+
+            return $"({perColumn})";
+        }
+
+        var expression = quoted.Join(", ");
 
         if (SortOrder != SortOrder.Asc)
         {
+            // A whole-index SortOrder appends one DESC, which attaches to the last column.
+            // Deliberately not re-interpreted as all-columns-descending: that would silently
+            // redefine every existing multi-column index using this property.
             expression += " DESC";
         }
 
         return $"({expression})";
     }
 
+    /// <summary>
+    ///     Does <paramref name="actual" /> satisfy this index, using the receiver's
+    ///     <see cref="CompareColumnDirection" /> setting?
+    /// </summary>
+    /// <remarks>
+    ///     <b>Directional</b>: the receiver is the declared index and the argument is what the
+    ///     database holds. Because the setting comes from the receiver this is not an equivalence
+    ///     relation, so do not use it for set membership; pass the setting to the overload instead.
+    /// </remarks>
     public bool Matches(IndexDefinition actual, Table parent)
-    {
-        var expectedExpression = correctedExpression();
+        => Matches(actual, parent, CompareColumnDirection);
 
-        var expectedSql = CanonicizeDdl(this, parent);
-
-        var actualSql = CanonicizeDdl(actual, parent);
-
-        return expectedSql == actualSql;
-    }
+    /// <summary>
+    ///     Does <paramref name="actual" /> satisfy this index, comparing per-column direction only
+    ///     when <paramref name="compareColumnDirection" /> says to? Symmetric for a given setting.
+    /// </summary>
+    public bool Matches(IndexDefinition actual, Table parent, bool compareColumnDirection)
+        => CanonicizeDdl(this, parent, compareColumnDirection)
+           == CanonicizeDdl(actual, parent, compareColumnDirection);
 
     public void AssertMatches(IndexDefinition actual, Table parent)
     {
-        var expectedExpression = correctedExpression();
-
-        var expectedSql = CanonicizeDdl(this, parent);
-
-        var actualSql = CanonicizeDdl(actual, parent);
+        var expectedSql = CanonicizeDdl(this, parent, CompareColumnDirection);
+        var actualSql = CanonicizeDdl(actual, parent, CompareColumnDirection);
 
         if (expectedSql != actualSql)
         {
+            // Comparing leniently is a policy decision; reporting falsely is not, so the message
+            // always shows the direction the database actually holds.
             throw new Exception(
-                $"Index did not match, expected{Environment.NewLine}{expectedSql}{Environment.NewLine}but got:{Environment.NewLine}{actualSql}");
+                $"Index did not match, expected{Environment.NewLine}{expectedSql}{Environment.NewLine}but got:{Environment.NewLine}{CanonicizeDdl(actual, parent, true)}");
         }
     }
 
@@ -221,8 +294,11 @@ public class IndexDefinition: ITableIndex
     ///     index scenario matrix (weasel#449).
     /// </remarks>
     public static string CanonicizeDdl(IndexDefinition index, Table parent)
+        => CanonicizeDdl(index, parent, true);
+
+    public static string CanonicizeDdl(IndexDefinition index, Table parent, bool compareColumnDirection)
     {
-        var sql = index.ToDDL(parent)
+        var sql = index.ToDDL(parent, compareColumnDirection)
             .Replace("\"\"", "\"")
             .Replace("  ", " ")
             .Replace("(", "")

--- a/src/Weasel.SqlServer/Tables/Table.FetchExisting.cs
+++ b/src/Weasel.SqlServer/Tables/Table.FetchExisting.cs
@@ -357,6 +357,11 @@ where s.name = @{schemaParam} and t.name = @{nameParam};
 
                 if (isDesc)
                 {
+                    // Both: the set records which column is actually descending, and SortOrder is
+                    // kept so a model that can only say "descending" still compares clean against
+                    // this one. SortOrder alone marks the LAST key column, so an index on
+                    // (a DESC, b) read into it re-emits (a, b DESC) -- a different index.
+                    index.DescendingColumns.Add(name);
                     index.SortOrder = SortOrder.Desc;
                 }
             }


### PR DESCRIPTION
SQL Server sets key direction per column. Weasel could only say "the index is descending", through a whole-index SortOrder that appends a single trailing DESC -- which attaches to the LAST key column.

So an index created as (a DESC, b) was read back as a model whose DDL is (a, b DESC): the wrong column marked descending. Two consequences. Anything that scripts from a fetched table emits an index that is not the one in the database. And a model that declares (a, b DESC) compares equal to a database index that is actually (a DESC, b), so a genuinely different index is never reported as drift and never repaired.

The direction is now read per column into DescendingColumns and rendered per column. Comparing it is opt-in through CompareColumnDirection, because a model that never stated a direction cannot express one: comparing unconditionally would report drift the user cannot resolve, and the migration "fixing" it would drop the index and recreate it from the coarse rendering, silently flipping columns from DESC to ASC. The opt-in is an explicit flag rather than "is DescendingColumns populated", so one stale entry cannot quietly turn strict comparison on.

A DescendingColumns entry that is not a key column is rejected rather than ignored, comparing bracketed and unbracketed spellings as the same column.