### PR TITLE
Fix/sqlite introspection fidelity

### DIFF
--- a/src/Weasel.Sqlite.Tests/Tables/composite_foreign_key_pairing.cs
+++ b/src/Weasel.Sqlite.Tests/Tables/composite_foreign_key_pairing.cs
@@ -1,0 +1,143 @@
+using Microsoft.Data.Sqlite;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Sqlite.Tables;
+using Xunit;
+
+namespace Weasel.Sqlite.Tests.Tables;
+
+/// <summary>
+///     A foreign key pairs its columns positionally. Sorting the dependent and the referenced list
+///     independently — which the property setters did — kept both lists tidy and destroyed the
+///     pairing between them: <c>(x, y) REFERENCES parent (b, a)</c> was emitted as
+///     <c>(x, y) REFERENCES parent (a, b)</c>, a constraint over different columns entirely.
+/// </summary>
+public class composite_foreign_key_pairing
+{
+    private static async Task<SqliteConnection> openAsync()
+    {
+        var conn = new SqliteConnection($"Data Source={Path.GetTempFileName()};");
+        await conn.OpenAsync();
+        await conn.ResetSchemaAsync("main");
+        return conn;
+    }
+
+    private static ForeignKey pairedKey(string name = "fk_pair")
+    {
+        var fk = new ForeignKey(name) { LinkedTable = new SqliteObjectName("cfk_parent") };
+        fk.LinkColumns("x", "b");
+        fk.LinkColumns("y", "a");
+        return fk;
+    }
+
+    [Fact]
+    public void the_pairing_survives_being_set()
+    {
+        var fk = pairedKey();
+
+        fk.ColumnNames.ShouldBe(["x", "y"]);
+        fk.LinkedNames.ShouldBe(["b", "a"]);
+    }
+
+    [Fact]
+    public void the_declaration_pairs_the_columns_as_declared()
+    {
+        var writer = new StringWriter();
+        pairedKey().WriteInlineDefinition(writer);
+
+        writer.ToString().ShouldBe("CONSTRAINT fk_pair FOREIGN KEY (x, y) REFERENCES cfk_parent (b, a)");
+    }
+
+    [Fact]
+    public async Task a_composite_key_round_trips_with_its_pairing_intact()
+    {
+        await using var conn = await openAsync();
+
+        var parent = new Table("cfk_parent");
+        parent.AddColumn<int>("a").AsPrimaryKey();
+        parent.AddColumn<int>("b").AsPrimaryKey();
+        await parent.CreateAsync(conn);
+
+        var child = new Table("cfk_child");
+        child.AddColumn<int>("id").AsPrimaryKey();
+        child.AddColumn<int>("x");
+        child.AddColumn<int>("y");
+        child.ForeignKeys.Add(pairedKey());
+        await child.CreateAsync(conn);
+
+        var existing = await child.FetchExistingAsync(conn);
+
+        var fk = existing!.ForeignKeys.ShouldHaveSingleItem();
+        fk.ColumnNames.Zip(fk.LinkedNames, (column, linked) => $"{column}->{linked}")
+            .ShouldBe(["x->b", "y->a"], ignoreOrder: true);
+    }
+
+    [Fact]
+    public async Task a_composite_key_converges_against_its_own_table()
+    {
+        await using var conn = await openAsync();
+
+        var parent = new Table("cfk_parent");
+        parent.AddColumn<int>("a").AsPrimaryKey();
+        parent.AddColumn<int>("b").AsPrimaryKey();
+        await parent.CreateAsync(conn);
+
+        var child = new Table("cfk_child2");
+        child.AddColumn<int>("id").AsPrimaryKey();
+        child.AddColumn<int>("x");
+        child.AddColumn<int>("y");
+        child.ForeignKeys.Add(pairedKey());
+        await child.CreateAsync(conn);
+
+        var delta = await child.FindDeltaAsync(conn);
+
+        delta.Difference.ShouldBe(SchemaPatchDifference.None);
+        delta.RequiresTableRecreation.ShouldBeFalse();
+    }
+
+    /// <summary>
+    ///     Upgrade safety: the same key written in the other order is the same constraint, and must
+    ///     not read as drift now that the lists are no longer normalised by sorting.
+    /// </summary>
+    [Fact]
+    public void the_same_pairs_written_in_another_order_are_equal()
+    {
+        var one = new ForeignKey("fk_same") { LinkedTable = new SqliteObjectName("cfk_parent") };
+        one.LinkColumns("x", "b");
+        one.LinkColumns("y", "a");
+
+        var other = new ForeignKey("fk_same") { LinkedTable = new SqliteObjectName("cfk_parent") };
+        other.LinkColumns("y", "a");
+        other.LinkColumns("x", "b");
+
+        one.ShouldBe(other);
+    }
+
+    [Fact]
+    public void differently_paired_columns_are_not_equal()
+    {
+        var one = new ForeignKey("fk_diff") { LinkedTable = new SqliteObjectName("cfk_parent") };
+        one.LinkColumns("x", "b");
+        one.LinkColumns("y", "a");
+
+        var other = new ForeignKey("fk_diff") { LinkedTable = new SqliteObjectName("cfk_parent") };
+        other.LinkColumns("x", "a");
+        other.LinkColumns("y", "b");
+
+        one.ShouldNotBe(other);
+    }
+
+    [Fact]
+    public void a_single_column_key_is_unaffected()
+    {
+        var one = new ForeignKey("fk_one") { LinkedTable = new SqliteObjectName("cfk_parent") };
+        one.LinkColumns("x", "a");
+
+        var other = new ForeignKey("fk_one") { LinkedTable = new SqliteObjectName("cfk_parent") };
+        other.LinkColumns("x", "a");
+
+        one.ShouldBe(other);
+        one.ColumnNames.ShouldBe(["x"]);
+        one.LinkedNames.ShouldBe(["a"]);
+    }
+}

--- a/src/Weasel.Sqlite.Tests/Tables/composite_primary_key_order.cs
+++ b/src/Weasel.Sqlite.Tests/Tables/composite_primary_key_order.cs
@@ -1,0 +1,214 @@
+using Microsoft.Data.Sqlite;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Sqlite.Tables;
+using Xunit;
+
+namespace Weasel.Sqlite.Tests.Tables;
+
+/// <summary>
+///     <c>pragma_table_xinfo.pk</c> is the column's 1-based position within the primary key, not a
+///     flag. Reading it as a flag returned the key in table column order, so a key declared
+///     <c>PRIMARY KEY (b, a)</c> read back as <c>(a, b)</c> — and on SQLite a key that compares
+///     unequal is repaired by rebuilding the table and copying every row into it.
+/// </summary>
+public class composite_primary_key_order
+{
+    private static async Task<SqliteConnection> openAsync()
+    {
+        var conn = new SqliteConnection($"Data Source={Path.GetTempFileName()};");
+        await conn.OpenAsync();
+        await conn.ResetSchemaAsync("main");
+        return conn;
+    }
+
+    private static async Task executeAsync(SqliteConnection conn, string sql)
+    {
+        var cmd = conn.CreateCommand();
+        cmd.CommandText = sql;
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    [Fact]
+    public async Task declared_key_order_is_read_back_faithfully()
+    {
+        await using var conn = await openAsync();
+        await executeAsync(conn, "create table pk_order (a int not null, b int not null, primary key (b, a))");
+
+        var existing = await new Table("pk_order").FetchExistingAsync(conn);
+
+        existing.ShouldNotBeNull();
+        existing.PrimaryKeyColumns.ShouldBe(["b", "a"]);
+    }
+
+    [Fact]
+    public async Task three_column_key_is_read_back_faithfully()
+    {
+        await using var conn = await openAsync();
+        await executeAsync(conn,
+            "create table pk_three (a int not null, b int not null, c int not null, primary key (c, a, b))");
+
+        var existing = await new Table("pk_three").FetchExistingAsync(conn);
+
+        existing.ShouldNotBeNull();
+        existing.PrimaryKeyColumns.ShouldBe(["c", "a", "b"]);
+    }
+
+    [Fact]
+    public async Task a_key_flagged_out_of_column_order_converges_against_its_own_table()
+    {
+        await using var conn = await openAsync();
+
+        var table = new Table("pk_reversed");
+        var a = table.AddColumn<int>("a");
+        var b = table.AddColumn<int>("b");
+        b.AsPrimaryKey();
+        a.AsPrimaryKey();
+
+        table.PrimaryKeyColumns.ShouldBe(["b", "a"]);
+        await table.CreateAsync(conn);
+
+        var delta = await table.FindDeltaAsync(conn);
+
+        delta.Difference.ShouldBe(SchemaPatchDifference.None);
+        delta.RequiresTableRecreation.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task a_pinned_order_is_read_back_and_converges()
+    {
+        await using var conn = await openAsync();
+
+        var table = new Table("pk_pinned");
+        table.AddColumn<int>("a").AsPrimaryKey();
+        table.AddColumn<int>("b").AsPrimaryKey();
+        table.SetPrimaryKeyOrder(["b", "a"]);
+
+        table.PrimaryKeyColumns.ShouldBe(["b", "a"]);
+        await table.CreateAsync(conn);
+
+        var existing = await table.FetchExistingAsync(conn);
+        existing!.PrimaryKeyColumns.ShouldBe(["b", "a"]);
+
+        var delta = await table.FindDeltaAsync(conn);
+        delta.Difference.ShouldBe(SchemaPatchDifference.None);
+        delta.RequiresTableRecreation.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task a_pin_that_disagrees_with_the_database_is_drift()
+    {
+        await using var conn = await openAsync();
+        await executeAsync(conn, "create table pk_pin_drift (a int not null, b int not null, primary key (a, b))");
+
+        var table = new Table("pk_pin_drift");
+        table.AddColumn<int>("a").AsPrimaryKey();
+        table.AddColumn<int>("b").AsPrimaryKey();
+        table.SetPrimaryKeyOrder(["b", "a"]);
+
+        var delta = await table.FindDeltaAsync(conn);
+
+        delta.PrimaryKeyDifference.ShouldBe(SchemaPatchDifference.Update);
+    }
+
+    /// <summary>
+    ///     Upgrade safety. A key the database declares in an order the model cannot express — the
+    ///     model only ever flags columns — must not start reporting drift, because the repair on
+    ///     SQLite is a full table rebuild.
+    /// </summary>
+    [Fact]
+    public async Task an_unpinned_model_does_not_drift_against_a_reordered_key()
+    {
+        await using var conn = await openAsync();
+        await executeAsync(conn, "create table pk_legacy (a int not null, b int not null, primary key (b, a))");
+
+        var table = new Table("pk_legacy");
+        table.AddColumn<int>("a").AsPrimaryKey();
+        table.AddColumn<int>("b").AsPrimaryKey();
+
+        var delta = await table.FindDeltaAsync(conn);
+
+        delta.PrimaryKeyDifference.ShouldBe(SchemaPatchDifference.None);
+        delta.Difference.ShouldBe(SchemaPatchDifference.None);
+        delta.RequiresTableRecreation.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task a_key_in_declaration_order_still_converges()
+    {
+        await using var conn = await openAsync();
+
+        var table = new Table("pk_plain");
+        table.AddColumn<int>("a").AsPrimaryKey();
+        table.AddColumn<int>("b").AsPrimaryKey();
+        await table.CreateAsync(conn);
+
+        var delta = await table.FindDeltaAsync(conn);
+
+        delta.Difference.ShouldBe(SchemaPatchDifference.None);
+        delta.RequiresTableRecreation.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task a_genuinely_different_key_is_still_drift()
+    {
+        await using var conn = await openAsync();
+        await executeAsync(conn,
+            "create table pk_changed (a int not null, b int not null, c int not null, primary key (a, b))");
+
+        var table = new Table("pk_changed");
+        table.AddColumn<int>("a").AsPrimaryKey();
+        table.AddColumn<int>("b");
+        table.AddColumn<int>("c").AsPrimaryKey();
+
+        var delta = await table.FindDeltaAsync(conn);
+
+        delta.PrimaryKeyDifference.ShouldBe(SchemaPatchDifference.Update);
+    }
+
+    [Fact]
+    public void a_pin_naming_a_column_outside_the_key_is_rejected()
+    {
+        var table = new Table("pk_bad");
+        table.AddColumn<int>("a").AsPrimaryKey();
+        table.AddColumn<int>("b").AsPrimaryKey();
+        table.AddColumn<int>("c");
+
+        Should.Throw<ArgumentException>(() => table.SetPrimaryKeyOrder(["a", "c"]));
+    }
+
+    [Fact]
+    public void a_partial_pin_is_rejected()
+    {
+        var table = new Table("pk_partial");
+        table.AddColumn<int>("a").AsPrimaryKey();
+        table.AddColumn<int>("b").AsPrimaryKey();
+
+        Should.Throw<ArgumentException>(() => table.SetPrimaryKeyOrder(["b"]));
+    }
+
+    [Fact]
+    public void a_pin_that_repeats_a_column_is_rejected()
+    {
+        var table = new Table("pk_dupe");
+        table.AddColumn<int>("a").AsPrimaryKey();
+        table.AddColumn<int>("b").AsPrimaryKey();
+
+        Should.Throw<ArgumentException>(() => table.SetPrimaryKeyOrder(["a", "a"]));
+    }
+
+    [Fact]
+    public void an_empty_pin_clears_the_pin()
+    {
+        var table = new Table("pk_clear");
+        table.AddColumn<int>("a").AsPrimaryKey();
+        table.AddColumn<int>("b").AsPrimaryKey();
+        table.SetPrimaryKeyOrder(["b", "a"]);
+        table.HasExplicitPrimaryKeyOrder.ShouldBeTrue();
+
+        table.SetPrimaryKeyOrder([]);
+
+        table.HasExplicitPrimaryKeyOrder.ShouldBeFalse();
+        table.PrimaryKeyColumns.ShouldBe(["a", "b"]);
+    }
+}

--- a/src/Weasel.Sqlite.Tests/Tables/foreign_key_introspection.cs
+++ b/src/Weasel.Sqlite.Tests/Tables/foreign_key_introspection.cs
@@ -1,0 +1,145 @@
+using Microsoft.Data.Sqlite;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Sqlite.Tables;
+using Xunit;
+
+namespace Weasel.Sqlite.Tests.Tables;
+
+/// <summary>
+///     <c>pragma_foreign_key_list</c> reports <c>to</c> as NULL for a constraint that omits the
+///     referenced column list — <c>REFERENCES parent</c>, the ordinary way to write a foreign key.
+///     Reading that NULL straight out of the reader threw, and it took the whole table read down
+///     with it, not just the foreign key.
+/// </summary>
+public class foreign_key_introspection
+{
+    private static async Task<SqliteConnection> openAsync()
+    {
+        var conn = new SqliteConnection($"Data Source={Path.GetTempFileName()};");
+        await conn.OpenAsync();
+        await conn.ResetSchemaAsync("main");
+        return conn;
+    }
+
+    private static async Task executeAsync(SqliteConnection conn, string sql)
+    {
+        var cmd = conn.CreateCommand();
+        cmd.CommandText = sql;
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    [Fact]
+    public async Task an_implicit_referenced_column_resolves_to_the_parents_primary_key()
+    {
+        await using var conn = await openAsync();
+        await executeAsync(conn, "create table fki_parent (id integer primary key, label text)");
+        await executeAsync(conn,
+            "create table fki_child (id integer primary key, parent_id integer references fki_parent)");
+
+        var existing = await new Table("fki_child").FetchExistingAsync(conn);
+
+        existing.ShouldNotBeNull();
+        var fk = existing.ForeignKeys.ShouldHaveSingleItem();
+        fk.LinkedTable.Name.ShouldBe("fki_parent");
+        fk.ColumnNames.ShouldBe(["parent_id"]);
+        fk.LinkedNames.ShouldBe(["id"]);
+    }
+
+    /// <summary>
+    ///     The read threw before it reached the columns, so a table carrying such a foreign key was
+    ///     unreadable in its entirety.
+    /// </summary>
+    [Fact]
+    public async Task the_rest_of_the_table_is_still_read()
+    {
+        await using var conn = await openAsync();
+        await executeAsync(conn, "create table fki_parent2 (id integer primary key)");
+        await executeAsync(conn,
+            "create table fki_child2 (id integer primary key, note text, parent_id integer references fki_parent2)");
+
+        var existing = await new Table("fki_child2").FetchExistingAsync(conn);
+
+        existing.ShouldNotBeNull();
+        existing.Columns.Select(x => x.Name).ShouldBe(["id", "note", "parent_id"]);
+    }
+
+    [Fact]
+    public async Task an_implicit_reference_to_a_composite_key_pairs_by_key_position()
+    {
+        await using var conn = await openAsync();
+        await executeAsync(conn,
+            "create table fki_ckey (a int not null, b int not null, primary key (b, a))");
+        await executeAsync(conn,
+            "create table fki_cchild (id integer primary key, x int, y int, foreign key (x, y) references fki_ckey)");
+
+        var existing = await new Table("fki_cchild").FetchExistingAsync(conn);
+
+        existing.ShouldNotBeNull();
+        var fk = existing.ForeignKeys.ShouldHaveSingleItem();
+        // The key is declared (b, a), so x pairs with b and y with a.
+        fk.ColumnNames.ShouldBe(["x", "y"]);
+        fk.LinkedNames.ShouldBe(["b", "a"], ignoreOrder: true);
+    }
+
+    [Fact]
+    public async Task a_reference_to_a_table_with_no_primary_key_is_left_out()
+    {
+        await using var conn = await openAsync();
+        await executeAsync(conn, "create table fki_keyless (v text)");
+        await executeAsync(conn,
+            "create table fki_dangling (id integer primary key, v text references fki_keyless)");
+
+        var existing = await new Table("fki_dangling").FetchExistingAsync(conn);
+
+        existing.ShouldNotBeNull();
+        existing.Columns.Select(x => x.Name).ShouldBe(["id", "v"]);
+        existing.ForeignKeys.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task an_explicit_referenced_column_is_still_read()
+    {
+        await using var conn = await openAsync();
+        await executeAsync(conn, "create table fki_parent3 (id integer primary key, code text unique)");
+        await executeAsync(conn,
+            "create table fki_child3 (id integer primary key, parent_code text references fki_parent3(code))");
+
+        var existing = await new Table("fki_child3").FetchExistingAsync(conn);
+
+        existing.ShouldNotBeNull();
+        var fk = existing.ForeignKeys.ShouldHaveSingleItem();
+        fk.ColumnNames.ShouldBe(["parent_code"]);
+        fk.LinkedNames.ShouldBe(["code"]);
+    }
+
+    [Fact]
+    public async Task referential_actions_are_still_read()
+    {
+        await using var conn = await openAsync();
+        await executeAsync(conn, "create table fki_parent4 (id integer primary key)");
+        await executeAsync(conn,
+            "create table fki_child4 (id integer primary key, parent_id integer references fki_parent4 on delete cascade on update set null)");
+
+        var existing = await new Table("fki_child4").FetchExistingAsync(conn);
+
+        var fk = existing!.ForeignKeys.ShouldHaveSingleItem();
+        fk.DeleteAction.ShouldBe(CascadeAction.Cascade);
+        fk.UpdateAction.ShouldBe(CascadeAction.SetNull);
+    }
+
+    [Fact]
+    public async Task several_foreign_keys_are_all_read()
+    {
+        await using var conn = await openAsync();
+        await executeAsync(conn, "create table fki_a (id integer primary key)");
+        await executeAsync(conn, "create table fki_b (id integer primary key)");
+        await executeAsync(conn,
+            "create table fki_multi (id integer primary key, a_id integer references fki_a, b_id integer references fki_b(id))");
+
+        var existing = await new Table("fki_multi").FetchExistingAsync(conn);
+
+        existing!.ForeignKeys.Count.ShouldBe(2);
+        existing.ForeignKeys.Select(x => x.LinkedTable.Name).ShouldBe(["fki_a", "fki_b"], ignoreOrder: true);
+    }
+}

--- a/src/Weasel.Sqlite.Tests/Tables/foreign_key_name_introspection.cs
+++ b/src/Weasel.Sqlite.Tests/Tables/foreign_key_name_introspection.cs
@@ -1,0 +1,140 @@
+using Microsoft.Data.Sqlite;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Sqlite.Tables;
+using Xunit;
+
+namespace Weasel.Sqlite.Tests.Tables;
+
+/// <summary>
+///     <c>pragma_foreign_key_list</c> has no name column, so the introspection made one up:
+///     <c>fk_{table}_{reftable}_{id}</c>. Every foreign key Weasel itself had written therefore read
+///     back under a name the model did not have — the delta saw one constraint missing and one
+///     extra, and on SQLite that is repaired by rebuilding the table and copying every row. The read
+///     could never converge, so it happened on every run.
+/// </summary>
+public class foreign_key_name_introspection
+{
+    private static async Task<SqliteConnection> openAsync()
+    {
+        var conn = new SqliteConnection($"Data Source={Path.GetTempFileName()};");
+        await conn.OpenAsync();
+        await conn.ResetSchemaAsync("main");
+        return conn;
+    }
+
+    private static async Task executeAsync(SqliteConnection conn, string sql)
+    {
+        var cmd = conn.CreateCommand();
+        cmd.CommandText = sql;
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private static async Task<Table> parentAsync(SqliteConnection conn, string name)
+    {
+        var parent = new Table(name);
+        parent.AddColumn<int>("id").AsPrimaryKey();
+        await parent.CreateAsync(conn);
+        return parent;
+    }
+
+    private static Table childWith(string name, string fkName, string parentName)
+    {
+        var child = new Table(name);
+        child.AddColumn<int>("id").AsPrimaryKey();
+        child.AddColumn<int>("parent_id");
+
+        var fk = new ForeignKey(fkName) { LinkedTable = new SqliteObjectName(parentName) };
+        fk.LinkColumns("parent_id", "id");
+        child.ForeignKeys.Add(fk);
+
+        return child;
+    }
+
+    [Fact]
+    public async Task the_declared_constraint_name_is_read_back()
+    {
+        await using var conn = await openAsync();
+        await parentAsync(conn, "fkn_customers");
+
+        var child = childWith("fkn_orders", "fk_orders_to_customers", "fkn_customers");
+        await child.CreateAsync(conn);
+
+        var existing = await child.FetchExistingAsync(conn);
+
+        existing!.ForeignKeys.ShouldHaveSingleItem().Name.ShouldBe("fk_orders_to_customers");
+    }
+
+    [Fact]
+    public async Task a_table_with_a_named_foreign_key_converges()
+    {
+        await using var conn = await openAsync();
+        await parentAsync(conn, "fkn_customers2");
+
+        var child = childWith("fkn_orders2", "fk_orders_to_customers", "fkn_customers2");
+        await child.CreateAsync(conn);
+
+        var delta = await child.FindDeltaAsync(conn);
+
+        delta.Difference.ShouldBe(SchemaPatchDifference.None);
+        delta.RequiresTableRecreation.ShouldBeFalse();
+        delta.ForeignKeys.Missing.ShouldBeEmpty();
+        delta.ForeignKeys.Extras.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task several_named_foreign_keys_keep_their_own_names()
+    {
+        await using var conn = await openAsync();
+        await parentAsync(conn, "fkn_a");
+        await parentAsync(conn, "fkn_b");
+
+        var child = new Table("fkn_two");
+        child.AddColumn<int>("id").AsPrimaryKey();
+        child.AddColumn<int>("a_id");
+        child.AddColumn<int>("b_id");
+
+        var toA = new ForeignKey("fk_two_a") { LinkedTable = new SqliteObjectName("fkn_a") };
+        toA.LinkColumns("a_id", "id");
+        var toB = new ForeignKey("fk_two_b") { LinkedTable = new SqliteObjectName("fkn_b") };
+        toB.LinkColumns("b_id", "id");
+        child.ForeignKeys.Add(toA);
+        child.ForeignKeys.Add(toB);
+
+        await child.CreateAsync(conn);
+
+        var existing = await child.FetchExistingAsync(conn);
+
+        existing!.ForeignKeys.Select(x => x.Name).ShouldBe(["fk_two_a", "fk_two_b"], ignoreOrder: true);
+        (await child.FindDeltaAsync(conn)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task a_renamed_constraint_is_still_drift()
+    {
+        await using var conn = await openAsync();
+        await parentAsync(conn, "fkn_customers3");
+
+        await childWith("fkn_orders3", "fk_the_old_name", "fkn_customers3").CreateAsync(conn);
+
+        var delta = await childWith("fkn_orders3", "fk_the_new_name", "fkn_customers3").FindDeltaAsync(conn);
+
+        delta.Difference.ShouldNotBe(SchemaPatchDifference.None);
+    }
+
+    /// <summary>
+    ///     An inline <c>REFERENCES</c> has no name in the DDL to read, so the synthesised one stands.
+    /// </summary>
+    [Fact]
+    public async Task an_unnamed_constraint_keeps_the_synthesised_name()
+    {
+        await using var conn = await openAsync();
+        await executeAsync(conn, "create table fkn_parent4 (id integer primary key)");
+        await executeAsync(conn,
+            "create table fkn_child4 (id integer primary key, parent_id integer references fkn_parent4(id))");
+
+        var existing = await new Table("fkn_child4").FetchExistingAsync(conn);
+
+        existing!.ForeignKeys.ShouldHaveSingleItem().Name.ShouldBe("fk_fkn_child4_fkn_parent4_0");
+    }
+}

--- a/src/Weasel.Sqlite.Tests/Tables/table_shape_introspection.cs
+++ b/src/Weasel.Sqlite.Tests/Tables/table_shape_introspection.cs
@@ -1,0 +1,182 @@
+using JasperFx;
+using Microsoft.Data.Sqlite;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Sqlite.Tables;
+using Xunit;
+
+namespace Weasel.Sqlite.Tests.Tables;
+
+/// <summary>
+///     <c>STRICT</c>, <c>WITHOUT ROWID</c> and <c>AUTOINCREMENT</c> live only in the stored
+///     <c>CREATE TABLE</c> text — no pragma reports them — and the introspection fetched that text
+///     and then discarded it. On SQLite that is not merely a lossy read: changing a column rebuilds
+///     the table from the model, and the rebuild dropped the two table options even when the model
+///     it was building from still declared them.
+/// </summary>
+public class table_shape_introspection
+{
+    private static async Task<SqliteConnection> openAsync()
+    {
+        var conn = new SqliteConnection($"Data Source={Path.GetTempFileName()};");
+        await conn.OpenAsync();
+        await conn.ResetSchemaAsync("main");
+        return conn;
+    }
+
+    private static async Task executeAsync(SqliteConnection conn, string sql)
+    {
+        var cmd = conn.CreateCommand();
+        cmd.CommandText = sql;
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private static async Task<string> tableSqlAsync(SqliteConnection conn, string name)
+    {
+        var cmd = conn.CreateCommand();
+        cmd.CommandText = $"select sql from sqlite_master where type = 'table' and name = '{name}'";
+        return (string)(await cmd.ExecuteScalarAsync())!;
+    }
+
+    [Fact]
+    public async Task autoincrement_is_read_back()
+    {
+        await using var conn = await openAsync();
+        await executeAsync(conn, "create table shape_ai (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)");
+
+        var existing = await new Table("shape_ai").FetchExistingAsync(conn);
+
+        existing!.ColumnFor("id")!.IsAutoNumber.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task a_plain_integer_key_is_not_reported_as_autoincrement()
+    {
+        await using var conn = await openAsync();
+        await executeAsync(conn, "create table shape_plain (id INTEGER PRIMARY KEY, name TEXT)");
+
+        var existing = await new Table("shape_plain").FetchExistingAsync(conn);
+
+        existing!.ColumnFor("id")!.IsAutoNumber.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task strict_and_without_rowid_are_read_back()
+    {
+        await using var conn = await openAsync();
+        await executeAsync(conn,
+            "create table shape_sr (id INTEGER NOT NULL, v TEXT, PRIMARY KEY (id)) WITHOUT ROWID, STRICT");
+
+        var existing = await new Table("shape_sr").FetchExistingAsync(conn);
+
+        existing!.WithoutRowId.ShouldBeTrue();
+        existing.StrictTypes.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task an_ordinary_table_reports_neither()
+    {
+        await using var conn = await openAsync();
+        await executeAsync(conn, "create table shape_ordinary (id INTEGER PRIMARY KEY, v TEXT)");
+
+        var existing = await new Table("shape_ordinary").FetchExistingAsync(conn);
+
+        existing!.WithoutRowId.ShouldBeFalse();
+        existing.StrictTypes.ShouldBeFalse();
+    }
+
+    /// <summary>
+    ///     A CHECK constraint puts parentheses inside the column list, so the table options have to
+    ///     be looked for past the column list's own closing paren, not past the last one.
+    /// </summary>
+    [Fact]
+    public async Task a_check_constraint_does_not_hide_the_table_options()
+    {
+        await using var conn = await openAsync();
+        await executeAsync(conn,
+            "create table shape_check (id INTEGER NOT NULL, qty INT CHECK (qty > (0)), PRIMARY KEY (id)) WITHOUT ROWID");
+
+        var existing = await new Table("shape_check").FetchExistingAsync(conn);
+
+        existing!.WithoutRowId.ShouldBeTrue();
+        existing.StrictTypes.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task rebuilding_a_strict_table_keeps_it_strict()
+    {
+        await using var conn = await openAsync();
+
+        var table = new Table("shape_rebuild") { StrictTypes = true };
+        table.AddColumn("id", "INTEGER").AsPrimaryKey();
+        table.AddColumn("qty", "INTEGER");
+        await table.CreateAsync(conn);
+
+        var changed = new Table("shape_rebuild") { StrictTypes = true };
+        changed.AddColumn("id", "INTEGER").AsPrimaryKey();
+        changed.AddColumn("qty", "TEXT");
+
+        var migration = await SchemaMigration.DetermineAsync(conn, CancellationToken.None, changed);
+        await new SqliteMigrator().ApplyAllAsync(conn, migration, AutoCreate.All);
+
+        (await tableSqlAsync(conn, "shape_rebuild")).ShouldContain("STRICT");
+        (await changed.FetchExistingAsync(conn))!.StrictTypes.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task rebuilding_a_without_rowid_table_keeps_it_without_rowid()
+    {
+        await using var conn = await openAsync();
+
+        var table = new Table("shape_rebuild2") { WithoutRowId = true };
+        table.AddColumn("id", "TEXT").AsPrimaryKey();
+        table.AddColumn("qty", "INTEGER");
+        await table.CreateAsync(conn);
+
+        var changed = new Table("shape_rebuild2") { WithoutRowId = true };
+        changed.AddColumn("id", "TEXT").AsPrimaryKey();
+        changed.AddColumn("qty", "TEXT");
+
+        var migration = await SchemaMigration.DetermineAsync(conn, CancellationToken.None, changed);
+        await new SqliteMigrator().ApplyAllAsync(conn, migration, AutoCreate.All);
+
+        (await tableSqlAsync(conn, "shape_rebuild2")).ShouldContain("WITHOUT ROWID");
+        (await changed.FetchExistingAsync(conn))!.WithoutRowId.ShouldBeTrue();
+    }
+
+    /// <summary>
+    ///     Upgrade safety: neither option is part of the comparison, so reading them cannot start
+    ///     reporting drift on a table that was already converged.
+    /// </summary>
+    [Fact]
+    public async Task reading_the_shape_does_not_introduce_drift()
+    {
+        await using var conn = await openAsync();
+
+        var table = new Table("shape_converge") { StrictTypes = true };
+        table.AddColumn("id", "INTEGER").AsPrimaryKey();
+        table.AddColumn("qty", "INTEGER");
+        await table.CreateAsync(conn);
+
+        var delta = await table.FindDeltaAsync(conn);
+
+        delta.Difference.ShouldBe(SchemaPatchDifference.None);
+        delta.RequiresTableRecreation.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task an_autoincrement_table_still_converges()
+    {
+        await using var conn = await openAsync();
+
+        var table = new Table("shape_ai2");
+        table.AddColumn("id", "INTEGER").AsPrimaryKey().AutoIncrement();
+        table.AddColumn<string>("name");
+        await table.CreateAsync(conn);
+
+        var delta = await table.FindDeltaAsync(conn);
+
+        delta.Difference.ShouldBe(SchemaPatchDifference.None);
+        delta.RequiresTableRecreation.ShouldBeFalse();
+    }
+}

--- a/src/Weasel.Sqlite/Tables/ForeignKey.cs
+++ b/src/Weasel.Sqlite/Tables/ForeignKey.cs
@@ -12,17 +12,63 @@ public class ForeignKey: ForeignKeyBase
     {
     }
 
+    /// <summary>
+    ///     Declaration order, not sorted order. A foreign key pairs its columns positionally, so
+    ///     sorting the two lists independently -- which is what these did -- repaired the ordering
+    ///     by destroying the pairing: a key declared <c>(x, y) REFERENCES parent (b, a)</c> became
+    ///     <c>(x, y) REFERENCES parent (a, b)</c>, a constraint over different columns entirely.
+    ///     The sort was standing in for order-insensitive comparison, which <see cref="Equals" />
+    ///     now does properly by comparing the pairs.
+    /// </summary>
     public override string[] ColumnNames
     {
         get => _columnNames;
-        set => _columnNames = value.OrderBy(x => x).ToArray();
+        set => _columnNames = value.ToArray();
     }
 
+    /// <inheritdoc cref="ColumnNames" />
     public override string[] LinkedNames
     {
         get => _linkedNames;
-        set => _linkedNames = value.OrderBy(x => x).ToArray();
+        set => _linkedNames = value.ToArray();
     }
+
+    /// <summary>
+    ///     The pairing, not the order the pairs are written in, is what defines the constraint.
+    ///     Comparing the two lists positionally would report drift on a key the caller merely wrote
+    ///     in another order and "fix" it by rebuilding the table.
+    /// </summary>
+    private bool SamePairs(ForeignKey other)
+    {
+        if (ColumnNames.Length != other.ColumnNames.Length ||
+            LinkedNames.Length != other.LinkedNames.Length ||
+            ColumnNames.Length != LinkedNames.Length)
+        {
+            return false;
+        }
+
+        IEnumerable<string> pairs(ForeignKey fk)
+            => fk.ColumnNames.Zip(fk.LinkedNames, (column, linked) => $"{column}\u0000{linked}")
+                .OrderBy(x => x, ColumnComparer);
+
+        return pairs(this).SequenceEqual(pairs(other), ColumnComparer);
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is not ForeignKey other)
+        {
+            return base.Equals(obj);
+        }
+
+        return base.Equals(obj) || (NameComparer.Equals(Name, other.Name)
+                                    && Equals(LinkedTable, other.LinkedTable)
+                                    && DeleteAction == other.DeleteAction
+                                    && UpdateAction == other.UpdateAction
+                                    && SamePairs(other));
+    }
+
+    public override int GetHashCode() => base.GetHashCode();
 
     /// <inheritdoc />
     protected override StringComparer NameComparer => StringComparer.OrdinalIgnoreCase;

--- a/src/Weasel.Sqlite/Tables/Table.FetchExisting.cs
+++ b/src/Weasel.Sqlite/Tables/Table.FetchExisting.cs
@@ -26,7 +26,7 @@ SELECT name, sql FROM sqlite_master
 WHERE type = 'index' AND tbl_name = '{sanitizedName}' AND sql IS NOT NULL;
 
 -- Get foreign key information (PRAGMA doesn't support parameter binding)
-SELECT * FROM pragma_foreign_key_list('{sanitizedName}');
+{ForeignKeyQuery(sanitizedName)}
 
 -- Get the triggers on this table. Not because the table owns them -- it does not, see
 -- TriggerBase -- but because DROP TABLE takes them with it, and this table may have to be
@@ -52,6 +52,31 @@ WHERE type = 'trigger' AND tbl_name = '{sanitizedName}' AND sql IS NOT NULL;
     /// <c>table_info</c> never showed us and which we have no business reporting as a real column.
     /// </para>
     /// </summary>
+    /// <summary>
+    /// The foreign key introspection query, shared by <see cref="ConfigureQueryCommand" /> and
+    /// <see cref="FetchExistingAsync" /> so the two can never drift apart.
+    /// <para>
+    /// <c>pragma_foreign_key_list</c> reports <c>to</c> as NULL when the constraint omits the
+    /// referenced column list -- <c>REFERENCES parent</c> rather than <c>REFERENCES parent (id)</c>.
+    /// That is not "no target": the target is the referenced table's primary key, positionally, and
+    /// <c>pragma_table_info.pk</c> is where that order lives. Reading the NULL straight out of the
+    /// reader threw and took the whole table read down with it.
+    /// </para>
+    /// <para>
+    /// The columns are projected explicitly, in <c>foreign_key_list</c>'s own order, because
+    /// <see cref="readForeignKeysAsync" /> reads them positionally. The ORDER BY is what makes a
+    /// composite key's column pairing reproducible; the pragma promises no row order of its own.
+    /// </para>
+    /// </summary>
+    private static string ForeignKeyQuery(string sanitizedName) =>
+        $"""
+         SELECT fk.id, fk.seq, fk."table", fk."from",
+                COALESCE(fk."to", (SELECT pk.name FROM pragma_table_info(fk."table") pk WHERE pk.pk = fk.seq + 1)),
+                fk.on_update, fk.on_delete
+         FROM pragma_foreign_key_list('{sanitizedName}') fk
+         ORDER BY fk.id, fk.seq;
+         """;
+
     private static string ColumnQuery(string sanitizedName) =>
         $"""SELECT cid, name, type, "notnull", dflt_value, pk FROM pragma_table_xinfo('{sanitizedName}') WHERE hidden <> 1;""";
 
@@ -74,7 +99,7 @@ SELECT name, sql FROM sqlite_master
 WHERE type = 'index' AND tbl_name = '{tableName}' AND sql IS NOT NULL;
 
 -- Get foreign key information
-SELECT * FROM pragma_foreign_key_list('{tableName}');
+{ForeignKeyQuery(tableName)}
 
 -- Get the triggers on this table (see ConfigureQueryCommand)
 SELECT sql FROM sqlite_master
@@ -240,18 +265,27 @@ WHERE type = 'trigger' AND tbl_name = '{tableName}' AND sql IS NOT NULL;
 
     private async Task readForeignKeysAsync(DbDataReader reader, Table existing, CancellationToken ct = default)
     {
-        // PRAGMA foreign_key_list returns: id, seq, table, from, to, on_update, on_delete, match
+        // ForeignKeyQuery projects: id, seq, table, from, to, on_update, on_delete
         var foreignKeyGroups = new Dictionary<long, ForeignKey>();
 
         while (await reader.ReadAsync(ct).ConfigureAwait(false))
         {
             var id = await reader.GetFieldValueAsync<long>(0, ct).ConfigureAwait(false);
-            var seq = await reader.GetFieldValueAsync<long>(1, ct).ConfigureAwait(false);
             var table = await reader.GetFieldValueAsync<string>(2, ct).ConfigureAwait(false);
             var from = await reader.GetFieldValueAsync<string>(3, ct).ConfigureAwait(false);
-            var to = await reader.GetFieldValueAsync<string>(4, ct).ConfigureAwait(false);
             var onUpdate = await reader.GetFieldValueAsync<string>(5, ct).ConfigureAwait(false);
             var onDelete = await reader.GetFieldValueAsync<string>(6, ct).ConfigureAwait(false);
+
+            // Still NULL after ForeignKeyQuery's COALESCE means the referenced table declares no
+            // primary key at all, which SQLite accepts at CREATE time and then rejects on every
+            // write as "foreign key mismatch". There is no column to report, and inventing one
+            // would put a constraint into the read model that the database does not have.
+            if (await reader.IsDBNullAsync(4, ct).ConfigureAwait(false))
+            {
+                continue;
+            }
+
+            var to = await reader.GetFieldValueAsync<string>(4, ct).ConfigureAwait(false);
 
             if (!foreignKeyGroups.TryGetValue(id, out var fk))
             {

--- a/src/Weasel.Sqlite/Tables/Table.FetchExisting.cs
+++ b/src/Weasel.Sqlite/Tables/Table.FetchExisting.cs
@@ -172,7 +172,10 @@ WHERE type = 'trigger' AND tbl_name = '{tableName}' AND sql IS NOT NULL;
 
     private async Task readColumnsAsync(DbDataReader reader, Table existing, CancellationToken ct = default)
     {
-        var primaryKeys = new List<string>();
+        // pragma_table_xinfo's pk is the column's 1-based position within the primary key, not a
+        // flag, and the rows arrive in declaration order. Reading it as a flag reported
+        // PRIMARY KEY (b, a) on a table declared (a, b) as the key (a, b).
+        var primaryKeys = new List<(long Position, string Name)>();
 
         // ColumnQuery projects: cid, name, type, notnull, dflt_value, pk
         while (await reader.ReadAsync(ct).ConfigureAwait(false))
@@ -195,7 +198,7 @@ WHERE type = 'trigger' AND tbl_name = '{tableName}' AND sql IS NOT NULL;
 
             if (pk > 0)
             {
-                primaryKeys.Add(name);
+                primaryKeys.Add((pk, name));
             }
 
             existing._columns.Add(column);
@@ -203,7 +206,7 @@ WHERE type = 'trigger' AND tbl_name = '{tableName}' AND sql IS NOT NULL;
 
         if (primaryKeys.Any())
         {
-            existing.ReadPrimaryKeyColumns(primaryKeys);
+            existing.ReadPrimaryKeyColumns(primaryKeys.OrderBy(x => x.Position).Select(x => x.Name).ToList());
         }
 
         await reader.NextResultAsync(ct).ConfigureAwait(false);

--- a/src/Weasel.Sqlite/Tables/Table.FetchExisting.cs
+++ b/src/Weasel.Sqlite/Tables/Table.FetchExisting.cs
@@ -146,6 +146,8 @@ WHERE type = 'trigger' AND tbl_name = '{tableName}' AND sql IS NOT NULL;
         // Read columns (second result set)
         await readColumnsAsync(reader, existing, ct).ConfigureAwait(false);
 
+        readTableShape(existing, tableSql);
+
         // Read indexes (third result set)
         await readIndexesAsync(reader, existing, ct).ConfigureAwait(false);
 
@@ -264,6 +266,55 @@ WHERE type = 'trigger' AND tbl_name = '{tableName}' AND sql IS NOT NULL;
 
         await reader.NextResultAsync(ct).ConfigureAwait(false);
     }
+
+    /// <summary>
+    ///     Read the parts of a table that no pragma reports: <c>STRICT</c>, <c>WITHOUT ROWID</c> and
+    ///     <c>AUTOINCREMENT</c>. They live only in the stored <c>CREATE TABLE</c> text.
+    /// </summary>
+    /// <remarks>
+    ///     <c>AUTOINCREMENT</c> is matched against the whole statement rather than per column
+    ///     because SQLite allows it on exactly one column -- the sole <c>INTEGER PRIMARY KEY</c> --
+    ///     so there is never a second candidate to confuse it with, and no column declaration has to
+    ///     be parsed to find it.
+    /// </remarks>
+    private static void readTableShape(Table existing, string? tableSql)
+    {
+        if (string.IsNullOrWhiteSpace(tableSql))
+        {
+            return;
+        }
+
+        var open = tableSql.IndexOf('(');
+        if (open >= 0)
+        {
+            var close = findMatchingParen(tableSql, open);
+            if (close >= 0)
+            {
+                var options = tableSql[(close + 1)..];
+                existing.WithoutRowId = _withoutRowId.IsMatch(options);
+                existing.StrictTypes = _strict.IsMatch(options);
+            }
+        }
+
+        if (!_autoIncrement.IsMatch(tableSql) || existing.PrimaryKeyColumns.Count != 1)
+        {
+            return;
+        }
+
+        var key = existing.Columns.FirstOrDefault(x => x.IsPrimaryKey && x.Type.EqualsIgnoreCase("INTEGER"));
+        if (key != null)
+        {
+            key.IsAutoNumber = true;
+        }
+    }
+
+    private static readonly Regex _withoutRowId =
+        new(@"\bWITHOUT\s+ROWID\b", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+    private static readonly Regex _strict = new(@"\bSTRICT\b", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+    private static readonly Regex _autoIncrement =
+        new(@"\bAUTOINCREMENT\b", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
 
     private async Task readForeignKeysAsync(DbDataReader reader, Table existing, string? tableSql,
         CancellationToken ct = default)

--- a/src/Weasel.Sqlite/Tables/Table.FetchExisting.cs
+++ b/src/Weasel.Sqlite/Tables/Table.FetchExisting.cs
@@ -1,4 +1,6 @@
 using System.Data.Common;
+using System.Text.RegularExpressions;
+using JasperFx.Core;
 using Microsoft.Data.Sqlite;
 using Weasel.Core;
 using DbCommandBuilder = Weasel.Core.DbCommandBuilder;
@@ -148,7 +150,7 @@ WHERE type = 'trigger' AND tbl_name = '{tableName}' AND sql IS NOT NULL;
         await readIndexesAsync(reader, existing, ct).ConfigureAwait(false);
 
         // Read foreign keys (fourth result set)
-        await readForeignKeysAsync(reader, existing, ct).ConfigureAwait(false);
+        await readForeignKeysAsync(reader, existing, tableSql, ct).ConfigureAwait(false);
 
         // Read the triggers on this table (fifth result set)
         await reader.NextResultAsync(ct).ConfigureAwait(false);
@@ -263,19 +265,14 @@ WHERE type = 'trigger' AND tbl_name = '{tableName}' AND sql IS NOT NULL;
         await reader.NextResultAsync(ct).ConfigureAwait(false);
     }
 
-    private async Task readForeignKeysAsync(DbDataReader reader, Table existing, CancellationToken ct = default)
+    private async Task readForeignKeysAsync(DbDataReader reader, Table existing, string? tableSql,
+        CancellationToken ct = default)
     {
         // ForeignKeyQuery projects: id, seq, table, from, to, on_update, on_delete
-        var foreignKeyGroups = new Dictionary<long, ForeignKey>();
+        var rows = new List<(long Id, string Table, string From, string To, string OnUpdate, string OnDelete)>();
 
         while (await reader.ReadAsync(ct).ConfigureAwait(false))
         {
-            var id = await reader.GetFieldValueAsync<long>(0, ct).ConfigureAwait(false);
-            var table = await reader.GetFieldValueAsync<string>(2, ct).ConfigureAwait(false);
-            var from = await reader.GetFieldValueAsync<string>(3, ct).ConfigureAwait(false);
-            var onUpdate = await reader.GetFieldValueAsync<string>(5, ct).ConfigureAwait(false);
-            var onDelete = await reader.GetFieldValueAsync<string>(6, ct).ConfigureAwait(false);
-
             // Still NULL after ForeignKeyQuery's COALESCE means the referenced table declares no
             // primary key at all, which SQLite accepts at CREATE time and then rejects on every
             // write as "foreign key mismatch". There is no column to report, and inventing one
@@ -285,22 +282,93 @@ WHERE type = 'trigger' AND tbl_name = '{tableName}' AND sql IS NOT NULL;
                 continue;
             }
 
-            var to = await reader.GetFieldValueAsync<string>(4, ct).ConfigureAwait(false);
+            rows.Add((
+                await reader.GetFieldValueAsync<long>(0, ct).ConfigureAwait(false),
+                await reader.GetFieldValueAsync<string>(2, ct).ConfigureAwait(false),
+                await reader.GetFieldValueAsync<string>(3, ct).ConfigureAwait(false),
+                await reader.GetFieldValueAsync<string>(4, ct).ConfigureAwait(false),
+                await reader.GetFieldValueAsync<string>(5, ct).ConfigureAwait(false),
+                await reader.GetFieldValueAsync<string>(6, ct).ConfigureAwait(false)));
+        }
 
-            if (!foreignKeyGroups.TryGetValue(id, out var fk))
+        var declaredNames = declaredForeignKeyNames(tableSql);
+
+        foreach (var group in rows.GroupBy(x => x.Id))
+        {
+            var first = group.First();
+            var columns = group.Select(x => x.From).ToArray();
+
+            var fk = new ForeignKey(
+                takeDeclaredName(declaredNames, first.Table, columns)
+                ?? $"fk_{existing.Identifier.Name}_{first.Table}_{first.Id}")
             {
-                fk = new ForeignKey($"fk_{existing.Identifier.Name}_{table}_{id}")
-                {
-                    LinkedTable = new SqliteObjectName(table)
-                };
-                fk.ReadReferentialActions(onDelete, onUpdate);
-                foreignKeyGroups[id] = fk;
-                existing.ForeignKeys.Add(fk);
+                LinkedTable = new SqliteObjectName(first.Table)
+            };
+
+            fk.ReadReferentialActions(first.OnDelete, first.OnUpdate);
+
+            foreach (var row in group)
+            {
+                fk.LinkColumns(row.From, row.To);
             }
 
-            fk.LinkColumns(from, to);
+            existing.ForeignKeys.Add(fk);
         }
     }
+
+    private static readonly Regex _declaredForeignKey = new(
+        """CONSTRAINT\s+(?<name>"(?:[^"]|"")*"|\[[^\]]*\]|`(?:[^`]|``)*`|[A-Za-z_][A-Za-z0-9_$]*)\s+FOREIGN\s+KEY\s*\(\s*(?<columns>[^)]*)\)\s*REFERENCES\s+(?<table>"(?:[^"]|"")*"|\[[^\]]*\]|`(?:[^`]|``)*`|[A-Za-z_][A-Za-z0-9_$]*)""",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+    /// <summary>
+    ///     The names the table declares for its foreign keys, keyed by what identifies a constraint
+    ///     in <c>pragma_foreign_key_list</c>: the referenced table and the dependent columns.
+    /// </summary>
+    /// <remarks>
+    ///     <c>pragma_foreign_key_list</c> has no name column at all, so the name has to come from the
+    ///     stored <c>CREATE TABLE</c> text or not at all. Synthesising one instead meant every
+    ///     foreign key Weasel itself had written read back under a name the model did not have: the
+    ///     delta saw one constraint missing and one extra, and on SQLite that is repaired by
+    ///     rebuilding the table -- on every run, forever, because the read could never converge.
+    ///     <para>
+    ///     Keyed rather than positional because the pragma promises no correspondence between its
+    ///     row order and declaration order, and because a constraint can also be written inline on
+    ///     the column, where it has no name to find.
+    ///     </para>
+    /// </remarks>
+    private static Dictionary<string, Queue<string>> declaredForeignKeyNames(string? tableSql)
+    {
+        var names = new Dictionary<string, Queue<string>>(StringComparer.OrdinalIgnoreCase);
+        if (string.IsNullOrWhiteSpace(tableSql))
+        {
+            return names;
+        }
+
+        foreach (Match match in _declaredForeignKey.Matches(tableSql))
+        {
+            var columns = match.Groups["columns"].Value.ToDelimitedArray(',');
+            var key = foreignKeyKey(SchemaUtils.Unquote(match.Groups["table"].Value), columns);
+
+            if (!names.TryGetValue(key, out var queue))
+            {
+                queue = new Queue<string>();
+                names[key] = queue;
+            }
+
+            queue.Enqueue(SchemaUtils.Unquote(match.Groups["name"].Value));
+        }
+
+        return names;
+    }
+
+    private static string foreignKeyKey(string linkedTable, IEnumerable<string> columns)
+        => $"{SchemaUtils.Unquote(linkedTable)}\u0000{columns.Select(x => SchemaUtils.Unquote(x.Trim())).Join("\u0000")}";
+
+    private static string? takeDeclaredName(Dictionary<string, Queue<string>> declaredNames, string linkedTable,
+        IEnumerable<string> columns)
+        => declaredNames.TryGetValue(foreignKeyKey(linkedTable, columns), out var queue) && queue.Count > 0
+            ? queue.Dequeue()
+            : null;
 
     private IndexDefinition ParseIndexFromSql(string indexName, string sql)
     {

--- a/src/Weasel.Sqlite/Tables/Table.cs
+++ b/src/Weasel.Sqlite/Tables/Table.cs
@@ -14,6 +14,8 @@ public partial class Table: TableBase<TableColumn, IndexDefinition, ForeignKey>
 
     internal readonly List<string> _primaryKeyColumns = new();
 
+    private string[]? _primaryKeyOrder;
+
     public Table(DbObjectName name)
         : base(name ?? throw new ArgumentNullException(nameof(name)))
     {
@@ -24,7 +26,85 @@ public partial class Table: TableBase<TableColumn, IndexDefinition, ForeignKey>
     }
 
     /// <inheritdoc />
-    public override IReadOnlyList<string> PrimaryKeyColumns => _primaryKeyColumns;
+    public override IReadOnlyList<string> PrimaryKeyColumns => orderedPrimaryKeyColumns();
+
+    /// <summary>
+    ///     Whether the key's column order was pinned with <see cref="SetPrimaryKeyOrder" />, rather
+    ///     than taken from the order the columns were flagged in.
+    /// </summary>
+    public bool HasExplicitPrimaryKeyOrder => _primaryKeyOrder != null;
+
+    private IReadOnlyList<string> orderedPrimaryKeyColumns()
+    {
+        var pinned = _primaryKeyOrder;
+        if (pinned == null)
+        {
+            return _primaryKeyColumns;
+        }
+
+        // The pin ORDERS the flagged set rather than replacing it, so flagging or removing a column
+        // afterwards still takes effect and a pin naming a since-dropped column cannot resurrect it.
+        return _primaryKeyColumns
+            .OrderBy(name =>
+            {
+                for (var i = 0; i < pinned.Length; i++)
+                {
+                    if (string.Equals(pinned[i], name, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return i;
+                    }
+                }
+
+                return int.MaxValue;
+            })
+            .ToList();
+    }
+
+    /// <summary>
+    ///     Pin the primary key's column order explicitly, rather than taking the order the columns
+    ///     were flagged in. Passing an empty list clears the pin.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    ///     The list repeats a column, names one that is not part of the primary key, or covers only
+    ///     part of it.
+    /// </exception>
+    public void SetPrimaryKeyOrder(IEnumerable<string> columnNames)
+    {
+        var ordered = columnNames.ToArray();
+        if (ordered.Length == 0)
+        {
+            _primaryKeyOrder = null;
+            return;
+        }
+
+        var duplicates = ordered.GroupBy(x => x, StringComparer.OrdinalIgnoreCase)
+            .Where(g => g.Count() > 1).Select(g => g.Key).ToArray();
+        if (duplicates.Any())
+        {
+            throw new ArgumentException(
+                $"Primary key order for {Identifier} repeats {duplicates.Join(", ")}.", nameof(columnNames));
+        }
+
+        var keyColumns = _primaryKeyColumns.ToArray();
+        var unknown = ordered.Where(x => !keyColumns.Contains(x, StringComparer.OrdinalIgnoreCase)).ToArray();
+        if (unknown.Any())
+        {
+            throw new ArgumentException(
+                $"Primary key order for {Identifier} names {unknown.Join(", ")}, which is not part of the key. The key is: {(keyColumns.Any() ? keyColumns.Join(", ") : "(no columns flagged as primary key)")}.",
+                nameof(columnNames));
+        }
+
+        // A partial pin would still opt the table into strict order comparison, silently reordering
+        // the columns it does not name. An order is only meaningful for the whole key.
+        if (ordered.Length != keyColumns.Length)
+        {
+            throw new ArgumentException(
+                $"Primary key order for {Identifier} lists {ordered.Length} of {keyColumns.Length} key columns. Name every column of the key, in order. The key is: {keyColumns.Join(", ")}.",
+                nameof(columnNames));
+        }
+
+        _primaryKeyOrder = ordered;
+    }
 
     /// <inheritdoc />
     /// <remarks>SQLite spells the auto-PK constraint name as <c>pk_{tableName}</c>.</remarks>

--- a/src/Weasel.Sqlite/Tables/TableDelta.cs
+++ b/src/Weasel.Sqlite/Tables/TableDelta.cs
@@ -335,8 +335,10 @@ public class TableDelta: SchemaObjectDelta<Table>, ISchemaObjectDeltaWithRebuild
         writer.WriteLine("-- Table recreation required due to SQLite ALTER TABLE limitations");
         writer.WriteLine();
 
-        // Create new table with temp name
-        var tempTable = new Table(tempName);
+        // Create new table with temp name. STRICT and WITHOUT ROWID are part of what the table
+        // IS, not decoration -- a rebuild that leaves them off silently returns the table to type
+        // affinity and to a rowid it was defined without.
+        var tempTable = new Table(tempName) { StrictTypes = Expected.StrictTypes, WithoutRowId = Expected.WithoutRowId };
         foreach (var column in Expected.Columns)
         {
             tempTable.AddColumn(column);
@@ -532,7 +534,7 @@ public class TableDelta: SchemaObjectDelta<Table>, ISchemaObjectDeltaWithRebuild
         writer.WriteLine();
 
         // Create temp table with actual (old) schema
-        var tempTable = new Table(tempName);
+        var tempTable = new Table(tempName) { StrictTypes = Actual.StrictTypes, WithoutRowId = Actual.WithoutRowId };
         foreach (var column in Actual.Columns)
         {
             tempTable.AddColumn(column);

--- a/src/Weasel.Sqlite/Tables/TableDelta.cs
+++ b/src/Weasel.Sqlite/Tables/TableDelta.cs
@@ -46,6 +46,17 @@ public class TableDelta: SchemaObjectDelta<Table>, ISchemaObjectDeltaWithRebuild
     public SchemaPatchDifference PrimaryKeyDifference { get; private set; }
     public bool RequiresTableRecreation { get; private set; }
 
+    // The actual key now carries the order the catalog declares, which for a composite key need not
+    // match the order the columns were flagged in. Comparing positionally would report drift on
+    // tables that are not drifted, and on SQLite "fixing" it means rebuilding the table and copying
+    // every row. Order is only compared when it was pinned deliberately.
+    private static bool primaryKeyColumnsMatch(Table expected, Table actual)
+        => expected.HasExplicitPrimaryKeyOrder
+            ? expected.PrimaryKeyColumns.SequenceEqual(actual.PrimaryKeyColumns, StringComparer.OrdinalIgnoreCase)
+            : expected.PrimaryKeyColumns.OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
+                .SequenceEqual(actual.PrimaryKeyColumns.OrderBy(x => x, StringComparer.OrdinalIgnoreCase),
+                    StringComparer.OrdinalIgnoreCase);
+
     protected override SchemaPatchDifference compare(Table expected, Table? actual)
     {
         if (actual == null)
@@ -75,8 +86,7 @@ public class TableDelta: SchemaObjectDelta<Table>, ISchemaObjectDeltaWithRebuild
         {
             PrimaryKeyDifference = SchemaPatchDifference.Update;
         }
-        else if (expected.PrimaryKeyColumns.Any() &&
-                 !expected.PrimaryKeyColumns.SequenceEqual(actual.PrimaryKeyColumns, StringComparer.OrdinalIgnoreCase))
+        else if (expected.PrimaryKeyColumns.Any() && !primaryKeyColumnsMatch(expected, actual))
         {
             PrimaryKeyDifference = SchemaPatchDifference.Update;
         }


### PR DESCRIPTION
Five introspection bugs, each with a test that fails on master.

- Named foreign keys never converged — the read invented a name, so the table was
  rebuilt and re-copied on every migration run.
- Composite foreign keys were mispaired: both column lists were sorted independently.
- `REFERENCES parent` with no column list threw, making the table unreadable.
- Composite primary key order was discarded — `pk` is a position, not a flag.
- STRICT, WITHOUT ROWID and AUTOINCREMENT were lost on rebuild.

Key order is compared only when pinned via the new `SetPrimaryKeyOrder`, so existing
models don't start drifting.