### PR TITLE
SQLite keep NOT NULL on a column that also declares an inline PRIMARY key

### DIFF
--- a/src/Weasel.Sqlite.Tests/Tables/primary_key_null_rejection.cs
+++ b/src/Weasel.Sqlite.Tests/Tables/primary_key_null_rejection.cs
@@ -1,0 +1,91 @@
+using Microsoft.Data.Sqlite;
+using Shouldly;
+using Weasel.Sqlite.Tables;
+using Xunit;
+
+namespace Weasel.Sqlite.Tests.Tables;
+
+/// <summary>
+///     SQLite does not imply NOT NULL for a primary key. Outside a WITHOUT ROWID table only
+///     <c>INTEGER PRIMARY KEY</c> is safe, and only because it is a rowid alias whose NULL is
+///     replaced by the next rowid rather than stored; a REAL or TEXT primary key stores the NULL.
+/// </summary>
+public class primary_key_null_rejection
+{
+    private static async Task<SqliteConnection> openAsync()
+    {
+        var conn = new SqliteConnection($"Data Source={Path.GetTempFileName()};");
+        await conn.OpenAsync();
+        await conn.ResetSchemaAsync("main");
+        return conn;
+    }
+
+    private static async Task<string?> insertNullKeyAsync(SqliteConnection conn, string table)
+    {
+        try
+        {
+            var cmd = conn.CreateCommand();
+            cmd.CommandText = $"insert into {table} (id) values (null)";
+            await cmd.ExecuteNonQueryAsync();
+            return null;
+        }
+        catch (SqliteException e)
+        {
+            return e.Message;
+        }
+    }
+
+    private static async Task createAsync(SqliteConnection conn, Table table)
+    {
+        var writer = new StringWriter();
+        table.WriteCreateStatement(new SqliteMigrator(), writer);
+
+        var cmd = conn.CreateCommand();
+        cmd.CommandText = writer.ToString();
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    [Fact]
+    public async Task a_text_primary_key_declared_not_null_rejects_a_null()
+    {
+        await using var conn = await openAsync();
+
+        var table = new Table("text_key");
+        table.AddColumn("id", "TEXT").AsPrimaryKey().NotNull();
+        await createAsync(conn, table);
+
+        (await insertNullKeyAsync(conn, "text_key")).ShouldContain("NOT NULL constraint failed");
+    }
+
+    [Fact]
+    public async Task a_real_primary_key_declared_not_null_rejects_a_null()
+    {
+        await using var conn = await openAsync();
+
+        var table = new Table("real_key");
+        table.AddColumn("id", "REAL").AsPrimaryKey().NotNull();
+        await createAsync(conn, table);
+
+        (await insertNullKeyAsync(conn, "real_key")).ShouldContain("NOT NULL constraint failed");
+    }
+
+    /// <summary>
+    ///     The rowid alias keeps its own behaviour: a NULL is still turned into the next rowid
+    ///     rather than rejected, so emitting NOT NULL alongside it costs nothing.
+    /// </summary>
+    [Fact]
+    public async Task an_integer_primary_key_still_assigns_a_rowid()
+    {
+        await using var conn = await openAsync();
+
+        var table = new Table("integer_key");
+        table.AddColumn("id", "INTEGER").AsPrimaryKey().NotNull();
+        await createAsync(conn, table);
+
+        (await insertNullKeyAsync(conn, "integer_key")).ShouldBeNull();
+
+        var cmd = conn.CreateCommand();
+        cmd.CommandText = "select id from integer_key";
+        (await cmd.ExecuteScalarAsync()).ShouldBe(1L);
+    }
+}

--- a/src/Weasel.Sqlite/Tables/TableColumn.cs
+++ b/src/Weasel.Sqlite/Tables/TableColumn.cs
@@ -91,25 +91,23 @@ public class TableColumn: ITableColumn
     /// Generate the column declaration. Pass <paramref name="emitInlinePrimaryKey"/> = false when
     /// the table is responsible for emitting a table-level <c>PRIMARY KEY (...)</c> constraint
     /// (e.g. composite primary keys on SQLite, where two inline <c>PRIMARY KEY</c> columns are
-    /// rejected with <c>'table ... has more than one primary key'</c>). When suppressed, the
-    /// column still emits <c>NOT NULL</c> on its own to match SQLite's implicit NOT NULL semantics
-    /// for primary-key columns.
+    /// rejected with <c>'table ... has more than one primary key'</c>).
     /// </summary>
     public string Declaration(bool emitInlinePrimaryKey)
     {
         var parts = new List<string>();
 
-        // NULL/NOT NULL constraint. When we're suppressing the inline PRIMARY KEY (composite-PK
-        // case), explicitly emit NOT NULL so the column doesn't silently become nullable —
-        // SQLite only auto-applies NOT NULL to columns whose PRIMARY KEY is declared inline.
-        var inlinePk = IsPrimaryKey && emitInlinePrimaryKey;
-        if (!inlinePk && !AllowNulls)
+        // SQLite does not imply NOT NULL for a primary key: outside a WITHOUT ROWID table, only
+        // INTEGER PRIMARY KEY is safe, and only because it is a rowid alias and a NULL is replaced
+        // by the next rowid rather than stored. A REAL or TEXT primary key stores the NULL, so
+        // suppressing NOT NULL here let a rebuilt table accept keys the original rejected.
+        if (!AllowNulls)
         {
             parts.Add("NOT NULL");
         }
 
         // PRIMARY KEY with optional AUTOINCREMENT
-        if (inlinePk)
+        if (IsPrimaryKey && emitInlinePrimaryKey)
         {
             if (IsAutoNumber)
             {


### PR DESCRIPTION
The column declaration suppressed NOT NULL whenever it emitted an inline PRIMARY KEY, on the stated grounds that SQLite applies NOT NULL to primary-key columns by itself. It does not. For  REAL or TEXT primary key NOT NULL needs to be added explicitly to not allow nulls.