### PR TITLE
SQLite: emit a STRICT-legal type for numeric, decimal and parameterized types

### DIFF
--- a/src/Weasel.Sqlite.Tests/Tables/declared_column_types.cs
+++ b/src/Weasel.Sqlite.Tests/Tables/declared_column_types.cs
@@ -10,7 +10,7 @@ namespace Weasel.Sqlite.Tests.Tables;
 ///     SQLite stores a column's declared type verbatim and derives its affinity from that text by
 ///     substring rules, so <c>TIMESTAMP</c> (NUMERIC affinity) and <c>TEXT</c> are different
 ///     columns. Normalizing the type in the constructor rewrote both the model's intent and what
-///     was read back out of an existing database (weasel#466).
+///     was read back out of an existing database (weasel#532).
 /// </summary>
 public class declared_column_types
 {

--- a/src/Weasel.Sqlite.Tests/Tables/strict_table_declared_types.cs
+++ b/src/Weasel.Sqlite.Tests/Tables/strict_table_declared_types.cs
@@ -1,0 +1,130 @@
+using Microsoft.Data.Sqlite;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Sqlite.Tables;
+using Xunit;
+
+namespace Weasel.Sqlite.Tests.Tables;
+
+/// <summary>
+///     A STRICT table accepts only INT, INTEGER, REAL, TEXT, BLOB and ANY. Any other declared type
+///     has to be mapped before it reaches the DDL, or SQLite rejects the CREATE outright.
+/// </summary>
+/// <remarks>
+///     Neither half of this was caught when it landed, because neither half is reachable from one
+///     change alone. weasel#532 made STRICT the only place a declared type is still normalized, and
+///     weasel#533 then made <c>numeric</c> and <c>decimal</c> normalize to NUMERIC -- which STRICT
+///     does not accept. Each PR was green on its own; the combination was not exercised because no
+///     test declared a numeric column on a STRICT table.
+/// </remarks>
+public class strict_table_declared_types
+{
+    private static async Task<SqliteConnection> openAsync()
+    {
+        var conn = new SqliteConnection($"Data Source={Path.GetTempFileName()};");
+        await conn.OpenAsync();
+        await conn.ResetSchemaAsync("main");
+        return conn;
+    }
+
+    private static async Task<string> tableSqlAsync(SqliteConnection conn, string name)
+    {
+        var cmd = conn.CreateCommand();
+        cmd.CommandText = $"select sql from sqlite_master where type = 'table' and name = '{name}'";
+        return (string)(await cmd.ExecuteScalarAsync())!;
+    }
+
+    private static Table StrictTableWith(string declaredType)
+    {
+        var table = new Table("strict_declared") { StrictTypes = true };
+        table.AddColumn("id", "INTEGER").AsPrimaryKey();
+        table.AddColumn("quantity", declaredType);
+        return table;
+    }
+
+    /// <summary>
+    ///     The regression from #533: NUMERIC has no STRICT equivalent, so the CREATE failed with
+    ///     <c>unknown datatype for strict_declared.quantity: "NUMERIC"</c>.
+    /// </summary>
+    [Theory]
+    [InlineData("numeric")]
+    [InlineData("decimal")]
+    public async Task a_numeric_column_can_be_declared_on_a_strict_table(string declaredType)
+    {
+        await using var conn = await openAsync();
+
+        await StrictTableWith(declaredType).CreateAsync(conn);
+
+        (await tableSqlAsync(conn, "strict_declared")).ShouldContain("ANY");
+    }
+
+    /// <summary>
+    ///     Pre-existing rather than a regression, but the same defect: a parameterized type never
+    ///     matched ConvertSynonyms' switch and was emitted verbatim, which STRICT also rejects.
+    /// </summary>
+    [Theory]
+    [InlineData("VARCHAR(255)")]
+    [InlineData("NVARCHAR(50)")]
+    public async Task a_parameterized_type_can_be_declared_on_a_strict_table(string declaredType)
+    {
+        await using var conn = await openAsync();
+
+        await StrictTableWith(declaredType).CreateAsync(conn);
+
+        (await tableSqlAsync(conn, "strict_declared")).ShouldContain("TEXT");
+    }
+
+    /// <summary>
+    ///     Emission and comparison have to agree. The database holds the type that was emitted, so
+    ///     normalizing the two sides differently reports drift on a column that already matches --
+    ///     and on SQLite a column-type delta rebuilds the table, so the migration would run, change
+    ///     nothing, and be needed again on the next run.
+    /// </summary>
+    [Theory]
+    [InlineData("numeric")]
+    [InlineData("decimal")]
+    [InlineData("VARCHAR(255)")]
+    [InlineData("DATETIME")]
+    [InlineData("BIGINT")]
+    [InlineData("REAL")]
+    public async Task a_strict_table_converges(string declaredType)
+    {
+        await using var conn = await openAsync();
+        await StrictTableWith(declaredType).CreateAsync(conn);
+
+        var delta = await StrictTableWith(declaredType).FindDeltaAsync(conn);
+
+        delta.Difference.ShouldBe(SchemaPatchDifference.None);
+        delta.RequiresTableRecreation.ShouldBeFalse();
+    }
+
+    /// <summary>
+    ///     ANY is chosen over REAL for NUMERIC because it is the one STRICT type that keeps a whole
+    ///     number an integer, which is the conversion weasel#533 exists to prevent.
+    /// </summary>
+    [Fact]
+    public async Task a_numeric_column_on_a_strict_table_keeps_a_whole_number_an_integer()
+    {
+        await using var conn = await openAsync();
+        await StrictTableWith("numeric").CreateAsync(conn);
+
+        await conn.CreateCommand("insert into strict_declared (id, quantity) values (1, 42)")
+            .ExecuteNonQueryAsync();
+
+        (await conn.CreateCommand("select typeof(quantity) from strict_declared").ExecuteScalarAsync())
+            .ShouldBe("integer");
+    }
+
+    [Theory]
+    [InlineData("numeric", "ANY")]
+    [InlineData("decimal", "ANY")]
+    [InlineData("VARCHAR(255)", "TEXT")]
+    [InlineData("datetime", "TEXT")]
+    [InlineData("bigint", "INTEGER")]
+    [InlineData("real", "REAL")]
+    [InlineData("blob", "BLOB")]
+    public void the_strict_mapping(string declaredType, string expected)
+    {
+        SqliteProvider.Instance.ToStrictType(declaredType).ShouldBe(expected);
+    }
+}

--- a/src/Weasel.Sqlite/SqliteProvider.cs
+++ b/src/Weasel.Sqlite/SqliteProvider.cs
@@ -126,6 +126,35 @@ public class SqliteProvider: DatabaseProvider<SqliteCommand, SqliteParameter, Sq
         return type;
     }
 
+    /// <summary>
+    ///     The type as a STRICT table has to declare it. STRICT accepts only INT, INTEGER, REAL,
+    ///     TEXT, BLOB and ANY, so anything else must be mapped before it reaches the DDL or SQLite
+    ///     rejects the CREATE outright with <c>unknown datatype</c>.
+    /// </summary>
+    /// <remarks>
+    ///     Two kinds of type reach here that <see cref="ConvertSynonyms" /> does not resolve to a
+    ///     legal one on its own. A parameterized type never matches its switch and came back
+    ///     unchanged, so <c>VARCHAR(255)</c> was emitted verbatim and rejected; the length is
+    ///     stripped first. And NUMERIC -- which <c>numeric</c> and <c>decimal</c> map to since
+    ///     weasel#533 -- has no STRICT equivalent at all.
+    ///
+    ///     NUMERIC becomes ANY rather than REAL because ANY is the one STRICT type that stores a
+    ///     whole number as an integer instead of converting it to a float, and that conversion is
+    ///     exactly what #533 exists to prevent. The cost is that ANY enforces nothing for that
+    ///     column, which is a real trade against the point of a STRICT table; REAL is the
+    ///     alternative if enforcement matters more than the stored value.
+    /// </remarks>
+    public string ToStrictType(string declaredType)
+    {
+        var converted = ConvertSynonyms(declaredType.Split('(')[0].Trim()).ToUpperInvariant();
+
+        return converted switch
+        {
+            "INT" or "INTEGER" or "REAL" or "TEXT" or "BLOB" or "ANY" => converted,
+            _ => "ANY"
+        };
+    }
+
     protected override bool determineParameterType(Type type, out SqliteType dbType)
     {
         var sqliteType = ResolveSqliteType(type);

--- a/src/Weasel.Sqlite/Tables/TableColumn.cs
+++ b/src/Weasel.Sqlite/Tables/TableColumn.cs
@@ -79,9 +79,25 @@ public class TableColumn: ITableColumn
     public string Name { get; }
     public string QuotedName => SchemaUtils.QuoteName(Name);
 
+    /// <summary>
+    ///     The type as it is written into DDL. A STRICT table accepts only INT, INTEGER, REAL,
+    ///     TEXT, BLOB and ANY, so the declared type is mapped onto one of those there; everywhere
+    ///     else SQLite stores the declared text verbatim and it is emitted as written.
+    /// </summary>
     public string DdlType => Parent is { StrictTypes: true }
-        ? SqliteProvider.Instance.ConvertSynonyms(Type)
+        ? SqliteProvider.Instance.ToStrictType(Type)
         : Type;
+
+    /// <summary>
+    ///     What a comparison reduces this column's type to. This has to agree with
+    ///     <see cref="DdlType" /> on a STRICT table: the database holds the type that was emitted,
+    ///     so comparing the model's declared type against it through a different normalization
+    ///     reports drift on a column that already matches, and the resulting migration never
+    ///     converges.
+    /// </summary>
+    private string ComparisonType => Parent is { StrictTypes: true }
+        ? DdlType
+        : SqliteProvider.Instance.ConvertSynonyms(RawType());
 
     public string RawType()
     {
@@ -147,8 +163,7 @@ public class TableColumn: ITableColumn
     protected bool Equals(TableColumn other)
     {
         return string.Equals(Name, other.Name, StringComparison.OrdinalIgnoreCase) &&
-               string.Equals(SqliteProvider.Instance.ConvertSynonyms(RawType()),
-                   SqliteProvider.Instance.ConvertSynonyms(other.RawType()), StringComparison.OrdinalIgnoreCase);
+               string.Equals(ComparisonType, other.ComparisonType, StringComparison.OrdinalIgnoreCase);
     }
 
     public override bool Equals(object? obj)
@@ -176,7 +191,7 @@ public class TableColumn: ITableColumn
         unchecked
         {
             return (Name.ToLowerInvariant().GetHashCode() * 397) ^
-                   SqliteProvider.Instance.ConvertSynonyms(RawType()).ToUpperInvariant().GetHashCode();
+                   ComparisonType.ToUpperInvariant().GetHashCode();
         }
     }
 


### PR DESCRIPTION
A STRICT table accepts only `INT`, `INTEGER`, `REAL`, `TEXT`, `BLOB` and `ANY`. Two kinds of declared type were reaching the DDL as something else, and SQLite rejects the CREATE outright:

```
SQLite Error 1: 'unknown datatype for strict_declared.quantity: "NUMERIC"'
SQLite Error 1: 'unknown datatype for strict_declared.quantity: "VARCHAR(255)"'
```

## NUMERIC is a regression from #532 + #533 together

#532 made STRICT the only place a declared type is still normalized. #533 then made `numeric` and `decimal` normalize to `NUMERIC` — which STRICT does not accept.

Neither PR breaks it alone, which is why both were green and why master is green now. Bisected against the merge commits:

| commit | STRICT + `numeric` |
| --- | --- |
| `e7b338d` (#534) | passes |
| `8edc6e8` (#532) | passes |
| `c2ee75e` (#533) | **fails** |

No test declared a numeric column on a STRICT table, so nothing caught the combination.

## VARCHAR(255) was already broken

Pre-existing rather than a regression, but the same defect and the same line: a parameterized type never matched `ConvertSynonyms`' switch, so it came back unchanged and was emitted verbatim. Fixed here because `DdlType` is supposed to guarantee a STRICT-legal type, and leaving half of that unmet in the property being changed seemed worse than the slightly wider scope. Say the word if you would rather it were split out.

## The choice worth reviewing: ANY, not REAL

`NUMERIC` has no STRICT equivalent, so it has to become something. This maps it to `ANY`, because `ANY` is the one STRICT type that stores a whole number as an integer rather than converting it to a float — and that conversion is exactly what #533 exists to prevent. Mapping to `REAL` would restore pre-#533 STRICT behaviour but reintroduce #533's bug inside STRICT tables.

The cost is real: `ANY` enforces nothing for that column, which is a trade against the point of a STRICT table. It is one line in `SqliteProvider.ToStrictType` if you would rather have `REAL`.

## Comparison had to move with emission

This is the part that turned a one-line fix into a two-part one. `Equals`/`GetHashCode` normalized through `ConvertSynonyms`, while the database holds whatever `DdlType` emitted. Changing only emission would have made a STRICT table with a `numeric` column report drift against itself on every run — and on SQLite a column-type delta rebuilds the table, so the migration would run, change nothing, and be needed again. Both sides now reduce to the same `ComparisonType`, and `a_strict_table_converges` pins it.

## Tests

18 new tests. Verified they fail first: with the product change reverted and the tests kept, 8 fail and 3 pass — the 3 being `DATETIME`, `BIGINT` and `REAL`, which already worked. Full SQLite suite is 519 green, including the existing `a_strict_table_still_normalizes_the_declared_type`, so `DATETIME → TEXT` is unchanged.

Also corrects a stale reference in #532's tests: `weasel#466` is the merged Oracle drop-views PR, not this defect. There is no issue for it, so it now points at #532.

## Still outstanding, not addressed here

`AssertPatchingIsValid` ([SchemaMigration.cs:390](https://github.com/JasperFx/weasel/blob/master/src/Weasel.Core/SchemaMigration.cs#L390)) rejects `SchemaPatchDifference.Invalid` on anything but `AutoCreate.All`, even though the rebuild path immediately above can apply it. That is #533's documented upgrade break and jakobt's proposed follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)