### PR TITLE
fix(postgresql): refuse a static partition alongside a partition manager, in both directions

### DIFF
--- a/src/Weasel.Postgresql.Tests/Tables/partitioning/partition_manager_guards.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/partitioning/partition_manager_guards.cs
@@ -1,0 +1,149 @@
+using Shouldly;
+using Weasel.Postgresql.Tables;
+using Weasel.Postgresql.Tables.Partitioning;
+using Xunit;
+
+namespace Weasel.Postgresql.Tests.Tables.partitioning;
+
+/// <summary>
+///     weasel#524. A partition manager owns the whole partition set, so a statically declared
+///     partition alongside one is silently ignored — the caller wrote something that cannot do what
+///     they meant.
+/// </summary>
+/// <remarks>
+///     <para>
+///     <c>RangePartitioning.AddRange</c> already refused this. <c>ListPartitioning.AddPartition</c>
+///     did not, and neither class guarded <c>UsePartitionManager</c> — so even where the refusal
+///     existed it depended on the order the fluent calls happened to be written in, which a fluent
+///     builder gives no reason to prefer. All four combinations are pinned here, including the one
+///     that already threw.
+///     </para>
+///     <para>
+///     This is a refusal, not a correctness fix. Since weasel#520 every call site resolves through
+///     the manager first, so a stray statically declared partition is inert rather than wrong.
+///     </para>
+/// </remarks>
+public class partition_manager_guards
+{
+    private sealed class StubListManager: IListPartitionManager
+    {
+        public IEnumerable<ListPartition> Partitions() => [new ListPartition("one", "'one'")];
+    }
+
+    private sealed class StubRangeManager: IRangePartitionManager
+    {
+        public IEnumerable<RangePartition> Partitions() => [new RangePartition("y2026", "'2026-01-01'", "'2027-01-01'")];
+    }
+
+    // ---- LIST -------------------------------------------------------------
+
+    [Fact]
+    public void list_manager_first_then_a_static_partition_is_refused()
+    {
+        var partitioning = new ListPartitioning { Columns = ["tenant_id"] }
+            .UsePartitionManager(new StubListManager());
+
+        Should.Throw<InvalidOperationException>(() => partitioning.AddPartition("two", "two"))
+            .Message.ShouldContain("owned by a partition manager");
+    }
+
+    [Fact]
+    public void list_static_partition_first_then_a_manager_is_refused()
+    {
+        var partitioning = new ListPartitioning { Columns = ["tenant_id"] }
+            .AddPartition("two", "two");
+
+        Should.Throw<InvalidOperationException>(() => partitioning.UsePartitionManager(new StubListManager()))
+            .Message.ShouldContain("two");
+    }
+
+    // ---- RANGE ------------------------------------------------------------
+
+    [Fact]
+    public void range_manager_first_then_a_static_range_is_refused()
+    {
+        var partitioning = new RangePartitioning { Columns = ["occurred_at"] }
+            .UsePartitionManager(new StubRangeManager());
+
+        Should.Throw<InvalidOperationException>(() => partitioning.AddRange("y2027", "2027-01-01", "2028-01-01"))
+            .Message.ShouldContain("owned by a partition manager");
+    }
+
+    [Fact]
+    public void range_static_range_first_then_a_manager_is_refused()
+    {
+        var partitioning = new RangePartitioning { Columns = ["occurred_at"] }
+            .AddRange("y2027", "2027-01-01", "2028-01-01");
+
+        Should.Throw<InvalidOperationException>(() => partitioning.UsePartitionManager(new StubRangeManager()))
+            .Message.ShouldContain("y2027");
+    }
+
+    // ---- what must still work ---------------------------------------------
+
+    /// <summary>
+    ///     The shape every caller in Weasel, its docs and Marten actually uses: a fresh partitioning
+    ///     with a manager attached and nothing declared statically.
+    /// </summary>
+    [Fact]
+    public void a_manager_on_a_fresh_partitioning_is_fine()
+    {
+        Should.NotThrow(() => new ListPartitioning { Columns = ["tenant_id"] }
+            .UsePartitionManager(new StubListManager()));
+
+        Should.NotThrow(() => new RangePartitioning { Columns = ["occurred_at"] }
+            .UsePartitionManager(new StubRangeManager()));
+    }
+
+    [Fact]
+    public void several_static_partitions_without_a_manager_are_fine()
+    {
+        Should.NotThrow(() => new ListPartitioning { Columns = ["tenant_id"] }
+            .AddPartition("one", "one")
+            .AddPartition("two", "two"));
+
+        Should.NotThrow(() => new RangePartitioning { Columns = ["occurred_at"] }
+            .AddRange("y2026", "2026-01-01", "2027-01-01")
+            .AddRange("y2027", "2027-01-01", "2028-01-01"));
+    }
+
+    /// <summary>
+    ///     <c>UsePartitionManager</c> clears the default partition, and that is load-bearing rather
+    ///     than incidental: it is what made the empty enumeration in weasel#520 total rather than
+    ///     merely short. Adding the guard above must not disturb it.
+    /// </summary>
+    [Fact]
+    public void a_list_manager_still_clears_the_default_partition()
+    {
+        var partitioning = new ListPartitioning { Columns = ["tenant_id"] };
+        partitioning.EnableDefaultPartition.ShouldBeTrue("the default starts enabled");
+
+        partitioning.UsePartitionManager(new StubListManager());
+
+        partitioning.EnableDefaultPartition.ShouldBeFalse();
+    }
+
+    /// <summary>
+    ///     The internal literal overload is deliberately unguarded — introspection populates a read
+    ///     table's partitions, and a table read back out of the catalog never carries a manager. It
+    ///     is pinned here so a later tidy-up does not "fix" it for symmetry and break the read path.
+    /// </summary>
+    [Fact]
+    public void the_internal_literal_overload_is_not_guarded()
+    {
+        var partitioning = new ListPartitioning { Columns = ["tenant_id"] }
+            .UsePartitionManager(new StubListManager());
+
+        Should.NotThrow(() => partitioning.AddPartitionWithSqlLiterals("read_back", "'x'"));
+    }
+
+    [Fact]
+    public void a_null_manager_is_still_an_argument_null_exception()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new ListPartitioning { Columns = ["tenant_id"] }.UsePartitionManager(null!));
+
+        Should.Throw<ArgumentNullException>(() =>
+            new RangePartitioning { Columns = ["occurred_at"] }.UsePartitionManager(null!));
+    }
+}

--- a/src/Weasel.Postgresql/Tables/Partitioning/ListPartitioning.cs
+++ b/src/Weasel.Postgresql/Tables/Partitioning/ListPartitioning.cs
@@ -25,6 +25,20 @@ public class ListPartitioning: IPartitionStrategy
     /// <returns></returns>
     public ListPartitioning UsePartitionManager(IListPartitionManager strategy)
     {
+        if (strategy == null) throw new ArgumentNullException(nameof(strategy));
+
+        // Guarded in both directions, so the refusal does not depend on the order the fluent calls
+        // happen to be written in. AddPartition refuses a manager that is already attached; this
+        // refuses partitions that were already declared.
+        if (_partitions.Any())
+        {
+            throw new InvalidOperationException(
+                $"This table already declares the partitions {_partitions.Select(x => x.Suffix).Join(", ")}, which a partition manager would silently ignore. Remove the AddPartition() calls or the UsePartitionManager() call.");
+        }
+
+        // A manager owns the whole partition set, so there is no residue for a default partition to
+        // catch. Clearing this is also what makes PartitionTableNames total rather than merely short
+        // -- see weasel#520.
         EnableDefaultPartition = false;
         PartitionManager = strategy;
 
@@ -61,6 +75,12 @@ public class ListPartitioning: IPartitionStrategy
     /// <returns></returns>
     public ListPartitioning AddPartition<T>(string suffix, params T[] values)
     {
+        if (PartitionManager != null)
+        {
+            throw new InvalidOperationException(
+                "This table's partitions are owned by a partition manager, so statically declared partitions would be silently ignored. Remove the UsePartitionManager() call or the AddPartition() call.");
+        }
+
         var partition = new ListPartition(suffix, values.Select(x => x.FormatSqlValue()).ToArray());
         _partitions.Add(partition);
 

--- a/src/Weasel.Postgresql/Tables/Partitioning/RangePartitioning.cs
+++ b/src/Weasel.Postgresql/Tables/Partitioning/RangePartitioning.cs
@@ -31,7 +31,17 @@ public class RangePartitioning: IPartitionStrategy
     /// </summary>
     public RangePartitioning UsePartitionManager(IRangePartitionManager manager)
     {
-        PartitionManager = manager ?? throw new ArgumentNullException(nameof(manager));
+        if (manager == null) throw new ArgumentNullException(nameof(manager));
+
+        // The mirror of the guard in AddRange, so the refusal does not depend on the order the
+        // fluent calls happen to be written in.
+        if (_ranges.Any())
+        {
+            throw new InvalidOperationException(
+                $"This table already declares the ranges {_ranges.Select(x => x.Suffix).Join(", ")}, which a partition manager would silently ignore. Remove the AddRange() calls or the UsePartitionManager() call.");
+        }
+
+        PartitionManager = manager;
         return this;
     }
 


### PR DESCRIPTION
Closes #524.

A partition manager owns the whole partition set, so a statically declared partition alongside one is silently ignored. `RangePartitioning.AddRange` already refused this; `ListPartitioning.AddPartition` did not, and **neither class guarded `UsePartitionManager`** — so even where the refusal existed it depended on the order the fluent calls happened to be written in.

| Order | Range (before) | List (before) | Both (after) |
|---|---|---|---|
| `UsePartitionManager()` → `AddRange`/`AddPartition` | throws | accepted | **throws** |
| `AddRange`/`AddPartition` → `UsePartitionManager()` | accepted | accepted | **throws** |

A fluent builder gives no reason to prefer one order, so the guard shouldn't either.

## Two things fall out

- **`ListPartitioning.UsePartitionManager` never null-checked its argument**, unlike the range version. A null manager was accepted and then silently fell back to the static partitions. It now throws `ArgumentNullException` like its twin — this surfaced as a test failing during the fails-first check, which is how I noticed.
- **`UsePartitionManager` clearing `EnableDefaultPartition` is load-bearing**, not incidental — it's what made #520's empty enumeration total rather than merely short. Now pinned by a test so the guard can't disturb it.

## Deliberately not guarded

`AddPartitionWithSqlLiterals` is `internal` and stays unguarded, with a test pinning that. Introspection populates a read table's partitions, and a table read back from the catalog never carries a manager — guarding it for symmetry would break the read path.

## Severity

This is a refusal, not a correctness fix. Since #522 every call site resolves through the manager first, so a stray statically declared partition is inert rather than wrong.

## Downstream check

Before adding the `UsePartitionManager` guard I checked Marten, since it's the main consumer of managed partitions. All four call sites there build a **fresh** `ListPartitioning` / `RangePartitioning`:

- `PartitioningExpression.cs:139`, `MartenManagedTenantListPartitions.cs:79`, `EventsTable.cs:208`, `StreamsTable.cs:80`

The archived-stream `AddPartition("archived", true)` is on a different partitioning entirely, and Marten rejects that combination at config time. So nothing downstream trips the new guard.

## Verification

All four cells tested, including the one that already threw as a control. With the guards reverted, the three new tests fail and the pre-existing `AddRange` one still passes.

Full suites: PostgreSQL **954 passed**, Core **309 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)