### PR TITLE
Terminate every batching provider's introspection query, and guard it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,33 @@ Oracle's `DropSchemaAsync` empties the schema rather than dropping it — a sess
 own user — and that a materialized view's container table appears in `all_tables` under the same
 name.
 
+#### The introspection query has to terminate itself
+
+The same shape of trap, one layer down. `SchemaMigration` concatenates every object of a migration
+into a single command, separated by `StartNewCommand()` — which is a **no-op on every provider
+except Oracle**. So each object's `ConfigureQueryCommand` output must end in `;`, or it runs
+straight into the next object's query:
+
+```
+Npgsql.PostgresException : 42601: syntax error at or near "select"
+```
+
+It only fails in combination. The object is fine alone, and fine when it happens to be last, which
+is exactly why per-object tests never caught it: PostgreSQL's stored procedure, user-defined type
+and trigger all shipped unterminated (weasel#515), SQLite's trigger with them, and MySQL's four
+(weasel#518). SQL Server's five survived only because T-SQL treats the separator as optional.
+
+**Oracle is the exception, and must stay unterminated.** ODP.NET will not execute several
+statements from one command, so `OracleDbCommandBuilder` overrides `StartNewCommand` to split the
+batch and hand back one command per statement. A `;` there is a syntax error, not a fix — so do not
+"tidy up" Oracle to match the others.
+
+`Weasel.Core.Tests/introspection_queries_terminate_themselves.cs` enforces all of this, including
+Oracle's exemption. It also asserts that every `ISchemaObject` type in every provider assembly has
+an instance registered in it, so **a new schema object type fails the build until it is added
+there**. That is deliberate: adding the instance is what gets the query checked. Do not satisfy the
+failure by narrowing the reflection scan.
+
 ### CreationStyle Enum
 - `CreateIfNotExists` - Safe creation (default)
 - `DropThenCreate` - Drop existing first

--- a/src/Weasel.Core.Tests/introspection_queries_terminate_themselves.cs
+++ b/src/Weasel.Core.Tests/introspection_queries_terminate_themselves.cs
@@ -1,0 +1,206 @@
+using System.Data.Common;
+using Microsoft.Data.SqlClient;
+using Microsoft.Data.Sqlite;
+using MySqlConnector;
+using Npgsql;
+using Shouldly;
+using Xunit;
+
+namespace Weasel.Core.Tests;
+
+/// <summary>
+///     Every schema object's introspection query has to terminate itself.
+/// </summary>
+/// <remarks>
+///     <para>
+///     <see cref="SchemaMigration" /> concatenates the objects of a migration into a single command,
+///     separating them with <see cref="CommandBuilderBase{TCommand,TParameter,TDbType}.StartNewCommand" />
+///     — which is a no-op on every provider but Oracle. So an object whose query does not end in a
+///     terminator runs straight into whatever follows it, and the migration fails with a syntax
+///     error at the next statement's first keyword.
+///     </para>
+///     <para>
+///     The failure only appears in combination. Each object is fine on its own, which is exactly why
+///     per-object tests never caught it: PostgreSQL's stored procedure, user-defined type and
+///     trigger shipped unterminated (weasel#515), and SQLite's trigger with them (weasel#518). This
+///     test exists so the next schema object type added cannot repeat it.
+///     </para>
+///     <para>
+///     <b>Oracle is deliberately excluded, and asserted separately below.</b> ODP.NET will not
+///     execute several statements from one command, so <c>OracleDbCommandBuilder</c> overrides
+///     <c>StartNewCommand</c> to split the batch and hand back one command per statement. A
+///     terminator there is a syntax error, not a fix — so a well-meaning sweep across all providers
+///     would break Oracle. That is the whole reason the exclusion is a test rather than a comment.
+///     </para>
+/// </remarks>
+public class introspection_queries_terminate_themselves
+{
+    /// <summary>
+    ///     One instance of every schema object type, per provider whose statements are concatenated.
+    /// </summary>
+    /// <remarks>
+    ///     Listed rather than reflected into existence: the constructors have nothing in common, and
+    ///     guessing arguments would fail in ways that look like product bugs.
+    ///     <see cref="every_schema_object_type_is_covered" /> is what keeps the list honest.
+    /// </remarks>
+    private static IEnumerable<(string Provider, ISchemaObject Object)> batchingObjects()
+    {
+        yield return ("PostgreSQL", new Postgresql.Tables.Table("test.thing"));
+        yield return ("PostgreSQL", new Postgresql.Sequence("test.thing_seq"));
+        yield return ("PostgreSQL", new Postgresql.Views.View("test.v_thing", "select 1"));
+        yield return ("PostgreSQL",
+            new Postgresql.Functions.Function(new DbObjectName("test", "fn_thing"), "create function test.fn_thing() returns int as $$ select 1 $$ language sql;"));
+        yield return ("PostgreSQL",
+            new Postgresql.Procedures.StoredProcedure(new DbObjectName("test", "p_thing"), "create procedure test.p_thing() language plpgsql as $$ begin end; $$;"));
+        yield return ("PostgreSQL", Postgresql.Types.UserDefinedType.Enum("test.mood", "happy", "sad"));
+        yield return ("PostgreSQL",
+            new Postgresql.Triggers.Trigger(new DbObjectName("test", "trg_thing"), new DbObjectName("test", "thing"),
+                "before insert on test.thing for each row execute function test.stamp()"));
+        yield return ("PostgreSQL", new Postgresql.Views.MaterializedView("test.mv_thing", "select 1"));
+        yield return ("PostgreSQL", new Postgresql.Extension("postgis"));
+        yield return ("PostgreSQL", new Postgresql.SchemaExistenceCheck([new Postgresql.Tables.Table("test.thing")]));
+        yield return ("PostgreSQL", new Postgresql.Tables.DatabasePoolTable("test"));
+        yield return ("PostgreSQL", new Postgresql.Tables.TenantAssignmentTable("test"));
+        yield return ("PostgreSQL",
+            new Postgresql.Functions.UpsertFunction(new DbObjectName("test", "upsert_thing"),
+                upsertTarget(), "id"));
+
+        yield return ("SQL Server", new SqlServer.Tables.Table("test.thing"));
+        yield return ("SQL Server", new SqlServer.Tables.TableType(new DbObjectName("test", "thing_type")));
+        yield return ("SQL Server", new SqlServer.Sequence("test.thing_seq"));
+        yield return ("SQL Server", new SqlServer.Views.View("test.v_thing", "select 1 as x"));
+        yield return ("SQL Server",
+            new SqlServer.Functions.Function(new DbObjectName("test", "fn_thing"), "create function test.fn_thing() returns int as begin return 1 end"));
+        yield return ("SQL Server",
+            new SqlServer.Procedures.StoredProcedure(new DbObjectName("test", "p_thing"), "create procedure test.p_thing as select 1"));
+        yield return ("SQL Server", new SqlServer.Synonyms.Synonym("test.s_thing", "test.thing"));
+        yield return ("SQL Server",
+            new SqlServer.Triggers.Trigger(new DbObjectName("test", "trg_thing"), new DbObjectName("test", "thing"),
+                "after insert as select 1"));
+
+        yield return ("SQLite", new Sqlite.Tables.Table("thing"));
+        yield return ("SQLite", new Sqlite.Views.View("v_thing", "select 1"));
+        yield return ("SQLite",
+            new Sqlite.Triggers.Trigger("trg_thing", "thing", "after insert on thing begin select 1; end"));
+
+        yield return ("MySQL", new MySql.Tables.Table("test.thing"));
+        yield return ("MySQL", new MySql.Sequence("test.thing_seq"));
+        yield return ("MySQL", new MySql.Views.View("test.v_thing", "select 1"));
+        yield return ("MySQL", new MySql.Functions.Function("test.fn_thing", "create function test.fn_thing() returns int return 1;"));
+        yield return ("MySQL",
+            new MySql.Procedures.StoredProcedure("test.p_thing", "create procedure test.p_thing() begin select 1; end"));
+        yield return ("MySQL",
+            new MySql.Triggers.Trigger("trg_thing", "test.thing", "after insert on test.thing for each row begin end"));
+    }
+
+    /// <summary>
+    ///     <see cref="Postgresql.Functions.UpsertFunction" /> derives its signature from a table, so
+    ///     it needs a real one with a primary key rather than an empty placeholder.
+    /// </summary>
+    private static Postgresql.Tables.Table upsertTarget()
+    {
+        var table = new Postgresql.Tables.Table("test.thing");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        return table;
+    }
+
+    /// <summary>
+    ///     The Oracle objects, which must NOT terminate. See the class remarks.
+    /// </summary>
+    private static IEnumerable<ISchemaObject> oracleObjects()
+    {
+        yield return new Oracle.Tables.Table("TEST.THING");
+        yield return new Oracle.Sequence("TEST.THING_SEQ");
+        yield return new Oracle.Views.View("TEST.V_THING", "select 1 from dual");
+        yield return new Oracle.Views.MaterializedView("TEST.MV_THING", "select 1 from dual");
+        yield return new Oracle.Synonyms.Synonym("TEST.S_THING", "TEST.THING");
+        yield return new Oracle.Functions.Function(new DbObjectName("TEST", "FN_THING"),
+            "create function TEST.FN_THING return number is begin return 1; end;");
+        yield return new Oracle.Procedures.StoredProcedure(new DbObjectName("TEST", "P_THING"),
+            "create procedure TEST.P_THING is begin null; end;");
+        yield return new Oracle.Packages.Package(new DbObjectName("TEST", "PKG_THING"),
+            "create package TEST.PKG_THING is end;", "create package body TEST.PKG_THING is end;");
+        yield return new Oracle.Triggers.Trigger(new DbObjectName("TEST", "TRG_THING"),
+            new DbObjectName("TEST", "THING"), "before insert on TEST.THING begin null; end;");
+    }
+
+    private static DbCommand commandFor(string provider) => provider switch
+    {
+        "PostgreSQL" => new NpgsqlCommand(),
+        "SQL Server" => new SqlCommand(),
+        "SQLite" => new SqliteCommand(),
+        "MySQL" => new MySqlCommand(),
+        _ => throw new ArgumentOutOfRangeException(nameof(provider), provider, "No command type registered")
+    };
+
+    private static string sqlFor(ISchemaObject schemaObject, DbCommand command)
+    {
+        var builder = new DbCommandBuilder(command);
+        schemaObject.ConfigureQueryCommand(builder);
+        return builder.ToString();
+    }
+
+    [Fact]
+    public void every_batching_provider_object_terminates_its_query()
+    {
+        var offenders = batchingObjects()
+            .Where(x => !sqlFor(x.Object, commandFor(x.Provider)).TrimEnd().EndsWith(';'))
+            .Select(x => $"{x.Provider}: {x.Object.GetType().FullName}")
+            .ToArray();
+
+        offenders.ShouldBeEmpty(
+            $"These introspection queries do not end in ';', so they will run into the next object's query when a migration contains more than one:{Environment.NewLine}"
+            + string.Join(Environment.NewLine, offenders));
+    }
+
+    /// <summary>
+    ///     Oracle's queries must stay unterminated. A ';' here is not a missing fix — it breaks the
+    ///     split that lets ODP.NET execute the batch at all.
+    /// </summary>
+    [Fact]
+    public void oracle_objects_do_not_terminate_their_queries()
+    {
+        var offenders = oracleObjects()
+            .Where(x => sqlFor(x, new global::Oracle.ManagedDataAccess.Client.OracleCommand()).TrimEnd().EndsWith(';'))
+            .Select(x => x.GetType().FullName!)
+            .ToArray();
+
+        offenders.ShouldBeEmpty(
+            $"Oracle executes one statement per command, so these must NOT end in ';':{Environment.NewLine}"
+            + string.Join(Environment.NewLine, offenders));
+    }
+
+    /// <summary>
+    ///     The guard on the guard: a schema object type that nothing above instantiates is a type
+    ///     whose query is never checked, and adding one is exactly when this mistake gets made.
+    /// </summary>
+    [Fact]
+    public void every_schema_object_type_is_covered()
+    {
+        var covered = batchingObjects().Select(x => x.Object.GetType())
+            .Concat(oracleObjects().Select(x => x.GetType()))
+            .ToHashSet();
+
+        var assemblies = new[]
+        {
+            typeof(Postgresql.Tables.Table).Assembly,
+            typeof(SqlServer.Tables.Table).Assembly,
+            typeof(Sqlite.Tables.Table).Assembly,
+            typeof(MySql.Tables.Table).Assembly,
+            typeof(Oracle.Tables.Table).Assembly
+        };
+
+        var missing = assemblies
+            .SelectMany(a => a.GetExportedTypes())
+            .Where(t => t is { IsAbstract: false, IsGenericTypeDefinition: false }
+                        && typeof(ISchemaObject).IsAssignableFrom(t)
+                        && !covered.Contains(t))
+            .Select(t => t.FullName!)
+            .OrderBy(x => x)
+            .ToArray();
+
+        missing.ShouldBeEmpty(
+            $"These schema object types are not covered by this test, so nothing checks whether their introspection query terminates. Add an instance to batchingObjects() -- or to oracleObjects() if the type is Oracle's:{Environment.NewLine}"
+            + string.Join(Environment.NewLine, missing));
+    }
+}

--- a/src/Weasel.MySql/Functions/Function.cs
+++ b/src/Weasel.MySql/Functions/Function.cs
@@ -74,7 +74,7 @@ public class Function: FunctionBase
 
         builder.Append(
             "SELECT routine_definition FROM information_schema.ROUTINES "
-            + $"WHERE routine_type = 'FUNCTION' AND routine_schema = @{schemaParam} AND routine_name = @{nameParam}");
+            + $"WHERE routine_type = 'FUNCTION' AND routine_schema = @{schemaParam} AND routine_name = @{nameParam};");
     }
 
     protected override async Task<FunctionBase?> ReadExistingFromReaderAsync(DbDataReader reader, CancellationToken ct)

--- a/src/Weasel.MySql/Procedures/StoredProcedure.cs
+++ b/src/Weasel.MySql/Procedures/StoredProcedure.cs
@@ -57,7 +57,7 @@ public class StoredProcedure: StoredProcedureBase
 
         builder.Append(
             "SELECT routine_definition FROM information_schema.ROUTINES "
-            + $"WHERE routine_type = 'PROCEDURE' AND routine_schema = @{schemaParam} AND routine_name = @{nameParam}");
+            + $"WHERE routine_type = 'PROCEDURE' AND routine_schema = @{schemaParam} AND routine_name = @{nameParam};");
     }
 
     /// <inheritdoc />

--- a/src/Weasel.MySql/Triggers/Trigger.cs
+++ b/src/Weasel.MySql/Triggers/Trigger.cs
@@ -84,7 +84,7 @@ public class Trigger: TriggerBase
 
         builder.Append(
             "SELECT action_statement FROM information_schema.TRIGGERS "
-            + $"WHERE trigger_schema = @{schemaParam} AND trigger_name = @{nameParam}");
+            + $"WHERE trigger_schema = @{schemaParam} AND trigger_name = @{nameParam};");
     }
 
     public override async Task<ISchemaObjectDelta> CreateDeltaAsync(DbDataReader reader, CancellationToken ct = default)

--- a/src/Weasel.MySql/Views/View.cs
+++ b/src/Weasel.MySql/Views/View.cs
@@ -100,7 +100,7 @@ public class View: ViewBase
         var nameParam = builder.AddParameter(Identifier.Name).ParameterName;
 
         builder.Append(
-            $"SELECT view_definition FROM information_schema.VIEWS WHERE table_schema = @{schemaParam} AND table_name = @{nameParam}");
+            $"SELECT view_definition FROM information_schema.VIEWS WHERE table_schema = @{schemaParam} AND table_name = @{nameParam};");
     }
 
     public override async Task<ISchemaObjectDelta> CreateDeltaAsync(DbDataReader reader, CancellationToken ct = default)

--- a/src/Weasel.SqlServer/Functions/Function.cs
+++ b/src/Weasel.SqlServer/Functions/Function.cs
@@ -30,7 +30,7 @@ public class Function: FunctionBase
     public override void ConfigureQueryCommand(DbCommandBuilder builder)
     {
         var nameParam = builder.AddParameter(Identifier.ToString()).ParameterName;
-        builder.Append($"SELECT sm.definition FROM sys.sql_modules AS sm WHERE sm.object_id = OBJECT_ID(@{nameParam})");
+        builder.Append($"SELECT sm.definition FROM sys.sql_modules AS sm WHERE sm.object_id = OBJECT_ID(@{nameParam});");
     }
 
     protected override Migrator GetDefaultMigrator() => new SqlServerMigrator();

--- a/src/Weasel.SqlServer/Procedures/StoredProcedure.cs
+++ b/src/Weasel.SqlServer/Procedures/StoredProcedure.cs
@@ -41,7 +41,7 @@ inner join sys.objects on sys.sql_modules.object_id = sys.objects.object_id
 inner join sys.schemas on sys.objects.schema_id = sys.schemas.schema_id
 where
     sys.objects.name = '{SchemaUtils.EscapeLiteral(Identifier.Name)}' and
-    sys.schemas.name = '{SchemaUtils.EscapeLiteral(Identifier.Schema)}'
+    sys.schemas.name = '{SchemaUtils.EscapeLiteral(Identifier.Schema)}';
 ");
     }
 

--- a/src/Weasel.SqlServer/Synonyms/Synonym.cs
+++ b/src/Weasel.SqlServer/Synonyms/Synonym.cs
@@ -55,7 +55,7 @@ public class Synonym: SchemaObjectBase
         builder.Append(
             "SELECT s.base_object_name FROM sys.synonyms s "
             + "INNER JOIN sys.schemas sch ON sch.schema_id = s.schema_id "
-            + $"WHERE s.name = @{nameParam} AND sch.name = @{schemaParam}");
+            + $"WHERE s.name = @{nameParam} AND sch.name = @{schemaParam};");
     }
 
     public override async Task<ISchemaObjectDelta> CreateDeltaAsync(DbDataReader reader, CancellationToken ct = default)

--- a/src/Weasel.SqlServer/Tables/TableType.cs
+++ b/src/Weasel.SqlServer/Tables/TableType.cs
@@ -43,7 +43,7 @@ from
 where
     sys.table_types.name = '{SchemaUtils.EscapeLiteral(Identifier.Name)}' and sys.schemas.name = '{SchemaUtils.EscapeLiteral(Identifier.Schema)}'
 order by
-    sys.columns.column_id
+    sys.columns.column_id;
 ");
     }
 

--- a/src/Weasel.SqlServer/Triggers/Trigger.cs
+++ b/src/Weasel.SqlServer/Triggers/Trigger.cs
@@ -78,7 +78,7 @@ public class Trigger: TriggerBase
         builder.Append(
             "SELECT sm.definition FROM sys.sql_modules AS sm "
             + "INNER JOIN sys.triggers AS t ON t.object_id = sm.object_id "
-            + $"WHERE t.object_id = OBJECT_ID(@{nameParam})");
+            + $"WHERE t.object_id = OBJECT_ID(@{nameParam});");
     }
 
     public override async Task<ISchemaObjectDelta> CreateDeltaAsync(DbDataReader reader, CancellationToken ct = default)

--- a/src/Weasel.SqlServer/Views/View.cs
+++ b/src/Weasel.SqlServer/Views/View.cs
@@ -58,7 +58,7 @@ public class View: ViewBase
     {
         var nameParam = builder.AddParameter(Identifier.ToString()).ParameterName;
         builder.Append(
-            $"SELECT sm.definition FROM sys.sql_modules AS sm INNER JOIN sys.views AS v ON v.object_id = sm.object_id WHERE sm.object_id = OBJECT_ID(@{nameParam})");
+            $"SELECT sm.definition FROM sys.sql_modules AS sm INNER JOIN sys.views AS v ON v.object_id = sm.object_id WHERE sm.object_id = OBJECT_ID(@{nameParam});");
     }
 
     public override async Task<ISchemaObjectDelta> CreateDeltaAsync(DbDataReader reader, CancellationToken ct = default)

--- a/src/Weasel.Sqlite/Triggers/Trigger.cs
+++ b/src/Weasel.Sqlite/Triggers/Trigger.cs
@@ -73,7 +73,7 @@ public class Trigger: TriggerBase
         var nameParam = builder.AddParameter(Identifier.Name).ParameterName;
 
         builder.Append(
-            $"SELECT sql FROM {SchemaUtils.QuoteName(Identifier.Schema)}.sqlite_master WHERE type = 'trigger' AND name = @{nameParam}");
+            $"SELECT sql FROM {SchemaUtils.QuoteName(Identifier.Schema)}.sqlite_master WHERE type = 'trigger' AND name = @{nameParam};");
     }
 
     public override async Task<ISchemaObjectDelta> CreateDeltaAsync(DbDataReader reader, CancellationToken ct = default)


### PR DESCRIPTION
Follow-up to #515, closing #518.

`SchemaMigration` concatenates the objects of a migration into a single command, separated by `StartNewCommand()` — which is a **no-op on every provider except Oracle**. So each object's `ConfigureQueryCommand` output has to end in `;`, or it runs straight into the next object's query and the migration fails at the following statement's first keyword. It only fails in combination, which is why per-object tests never caught it.

#515 fixed PostgreSQL's three. This fixes the rest.

## Confirmed broken, now fixed

- **SQLite** — `Trigger`. `SQLite Error 1: 'near "SELECT": syntax error'`
- **MySQL** — `Function`, `StoredProcedure`, `Trigger`, `View`. Verified against MySQL 8.0: `You have an error in your SQL syntax ... near 'SELECT`. This was the open question in #518; it is answered.

## Latent, now tidied

- **SQL Server** — `Function`, `StoredProcedure`, `Synonym`, `Trigger`, `View`, `TableType`. Not broken today: T-SQL treats the statement separator as optional. But relying on that is a trap that reads as intentional, and Microsoft has deprecated omitting it.

`TableType` was **not** in the original audit — it implements `ISchemaObject` without the `override` keyword the grep looked for. The reflection-based coverage guard below is what found it, which is rather the point of having one.

## The guard

`Weasel.Core.Tests/introspection_queries_terminate_themselves.cs` — no database required, and Core CI gates every workflow. Three assertions:

1. **Every schema object on a batching provider terminates its query.** Verified to bite: removing one terminator fails it.
2. **Every Oracle object does *not*.** ODP.NET will not execute several statements from one command, so `OracleDbCommandBuilder` splits the batch and hands back one command per statement — a `;` there is a syntax error, not a missing fix. Asserted rather than commented, so a well-meaning sweep across providers cannot quietly break Oracle.
3. **Every `ISchemaObject` type in every provider assembly has an instance registered in the test.** A new schema object type fails until someone adds one — which is exactly what gets its query checked.

Instances are listed rather than reflected into existence: the constructors have nothing in common, and guessing arguments would fail in ways that look like product bugs. Assertion 3 is what keeps the list honest.

## CLAUDE.md

Documented beside the existing `DropSchemaAsync` section — same shape of trap: a convention a new object type must follow, which fails silently and only in combination. Includes the warning not to "tidy up" Oracle to match.

## Verification

All suites run locally on the branch:

| Suite | Result |
|---|---|
| Core | 285 passed |
| PostgreSQL | 938 passed |
| SQL Server | 540 passed, 8 skipped |
| SQLite | 472 passed |
| MySQL | 295 passed |

Oracle has no local instance here, but no Oracle production code changed — and its exemption is asserted in Core, which needs no database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)