### PR TITLE
9.27.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>9.27.1</Version>
+        <Version>9.27.2</Version>
         <LangVersion>13.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>


### PR DESCRIPTION
Version bump for the 9.27.2 patch release.

One change since 9.27.1: #525 — a statically declared partition alongside a partition manager is now refused in all four combinations, rather than depending on the order the fluent calls happened to be written in.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)