### PR TITLE
Foreign key cycle creation

### DIFF
--- a/src/Weasel.Core/ISchemaObjectDelta.cs
+++ b/src/Weasel.Core/ISchemaObjectDelta.cs
@@ -42,3 +42,31 @@ public interface ISchemaObjectDelta
     /// <param name="writer"></param>
     void WriteRestorationOfPreviousState(Migrator rules, TextWriter writer);
 }
+
+/// <summary>
+///     A delta that writes foreign keys as part of its object's creation, and which can hold some of
+///     them back so they are applied once every delta in the migration has run.
+/// </summary>
+/// <remarks>
+///     A key pointing at a table the same migration has not created yet references something that does
+///     not exist, and ordering cannot solve it when two tables reference each other -- neither can go
+///     first, so the schema could never be created from scratch. <see cref="SchemaMigration" /> decides
+///     which keys to defer; it defers only the ones that would fail, so the DDL generated for schemas
+///     that never had the problem is unchanged.
+/// </remarks>
+public interface ISchemaObjectDeltaWithDeferrableForeignKeys: ISchemaObjectDelta
+{
+    IEnumerable<(string Name, DbObjectName LinkedTable)> ForeignKeysToCreate { get; }
+
+    bool HasDeferredForeignKeys { get; }
+
+    /// <summary>
+    ///     Hold back the key named <paramref name="name" />, which is one of the names this delta
+    ///     reported from <see cref="ForeignKeysToCreate" />.
+    /// </summary>
+    void DeferForeignKey(string name);
+
+    void WriteCreateWithoutDeferredForeignKeys(Migrator rules, TextWriter writer);
+
+    void WriteDeferredForeignKeys(Migrator rules, TextWriter writer);
+}

--- a/src/Weasel.Core/Migrator.cs
+++ b/src/Weasel.Core/Migrator.cs
@@ -211,7 +211,7 @@ public abstract class
                 return false;
 
             case SchemaPatchDifference.Create:
-                delta.SchemaObject.WriteCreateStatement(this, writer);
+                writeCreation(delta, writer);
                 return true;
 
             case SchemaPatchDifference.Update:
@@ -229,11 +229,22 @@ public abstract class
                 }
 
                 delta.SchemaObject.WriteDropStatement(this, writer);
-                delta.SchemaObject.WriteCreateStatement(this, writer);
+                writeCreation(delta, writer);
                 return true;
         }
 
         return false;
+    }
+
+    private void writeCreation(ISchemaObjectDelta delta, TextWriter writer)
+    {
+        if (delta is ISchemaObjectDeltaWithDeferrableForeignKeys { HasDeferredForeignKeys: true } deferrable)
+        {
+            deferrable.WriteCreateWithoutDeferredForeignKeys(this, writer);
+            return;
+        }
+
+        delta.SchemaObject.WriteCreateStatement(this, writer);
     }
 
     /// <summary>

--- a/src/Weasel.Core/SchemaMigration.cs
+++ b/src/Weasel.Core/SchemaMigration.cs
@@ -24,6 +24,55 @@ public class SchemaMigration
         {
             Difference = _deltas.Min(x => x.Difference);
         }
+
+        deferForeignKeysToTablesCreatedLater();
+    }
+
+    private void deferForeignKeysToTablesCreatedLater()
+    {
+        if (!_deltas.Any(x => x is ISchemaObjectDeltaWithDeferrableForeignKeys))
+        {
+            return;
+        }
+
+        // Keyed on QualifiedName with an OrdinalIgnoreCase comparer rather than on DbObjectName itself:
+        // DbObjectName.Equals compares QualifiedName ignoring case, but GetHashCode hashes it ordinally,
+        // so two names differing only in case are equal yet land in different buckets.
+        var creations = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < _deltas.Count; i++)
+        {
+            if (_deltas[i].Difference != SchemaPatchDifference.Create)
+            {
+                continue;
+            }
+
+            var identifier = _deltas[i].SchemaObject?.Identifier?.QualifiedName;
+            if (identifier != null)
+            {
+                creations.TryAdd(identifier, i);
+            }
+        }
+
+        if (creations.Count == 0)
+        {
+            return;
+        }
+
+        for (var i = 0; i < _deltas.Count; i++)
+        {
+            if (_deltas[i] is not ISchemaObjectDeltaWithDeferrableForeignKeys delta)
+            {
+                continue;
+            }
+
+            foreach (var (name, linkedTable) in delta.ForeignKeysToCreate)
+            {
+                if (creations.TryGetValue(linkedTable.QualifiedName, out var created) && created > i)
+                {
+                    delta.DeferForeignKey(name);
+                }
+            }
+        }
     }
 
     public SchemaMigration(ISchemaObjectDelta delta): this(new[] { delta })
@@ -297,33 +346,22 @@ public class SchemaMigration
         AssertPatchingIsValid(autoCreate);
         foreach (var delta in _deltas)
         {
-            switch (delta.Difference)
+            rules.WriteUpdate(writer, delta);
+        }
+
+        WriteDeferredForeignKeys(writer, rules);
+    }
+
+    public void WriteDeferredForeignKeys(TextWriter writer, Migrator rules)
+    {
+        foreach (var delta in _deltas.OfType<ISchemaObjectDeltaWithDeferrableForeignKeys>())
+        {
+            if (!delta.HasDeferredForeignKeys)
             {
-                case SchemaPatchDifference.None:
-                    break;
-
-                case SchemaPatchDifference.Create:
-                    delta.SchemaObject.WriteCreateStatement(rules, writer);
-                    break;
-
-                case SchemaPatchDifference.Update:
-                    delta.WriteUpdate(rules, writer);
-                    break;
-
-                case SchemaPatchDifference.Invalid:
-                    if (delta is ISchemaObjectDeltaWithRebuild { CanRebuildInPlace: true })
-                    {
-                        // The delta cannot express the change as an ALTER, but it can make it
-                        // without discarding the data. Dropping and recreating would be a silent
-                        // data loss (weasel#477).
-                        delta.WriteUpdate(rules, writer);
-                        break;
-                    }
-
-                    delta.SchemaObject.WriteDropStatement(rules, writer);
-                    delta.SchemaObject.WriteCreateStatement(rules, writer);
-                    break;
+                continue;
             }
+
+            delta.WriteDeferredForeignKeys(rules, writer);
         }
     }
 

--- a/src/Weasel.MySql/MySqlMigrator.cs
+++ b/src/Weasel.MySql/MySqlMigrator.cs
@@ -100,6 +100,14 @@ public class MySqlMigrator: Migrator
                 await executeCommand(conn, logger, writer, ct).ConfigureAwait(false);
             }
         }
+
+        var deferred = new StringWriter();
+        migration.WriteDeferredForeignKeys(deferred, this);
+
+        if (deferred.ToString().Trim().IsNotEmpty())
+        {
+            await executeCommand(conn, logger, deferred, ct).ConfigureAwait(false);
+        }
     }
 
     public override string ToExecuteScriptLine(string scriptName)

--- a/src/Weasel.Oracle/OracleMigrator.cs
+++ b/src/Weasel.Oracle/OracleMigrator.cs
@@ -109,6 +109,14 @@ END;");
                 await executeCommand(conn, logger, writer, ct).ConfigureAwait(false);
             }
         }
+
+        var deferred = new StringWriter();
+        migration.WriteDeferredForeignKeys(deferred, this);
+
+        if (deferred.ToString().Trim().IsNotEmpty())
+        {
+            await executeCommand(conn, logger, deferred, ct).ConfigureAwait(false);
+        }
     }
 
     public override string ToExecuteScriptLine(string scriptName)

--- a/src/Weasel.Postgresql.Tests/Tables/foreign_key_cycles.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/foreign_key_cycles.cs
@@ -1,0 +1,105 @@
+using JasperFx;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Postgresql.Tables;
+using Xunit;
+
+namespace Weasel.Postgresql.Tests.Tables;
+
+[Collection("fkcycles")]
+public class foreign_key_cycles: IntegrationContext
+{
+    public foreign_key_cycles(): base("fkcycles")
+    {
+    }
+
+    private static Table BuildTable(string name, string linkedTable, string foreignKeyName)
+    {
+        var table = new Table(new PostgresqlObjectName("fkcycles", name));
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn<int>("other_id").AllowNulls();
+
+        table.ForeignKeys.Add(new ForeignKey(foreignKeyName)
+        {
+            LinkedTable = new PostgresqlObjectName("fkcycles", linkedTable),
+            ColumnNames = ["other_id"],
+            LinkedNames = ["id"]
+        });
+
+        return table;
+    }
+
+    private async Task<bool> ConstraintExistsAsync(string name)
+    {
+        var count = await theConnection.CreateCommand(
+                "select count(*) from pg_constraint where conname = :name and contype = 'f'")
+            .With("name", name)
+            .ExecuteScalarAsync();
+
+        return Convert.ToInt32(count) == 1;
+    }
+
+    [Fact]
+    public async Task mutually_referencing_tables_are_created_from_scratch()
+    {
+        await ResetSchema();
+
+        var db = new DatabaseWithTables("cycles", theDataSource);
+        db.AddTable(BuildTable("fk_cycle_a", "fk_cycle_b", "fk_cycle_a_to_b"));
+        db.AddTable(BuildTable("fk_cycle_b", "fk_cycle_a", "fk_cycle_b_to_a"));
+
+        await db.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        (await ConstraintExistsAsync("fk_cycle_a_to_b")).ShouldBeTrue();
+        (await ConstraintExistsAsync("fk_cycle_b_to_a")).ShouldBeTrue();
+
+        await db.AssertDatabaseMatchesConfigurationAsync();
+    }
+
+    [Fact]
+    public async Task a_partially_created_cycle_is_completed_by_the_next_apply()
+    {
+        await ResetSchema();
+
+        var first = new DatabaseWithTables("cycles", theDataSource);
+        var withoutForeignKey = new Table(new PostgresqlObjectName("fkcycles", "fk_half_a"));
+        withoutForeignKey.AddColumn<int>("id").AsPrimaryKey();
+        withoutForeignKey.AddColumn<int>("other_id").AllowNulls();
+        first.AddTable(withoutForeignKey);
+
+        await first.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var db = new DatabaseWithTables("cycles", theDataSource);
+        db.AddTable(BuildTable("fk_half_a", "fk_half_b", "fk_half_a_to_b"));
+        db.AddTable(BuildTable("fk_half_b", "fk_half_a", "fk_half_b_to_a"));
+
+        await db.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        (await ConstraintExistsAsync("fk_half_a_to_b")).ShouldBeTrue();
+        (await ConstraintExistsAsync("fk_half_b_to_a")).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void an_acyclic_migration_generates_exactly_the_same_ddl_as_before()
+    {
+        var parent = new Table(new PostgresqlObjectName("fkcycles", "fk_parent"));
+        parent.AddColumn<int>("id").AsPrimaryKey();
+
+        var child = BuildTable("fk_child", "fk_parent", "fk_child_to_parent");
+
+        var migrator = new PostgresqlMigrator();
+        var migration = new SchemaMigration(new ISchemaObjectDelta[]
+        {
+            new TableDelta(parent, null), new TableDelta(child, null)
+        });
+
+        var actual = new StringWriter();
+        migration.WriteAllUpdates(actual, migrator, AutoCreate.All);
+
+        var expected = new StringWriter();
+        parent.WriteCreateStatement(migrator, expected);
+        child.WriteCreateStatement(migrator, expected);
+
+        actual.ToString().ShouldBe(expected.ToString());
+    }
+}

--- a/src/Weasel.Postgresql/Tables/Table.cs
+++ b/src/Weasel.Postgresql/Tables/Table.cs
@@ -73,6 +73,9 @@ public partial class Table: TableBase<TableColumn, IndexDefinition, ForeignKey>,
     public IDdlSyntaxStrategy Syntax => PostgresqlDdlSyntax.Instance;
 
     public override void WriteCreateStatement(Migrator migrator, TextWriter writer)
+        => WriteCreateStatement(migrator, writer, null);
+
+    public void WriteCreateStatement(Migrator migrator, TextWriter writer, IReadOnlySet<string>? deferredForeignKeys)
     {
         if (migrator.TableCreation == CreationStyle.DropThenCreate)
         {
@@ -135,6 +138,11 @@ public partial class Table: TableBase<TableColumn, IndexDefinition, ForeignKey>,
 
         foreach (var foreignKey in ForeignKeys)
         {
+            if (deferredForeignKeys?.Contains(foreignKey.Name) == true)
+            {
+                continue;
+            }
+
             writer.WriteLine();
             writer.WriteLine(foreignKey.ToDDL(this));
         }

--- a/src/Weasel.Postgresql/Tables/TableDelta.cs
+++ b/src/Weasel.Postgresql/Tables/TableDelta.cs
@@ -5,13 +5,44 @@ using Weasel.Postgresql.Tables.Partitioning;
 
 namespace Weasel.Postgresql.Tables;
 
-public class TableDelta: SchemaObjectDelta<Table>, ISchemaObjectDeltaWithPostProcessing
+public class TableDelta: SchemaObjectDelta<Table>, ISchemaObjectDeltaWithPostProcessing,
+    ISchemaObjectDeltaWithDeferrableForeignKeys
 {
 
 
     public TableDelta(Table expected, Table? actual): base(expected, actual)
     {
 
+    }
+
+    private readonly HashSet<string> _deferredForeignKeys = new(StringComparer.OrdinalIgnoreCase);
+
+    public bool HasDeferredForeignKeys => _deferredForeignKeys.Count > 0;
+
+    public void DeferForeignKey(string name) => _deferredForeignKeys.Add(name);
+
+    public IEnumerable<(string Name, DbObjectName LinkedTable)> ForeignKeysToCreate =>
+        foreignKeysThisDeltaCreates()
+            .Where(x => x.LinkedTable != null)
+            .Select(x => (x.Name, x.LinkedTable!));
+
+    private IEnumerable<ForeignKey> foreignKeysThisDeltaCreates()
+        => Difference switch
+        {
+            SchemaPatchDifference.Create or SchemaPatchDifference.Invalid => Expected.ForeignKeys,
+            SchemaPatchDifference.Update => ForeignKeys.Missing,
+            _ => []
+        };
+
+    public void WriteCreateWithoutDeferredForeignKeys(Migrator rules, TextWriter writer)
+        => Expected.WriteCreateStatement(rules, writer, _deferredForeignKeys);
+
+    public void WriteDeferredForeignKeys(Migrator rules, TextWriter writer)
+    {
+        foreach (var foreignKey in Expected.ForeignKeys.Where(x => _deferredForeignKeys.Contains(x.Name)))
+        {
+            foreignKey.WriteAddStatement(Expected, writer);
+        }
     }
 
     public IPartition[] MissingPartitions { get; private set; } = Array.Empty<IPartition>();
@@ -186,7 +217,7 @@ public class TableDelta: SchemaObjectDelta<Table>, ISchemaObjectDeltaWithPostPro
             writer.WriteLine($"create table {tempName} as select * from {Expected.Identifier};");
             writer.WriteLine($"drop table {Expected.Identifier} cascade;");
 
-            Expected.WriteCreateStatement(rules, writer);
+            Expected.WriteCreateStatement(rules, writer, _deferredForeignKeys);
 
             writer.WriteLine();
 
@@ -231,7 +262,8 @@ public class TableDelta: SchemaObjectDelta<Table>, ISchemaObjectDeltaWithPostPro
 
     private void writeForeignKeyUpdates(TextWriter writer)
     {
-        foreach (var foreignKey in ForeignKeys.Missing) foreignKey.WriteAddStatement(Expected, writer);
+        foreach (var foreignKey in ForeignKeys.Missing.Where(x => !_deferredForeignKeys.Contains(x.Name)))
+            foreignKey.WriteAddStatement(Expected, writer);
 
         foreach (var foreignKey in ForeignKeys.Extras) foreignKey.WriteDropStatement(Expected, writer);
 

--- a/src/Weasel.SqlServer.Tests/Tables/foreign_key_cycles.cs
+++ b/src/Weasel.SqlServer.Tests/Tables/foreign_key_cycles.cs
@@ -1,0 +1,176 @@
+using JasperFx;
+using Microsoft.Data.SqlClient;
+using Shouldly;
+using Weasel.Core;
+using Weasel.SqlServer.Tables;
+using Xunit;
+
+namespace Weasel.SqlServer.Tests.Tables;
+
+[Collection("integration")]
+public class foreign_key_cycles
+{
+    private static Table BuildTable(string name, string linkedTable, string foreignKeyName)
+    {
+        var table = new Table(new SqlServerObjectName("dbo", name));
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn<int>("other_id").AllowNulls();
+
+        table.ForeignKeys.Add(new ForeignKey(foreignKeyName)
+        {
+            LinkedTable = new SqlServerObjectName("dbo", linkedTable),
+            ColumnNames = ["other_id"],
+            LinkedNames = ["id"]
+        });
+
+        return table;
+    }
+
+    private static async Task DropAsync(params string[] tableNames)
+    {
+        await using var conn = new SqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+
+        foreach (var name in tableNames)
+        {
+            await conn.CreateCommand($@"
+declare @sql nvarchar(max) = '';
+select @sql = @sql + 'ALTER TABLE ' + QUOTENAME(OBJECT_SCHEMA_NAME(fk.parent_object_id)) + '.' + QUOTENAME(OBJECT_NAME(fk.parent_object_id)) + ' DROP CONSTRAINT ' + QUOTENAME(fk.name) + ';'
+from sys.foreign_keys fk where fk.referenced_object_id = OBJECT_ID('dbo.{name}');
+exec sp_executesql @sql;").ExecuteNonQueryAsync();
+        }
+
+        foreach (var name in tableNames)
+        {
+            await conn.CreateCommand($"drop table if exists dbo.{name};").ExecuteNonQueryAsync();
+        }
+    }
+
+    private static async Task<bool> ConstraintExistsAsync(string name)
+    {
+        await using var conn = new SqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+
+        var count = await conn.CreateCommand("select count(*) from sys.foreign_keys where name = @name")
+            .With("name", name)
+            .ExecuteScalarAsync();
+
+        return Convert.ToInt32(count) == 1;
+    }
+
+    [Fact]
+    public async Task mutually_referencing_tables_are_created_from_scratch()
+    {
+        await DropAsync("fk_cycle_a", "fk_cycle_b");
+
+        var db = new DatabaseWithTables("cycles", ConnectionSource.ConnectionString);
+        db.AddTable(BuildTable("fk_cycle_a", "fk_cycle_b", "fk_cycle_a_to_b"));
+        db.AddTable(BuildTable("fk_cycle_b", "fk_cycle_a", "fk_cycle_b_to_a"));
+
+        await db.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        (await ConstraintExistsAsync("fk_cycle_a_to_b")).ShouldBeTrue();
+        (await ConstraintExistsAsync("fk_cycle_b_to_a")).ShouldBeTrue();
+
+        await db.AssertDatabaseMatchesConfigurationAsync();
+
+        await DropAsync("fk_cycle_a", "fk_cycle_b");
+    }
+
+    [Fact]
+    public async Task a_partially_created_cycle_is_completed_by_the_next_apply()
+    {
+        await DropAsync("fk_half_a", "fk_half_b");
+
+        var first = new DatabaseWithTables("cycles", ConnectionSource.ConnectionString);
+        var withoutForeignKey = new Table(new SqlServerObjectName("dbo", "fk_half_a"));
+        withoutForeignKey.AddColumn<int>("id").AsPrimaryKey();
+        withoutForeignKey.AddColumn<int>("other_id").AllowNulls();
+        first.AddTable(withoutForeignKey);
+
+        await first.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var db = new DatabaseWithTables("cycles", ConnectionSource.ConnectionString);
+        db.AddTable(BuildTable("fk_half_a", "fk_half_b", "fk_half_a_to_b"));
+        db.AddTable(BuildTable("fk_half_b", "fk_half_a", "fk_half_b_to_a"));
+
+        await db.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        (await ConstraintExistsAsync("fk_half_a_to_b")).ShouldBeTrue();
+        (await ConstraintExistsAsync("fk_half_b_to_a")).ShouldBeTrue();
+
+        await DropAsync("fk_half_a", "fk_half_b");
+    }
+
+    [Fact]
+    public void an_acyclic_migration_generates_exactly_the_same_ddl_as_before()
+    {
+        var parent = new Table(new SqlServerObjectName("dbo", "fk_parent"));
+        parent.AddColumn<int>("id").AsPrimaryKey();
+
+        var child = BuildTable("fk_child", "fk_parent", "fk_child_to_parent");
+
+        var migrator = new SqlServerMigrator();
+        var migration = new SchemaMigration(new ISchemaObjectDelta[]
+        {
+            new TableDelta(parent, null), new TableDelta(child, null)
+        });
+
+        var actual = new StringWriter();
+        migration.WriteAllUpdates(actual, migrator, AutoCreate.All);
+
+        var expected = new StringWriter();
+        parent.WriteCreateStatement(migrator, expected);
+        child.WriteCreateStatement(migrator, expected);
+
+        actual.ToString().ShouldBe(expected.ToString());
+    }
+
+    [Fact]
+    public void a_target_created_earlier_is_not_deferred_against_a_later_duplicate_of_itself()
+    {
+        var parent = new Table(new SqlServerObjectName("dbo", "fk_parent"));
+        parent.AddColumn<int>("id").AsPrimaryKey();
+
+        var child = BuildTable("fk_child", "fk_parent", "fk_child_to_parent");
+
+        var migrator = new SqlServerMigrator();
+        var migration = new SchemaMigration(new ISchemaObjectDelta[]
+        {
+            new TableDelta(parent, null), new TableDelta(child, null), new TableDelta(parent, null)
+        });
+
+        var actual = new StringWriter();
+        migration.WriteAllUpdates(actual, migrator, AutoCreate.All);
+
+        var expected = new StringWriter();
+        parent.WriteCreateStatement(migrator, expected);
+        child.WriteCreateStatement(migrator, expected);
+        parent.WriteCreateStatement(migrator, expected);
+
+        actual.ToString().ShouldBe(expected.ToString());
+    }
+
+    [Fact]
+    public void a_cyclic_migration_moves_the_backward_key_to_the_end()
+    {
+        var a = BuildTable("fk_cycle_a", "fk_cycle_b", "fk_cycle_a_to_b");
+        var b = BuildTable("fk_cycle_b", "fk_cycle_a", "fk_cycle_b_to_a");
+
+        var migrator = new SqlServerMigrator();
+        var migration = new SchemaMigration(new ISchemaObjectDelta[]
+        {
+            new TableDelta(a, null), new TableDelta(b, null)
+        });
+
+        var writer = new StringWriter();
+        migration.WriteAllUpdates(writer, migrator, AutoCreate.All);
+        var sql = writer.ToString();
+
+        sql.IndexOf("fk_cycle_a_to_b", StringComparison.Ordinal)
+            .ShouldBeGreaterThan(sql.IndexOf("CREATE TABLE dbo.fk_cycle_b", StringComparison.Ordinal));
+
+        sql.IndexOf("fk_cycle_b_to_a", StringComparison.Ordinal)
+            .ShouldBeGreaterThan(sql.IndexOf("CREATE TABLE dbo.fk_cycle_a", StringComparison.Ordinal));
+    }
+}

--- a/src/Weasel.SqlServer/SqlServerMigrator.cs
+++ b/src/Weasel.SqlServer/SqlServerMigrator.cs
@@ -130,6 +130,14 @@ $$;
                 await executeCommand(conn, logger, writer, ct).ConfigureAwait(false);
             }
         }
+
+        var deferred = new StringWriter();
+        migration.WriteDeferredForeignKeys(deferred, this);
+
+        if (deferred.ToString().Trim().IsNotEmpty())
+        {
+            await executeCommand(conn, logger, deferred, ct).ConfigureAwait(false);
+        }
     }
 
     public override string ToExecuteScriptLine(string scriptName)

--- a/src/Weasel.SqlServer/Tables/Table.cs
+++ b/src/Weasel.SqlServer/Tables/Table.cs
@@ -157,6 +157,9 @@ public partial class Table: TableBase<TableColumn, IndexDefinition, ForeignKey>
     }
 
     public override void WriteCreateStatement(Migrator migrator, TextWriter writer)
+        => WriteCreateStatement(migrator, writer, null);
+
+    public void WriteCreateStatement(Migrator migrator, TextWriter writer, IReadOnlySet<string>? deferredForeignKeys)
     {
         // Write partition function and scheme DDL before the table if partitioning is configured
         if (SqlServerPartitioning != null)
@@ -262,6 +265,11 @@ public partial class Table: TableBase<TableColumn, IndexDefinition, ForeignKey>
 
         foreach (var foreignKey in ForeignKeys)
         {
+            if (deferredForeignKeys?.Contains(foreignKey.Name) == true)
+            {
+                continue;
+            }
+
             writer.WriteLine();
             writer.WriteLine(foreignKey.ToDDL(this));
         }

--- a/src/Weasel.SqlServer/Tables/TableDelta.cs
+++ b/src/Weasel.SqlServer/Tables/TableDelta.cs
@@ -3,10 +3,40 @@ using Weasel.Core;
 
 namespace Weasel.SqlServer.Tables;
 
-public class TableDelta: SchemaObjectDelta<Table>
+public class TableDelta: SchemaObjectDelta<Table>, ISchemaObjectDeltaWithDeferrableForeignKeys
 {
     public TableDelta(Table expected, Table? actual): base(expected, actual)
     {
+    }
+
+    private readonly HashSet<string> _deferredForeignKeys = new(StringComparer.OrdinalIgnoreCase);
+
+    public bool HasDeferredForeignKeys => _deferredForeignKeys.Count > 0;
+
+    public void DeferForeignKey(string name) => _deferredForeignKeys.Add(name);
+
+    public IEnumerable<(string Name, DbObjectName LinkedTable)> ForeignKeysToCreate =>
+        foreignKeysThisDeltaCreates()
+            .Where(x => x.LinkedTable != null)
+            .Select(x => (x.Name, x.LinkedTable!));
+
+    private IEnumerable<ForeignKey> foreignKeysThisDeltaCreates()
+        => Difference switch
+        {
+            SchemaPatchDifference.Create or SchemaPatchDifference.Invalid => Expected.ForeignKeys,
+            SchemaPatchDifference.Update => ForeignKeys.Missing,
+            _ => []
+        };
+
+    public void WriteCreateWithoutDeferredForeignKeys(Migrator rules, TextWriter writer)
+        => Expected.WriteCreateStatement(rules, writer, _deferredForeignKeys);
+
+    public void WriteDeferredForeignKeys(Migrator rules, TextWriter writer)
+    {
+        foreach (var foreignKey in Expected.ForeignKeys.Where(x => _deferredForeignKeys.Contains(x.Name)))
+        {
+            foreignKey.WriteAddStatement(Expected, writer);
+        }
     }
 
     internal ItemDelta<TableColumn> Columns { get; private set; } = null!;
@@ -197,7 +227,8 @@ public class TableDelta: SchemaObjectDelta<Table>
 
     private void writeForeignKeyUpdates(TextWriter writer)
     {
-        foreach (var foreignKey in ForeignKeys.Missing) foreignKey.WriteAddStatement(Expected, writer);
+        foreach (var foreignKey in ForeignKeys.Missing.Where(x => !_deferredForeignKeys.Contains(x.Name)))
+            foreignKey.WriteAddStatement(Expected, writer);
 
         foreach (var foreignKey in ForeignKeys.Extras) foreignKey.WriteDropStatement(Expected, writer);
 

--- a/src/Weasel.Sqlite/SqliteMigrator.cs
+++ b/src/Weasel.Sqlite/SqliteMigrator.cs
@@ -180,12 +180,16 @@ public class SqliteMigrator: Migrator
             }
         }
 
+        // Inside writeDeltasAsync rather than after it, so a rebuild's deferred keys are added
+        // within the same transaction as the rebuild and roll back with it. failureIsFatal has to
+        // carry through for the same reason: swallowing a failure here would let a rebuild reach
+        // COMMIT with a key missing.
         var deferred = new StringWriter();
         migration.WriteDeferredForeignKeys(deferred, this);
 
         if (deferred.ToString().Trim().IsNotEmpty())
         {
-            await executeCommand(conn, logger, deferred, ct).ConfigureAwait(false);
+            await executeCommand(conn, logger, deferred, failureIsFatal, ct).ConfigureAwait(false);
         }
     }
 

--- a/src/Weasel.Sqlite/SqliteMigrator.cs
+++ b/src/Weasel.Sqlite/SqliteMigrator.cs
@@ -76,6 +76,14 @@ public class SqliteMigrator: Migrator
                 await executeCommand(conn, logger, writer, ct).ConfigureAwait(false);
             }
         }
+
+        var deferred = new StringWriter();
+        migration.WriteDeferredForeignKeys(deferred, this);
+
+        if (deferred.ToString().Trim().IsNotEmpty())
+        {
+            await executeCommand(conn, logger, deferred, ct).ConfigureAwait(false);
+        }
     }
 
     public override string ToExecuteScriptLine(string scriptName)


### PR DESCRIPTION
A table's foreign keys are written into its own create statement, so a key pointing at a
table the migration hasn't created yet references nothing. Two tables referencing each
other can never be created from scratch — neither can go first, the apply throws on the
first `ALTER`, and every later delta is abandoned, including the create of the table the
key was waiting for. Re-running reproduces the same failing statement, so it never
recovers.

A migration now holds back exactly the keys that would fail — those whose referenced table
is created by a later delta — and applies them once every delta has run. Keys whose target
already exists, or is created earlier in the same migration, stay where they were, so
schemas that never had the problem generate byte-for-byte identical DDL.

Only SQL Server and PostgreSQL can defer. SQLite writes its foreign keys inline in
`CREATE TABLE` and never had the problem.