### PR TITLE
fix: create the batch command before AppendWithParameters writes SQL

### DIFF
--- a/src/Weasel.Postgresql.Tests/BatchBuilderTests.cs
+++ b/src/Weasel.Postgresql.Tests/BatchBuilderTests.cs
@@ -84,3 +84,22 @@ public class BatchBuilderTests : IntegrationContext
         (await reader.GetFieldValueAsync<int>(2)).ShouldBe(14);
     }
 }
+
+public class BatchBuilderParameterlessStatementTests
+{
+    [Fact]
+    public void parameterless_sql_is_not_discarded_by_the_next_command()
+    {
+        var batcher = new BatchBuilder();
+
+        batcher.AppendWithParameters("delete from batching.thing where tag = 'blue'");
+        batcher.StartNewCommand();
+        batcher.AppendWithParameters("insert into batching.thing (id) values (?)");
+
+        var batch = batcher.Compile();
+
+        batch.BatchCommands.Count.ShouldBe(2);
+        batch.BatchCommands[0].CommandText.ShouldBe("delete from batching.thing where tag = 'blue'");
+        batch.BatchCommands[1].CommandText.ShouldBe("insert into batching.thing (id) values ($1)");
+    }
+}

--- a/src/Weasel.Postgresql/BatchBuilder.cs
+++ b/src/Weasel.Postgresql/BatchBuilder.cs
@@ -146,6 +146,11 @@ public class BatchBuilder: ICommandBuilder
 #if NET6_0 || NET7_0
     public NpgsqlParameter[] AppendWithParameters(string text, char placeholder)
     {
+        // Pin the batch command down *before* any text is written. With zero placeholders
+        // AppendParameter never runs, and the SQL would be silently discarded by the next
+        // StartNewCommand(). See weasel#526.
+        _current ??= appendCommand();
+
         var split = text.Split(placeholder);
         var parameters = new NpgsqlParameter[split.Length - 1];
 
@@ -163,6 +168,11 @@ public class BatchBuilder: ICommandBuilder
 #else
     public NpgsqlParameter[] AppendWithParameters(string text, char separator)
     {
+        // Pin the batch command down *before* any text is written. With zero placeholders
+        // AppendParameter never runs, and the SQL would be silently discarded by the next
+        // StartNewCommand(). See weasel#526.
+        _current ??= appendCommand();
+
         var span = text.AsSpan();
 
         var parameters = new NpgsqlParameter[span.Count(separator)];

--- a/src/Weasel.SqlServer.Tests/BatchBuilderTests.cs
+++ b/src/Weasel.SqlServer.Tests/BatchBuilderTests.cs
@@ -82,3 +82,22 @@ public class BatchBuilderTests : IntegrationContext
         (await reader.GetFieldValueAsync<int>(2)).ShouldBe(14);
     }
 }
+
+public class BatchBuilderParameterlessStatementTests
+{
+    [Fact]
+    public void parameterless_sql_is_not_discarded_by_the_next_command()
+    {
+        var batcher = new BatchBuilder();
+
+        batcher.AppendWithParameters("delete from batching.thing where tag = 'blue'");
+        batcher.StartNewCommand();
+        batcher.AppendWithParameters("insert into batching.thing (id) values (?)");
+
+        var batch = batcher.Compile();
+
+        batch.BatchCommands.Count.ShouldBe(2);
+        batch.BatchCommands[0].CommandText.ShouldBe("delete from batching.thing where tag = 'blue'");
+        batch.BatchCommands[1].CommandText.ShouldBe("insert into batching.thing (id) values (@p0)");
+    }
+}

--- a/src/Weasel.SqlServer/BatchBuilder.cs
+++ b/src/Weasel.SqlServer/BatchBuilder.cs
@@ -168,6 +168,11 @@ public class BatchBuilder: ICommandBuilder
 #if NET8_0
     public SqlParameter[] AppendWithParameters(string text, char placeholder)
     {
+        // Pin the batch command down *before* any text is written. With zero placeholders
+        // AppendParameter never runs, and the SQL would be silently discarded by the next
+        // StartNewCommand(). See weasel#526.
+        _current ??= appendCommand();
+
         var split = text.Split(placeholder);
         var parameters = new SqlParameter[split.Length - 1];
 
@@ -185,6 +190,11 @@ public class BatchBuilder: ICommandBuilder
 #else
     public SqlParameter[] AppendWithParameters(string text, char separator)
     {
+        // Pin the batch command down *before* any text is written. With zero placeholders
+        // AppendParameter never runs, and the SQL would be silently discarded by the next
+        // StartNewCommand(). See weasel#526.
+        _current ??= appendCommand();
+
         var span = text.AsSpan();
 
         var parameters = new SqlParameter[span.Count(separator)];


### PR DESCRIPTION
Closes #526.

## The bug

`BatchBuilder.AppendWithParameters` appends its text to the shared `StringBuilder` but only creates the underlying batch command as a side effect of `AppendParameter`. With **zero placeholders**, `_current` stays `null`, so the next `StartNewCommand()` skips the `CommandText` assignment and clears the builder — the SQL is gone, silently. Same shape in both dialects.

Whether it bites depends on the caller's loop convention, not on the SQL:

| Caller pattern | Outcome |
|---|---|
| `StartNewCommand()` before every operation | safe |
| `StartNewCommand()` only *between* operations | **first parameterless statement discarded** |
| single operation, no `StartNewCommand()` | safe (`Compile()` creates one) |

Marten is in the first row and unaffected. Polecat was in the second and lost user SQL: JasperFx/polecat#517 — `QueueSqlCommand` dropped whenever the session also carried a document operation, with `SaveChangesAsync` reporting success.

## The fix

`_current ??= appendCommand();` at the top of both `AppendWithParameters(text, separator)` overloads (the modern span path and the `NET6_0/NET7_0` / `NET8_0` split path) in both `Weasel.Postgresql` and `Weasel.SqlServer` — the same guard `Append`, `AppendParameter` and `AddParameters` already carry.

## Tests

One regression test per dialect, pure unit tests with no database: append a parameterless statement, `StartNewCommand()`, append a parameterized one, `Compile()`, then assert **two** batch commands with both texts intact. Verified both fail without the guard (`BatchCommands.Count` is 1, holding only the second statement) and pass with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)