### PR TITLE
fix(postgresql): resolve list partitions manager-first when enumerating table names

### DIFF
--- a/src/Weasel.Postgresql.Tests/Tables/partitioning/managed_list_partition_table_names.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/partitioning/managed_list_partition_table_names.cs
@@ -1,0 +1,229 @@
+using JasperFx;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Postgresql.Tables;
+using Weasel.Postgresql.Tables.Partitioning;
+using Xunit;
+
+namespace Weasel.Postgresql.Tests.Tables.partitioning;
+
+/// <summary>
+///     weasel#520. <see cref="ListPartitioning" /> resolved its partitions manager-first in
+///     <c>WriteCreateStatement</c> and <c>CreateDelta</c>, but <c>PartitionTableNames</c> read the
+///     statically declared list directly.
+/// </summary>
+/// <remarks>
+///     <para>
+///     <see cref="ListPartitioning.UsePartitionManager" /> also clears
+///     <see cref="ListPartitioning.EnableDefaultPartition" />, so for a manager-owned partitioning the
+///     name enumeration returned the <b>empty</b> sequence — not a short list, nothing at all.
+///     </para>
+///     <para>
+///     <see cref="RangePartitioning" /> never had the problem: its <c>PartitionTableNames</c> goes
+///     through the same manager-first resolution as everything else, which is the shape
+///     <c>ListPartitioning.expectedPartitions</c> now copies.
+///     </para>
+/// </remarks>
+[Collection("managed_list_names")]
+public class managed_list_partition_table_names: IntegrationContext
+{
+    public managed_list_partition_table_names(): base("managed_list_names")
+    {
+    }
+
+    public override ValueTask InitializeAsync() => new(ResetSchema());
+
+    /// <summary>
+    ///     The manager in the product reads its partitions out of a lookup table. Nothing here needs
+    ///     that machinery — only that the partitions come from the manager rather than from
+    ///     <c>AddPartition</c>.
+    /// </summary>
+    private sealed class StubPartitionManager: IListPartitionManager
+    {
+        private readonly ListPartition[] _partitions;
+
+        public StubPartitionManager(params string[] values)
+            => _partitions = values.Select(x => new ListPartition(x, x.FormatSqlValue())).ToArray();
+
+        public IEnumerable<ListPartition> Partitions() => _partitions;
+    }
+
+    private Table managedTable(bool withConcurrentIndex)
+    {
+        var table = new Table(new PostgresqlObjectName(SchemaName, "managed_docs"));
+        table.AddColumn<Guid>("id").AsPrimaryKey();
+        table.AddColumn<string>("tenant_id").AsPrimaryKey().NotNull()
+            .PartitionByListValues()
+            .UsePartitionManager(new StubPartitionManager("one", "two"));
+        table.AddColumn<string>("body");
+
+        if (withConcurrentIndex)
+        {
+            var index = new IndexDefinition("idx_managed_docs_body") { IsConcurrent = true };
+            index.AgainstColumns("body");
+            table.Indexes.Add(index);
+        }
+
+        return table;
+    }
+
+    [Fact]
+    public void the_manager_supplies_the_partition_table_names()
+    {
+        var table = managedTable(withConcurrentIndex: false);
+
+        table.Partitioning!.PartitionTableNames(table)
+            .ShouldBe(["managed_docs_one", "managed_docs_two"]);
+    }
+
+    /// <summary>
+    ///     The empty sequence is the specific failure: UsePartitionManager clears the default
+    ///     partition, so nothing at all came back rather than merely the wrong thing.
+    /// </summary>
+    [Fact]
+    public void a_manager_owned_partitioning_does_not_enumerate_nothing()
+    {
+        var table = managedTable(withConcurrentIndex: false);
+
+        table.Partitioning!.PartitionTableNames(table).ShouldNotBeEmpty();
+    }
+
+    /// <summary>
+    ///     A statically declared partitioning still reports its own partitions and its default one,
+    ///     so the manager-first resolution did not change the case that already worked.
+    /// </summary>
+    [Fact]
+    public void a_statically_declared_partitioning_is_unaffected()
+    {
+        var table = new Table(new PostgresqlObjectName(SchemaName, "static_docs"));
+        table.AddColumn<Guid>("id").AsPrimaryKey();
+        table.AddColumn<string>("tenant_id").AsPrimaryKey().NotNull()
+            .PartitionByListValues()
+            .AddPartition("one", "one")
+            .AddPartition("two", "two");
+
+        table.Partitioning!.PartitionTableNames(table)
+            .ShouldBe(["static_docs_one", "static_docs_two", "static_docs_default"]);
+    }
+
+    private async Task<bool> parentIndexIsValidAsync()
+    {
+        var result = await theConnection.CreateCommand(
+                "select i.indisvalid from pg_index i "
+                + "join pg_class c on c.oid = i.indexrelid "
+                + "join pg_namespace n on n.oid = c.relnamespace "
+                + $"where n.nspname = '{SchemaName}' and c.relname = 'idx_managed_docs_body'")
+            .ExecuteScalarAsync();
+
+        result.ShouldNotBeNull("the parent index was never created");
+        return (bool)result!;
+    }
+
+    private async Task<int> attachedChildIndexCountAsync()
+    {
+        var result = await theConnection.CreateCommand(
+                "select count(*) from pg_inherits h "
+                + "join pg_class parent on parent.oid = h.inhparent "
+                + "join pg_namespace n on n.oid = parent.relnamespace "
+                + $"where n.nspname = '{SchemaName}' and parent.relname = 'idx_managed_docs_body'")
+            .ExecuteScalarAsync();
+
+        return Convert.ToInt32(result);
+    }
+
+    /// <summary>
+    ///     The consequence the issue is actually about. With an empty name list only step 1 of the
+    ///     three-step sequence renders — <c>CREATE INDEX ON ONLY parent</c>, which is metadata-only
+    ///     and leaves the parent index invalid by design, waiting for children that never arrive.
+    /// </summary>
+    [Fact]
+    public async Task a_concurrent_index_on_a_manager_owned_table_becomes_valid()
+    {
+        var table = managedTable(withConcurrentIndex: true);
+
+        await new PostgresqlMigrator().ApplyAllAsync(theConnection,
+            await SchemaMigration.DetermineAsync(theConnection, table), AutoCreate.CreateOrUpdate);
+
+        (await attachedChildIndexCountAsync()).ShouldBe(2, "one attached index per manager partition");
+        (await parentIndexIsValidAsync()).ShouldBeTrue("the parent index is still invalid");
+    }
+
+    /// <summary>
+    ///     Adding the index to a table that already exists and holds rows — the case someone reaches
+    ///     for <c>IsConcurrent</c> to avoid an outage over.
+    /// </summary>
+    [Fact]
+    public async Task a_concurrent_index_can_be_added_to_an_existing_manager_owned_table()
+    {
+        await new PostgresqlMigrator().ApplyAllAsync(theConnection,
+            await SchemaMigration.DetermineAsync(theConnection, managedTable(withConcurrentIndex: false)),
+            AutoCreate.CreateOrUpdate);
+
+        await theConnection.CreateCommand(
+                $"insert into {SchemaName}.managed_docs (id, tenant_id, body) values (gen_random_uuid(), 'one', 'x')")
+            .ExecuteNonQueryAsync();
+
+        var withIndex = managedTable(withConcurrentIndex: true);
+        var migration = await SchemaMigration.DetermineAsync(theConnection, withIndex);
+        migration.Difference.ShouldBe(SchemaPatchDifference.Update);
+
+        await new PostgresqlMigrator().ApplyAllAsync(theConnection, migration, AutoCreate.CreateOrUpdate);
+
+        (await attachedChildIndexCountAsync()).ShouldBe(2);
+        (await parentIndexIsValidAsync()).ShouldBeTrue("the parent index is still invalid");
+    }
+
+    /// <summary>
+    ///     The other consumer of this list, called out in weasel#520 as changing behaviour with the
+    ///     fix and wanting a test rather than a hope: <c>ReadOtherTables</c> strips foreign keys that
+    ///     point at a <em>partition</em> of a partitioned table.
+    /// </summary>
+    /// <remarks>
+    ///     The strip is driven by a foreign key to the partitioned <em>parent</em> — that is what
+    ///     locates the partitioned table — and then removes any key pointing at one of its
+    ///     partitions. So both keys have to be present for the case to arise at all, and the parent
+    ///     one has to survive, or this would just be "remove every foreign key".
+    ///     <para>
+    ///     With an empty name list the partition key was never stripped, because there were no names
+    ///     to match it against.
+    ///     </para>
+    /// </remarks>
+    [Fact]
+    public void a_foreign_key_to_a_manager_owned_partition_is_stripped()
+    {
+        var parent = managedTable(withConcurrentIndex: false);
+
+        var child = new Table(new PostgresqlObjectName(SchemaName, "child_docs"));
+        child.AddColumn<Guid>("id").AsPrimaryKey();
+        child.AddColumn<Guid>("doc_id")
+            .ForeignKeyTo(new PostgresqlObjectName(SchemaName, "managed_docs"), "id");
+        child.AddColumn<Guid>("partition_doc_id")
+            .ForeignKeyTo(new PostgresqlObjectName(SchemaName, "managed_docs_one"), "id");
+
+        child.ForeignKeys.Count.ShouldBe(2, "the fixture did not add both foreign keys");
+
+        child.ReadOtherTables([parent]);
+
+        child.ForeignKeys.Select(x => x.LinkedTable.Name)
+            .ShouldBe(["managed_docs"], "the key to the partition should be stripped and the one to the parent kept");
+    }
+
+    /// <summary>
+    ///     Nothing is stripped when the table a key points at is not partitioned at all.
+    /// </summary>
+    [Fact]
+    public void a_foreign_key_to_an_unpartitioned_table_is_kept()
+    {
+        var plain = new Table(new PostgresqlObjectName(SchemaName, "plain_docs"));
+        plain.AddColumn<Guid>("id").AsPrimaryKey();
+
+        var child = new Table(new PostgresqlObjectName(SchemaName, "child_docs2"));
+        child.AddColumn<Guid>("id").AsPrimaryKey();
+        child.AddColumn<Guid>("doc_id")
+            .ForeignKeyTo(new PostgresqlObjectName(SchemaName, "plain_docs"), "id");
+
+        child.ReadOtherTables([plain]);
+
+        child.ForeignKeys.Count.ShouldBe(1);
+    }
+}

--- a/src/Weasel.Postgresql/Tables/Partitioning/ListPartitioning.cs
+++ b/src/Weasel.Postgresql/Tables/Partitioning/ListPartitioning.cs
@@ -32,6 +32,27 @@ public class ListPartitioning: IPartitionStrategy
     }
 
     /// <summary>
+    /// The partitions this strategy currently expects: the manager's set when one is attached,
+    /// otherwise the statically declared ones.
+    /// </summary>
+    /// <remarks>
+    /// Every call site resolves through here, the way <c>RangePartitioning.expectedRanges</c> does.
+    /// PartitionTableNames used to read <c>_partitions</c> directly, so for a manager-owned
+    /// partitioning -- where <see cref="UsePartitionManager"/> also clears
+    /// <see cref="EnableDefaultPartition"/> -- it returned the EMPTY sequence rather than a short
+    /// one, and a concurrent index over the table rendered only its first step and stayed invalid
+    /// forever (weasel#520).
+    /// <para>
+    /// A manager reads its partitions from a lookup table, so this is a point-in-time answer. That
+    /// is correct for a migration -- a partition created afterwards inherits the parent's indexes
+    /// automatically -- but any DDL built from it is only as complete as the manager's state at the
+    /// moment it was rendered.
+    /// </para>
+    /// </remarks>
+    private IReadOnlyList<ListPartition> expectedPartitions()
+        => PartitionManager == null ? _partitions : PartitionManager.Partitions().ToList();
+
+    /// <summary>
     /// Add another list partition table based on the supplied table suffix and values
     /// </summary>
     /// <param name="suffix"></param>
@@ -68,7 +89,7 @@ public class ListPartitioning: IPartitionStrategy
 
     void IPartitionStrategy.WriteCreateStatement(TextWriter writer, Table parent)
     {
-        var partitions = PartitionManager?.Partitions() ?? _partitions;
+        var partitions = expectedPartitions();
 
         foreach (IPartition partition in partitions)
         {
@@ -92,7 +113,7 @@ public class ListPartitioning: IPartitionStrategy
         missing = default;
         if (actual is ListPartitioning other)
         {
-            var partitions = PartitionManager?.Partitions().ToList() ?? _partitions;
+            var partitions = expectedPartitions();
 
             if (!Columns.SequenceEqual(other.Columns))
             {
@@ -124,7 +145,7 @@ public class ListPartitioning: IPartitionStrategy
 
     public IEnumerable<string> PartitionTableNames(Table parent)
     {
-        foreach (var partition in _partitions)
+        foreach (var partition in expectedPartitions())
         {
             yield return $"{parent.Identifier.Name.ToLowerInvariant()}_{partition.Suffix.ToLowerInvariant()}";
         }


### PR DESCRIPTION
Closes #520.

`ListPartitioning` resolved its partitions manager-first in `WriteCreateStatement` and `CreateDelta`, but `PartitionTableNames` read `_partitions` directly. Since `UsePartitionManager` also clears `EnableDefaultPartition`, a manager-owned partitioning enumerated the **empty** sequence — not a short list, nothing at all.

`IndexDefinition.toPartitionedConcurrentDDL` builds the whole three-step concurrent index sequence from those names. With an empty list, steps 2 and 3 never render and only step 1 survives:

```sql
CREATE INDEX idx_mt_events_tags ON ONLY schema.mt_events USING gin (tags);
```

which is metadata-only and leaves the parent index **invalid by design**, waiting for children that are never attached. The planner will not use it, #508 then correctly reports it as drift, and every subsequent apply retries the same no-op — worse than the blocking `CREATE INDEX` it replaced, and `IsConcurrent` is set precisely by someone trying to avoid an outage.

## The fix

All three call sites now resolve through one `expectedPartitions()` helper, mirroring `RangePartitioning.expectedRanges()`. `RangePartitioning` never had this bug for exactly that reason — patching only the third site would have left the same seam open.

## Tests

Both consumers of the list are covered, including the second one the issue flagged as changing behaviour here and wanting a test rather than a hope:

- the concurrent index sequence completes and the parent index ends up **valid**, on a fresh table and on an existing one holding rows;
- `Table.ReadOtherTables` strips a foreign key pointing at a manager-owned *partition* while keeping the one pointing at the partitioned *parent*. That test needs both keys present, because the key to the parent is what locates the partitioned table in the first place.

**5 of the 7 fail with `PartitionTableNames` reverted.** The 2 that don't are the negative gates — a statically declared partitioning, and a foreign key to an unpartitioned table — which should pass either way.

Full PostgreSQL suite green locally: **945 passed, 3 skipped**.

## On the two things to decide alongside

1. **The `ReadOtherTables` consumer** — covered by a test, as above.
2. **A drifting partition set** — documented on `expectedPartitions()`: it is a point-in-time answer, which is correct for a migration since a partition created afterwards inherits the parent's indexes automatically, but any DDL built from it is only as complete as the manager's state when it was rendered.

Not addressed here, deliberately: `ListPartitioning.AddPartition` still has no guard against being called while a manager is attached, where `RangePartitioning.AddRange` throws. That is the same seam but not this bug — `_partitions` being non-empty and meaningless is now harmless, since nothing reads it when a manager is present. Worth its own issue if you want the symmetry.

## Downstream

Once this is released, the guard in [marten#5291](https://github.com/JasperFx/marten/pull/5291) — which refuses `BuildHStoreTagIndexConcurrently` together with `UseTenantPartitionedEvents` — can come out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)