### PR TITLE
fix(postgresql): compare hash partitions by bound, not by catalog order

### DIFF
--- a/src/Weasel.Postgresql.Tests/Tables/partitioning/hash_partition_ordering.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/partitioning/hash_partition_ordering.cs
@@ -1,0 +1,55 @@
+using System.Reflection;
+using Shouldly;
+using Weasel.Postgresql.Tables;
+using Weasel.Postgresql.Tables.Partitioning;
+using Xunit;
+
+namespace Weasel.Postgresql.Tests.Tables.partitioning;
+
+/// <summary>
+///     pg_inherits has no inherent order and the read query imposes none, so the partitions of a
+///     hash-partitioned table can come back in any order.
+/// </summary>
+public class hash_partition_ordering
+{
+    // The public API assigns remainders by position, so it cannot express "the same partitions in a
+    // different order" -- which is exactly what the catalog hands back. Reordering the backing list
+    // is the only way to reproduce a read whose rows arrived in another order.
+    private static HashPartitioning asReadInOrder(params string[] catalogOrder)
+    {
+        var partitioning = new HashPartitioning { Columns = ["last_name"], Suffixes = ["one", "two", "three"] };
+
+        var field = typeof(HashPartitioning)
+            .GetField("_partitions", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var partitions = (List<HashPartition>)field.GetValue(partitioning)!;
+
+        var reordered = catalogOrder.Select(s => partitions.Single(p => p.Suffix == s)).ToList();
+        partitions.Clear();
+        partitions.AddRange(reordered);
+
+        return partitioning;
+    }
+
+    [Theory]
+    [InlineData("one", "two", "three")]
+    [InlineData("three", "one", "two")]
+    [InlineData("two", "three", "one")]
+    [InlineData("three", "two", "one")]
+    public void the_same_partitions_in_any_order_are_not_a_rebuild(params string[] catalogOrder)
+    {
+        var expected = new HashPartitioning { Columns = ["last_name"], Suffixes = ["one", "two", "three"] };
+
+        expected.CreateDelta(new Table("partitions.people"), asReadInOrder(catalogOrder), out _)
+            .ShouldBe(PartitionDelta.None);
+    }
+
+    [Fact]
+    public void swapping_which_suffix_holds_which_remainder_is_still_a_rebuild()
+    {
+        var expected = new HashPartitioning { Columns = ["last_name"], Suffixes = ["one", "two", "three"] };
+        var actual = new HashPartitioning { Columns = ["last_name"], Suffixes = ["two", "one", "three"] };
+
+        expected.CreateDelta(new Table("partitions.people"), actual, out _)
+            .ShouldBe(PartitionDelta.Rebuild);
+    }
+}

--- a/src/Weasel.Postgresql.Tests/Tables/partitioning/hash_partitions.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/partitioning/hash_partitions.cs
@@ -1,4 +1,5 @@
 using Shouldly;
+using Weasel.Core;
 using Weasel.Postgresql.Tables;
 using Weasel.Postgresql.Tables.Partitioning;
 using Xunit;
@@ -32,6 +33,25 @@ public class hash_partitions: IntegrationContext
     private Task<Table> tryToFetchExisting()
     {
         return theTable.FetchExistingAsync(theConnection);
+    }
+
+    [Fact]
+    public async Task reattaching_a_partition_is_not_drift()
+    {
+        await tryToCreateTable();
+
+        // DETACH/ATTACH deletes and re-inserts the pg_inherits row, which moves it to the end of
+        // the heap -- the same reordering a parallel pg_restore or a recreated partition produces.
+        await theConnection.CreateCommand(
+                "alter table partitions.people detach partition partitions.people_two")
+            .ExecuteNonQueryAsync();
+        await theConnection.CreateCommand(
+                "alter table partitions.people attach partition partitions.people_two for values with (modulus 3, remainder 1)")
+            .ExecuteNonQueryAsync();
+
+        var delta = await theTable.FindDeltaAsync(theConnection);
+
+        delta.Difference.ShouldBe(SchemaPatchDifference.None);
     }
 
     [Fact]

--- a/src/Weasel.Postgresql/Tables/Partitioning/HashPartitioning.cs
+++ b/src/Weasel.Postgresql/Tables/Partitioning/HashPartitioning.cs
@@ -63,8 +63,11 @@ public class HashPartitioning : IPartitionStrategy
                 return PartitionDelta.Rebuild;
             }
 
-            var match = _partitions.OrderBy(x => x.Modulus).ToArray()
-                .SequenceEqual(other.Partitions.OrderBy(x => x.Modulus).ToArray());
+            // Sorted because the actual side comes from pg_inherits, which is read with no
+            // ORDER BY. Modulus alone was no sort at all on a table this class created, where
+            // Suffixes gives every partition the same one.
+            var match = _partitions.OrderBy(x => x.Modulus).ThenBy(x => x.Remainder).ToArray()
+                .SequenceEqual(other.Partitions.OrderBy(x => x.Modulus).ThenBy(x => x.Remainder).ToArray());
 
             if (match) return PartitionDelta.None;
 


### PR DESCRIPTION
Discovered as a flaky test in https://github.com/JasperFx/weasel/actions/runs/32711119591/job/97382530316?pr=513 caused by 
CreateDelta sorted both sides by Modulus before SequenceEqual. On a table this class created that sorts nothing -- Suffixes assigns every partition the same modulus -- so the comparison stayed positional. The actual side comes from pg_inherits, which has no inherent order and is read without an ORDER BY, so a hash-partitioned table compared equal or unequal to itself depending on the order the catalog happened to return.

The symptom is an intermittently failing test (apply_migration_to_hash_partitioned has failed twice in the last 25 Postgres CI runs on master). The consequence is that an unchanged table can report PartitionDelta.Rebuild, and rebuilding a partitioned table by accident is not cheap.

Sorting by modulus and then remainder is a total order over a legal partition set: PostgreSQL rejects two partitions that share a remainder because their bounds would overlap, so the pair is unique per partition. Note this also holds for a table with mixed moduli -- (modulus 2, remainder 0) alongside (modulus 4, remainder 1) is legal, though Suffixes cannot express it.

Ordering the query instead would not fix this and would make it worse: ordering by partition name gives one, three, two for the suffixes in these tests, so a still-positional comparison would fail every time rather than occasionally.