### PR TITLE
9.27.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>9.27.0</Version>
+        <Version>9.27.1</Version>
         <LangVersion>13.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/docs/release-9-27.md
+++ b/docs/release-9-27.md
@@ -11,6 +11,39 @@ generated patch ran, the next run produced the same patch, and it repeated forev
 describes your schema, the repetition stops when you upgrade.
 :::
 
+## What 9.27.1 changes
+
+One fix, and it is the same shape as the nine in 9.27.0: the code did the right thing everywhere
+except one path, and the one path failed without saying so.
+
+### A parameterless statement in a batch could be silently discarded
+
+[#526](https://github.com/JasperFx/weasel/issues/526). `BatchBuilder.AppendWithParameters` — both
+the PostgreSQL and the SQL Server one — wrote its SQL into the shared `StringBuilder` but only
+created the underlying batch command as a side effect of appending a **parameter**. A statement
+with no placeholders never reached that code, so the command was never created, and the next
+`StartNewCommand()` cleared the builder. The SQL was gone. No exception, no log; the batch simply
+executed without it.
+
+Whether it bit you depended on the caller's loop, not on the SQL:
+
+| Caller pattern | Outcome |
+| --- | --- |
+| `StartNewCommand()` before **every** operation | safe |
+| `StartNewCommand()` only *between* operations | **the first parameterless statement was discarded** |
+| a single operation, no `StartNewCommand()` at all | safe |
+
+Marten is in the first row and was never affected. Polecat was in the second and lost user SQL:
+[polecat#517](https://github.com/JasperFx/polecat/issues/517), where a statement queued through
+`IDocumentSession.QueueSqlCommand` disappeared whenever the same session also carried a document
+operation — and `SaveChangesAsync` reported success, so callers believed both had landed.
+
+The tell that isolated it: the identical statement written **with** a parameter placeholder always
+worked, because the first parameter materialized the command.
+
+`AppendWithParameters` now pins the command down before writing anything, the same guard `Append`,
+`AppendParameter` and `AddParameters` have always carried. There is nothing to change on upgrade.
+
 ## The ones that never converged
 
 A delta that cannot converge is worse than a wrong one. The patch is applied, the read-back is


### PR DESCRIPTION
Version bump for the one fix that has landed since 9.27.0, plus its release note.

[#527](https://github.com/JasperFx/weasel/pull/527) / [#526](https://github.com/JasperFx/weasel/issues/526) — `BatchBuilder.AppendWithParameters` created the underlying batch command only as a side effect of appending a parameter, so a statement with **no placeholders** was silently discarded by the next `StartNewCommand()`. Marten's loop convention made it immune; Polecat's did not, and `QueueSqlCommand` lost user SQL while `SaveChangesAsync` reported success ([polecat#517](https://github.com/JasperFx/polecat/issues/517)).

Patch release, so the note extends `docs/release-9-27.md` rather than adding a page. Nothing to do on upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)