### PR TITLE
9.28.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>9.27.2</Version>
+        <Version>9.28.0</Version>
         <LangVersion>13.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>


### PR DESCRIPTION
Version bump for the SQLite set: [#531](https://github.com/JasperFx/weasel/pull/531), [#532](https://github.com/JasperFx/weasel/pull/532), [#533](https://github.com/JasperFx/weasel/pull/533), [#534](https://github.com/JasperFx/weasel/pull/534) and [#535](https://github.com/JasperFx/weasel/pull/535).

Minor rather than patch because four of the five change the DDL Weasel **emits** — a SQLite database created by 9.28 does not have the same column types as one created by 9.27. 9.27.x was the opposite: fixes to what Weasel *read back*, with emitted DDL unchanged.

Ships with one known upgrade break, documented in [the 9.28 guide](https://weasel.jasperfx.net/release-9-28): a table declaring a column `numeric` or `decimal` fails its first migration on every `AutoCreate` except `All`, because `AssertPatchingIsValid` refuses `SchemaPatchDifference.Invalid` regardless of whether the rebuild path could apply it — and it can, preserving the data. The guard fix is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)