### PR TITLE
Split a view on its own AS, not on the first column alias

### DIFF
--- a/src/Weasel.Core.Tests/ViewDefinitionTests.cs
+++ b/src/Weasel.Core.Tests/ViewDefinitionTests.cs
@@ -1,0 +1,113 @@
+using Shouldly;
+using Weasel.Core;
+using Xunit;
+
+namespace Weasel.Core.Tests;
+
+public class ViewDefinitionTests
+{
+    private const string SqlServerDelimiters = "[\"";
+
+    /// <summary>
+    ///     The three cases that fail against the previous implementation, which took everything
+    ///     after the first <c>" AS "</c>. Each one puts an <c>AS</c> somewhere a view header may
+    ///     legally carry it, ahead of the view's own.
+    /// </summary>
+    public class the_defect
+    {
+        [Fact]
+        public void a_column_alias_is_not_mistaken_for_the_views_own_as()
+        {
+            ViewDefinition.ExtractBody(
+                    "CREATE VIEW dbo.v_person\nAS\nSELECT id, first_name AS given_name FROM dbo.person",
+                    SqlServerDelimiters)
+                .ShouldBe("SELECT id, first_name AS given_name FROM dbo.person");
+        }
+
+        [Fact]
+        public void an_as_inside_a_delimited_identifier_is_not_the_separator()
+        {
+            ViewDefinition.ExtractBody("CREATE VIEW [dbo].[my as view] AS SELECT 1 AS one", SqlServerDelimiters)
+                .ShouldBe("SELECT 1 AS one");
+        }
+
+        [Fact]
+        public void an_as_inside_a_leading_comment_is_not_the_separator()
+        {
+            ViewDefinition.ExtractBody("/* selects x AS y */\nCREATE VIEW dbo.v AS SELECT 1", SqlServerDelimiters)
+                .ShouldBe("SELECT 1");
+        }
+    }
+
+    /// <summary>
+    ///     Behaviour that was already correct and is pinned so the rewrite cannot quietly lose it.
+    ///     These pass against the previous implementation too.
+    /// </summary>
+    public class guards
+    {
+        [Fact]
+        public void the_body_starts_after_the_views_own_as()
+        {
+            ViewDefinition.ExtractBody("CREATE VIEW dbo.v AS SELECT id FROM dbo.t", SqlServerDelimiters)
+                .ShouldBe("SELECT id FROM dbo.t");
+        }
+
+        [Fact]
+        public void an_as_inside_a_declared_column_list_is_not_the_separator()
+        {
+            ViewDefinition.ExtractBody("CREATE VIEW dbo.v (a, b) AS SELECT x AS a, y AS b FROM dbo.t",
+                    SqlServerDelimiters)
+                .ShouldBe("SELECT x AS a, y AS b FROM dbo.t");
+        }
+
+        [Fact]
+        public void an_as_inside_a_string_literal_is_not_the_separator()
+        {
+            ViewDefinition.ExtractBody("CREATE VIEW dbo.v AS SELECT 'x AS y' AS label", SqlServerDelimiters)
+                .ShouldBe("SELECT 'x AS y' AS label");
+        }
+
+        [Fact]
+        public void a_view_header_carrying_options_still_splits_on_its_own_as()
+        {
+            ViewDefinition.ExtractBody("CREATE VIEW dbo.v WITH SCHEMABINDING AS SELECT id FROM dbo.t",
+                    SqlServerDelimiters)
+                .ShouldBe("SELECT id FROM dbo.t");
+        }
+
+        [Fact]
+        public void a_word_merely_beginning_with_as_is_not_the_separator()
+        {
+            ViewDefinition.ExtractBody("CREATE VIEW dbo.assets AS SELECT 1", SqlServerDelimiters)
+                .ShouldBe("SELECT 1");
+        }
+
+        [Fact]
+        public void text_with_no_separator_at_all_comes_back_unchanged()
+        {
+            ViewDefinition.ExtractBody("SELECT 1", SqlServerDelimiters).ShouldBe("SELECT 1");
+        }
+    }
+
+    /// <summary>
+    ///     A delimiter is only skipped when the dialect actually uses it, which is why the caller
+    ///     supplies them rather than Core assuming every dialect's. The backtick case fails against
+    ///     the previous implementation too; the bracket case passes on both.
+    /// </summary>
+    public class per_dialect_delimiters
+    {
+        [Fact]
+        public void sqlite_skips_a_backtick_quoted_name()
+        {
+            ViewDefinition.ExtractBody("CREATE VIEW `my as view` AS SELECT 1", "\"[`")
+                .ShouldBe("SELECT 1");
+        }
+
+        [Fact]
+        public void a_bracket_is_an_ordinary_character_where_it_does_not_delimit()
+        {
+            ViewDefinition.ExtractBody("CREATE VIEW \"v\" AS SELECT a[1] AS first", "\"")
+                .ShouldBe("SELECT a[1] AS first");
+        }
+    }
+}

--- a/src/Weasel.Core/ViewDefinition.cs
+++ b/src/Weasel.Core/ViewDefinition.cs
@@ -1,0 +1,139 @@
+namespace Weasel.Core;
+
+/// <summary>
+///     Splits a stored <c>CREATE VIEW … AS …</c> text into header and body.
+/// </summary>
+/// <remarks>
+///     Only the providers whose catalog hands back the whole <c>CREATE VIEW</c> statement need this
+///     -- SQL Server's <c>sys.sql_modules</c> and SQLite's <c>sqlite_master</c>. PostgreSQL's
+///     <c>pg_get_viewdef</c> and Oracle's <c>all_views.text</c> return the body already, so they do
+///     not call it. It lives here rather than in either provider because both had a copy and both
+///     copies had the same defect; which characters delimit an identifier is passed in, the way
+///     <see cref="IdentifierValidation" /> takes its unsafe characters.
+/// </remarks>
+public static class ViewDefinition
+{
+    /// <summary>
+    ///     The body of a view, given the whole <c>CREATE VIEW</c> text a catalog hands back.
+    /// </summary>
+    /// <param name="definition">The stored <c>CREATE VIEW … AS …</c> text.</param>
+    /// <param name="identifierDelimiters">
+    ///     The characters that open a delimited identifier in this dialect: <c>"</c> everywhere,
+    ///     <c>[</c> on SQL Server, <c>`</c> where MySQL syntax is accepted. A single quote is always
+    ///     treated as a string literal and does not need to be listed.
+    /// </param>
+    /// <remarks>
+    ///     Searching for the first <c>" AS "</c> is wrong whenever the view's own <c>AS</c> stands on
+    ///     a line by itself, because the first match is then a column alias inside the SELECT list and
+    ///     the body is cut short. Both sides of a delta go through this same extraction, so the
+    ///     truncation cancels out and the comparison reports no drift while the rebuilt view fails to
+    ///     be created at all.
+    ///
+    ///     The separator is instead the first <c>AS</c> that is a word of its own and is not nested
+    ///     inside parentheses, skipping the three things a view header may legally contain ahead of
+    ///     it: comments, delimited identifiers, and a declared column list.
+    /// </remarks>
+    public static string ExtractBody(string definition, string identifierDelimiters)
+    {
+        if (string.IsNullOrEmpty(definition))
+        {
+            return definition;
+        }
+
+        var depth = 0;
+        var i = 0;
+
+        while (i < definition.Length)
+        {
+            if (SkippedComment(definition, ref i) || SkippedDelimited(definition, identifierDelimiters, ref i))
+            {
+                continue;
+            }
+
+            switch (definition[i])
+            {
+                case '(':
+                    depth++;
+                    break;
+
+                case ')':
+                    depth--;
+                    break;
+
+                default:
+                    if (depth == 0 && IsBareAsAt(definition, i))
+                    {
+                        return definition[(i + 2)..].Trim();
+                    }
+
+                    break;
+            }
+
+            i++;
+        }
+
+        return definition;
+    }
+
+    private static bool SkippedComment(string sql, ref int i)
+    {
+        if (i + 1 >= sql.Length || sql[i] != '-' && sql[i] != '/')
+        {
+            return false;
+        }
+
+        if (sql[i] == '-' && sql[i + 1] == '-')
+        {
+            while (i < sql.Length && sql[i] != '\n')
+            {
+                i++;
+            }
+
+            return true;
+        }
+
+        if (sql[i] == '/' && sql[i + 1] == '*')
+        {
+            i += 2;
+            while (i + 1 < sql.Length && !(sql[i] == '*' && sql[i + 1] == '/'))
+            {
+                i++;
+            }
+
+            i = Math.Min(i + 2, sql.Length);
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool SkippedDelimited(string sql, string identifierDelimiters, ref int i)
+    {
+        var opening = sql[i];
+        if (opening != '\'' && !identifierDelimiters.Contains(opening))
+        {
+            return false;
+        }
+
+        var closing = opening == '[' ? ']' : opening;
+
+        i++;
+        while (i < sql.Length && sql[i] != closing)
+        {
+            i++;
+        }
+
+        i++;
+        return true;
+    }
+
+    private static bool IsBareAsAt(string sql, int i)
+        => (sql[i] == 'a' || sql[i] == 'A')
+           && i + 1 < sql.Length
+           && (sql[i + 1] == 's' || sql[i + 1] == 'S')
+           && (i == 0 || !IsWordCharacter(sql[i - 1]))
+           && (i + 2 >= sql.Length || !IsWordCharacter(sql[i + 2]));
+
+    private static bool IsWordCharacter(char c)
+        => char.IsLetterOrDigit(c) || c == '_' || c == '@' || c == '#' || c == '$';
+}

--- a/src/Weasel.SqlServer.Tests/Views/ViewTests.cs
+++ b/src/Weasel.SqlServer.Tests/Views/ViewTests.cs
@@ -64,6 +64,35 @@ public class ViewTests: IntegrationContext
             .ShouldBe(View.NormalizeSql("select id, name from views.source where quantity > 0"));
     }
 
+    /// <summary>
+    ///     The shape that broke: SQL Server stores a view's text as submitted and puts <c>AS</c> on
+    ///     a line of its own, so the first literal <c>" AS "</c> in the stored text is a column
+    ///     alias in the SELECT list rather than the view's own separator.
+    /// </summary>
+    /// <remarks>
+    ///     This has to create the view with raw SQL rather than through Weasel: a view Weasel wrote
+    ///     has its AS inline, so the defect cannot reproduce from Weasel's own formatting. Reading
+    ///     the body back is not enough on its own either -- the truncated body still compared equal
+    ///     to itself -- so the body is used to create a second view, which is what actually failed.
+    /// </remarks>
+    [Fact]
+    public async Task a_view_whose_own_as_is_on_its_own_line_reads_back_a_usable_body()
+    {
+        await ResetSchema();
+        await createSourceTableAsync("source");
+
+        await theConnection
+            .CreateCommand("CREATE VIEW views.aliased\nAS\nSELECT id, name AS display_name FROM views.source")
+            .ExecuteNonQueryAsync();
+
+        var existing = await new View("views.aliased", "select 1").FetchExistingAsync(theConnection);
+
+        existing.ShouldNotBeNull();
+        existing!.ViewSql.ShouldContain("SELECT id, name AS display_name");
+
+        await CreateSchemaObjectInDatabase(new View("views.aliased_rebuilt", existing.ViewSql));
+    }
+
     [Fact]
     public async Task a_view_that_matches_reports_no_delta()
     {

--- a/src/Weasel.SqlServer/Views/View.cs
+++ b/src/Weasel.SqlServer/Views/View.cs
@@ -103,8 +103,14 @@ public class View: ViewBase
 
         var definition = await reader.GetFieldValueAsync<string>(0, ct).ConfigureAwait(false);
 
-        return string.IsNullOrEmpty(definition) ? null : ExtractViewBody(definition);
+        return string.IsNullOrEmpty(definition) ? null : ViewDefinition.ExtractBody(definition, SqlServerIdentifierDelimiters);
     }
+
+    /// <summary>
+    ///     SQL Server delimits an identifier with <c>[...]</c>, and with <c>"..."</c> under
+    ///     <c>QUOTED_IDENTIFIER ON</c>.
+    /// </summary>
+    private const string SqlServerIdentifierDelimiters = "[\"";
 
     /// <summary>
     ///     Whitespace-insensitive and case-insensitive, because <c>sys.sql_modules</c> hands back
@@ -120,20 +126,4 @@ public class View: ViewBase
             .TrimEnd(';')
             .ToUpperInvariant();
 
-    /// <summary>
-    ///     <c>sys.sql_modules</c> stores the whole <c>CREATE VIEW … AS …</c> text, so the body is
-    ///     what follows the first <c>AS</c> that stands on its own.
-    /// </summary>
-    private static string ExtractViewBody(string definition)
-    {
-        var asIndex = definition.IndexOf(" AS ", StringComparison.OrdinalIgnoreCase);
-        if (asIndex < 0)
-        {
-            // The create may have been written with a newline instead of a space before AS.
-            asIndex = definition.IndexOf("\nAS", StringComparison.OrdinalIgnoreCase);
-            return asIndex < 0 ? definition : definition.Substring(asIndex + 3).Trim();
-        }
-
-        return definition.Substring(asIndex + 4).Trim();
-    }
 }

--- a/src/Weasel.Sqlite.Tests/Views/ViewIntegrationTests.cs
+++ b/src/Weasel.Sqlite.Tests/Views/ViewIntegrationTests.cs
@@ -50,6 +50,38 @@ public class ViewIntegrationTests
         await cmd.ExecuteNonQueryAsync();
     }
 
+    /// <summary>
+    ///     The shape that broke: a view whose own <c>AS</c> stands on a line of its own, so the
+    ///     first literal <c>" AS "</c> in the stored text is a column alias instead.
+    /// </summary>
+    /// <remarks>
+    ///     Created with raw SQL on purpose -- a view Weasel wrote has its AS inline, so the defect
+    ///     cannot reproduce from Weasel's own formatting. The read-back body is then used to create
+    ///     a second view, because a truncated body still compared equal to itself.
+    /// </remarks>
+    [Fact]
+    public async Task a_view_whose_own_as_is_on_its_own_line_reads_back_a_usable_body()
+    {
+        await using var connection = await OpenConnectionAsync();
+        await CreateUsersTable(connection);
+
+        var create = connection.CreateCommand();
+        create.CommandText = "CREATE VIEW aliased\nAS\nSELECT id, name AS display_name FROM users";
+        await create.ExecuteNonQueryAsync();
+
+        var existing = await new View("aliased", "select 1").FetchExistingAsync(connection);
+
+        existing.ShouldNotBeNull();
+        existing!.ViewSql.ShouldContain("name AS display_name");
+
+        var writer = new StringWriter();
+        new View("aliased_rebuilt", existing.ViewSql).WriteCreateStatement(new SqliteMigrator(), writer);
+
+        var rebuild = connection.CreateCommand();
+        rebuild.CommandText = writer.ToString();
+        await rebuild.ExecuteNonQueryAsync();
+    }
+
     [Fact]
     public async Task create_simple_view()
     {

--- a/src/Weasel.Sqlite/Views/View.cs
+++ b/src/Weasel.Sqlite/Views/View.cs
@@ -11,6 +11,12 @@ namespace Weasel.Sqlite.Views;
 public class View : ViewBase
 {
     /// <summary>
+    ///     SQLite accepts all three delimiters, not just its own <c>"..."</c>: <c>[...]</c> and
+    ///     backticks are recognised for compatibility with SQL Server and MySQL syntax.
+    /// </summary>
+    private const string SqliteIdentifierDelimiters = "\"[`";
+
+    /// <summary>
     /// Create a view with the specified name and SQL definition
     /// </summary>
     /// <param name="viewName">Name of the view (can include schema prefix)</param>
@@ -79,7 +85,7 @@ public class View : ViewBase
             if (!string.IsNullOrEmpty(existingSql))
             {
                 // Extract just the view body (the SELECT part) from the existing SQL
-                var existingBody = ExtractViewBody(existingSql);
+                var existingBody = ViewDefinition.ExtractBody(existingSql, SqliteIdentifierDelimiters);
 
                 // Normalize both SQL statements for comparison (just compare the SELECT portion)
                 var normalizedExisting = NormalizeSql(existingBody);
@@ -130,7 +136,7 @@ public class View : ViewBase
             if (!string.IsNullOrEmpty(sql))
             {
                 // Extract the view body from the CREATE VIEW statement
-                var viewBody = ExtractViewBody(sql);
+                var viewBody = ViewDefinition.ExtractBody(sql, SqliteIdentifierDelimiters);
                 return new View(Identifier, viewBody);
             }
         }
@@ -153,15 +159,4 @@ public class View : ViewBase
         return normalized;
     }
 
-    private static string ExtractViewBody(string createViewSql)
-    {
-        // Extract the SELECT portion from "CREATE VIEW name AS SELECT ..."
-        var asIndex = createViewSql.IndexOf(" AS ", StringComparison.OrdinalIgnoreCase);
-        if (asIndex >= 0)
-        {
-            return createViewSql.Substring(asIndex + 4).Trim();
-        }
-
-        return createViewSql;
-    }
 }


### PR DESCRIPTION
When trying to match existing views by setting up definitions in Weasel you will bump into this, the existing code targeted " AS " to remove the CREATE part from the view body which would fail when having a view definition where the AS is not surrounded by spaces like

CREATE VIEW foo
AS
SELECT 1 AS MyColumn

It would instead do the split on the aliased column.

Touches core,sqlserver,sqlite not applicable for PostgreSQL as the metadata extraction natively only gets the body.