### PR TITLE
fix(core): let a rebuildable Invalid delta through AssertPatchingIsValid

### DIFF
--- a/docs/release-9-28.md
+++ b/docs/release-9-28.md
@@ -4,11 +4,12 @@
 a schema back wrong — four of these change the DDL Weasel **emits**. A SQLite database created by
 9.28 does not have the same column types as one created by 9.27.
 
-::: danger The first migration after upgrading can throw
-If any table declares a column as `numeric` or `decimal`, the first migration after upgrading fails
-with a `SchemaMigrationException` on every `AutoCreate` setting except `AutoCreate.All`. The change
-is safe and the rebuild that applies it preserves your data — it is the guard in front of it that
-refuses. [Read this before upgrading](#the-first-migration-can-throw).
+::: danger The first migration on 9.28.0 can throw — fixed in 9.28.1
+If any table declares a column as `numeric` or `decimal`, the first migration after upgrading to
+**9.28.0** fails with a `SchemaMigrationException` on every `AutoCreate` setting except
+`AutoCreate.All`. The change is safe and the rebuild that applies it preserves your data — it was
+the guard in front of it that refused. **9.28.1 fixes the guard**; go straight to it and there is
+nothing to do. [Read this if you are on 9.28.0](#the-first-migration-can-throw).
 :::
 
 ::: warning SQLite column types are what you declared them to be now
@@ -25,22 +26,29 @@ a table Weasel created before 9.28 has a `REAL` column where the model now asks 
 SQLite cannot express a column type change as an `ALTER`, so the delta comes back as
 `SchemaPatchDifference.Invalid`.
 
-That difference is applied by rebuilding the table and copying every row, and that path works — but
-`SchemaMigration.AssertPatchingIsValid` rejects `Invalid` on anything except `AutoCreate.All`,
-regardless of whether a rebuild could apply it. So the migration that would have succeeded never
-runs, and you get a `Weasel.Core.SchemaMigrationException` reading
-`Cannot derive schema migrations for … AutoCreate.CreateOrUpdate`.
+That difference is applied by rebuilding the table and copying every row, and that path works. On
+9.28.0 the guard above it did not agree: `SchemaMigration.AssertPatchingIsValid` rejected `Invalid`
+on anything except `AutoCreate.All`, regardless of whether a rebuild could apply it. So the
+migration that would have succeeded never ran, and you got a `Weasel.Core.SchemaMigrationException`
+reading `Cannot derive schema migrations for … AutoCreate.CreateOrUpdate`.
 
-**Upgrading.** One of:
+**[#538](https://github.com/JasperFx/weasel/issues/538) fixes this in 9.28.1.** The guard now asks
+the delta whether it can rebuild in place — the same question both apply paths below it already
+ask — and lets it through under `AutoCreate.CreateOrUpdate` when it can. `AutoCreate.CreateOnly`
+still refuses, because a rebuild recreates a table that is already there and that is an update.
 
-- Run the first migration with `AutoCreate.All`. The rebuild applies, data is copied, and every
-  subsequent run is clean — there is nothing left to do on the second migration.
-- Declare the column as `real` in your model if `REAL` is genuinely what you want. Nothing changes
-  and no migration is needed.
-- Stay on 9.27 until the guard is fixed.
+**Upgrading.**
 
-This is a gap in the guard rather than in the change, and it affects any SQLite column-type change,
-not only this one. It is tracked as a follow-up.
+- **From 9.27 or earlier:** upgrade to 9.28.1 rather than 9.28.0 and there is nothing to do. The
+  first migration rebuilds the table, copies every row, and converges.
+- **Already on 9.28.0:** upgrade to 9.28.1, or run the first migration once with `AutoCreate.All`.
+  Either applies the same rebuild.
+- Declaring the column as `real` in your model also works if `REAL` is genuinely what you want —
+  nothing changes and no migration is needed.
+
+Note that the gap was never specific to `numeric`: it affected **any** SQLite column type change, as
+well as adding or dropping a foreign key and changing a primary key. The `numeric` change is only
+what made it reachable for people who had not changed their model at all.
 
 ## What changed
 

--- a/src/Weasel.Core.Tests/Migrations/rebuildable_invalid_deltas_pass_the_gate.cs
+++ b/src/Weasel.Core.Tests/Migrations/rebuildable_invalid_deltas_pass_the_gate.cs
@@ -1,0 +1,148 @@
+using System.Data.Common;
+using JasperFx;
+using Shouldly;
+using Weasel.Core;
+using Xunit;
+
+namespace Weasel.Core.Tests.Migrations;
+
+/// <summary>
+///     weasel#538: <see cref="SchemaMigration.AssertPatchingIsValid" /> refused every
+///     <see cref="SchemaPatchDifference.Invalid" /> delta below <see cref="AutoCreate.All" />
+///     without asking whether the delta could actually carry the change out.
+/// </summary>
+/// <remarks>
+///     <para>
+///         weasel#477 taught both apply paths — <see cref="SchemaMigration.WriteAllUpdates" /> and
+///         <see cref="Migrator.WriteUpdate(TextWriter, ISchemaObjectDelta)" /> — to honour
+///         <see cref="ISchemaObjectDeltaWithRebuild.CanRebuildInPlace" /> and rebuild the object
+///         instead of dropping it. The gate above them was not, so it rejected migrations the
+///         machinery it guards would have applied correctly, and with the data intact.
+///     </para>
+///     <para>
+///         These are at the Core level with fakes because the rule is a Core rule. The end-to-end
+///         proof against a real database is in
+///         <c>Weasel.Sqlite.Tests/Tables/rebuildable_invalid_is_permitted.cs</c>; SQLite is the only
+///         provider implementing the interface today.
+///     </para>
+/// </remarks>
+public class rebuildable_invalid_deltas_pass_the_gate
+{
+    [Theory]
+    [InlineData(AutoCreate.All)]
+    [InlineData(AutoCreate.CreateOrUpdate)]
+    public void a_rebuildable_invalid_is_permitted(AutoCreate autoCreate)
+    {
+        var migration = new SchemaMigration(new RebuildableDelta(canRebuildInPlace: true));
+
+        Should.NotThrow(() => migration.AssertPatchingIsValid(autoCreate));
+    }
+
+    /// <summary>
+    ///     A rebuild recreates an object that is already there, which is an update however you look
+    ///     at it, so <see cref="AutoCreate.CreateOnly" /> still refuses. This is the question
+    ///     weasel#538 left open; it falls out of the existing <c>CreateOnly</c> branch rather than
+    ///     needing a special case, but it is a decision and so it gets a test.
+    /// </summary>
+    [Fact]
+    public void create_only_still_refuses_a_rebuildable_invalid()
+    {
+        var migration = new SchemaMigration(new RebuildableDelta(canRebuildInPlace: true));
+
+        Should.Throw<SchemaMigrationException>(
+            () => migration.AssertPatchingIsValid(AutoCreate.CreateOnly));
+    }
+
+    /// <summary>
+    ///     The gate is narrowed, not opened: an <c>Invalid</c> delta that cannot rebuild is still
+    ///     refused, because for it the apply path really would drop and recreate.
+    /// </summary>
+    [Theory]
+    [InlineData(AutoCreate.CreateOrUpdate)]
+    [InlineData(AutoCreate.CreateOnly)]
+    public void an_invalid_delta_that_cannot_rebuild_is_still_refused(AutoCreate autoCreate)
+    {
+        var migration = new SchemaMigration(new RebuildableDelta(canRebuildInPlace: false));
+
+        Should.Throw<SchemaMigrationException>(
+            () => migration.AssertPatchingIsValid(autoCreate));
+    }
+
+    /// <summary>
+    ///     A delta that does not implement the interface at all is the common case and must not have
+    ///     moved.
+    /// </summary>
+    [Fact]
+    public void a_plain_invalid_delta_is_still_refused()
+    {
+        var migration = new SchemaMigration(
+            new SchemaObjectDelta(new FakeSchemaObject(), SchemaPatchDifference.Invalid));
+
+        Should.Throw<SchemaMigrationException>(
+            () => migration.AssertPatchingIsValid(AutoCreate.CreateOrUpdate));
+    }
+
+    /// <summary>
+    ///     A migration mixing a rebuildable <c>Invalid</c> with one that cannot rebuild is still
+    ///     refused — and the message names only the one that is genuinely stuck.
+    /// </summary>
+    [Fact]
+    public void a_mixed_migration_is_refused_and_names_only_the_stuck_delta()
+    {
+        var migration = new SchemaMigration(new ISchemaObjectDelta[]
+        {
+            new RebuildableDelta(canRebuildInPlace: true, name: "rebuildable"),
+            new RebuildableDelta(canRebuildInPlace: false, name: "stuck")
+        });
+
+        var ex = Should.Throw<SchemaMigrationException>(
+            () => migration.AssertPatchingIsValid(AutoCreate.CreateOrUpdate));
+
+        ex.Message.ShouldContain("stuck");
+        ex.Message.ShouldNotContain("rebuildable");
+    }
+
+    public class RebuildableDelta: ISchemaObjectDeltaWithRebuild
+    {
+        private readonly string _name;
+
+        public RebuildableDelta(bool canRebuildInPlace, string name = "fake")
+        {
+            CanRebuildInPlace = canRebuildInPlace;
+            _name = name;
+            SchemaObject = new FakeSchemaObject(name);
+        }
+
+        public bool CanRebuildInPlace { get; }
+        public ISchemaObject SchemaObject { get; }
+        public SchemaPatchDifference Difference => SchemaPatchDifference.Invalid;
+
+        public void WriteUpdate(Migrator rules, TextWriter writer) => writer.WriteLine("rebuild");
+        public void WriteRollback(Migrator rules, TextWriter writer) { }
+        public void WriteRestorationOfPreviousState(Migrator rules, TextWriter writer) { }
+
+        public override string ToString() => _name;
+    }
+
+    public class FakeSchemaObject: ISchemaObject
+    {
+        public FakeSchemaObject(string name = "fake")
+        {
+            Identifier = new DbObjectName("public", name);
+        }
+
+        public DbObjectName Identifier { get; }
+
+        public void WriteCreateStatement(Migrator migrator, TextWriter writer) { }
+        public void WriteDropStatement(Migrator rules, TextWriter writer) { }
+        public void ConfigureQueryCommand(DbCommandBuilder builder) { }
+
+        public Task<ISchemaObjectDelta> CreateDeltaAsync(DbDataReader reader, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public IEnumerable<DbObjectName> AllNames()
+        {
+            yield return Identifier;
+        }
+    }
+}

--- a/src/Weasel.Core/ISchemaObject.cs
+++ b/src/Weasel.Core/ISchemaObject.cs
@@ -61,10 +61,25 @@ public interface ISchemaObjectWithPostProcessing : ISchemaObject
 ///         (weasel#477).
 ///     </para>
 ///     <para>
-///         Implementing this does not make the change safe enough to apply under
-///         <c>AutoCreate.CreateOrUpdate</c>. It is still destructive in the sense that matters for
-///         permission — a column being removed takes its data with it — so it still requires
-///         <c>AutoCreate.All</c>. What changes is only what <c>All</c> then does.
+///         <c>AutoCreate.CreateOrUpdate</c> permits this, and <c>AutoCreate.CreateOnly</c> does not.
+///         weasel#477 first landed with the opposite rule — a rebuild still required
+///         <c>AutoCreate.All</c>, on the reasoning that a rebuild which also drops a column takes
+///         that column's data with it. But <c>SchemaMigration.AssertPatchingIsValid</c> could only
+///         express that by refusing every rebuildable delta, including the great majority that drop
+///         nothing: a column type change, a foreign key, a primary key. SQLite's ordinary
+///         <c>Update</c> path already emits <c>ALTER TABLE … DROP COLUMN</c> under
+///         <c>CreateOrUpdate</c>, so the strict rule was not buying the protection it claimed —
+///         it only refused the same loss when the column happened to sit in a key (weasel#538).
+///     </para>
+///     <para>
+///         A rebuild is an update, not a create, so <c>CreateOnly</c> still refuses it. That falls
+///         out of the <c>CreateOnly</c> branch on its own: the delta is still <c>Invalid</c>, so the
+///         migration's <c>Difference</c> is still not <c>Create</c>.
+///     </para>
+///     <para>
+///         Worth knowing before implementing this on another provider: a rebuild copies every row.
+///         On a large table that is a very different proposition from an <c>ALTER</c>, even though
+///         both are "an update".
 ///     </para>
 /// </remarks>
 public interface ISchemaObjectDeltaWithRebuild : ISchemaObjectDelta

--- a/src/Weasel.Core/SchemaMigration.cs
+++ b/src/Weasel.Core/SchemaMigration.cs
@@ -389,8 +389,23 @@ public class SchemaMigration
 
         if (Difference == SchemaPatchDifference.Invalid)
         {
-            var invalids = _deltas.Where(x => x.Difference == SchemaPatchDifference.Invalid);
-            throw new SchemaMigrationException(autoCreate, invalids);
+            // Only the deltas that are genuinely stuck. A delta that can rebuild in place is not:
+            // both apply paths below -- WriteAllUpdates and Migrator.WriteUpdate -- answer such a
+            // delta by calling its WriteUpdate rather than dropping and recreating (weasel#477), so
+            // refusing it here rejects a migration the machinery would have carried out correctly
+            // and with the data intact (weasel#538).
+            //
+            // It is still Invalid, so it still fails the CreateOnly check below. A rebuild recreates
+            // an object that is already there, which is an update whichever way you look at it.
+            var invalids = _deltas
+                .Where(x => x.Difference == SchemaPatchDifference.Invalid)
+                .Where(x => x is not ISchemaObjectDeltaWithRebuild { CanRebuildInPlace: true })
+                .ToArray();
+
+            if (invalids.Any())
+            {
+                throw new SchemaMigrationException(autoCreate, invalids);
+            }
         }
 
         switch (autoCreate)

--- a/src/Weasel.Sqlite.Tests/Tables/rebuildable_invalid_is_permitted.cs
+++ b/src/Weasel.Sqlite.Tests/Tables/rebuildable_invalid_is_permitted.cs
@@ -1,0 +1,127 @@
+using JasperFx;
+using Microsoft.Data.Sqlite;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Sqlite.Tables;
+using Xunit;
+
+namespace Weasel.Sqlite.Tests.Tables;
+
+/// <summary>
+///     weasel#538: <c>SchemaMigration.AssertPatchingIsValid</c> refused every <c>Invalid</c> delta
+///     below <see cref="AutoCreate.All" />, including the ones the apply path right below it knows
+///     how to carry out without losing a row.
+/// </summary>
+/// <remarks>
+///     <para>
+///         weasel#477 taught <c>SchemaMigration.WriteAllUpdates</c> and <c>Migrator.WriteUpdate</c>
+///         to honour <see cref="ISchemaObjectDeltaWithRebuild.CanRebuildInPlace" /> and rebuild the
+///         table rather than drop it. The gate was not taught the same thing, so it rejected
+///         migrations the machinery it guards would have applied correctly.
+///     </para>
+///     <para>
+///         Reachable in 9.28.0 through weasel#533: a table Weasel created from a model declaring
+///         <c>numeric</c> or <c>decimal</c> has a <c>REAL</c> column, and the model now asks for
+///         <c>NUMERIC</c>. That is a column type change, which SQLite reports as <c>Invalid</c>, so
+///         the first migration after upgrading threw under <c>CreateOrUpdate</c>.
+///     </para>
+/// </remarks>
+public class rebuildable_invalid_is_permitted
+{
+    private readonly string _connectionString = $"Data Source={Path.GetTempFileName()};";
+
+    private async Task<SqliteConnection> openAsync()
+    {
+        var conn = new SqliteConnection(_connectionString);
+        await conn.OpenAsync();
+        await conn.ResetSchemaAsync("main");
+        return conn;
+    }
+
+    private static Table PricesTable(string amountType)
+    {
+        var table = new Table("pm_prices");
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn("amount", amountType);
+        return table;
+    }
+
+    /// <summary>
+    ///     The 9.28.0 upgrade shape: a table created when <c>numeric</c> mapped to <c>REAL</c>,
+    ///     against a model that now asks for <c>NUMERIC</c>.
+    /// </summary>
+    private async Task<SqliteConnection> upgradedDatabaseAsync()
+    {
+        var conn = await openAsync();
+
+        var asCreatedBefore928 = await SchemaMigration.DetermineAsync(
+            conn, CancellationToken.None, PricesTable("REAL"));
+        await new SqliteMigrator().ApplyAllAsync(conn, asCreatedBefore928, AutoCreate.All);
+
+        await conn.CreateCommand("INSERT INTO pm_prices (id, amount) VALUES (1, 19.95)")
+            .ExecuteNonQueryAsync();
+
+        return conn;
+    }
+
+    [Fact]
+    public async Task the_upgrade_delta_is_invalid_but_rebuildable()
+    {
+        await using var conn = await upgradedDatabaseAsync();
+
+        var delta = await PricesTable("NUMERIC").FindDeltaAsync(conn);
+
+        delta.Difference.ShouldBe(SchemaPatchDifference.Invalid);
+        delta.CanRebuildInPlace.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task create_or_update_permits_a_rebuildable_invalid()
+    {
+        await using var conn = await upgradedDatabaseAsync();
+
+        var migration = await SchemaMigration.DetermineAsync(
+            conn, CancellationToken.None, PricesTable("NUMERIC"));
+
+        Should.NotThrow(() => migration.AssertPatchingIsValid(AutoCreate.CreateOrUpdate));
+    }
+
+    /// <summary>
+    ///     And the permission is worth something: the migration it let through actually converges,
+    ///     and the row is still there afterwards.
+    /// </summary>
+    [Fact]
+    public async Task create_or_update_applies_the_rebuild_and_keeps_the_rows()
+    {
+        await using var conn = await upgradedDatabaseAsync();
+
+        var migration = await SchemaMigration.DetermineAsync(
+            conn, CancellationToken.None, PricesTable("NUMERIC"));
+        await new SqliteMigrator().ApplyAllAsync(conn, migration, AutoCreate.CreateOrUpdate);
+
+        var amount = await conn.CreateCommand("SELECT amount FROM pm_prices WHERE id = 1")
+            .ExecuteScalarAsync();
+        Convert.ToDecimal(amount).ShouldBe(19.95m);
+
+        var after = await PricesTable("NUMERIC").FindDeltaAsync(conn);
+        after.Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    /// <summary>
+    ///     A rebuild recreates a table that is already there, which is an update however you look at
+    ///     it — so <see cref="AutoCreate.CreateOnly" /> still refuses it. This falls out of the
+    ///     existing <c>CreateOnly</c> branch rather than being special-cased, but it is the open
+    ///     question in weasel#538 and deserves to be pinned.
+    /// </summary>
+    [Fact]
+    public async Task create_only_still_refuses_a_rebuildable_invalid()
+    {
+        await using var conn = await upgradedDatabaseAsync();
+
+        var migration = await SchemaMigration.DetermineAsync(
+            conn, CancellationToken.None, PricesTable("NUMERIC"));
+
+        Should.Throw<SchemaMigrationException>(
+            () => migration.AssertPatchingIsValid(AutoCreate.CreateOnly));
+    }
+}


### PR DESCRIPTION
Closes #538.

## The gap

`SchemaMigration.AssertPatchingIsValid` threw for `SchemaPatchDifference.Invalid` on every `AutoCreate` except `All`, without asking whether the delta could actually apply the change. Both apply paths directly below it *do* ask:

- `SchemaMigration.WriteAllUpdates`
- `Migrator.WriteUpdate`

Both honour `ISchemaObjectDeltaWithRebuild.CanRebuildInPlace` and call `WriteUpdate` rather than drop-and-create — which is what #477 added so a rebuild would copy the data instead of discarding it. The gate was stricter than the thing it gates.

## The fix

```csharp
var invalids = _deltas
    .Where(x => x.Difference == SchemaPatchDifference.Invalid)
    .Where(x => x is not ISchemaObjectDeltaWithRebuild { CanRebuildInPlace: true })
    .ToArray();

if (invalids.Any())
{
    throw new SchemaMigrationException(autoCreate, invalids);
}
```

## The open question, decided: `CreateOnly` still refuses

A rebuild recreates a table that is already there, which is an update however you look at it. This needs no special case — the delta is still `Invalid`, so the migration's `Difference` is still not `Create`, and the existing `CreateOnly` branch throws. Pinned by a test in both suites rather than left to fall out silently.

## The doc said the opposite, and was wrong on its own terms

`ISchemaObjectDeltaWithRebuild`'s XML doc claimed a rebuild always requires `AutoCreate.All`, because a rebuild that also drops a column takes that column's data with it.

That reasoning does not survive contact with the code. `AssertPatchingIsValid` could only express it by refusing *every* rebuildable delta, including the great majority that drop nothing — a column type change, a foreign key, a primary key. And measured against a real SQLite database: the ordinary `Update` path already emits `ALTER TABLE … DROP COLUMN` and is already permitted under `CreateOrUpdate`. So the strict rule was not buying the protection it claimed; it refused the same data loss only when the dropped column happened to sit in a key, and refused three harmless changes to do it.

The doc is rewritten to record the decision and the measurement, and keeps the point that is still worth knowing: a rebuild copies every row, so on a large table it is a very different proposition from an `ALTER`.

## Reproduction

The issue cites `Weasel.Sqlite.Tests/Tables/numeric_upgrade_rebuild.cs`, which does not exist on master — so the reproduction is built here from scratch, in the 9.28.0 upgrade shape: a table created when `numeric` mapped to `REAL`, against a model that now asks for `NUMERIC`. Confirmed failing before the change:

```
Shouldly.ShouldAssertException : `migration.AssertPatchingIsValid(AutoCreate.CreateOrUpdate)`
should not throw but threw Weasel.Core.SchemaMigrationException
with message "Cannot derive schema migrations for Weasel.Sqlite.Tables.TableDelta AutoCreate.CreateOrUpdate"
```

## Tests

`Weasel.Core.Tests/Migrations/rebuildable_invalid_deltas_pass_the_gate.cs` — the rule is a Core rule, so it is tested at Core with fakes: permitted under `All`/`CreateOrUpdate`, refused under `CreateOnly`, still refused when `CanRebuildInPlace` is false, still refused for a delta not implementing the interface, and a mixed migration refused with only the genuinely stuck delta named in the message.

`Weasel.Sqlite.Tests/Tables/rebuildable_invalid_is_permitted.cs` — end to end against a real database, since SQLite is the only provider implementing the interface today. Asserts the permission is worth something: the migration it lets through converges to `None` and the row survives with its value.

Full `Weasel.Core.Tests` (327) and `Weasel.Sqlite.Tests` (523) green.

## Docs

`docs/release-9-28.md` documented this as a known break with "stay on 9.27 until the guard is fixed". Rewritten for 9.28.1, keeping the workaround for anyone already on 9.28.0, and noting that the gap was never specific to `numeric` — it affected any SQLite column type change, foreign key change or primary key change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)