### PR TITLE
SQLite map numeric and decimal to NUMERIC affinity, not REAL

### DIFF
--- a/src/Weasel.Sqlite.Tests/Tables/numeric_upgrade_rebuild.cs
+++ b/src/Weasel.Sqlite.Tests/Tables/numeric_upgrade_rebuild.cs
@@ -1,0 +1,99 @@
+using JasperFx;
+using Microsoft.Data.Sqlite;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Sqlite.Tables;
+using Xunit;
+
+namespace Weasel.Sqlite.Tests.Tables;
+
+public class numeric_upgrade_rebuild
+{
+    private readonly string _connectionString = $"Data Source={Path.GetTempFileName()};";
+
+    private static Table AmountsTable(string quantityType)
+    {
+        var table = new Table("nu_amounts");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn("quantity", quantityType);
+        return table;
+    }
+
+    private static async Task ApplyAsync(SqliteConnection conn, Table table)
+    {
+        var migration = await SchemaMigration.DetermineAsync(conn, CancellationToken.None, table);
+        await new SqliteMigrator().ApplyAllAsync(conn, migration, AutoCreate.All);
+    }
+
+    private async Task<SqliteConnection> ATableCreatedBeforeTheChangeAsync()
+    {
+        var conn = new SqliteConnection(_connectionString);
+        await conn.OpenAsync();
+        await conn.ResetSchemaAsync("main");
+
+        await ApplyAsync(conn, AmountsTable("REAL"));
+
+        await conn.CreateCommand("INSERT INTO nu_amounts (id, quantity) VALUES (1, 1)").ExecuteNonQueryAsync();
+        await conn.CreateCommand("INSERT INTO nu_amounts (id, quantity) VALUES (2, 42)").ExecuteNonQueryAsync();
+        await conn.CreateCommand("INSERT INTO nu_amounts (id, quantity) VALUES (3, 2.5)").ExecuteNonQueryAsync();
+
+        var stored = await conn.CreateCommand("SELECT typeof(quantity) FROM nu_amounts WHERE id = 1")
+            .ExecuteScalarAsync();
+        stored.ShouldBe("real");
+
+        return conn;
+    }
+
+    [Fact]
+    public async Task the_first_migration_after_upgrading_needs_a_rebuild()
+    {
+        await using var conn = await ATableCreatedBeforeTheChangeAsync();
+
+        var delta = await AmountsTable("numeric").FindDeltaAsync(conn);
+
+        delta.Difference.ShouldBe(SchemaPatchDifference.Invalid);
+        delta.CanRebuildInPlace.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task the_rebuild_repairs_the_stored_values()
+    {
+        await using var conn = await ATableCreatedBeforeTheChangeAsync();
+
+        await ApplyAsync(conn, AmountsTable("numeric"));
+
+        var rows = new List<(string Type, object? Value)>();
+        await using (var reader = await conn
+                         .CreateCommand("SELECT typeof(quantity), quantity FROM nu_amounts ORDER BY id")
+                         .ExecuteReaderAsync())
+        {
+            while (await reader.ReadAsync())
+            {
+                rows.Add((reader.GetString(0), reader.GetValue(1)));
+            }
+        }
+
+        rows.Count.ShouldBe(3);
+
+        rows[0].Type.ShouldBe("integer");
+        Convert.ToDouble(rows[0].Value).ShouldBe(1d);
+
+        rows[1].Type.ShouldBe("integer");
+        Convert.ToDouble(rows[1].Value).ShouldBe(42d);
+
+        rows[2].Type.ShouldBe("real");
+        Convert.ToDouble(rows[2].Value).ShouldBe(2.5d);
+    }
+
+    [Fact]
+    public async Task a_second_migration_has_nothing_left_to_do()
+    {
+        await using var conn = await ATableCreatedBeforeTheChangeAsync();
+
+        await ApplyAsync(conn, AmountsTable("numeric"));
+
+        var delta = await AmountsTable("numeric").FindDeltaAsync(conn);
+
+        delta.Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+}

--- a/src/Weasel.Sqlite.Tests/numeric_type_affinity.cs
+++ b/src/Weasel.Sqlite.Tests/numeric_type_affinity.cs
@@ -1,0 +1,51 @@
+using Microsoft.Data.Sqlite;
+using Shouldly;
+using Weasel.Sqlite.Tables;
+using Xunit;
+
+namespace Weasel.Sqlite.Tests;
+
+/// <summary>
+///     SQLite gives a declared type REAL affinity only when it contains REAL, FLOA or DOUB.
+///     NUMERIC and DECIMAL get NUMERIC affinity, which stores a whole number as an integer.
+/// </summary>
+public class numeric_type_affinity
+{
+    [Theory]
+    [InlineData("numeric", "NUMERIC")]
+    [InlineData("decimal", "NUMERIC")]
+    [InlineData("real", "REAL")]
+    [InlineData("float", "REAL")]
+    [InlineData("double", "REAL")]
+    public void a_declared_type_keeps_its_affinity(string declared, string expected)
+    {
+        SqliteProvider.Instance.ConvertSynonyms(declared).ShouldBe(expected);
+    }
+
+    [Fact]
+    public async Task a_numeric_column_stores_a_whole_number_as_an_integer()
+    {
+        await using var conn = new SqliteConnection($"Data Source={Path.GetTempFileName()};");
+        await conn.OpenAsync();
+        await conn.ResetSchemaAsync("main");
+
+        var table = new Table("amounts");
+        table.AddColumn("id", "INTEGER").AsPrimaryKey();
+        table.AddColumn("quantity", "numeric");
+
+        var writer = new StringWriter();
+        table.WriteCreateStatement(new SqliteMigrator(), writer);
+
+        var create = conn.CreateCommand();
+        create.CommandText = writer.ToString();
+        await create.ExecuteNonQueryAsync();
+
+        var insert = conn.CreateCommand();
+        insert.CommandText = "insert into amounts (id, quantity) values (1, 1)";
+        await insert.ExecuteNonQueryAsync();
+
+        var query = conn.CreateCommand();
+        query.CommandText = "select typeof(quantity) from amounts";
+        (await query.ExecuteScalarAsync()).ShouldBe("integer");
+    }
+}

--- a/src/Weasel.Sqlite/SqliteProvider.cs
+++ b/src/Weasel.Sqlite/SqliteProvider.cs
@@ -106,9 +106,15 @@ public class SqliteProvider: DatabaseProvider<SqliteCommand, SqliteParameter, Sq
             case "double precision":
             case "float":
             case "real":
+                return "REAL";
+
+            // NUMERIC and DECIMAL are not REAL. SQLite gives a declared type REAL affinity only
+            // when it contains REAL, FLOA or DOUB; NUMERIC and DECIMAL get NUMERIC affinity, which
+            // stores a whole number as an integer. Mapping them to REAL changed stored values --
+            // an id declared numeric came back as 1.0 rather than 1.
             case "numeric":
             case "decimal":
-                return "REAL";
+                return "NUMERIC";
 
             case "blob":
             case "binary":


### PR DESCRIPTION
ConvertSynonyms folded numeric and decimal in with double, float and real and returned REAL for all of them. SQLite gives a declared type REAL affinity only when it contains REAL, FLOA or DOUB; NUMERIC and DECIMAL get NUMERIC affinity, and the two store data differently -- NUMERIC keeps a whole number as an integer, REAL converts it to a float.

Upgrade note: the first migration after this change fails on the default AutoCreate. A table Weasel created from a model declaring a bare numeric or decimal has a REAL column today, and the model now asks for NUMERIC. SQLite reports a column type change as SchemaPatchDifference.Invalid, It seems that there has been some plan for this to trigger an rebuild but it currently doesnt. I will put up another PR for that as it seems quite risky and is not really part of this.
