### PR TITLE
Terminate the introspection query for a procedure,type and trigger

### DIFF
--- a/src/Weasel.Postgresql.Tests/batched_introspection_queries.cs
+++ b/src/Weasel.Postgresql.Tests/batched_introspection_queries.cs
@@ -1,0 +1,73 @@
+using Shouldly;
+using Weasel.Core;
+using Weasel.Postgresql.Procedures;
+using Weasel.Postgresql.Tables;
+using Weasel.Postgresql.Triggers;
+using Weasel.Postgresql.Types;
+using Xunit;
+
+namespace Weasel.Postgresql.Tests;
+
+/// <summary>
+///     SchemaMigration concatenates every object's introspection query into one command, so each
+///     query has to terminate itself. An object whose query does not is fine alone and breaks the
+///     moment anything follows it.
+/// </summary>
+[Collection("batched")]
+public class batched_introspection_queries: IntegrationContext
+{
+    public batched_introspection_queries(): base("batched")
+    {
+    }
+
+    private Table aTable()
+    {
+        var table = new Table("batched.thing");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        return table;
+    }
+
+    [Fact]
+    public async Task a_stored_procedure_followed_by_another_object()
+    {
+        await ResetSchema();
+
+        var proc = new StoredProcedure(new DbObjectName("batched", "do_thing"), @"
+create or replace procedure batched.do_thing() language plpgsql as $$
+begin
+  perform 1;
+end;
+$$;");
+
+        var migration = await SchemaMigration.DetermineAsync(theConnection, proc, aTable());
+
+        migration.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task a_user_defined_type_followed_by_another_object()
+    {
+        await ResetSchema();
+
+        var type = UserDefinedType.Enum("batched.mood", "happy", "sad");
+
+        var migration = await SchemaMigration.DetermineAsync(theConnection, type, aTable());
+
+        migration.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task a_trigger_followed_by_another_object()
+    {
+        await ResetSchema();
+
+        var trigger = new Trigger(
+            new DbObjectName("batched", "thing_stamp"),
+            new DbObjectName("batched", "thing"),
+            "before insert on batched.thing for each row execute function batched.stamp()");
+
+        var migration = await SchemaMigration.DetermineAsync(theConnection, trigger, aTable());
+
+        migration.ShouldNotBeNull();
+    }
+}

--- a/src/Weasel.Postgresql/Procedures/StoredProcedure.cs
+++ b/src/Weasel.Postgresql/Procedures/StoredProcedure.cs
@@ -56,7 +56,7 @@ public class StoredProcedure: StoredProcedureBase
 SELECT p.prosrc
 FROM pg_proc p
 JOIN pg_namespace n ON n.oid = p.pronamespace
-WHERE p.prokind = 'p' AND p.proname = :{nameParam} AND n.nspname = :{schemaParam}");
+WHERE p.prokind = 'p' AND p.proname = :{nameParam} AND n.nspname = :{schemaParam};");
     }
 
     /// <inheritdoc />

--- a/src/Weasel.Postgresql/Triggers/Trigger.cs
+++ b/src/Weasel.Postgresql/Triggers/Trigger.cs
@@ -80,7 +80,7 @@ JOIN pg_namespace n ON n.oid = c.relnamespace
 WHERE NOT t.tgisinternal
   AND t.tgname = :{nameParam}
   AND c.relname = :{tableParam}
-  AND n.nspname = :{schemaParam}");
+  AND n.nspname = :{schemaParam};");
     }
 
     public override async Task<ISchemaObjectDelta> CreateDeltaAsync(DbDataReader reader, CancellationToken ct = default)

--- a/src/Weasel.Postgresql/Types/UserDefinedType.cs
+++ b/src/Weasel.Postgresql/Types/UserDefinedType.cs
@@ -107,7 +107,7 @@ SELECT
 FROM pg_type t
 JOIN pg_namespace n ON n.oid = t.typnamespace
 WHERE t.typname = :{nameParam} AND n.nspname = :{schemaParam}
-  AND t.typtype IN ('e', 'd', 'c')");
+  AND t.typtype IN ('e', 'd', 'c');");
     }
 
     public override async Task<ISchemaObjectDelta> CreateDeltaAsync(DbDataReader reader, CancellationToken ct = default)


### PR DESCRIPTION
SchemaMigration concatenates every schema object's introspection query into a single command, so each query has to terminate itself. StoredProcedure, UserDefinedType and Trigger did not, so the statement that followed ran straight into the previous one:

    Npgsql.PostgresException : 42601: syntax error at or near "select"

Any migration containing one of these three plus another object fails, unless the unterminated one happens to be last. That ordering is why it was not caught: each of the three has tests, and each is tested alone.

The three types were added recently; Function, View and Sequence have always terminated their queries, which is where the convention comes from.