### PR TITLE
feat(postgresql): index a pre-built tsvector, making setweight() weighting reachable

### DIFF
--- a/docs/postgresql/tables.md
+++ b/docs/postgresql/tables.md
@@ -13,7 +13,7 @@ var table = new Table("users");
 // Create a table in a specific schema
 var schemaTable = new Table("myschema.users");
 ```
-<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/PostgresqlTableSamples.cs#L11-L17' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_pg_create_a_table' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/PostgresqlTableSamples.cs#L12-L18' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_pg_create_a_table' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Adding Columns
@@ -31,7 +31,7 @@ table.AddColumn<string>("email").NotNull();
 table.AddColumn<DateTime>("created_at").NotNull();
 table.AddColumn("metadata", "jsonb");
 ```
-<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/PostgresqlTableSamples.cs#L22-L30' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_pg_add_columns' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/PostgresqlTableSamples.cs#L23-L31' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_pg_add_columns' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The fluent `ColumnExpression` returned by `AddColumn` supports:
@@ -63,7 +63,7 @@ var compositeTable = new Table("tenant_orders");
 compositeTable.AddColumn<int>("tenant_id").AsPrimaryKey();
 compositeTable.AddColumn<int>("order_id").AsPrimaryKey();
 ```
-<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/PostgresqlTableSamples.cs#L35-L45' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_pg_primary_keys' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/PostgresqlTableSamples.cs#L36-L46' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_pg_primary_keys' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 You can customize the primary key constraint name via `table.PrimaryKeyName`.
@@ -79,7 +79,7 @@ table.AddColumn<int>("company_id")
     .ForeignKeyTo("companies", "id",
         onDelete: CascadeAction.Cascade);
 ```
-<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/PostgresqlTableSamples.cs#L66-L72' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_pg_foreign_keys' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/PostgresqlTableSamples.cs#L67-L73' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_pg_foreign_keys' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Or add foreign keys directly to the `ForeignKeys` collection for multi-column keys.
@@ -100,10 +100,70 @@ var index = new IndexDefinition("idx_users_email")
 index.Columns = new[] { "email" };
 table.Indexes.Add(index);
 ```
-<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/PostgresqlTableSamples.cs#L77-L88' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_pg_indexes' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/PostgresqlTableSamples.cs#L78-L89' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_pg_indexes' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Indexes support GIN, GiST, BRIN, and hash methods via the `IndexMethod` enum. Expression-based indexes and sort order (`SortOrder`, `NullsSortOrder`) are also available.
+
+### Full Text Indexes
+
+`FullTextIndexDefinition` builds a GIN index over a `tsvector`. In the ordinary case you give it the
+text and it does the conversion:
+
+<!-- snippet: sample_pg_full_text_index -->
+<a id='snippet-sample_pg_full_text_index'></a>
+```cs
+var table = new Table("articles");
+
+// Weasel converts the text for you: to_tsvector('english', data)
+table.ModifyColumn("data").AddFullTextIndex();
+```
+<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/PostgresqlTableSamples.cs#L94-L99' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_pg_full_text_index' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+#### Weighting with setweight
+
+PostgreSQL's [ranking support](https://www.postgresql.org/docs/current/textsearch-features.html#TEXTSEARCH-MANIPULATE-TSVECTOR)
+lets you weight one member above another, so a match in a title outranks the same match in a body.
+It works by labelling each member's *vector* and concatenating the vectors — not by concatenating
+the text and converting once. The expression is therefore already a `tsvector` at the top level, and
+wrapping it in another `to_tsvector` is a type error rather than a weighted index.
+
+Use `FullTextIndexDefinition.ForTsVector` for these, or set `TsVectorExpression` on an existing
+definition:
+
+<!-- snippet: sample_pg_weighted_full_text_index -->
+<a id='snippet-sample_pg_weighted_full_text_index'></a>
+```cs
+var table = new Table("articles");
+
+// setweight() labels a tsvector, so weighting concatenates the vectors -- not the text.
+// The expression is therefore already a tsvector, and must not be wrapped in another
+// to_tsvector call.
+var weighted =
+    "setweight(to_tsvector('english', coalesce(data ->> 'Title', '')), 'A') || " +
+    "setweight(to_tsvector('english', coalesce(data ->> 'Body', '')), 'B')";
+
+var index = FullTextIndexDefinition.ForTsVector(
+    PostgresqlObjectName.From(table.Identifier), weighted);
+
+table.Indexes.Add(index);
+
+// Read the indexed vector back off the definition when you build the query-side filter,
+// so the vector you search cannot drift from the vector you indexed. A ts_rank computed
+// over a different vector than the one @@ filtered on is silently wrong, not just slow.
+var where = $"{index.IndexedTsVector} @@ plainto_tsquery('english', :term)";
+```
+<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/PostgresqlTableSamples.cs#L104-L123' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_pg_weighted_full_text_index' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+Read `IndexedTsVector` — never `DocumentConfig` or `TsVectorExpression` directly — when you build the
+query-side filter. It is the one property both the DDL and your query read, whichever way the index
+was configured, so the vector you search cannot drift from the vector you indexed.
+
+`DocumentConfig` and `RegConfig` take no part in the DDL once `TsVectorExpression` is set: a
+pre-built vector already carries its own text search configuration inside the expression. Leave
+`TsVectorExpression` unset and the definition behaves exactly as it always has.
 
 ## Default Values
 
@@ -118,7 +178,7 @@ table.AddColumn<string>("status").DefaultValueByString("pending");
 table.AddColumn<DateTimeOffset>("created_at")
     .DefaultValueByExpression("now()");
 ```
-<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/PostgresqlTableSamples.cs#L93-L101' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_pg_default_values' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/PostgresqlTableSamples.cs#L130-L138' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_pg_default_values' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Generated Columns
@@ -139,7 +199,7 @@ table.AddColumn<string>("last_name");
 table.AddColumn("full_name", "text")
     .GeneratedAs("first_name || ' ' || last_name");
 ```
-<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/PostgresqlTableSamples.cs#L50-L61' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_pg_generated_columns' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/PostgresqlTableSamples.cs#L51-L62' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_pg_generated_columns' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Delta Detection and Migration
@@ -165,7 +225,7 @@ var existing = await table.FetchExistingAsync(conn);
 var delta = new TableDelta(table, existing);
 // delta.Difference tells you: None, Create, Update, or Recreate
 ```
-<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/PostgresqlTableSamples.cs#L106-L122' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_pg_table_delta_detection' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/PostgresqlTableSamples.cs#L143-L159' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_pg_table_delta_detection' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Generating DDL
@@ -180,5 +240,5 @@ var writer = new StringWriter();
 table.WriteCreateStatement(migrator, writer);
 Console.WriteLine(writer.ToString());
 ```
-<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/PostgresqlTableSamples.cs#L127-L134' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_pg_table_generate_ddl' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/PostgresqlTableSamples.cs#L164-L171' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_pg_table_generate_ddl' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/src/DocSamples/PostgresqlTableSamples.cs
+++ b/src/DocSamples/PostgresqlTableSamples.cs
@@ -1,6 +1,7 @@
 using Npgsql;
 using Weasel.Postgresql;
 using Weasel.Postgresql.Tables;
+using Weasel.Postgresql.Tables.Indexes;
 
 namespace DocSamples;
 
@@ -86,6 +87,42 @@ public class PostgresqlTableSamples
         index.Columns = new[] { "email" };
         table.Indexes.Add(index);
         #endregion
+    }
+
+    public void full_text_indexes()
+    {
+        #region sample_pg_full_text_index
+        var table = new Table("articles");
+
+        // Weasel converts the text for you: to_tsvector('english', data)
+        table.ModifyColumn("data").AddFullTextIndex();
+        #endregion
+    }
+
+    public void weighted_full_text_indexes()
+    {
+        #region sample_pg_weighted_full_text_index
+        var table = new Table("articles");
+
+        // setweight() labels a tsvector, so weighting concatenates the vectors -- not the text.
+        // The expression is therefore already a tsvector, and must not be wrapped in another
+        // to_tsvector call.
+        var weighted =
+            "setweight(to_tsvector('english', coalesce(data ->> 'Title', '')), 'A') || " +
+            "setweight(to_tsvector('english', coalesce(data ->> 'Body', '')), 'B')";
+
+        var index = FullTextIndexDefinition.ForTsVector(
+            PostgresqlObjectName.From(table.Identifier), weighted);
+
+        table.Indexes.Add(index);
+
+        // Read the indexed vector back off the definition when you build the query-side filter,
+        // so the vector you search cannot drift from the vector you indexed. A ts_rank computed
+        // over a different vector than the one @@ filtered on is silently wrong, not just slow.
+        var where = $"{index.IndexedTsVector} @@ plainto_tsquery('english', :term)";
+        #endregion
+
+        Console.WriteLine(where);
     }
 
     public void default_values()

--- a/src/Weasel.Postgresql.Tests/Tables/Indexes/full_text_index_over_a_prebuilt_tsvector.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/Indexes/full_text_index_over_a_prebuilt_tsvector.cs
@@ -1,0 +1,141 @@
+using Shouldly;
+using Weasel.Postgresql.Tables;
+using Weasel.Postgresql.Tables.Indexes;
+using Xunit;
+
+namespace Weasel.Postgresql.Tests.Tables.Indexes;
+
+/// <summary>
+///     weasel#541: <see cref="FullTextIndexDefinition" /> wrapped whatever it was given in
+///     <c>to_tsvector</c>, so an expression that is <em>already</em> a <c>tsvector</c> could not be
+///     indexed — and per-member <c>setweight</c> weighting with it.
+/// </summary>
+/// <remarks>
+///     PostgreSQL's weighting labels each member's vector and concatenates the vectors, not the
+///     text. Passed as <see cref="FullTextIndexDefinition.DocumentConfig" /> that expression came
+///     out as <c>to_tsvector('english', setweight(…) || setweight(…))</c>, which is a type error
+///     rather than a weighted index. Raised from JasperFx/marten#5298.
+/// </remarks>
+public class full_text_index_over_a_prebuilt_tsvector
+{
+    private const string TablePrefix = "mt_";
+    private static readonly PostgresqlObjectName TableName = new("public", "mt_doc_achievement");
+    private readonly Table parent = new(TableName);
+
+    private const string Weighted =
+        "setweight(to_tsvector('english', coalesce(data ->> 'Title', '')), 'A') || " +
+        "setweight(to_tsvector('english', coalesce(data ->> 'Description', '')), 'C')";
+
+    [Fact]
+    public void the_expression_is_indexed_without_a_to_tsvector_wrapper()
+    {
+        var index = FullTextIndexDefinition.ForTsVector(TableName, Weighted);
+
+        index.ToDDL(parent).ShouldBe(
+            $"CREATE INDEX {TableName.Name}_idx_fts ON {TableName.QualifiedName} USING gin (({Weighted}));");
+    }
+
+    /// <summary>
+    ///     The point of the whole exercise: the emitted DDL is the shape PostgreSQL documents for
+    ///     weighting, with the <c>tsvector</c> at the top level rather than inside a conversion.
+    /// </summary>
+    [Fact]
+    public void the_ddl_does_not_convert_the_vector_again()
+    {
+        var ddl = FullTextIndexDefinition.ForTsVector(TableName, Weighted).ToDDL(parent);
+
+        ddl.ShouldNotContain("to_tsvector('english',setweight");
+        ddl.ShouldContain("gin ((setweight(");
+    }
+
+    [Fact]
+    public void the_index_name_still_derives_and_still_takes_a_prefix()
+    {
+        FullTextIndexDefinition.ForTsVector(TableName, Weighted)
+            .Name.ShouldBe($"{TableName.Name}_idx_fts");
+
+        FullTextIndexDefinition.ForTsVector(TableName, Weighted, "ranked", TablePrefix)
+            .Name.ShouldBe($"{TablePrefix}ranked");
+    }
+
+    /// <summary>
+    ///     One property that both the DDL and a consumer's query-side filter read, so the indexed
+    ///     vector and the searched vector cannot drift apart. Marten's <c>FullTextWhereFragment</c>
+    ///     reads the expression back off the index definition for exactly this reason, and ranking
+    ///     makes the coupling stricter still.
+    /// </summary>
+    [Fact]
+    public void the_indexed_vector_is_readable_back_off_the_definition()
+    {
+        FullTextIndexDefinition.ForTsVector(TableName, Weighted)
+            .IndexedTsVector.ShouldBe($"({Weighted})");
+
+        new FullTextIndexDefinition(TableName, "data")
+            .IndexedTsVector.ShouldBe("to_tsvector('english',data)");
+
+        new FullTextIndexDefinition(TableName, "data", "italian")
+            .IndexedTsVector.ShouldBe("to_tsvector('italian',data)");
+    }
+
+    [Fact]
+    public void the_indexed_vector_is_exactly_what_lands_in_the_ddl()
+    {
+        foreach (var index in new[]
+                 {
+                     FullTextIndexDefinition.ForTsVector(TableName, Weighted),
+                     new FullTextIndexDefinition(TableName, "data"),
+                     new FullTextIndexDefinition(TableName, "(data ->> 'Name')", "italian")
+                 })
+        {
+            index.ToDDL(parent).ShouldContain($"USING gin ({index.IndexedTsVector});");
+        }
+    }
+
+    [Fact]
+    public void an_empty_tsvector_expression_is_refused()
+    {
+        Should.Throw<ArgumentOutOfRangeException>(
+            () => FullTextIndexDefinition.ForTsVector(TableName, "  "));
+    }
+
+    /// <summary>
+    ///     Setting the property back to nothing returns the definition to the ordinary
+    ///     <c>DocumentConfig</c> behaviour rather than leaving it in a half-configured state.
+    /// </summary>
+    [Fact]
+    public void clearing_the_expression_falls_back_to_the_document_config()
+    {
+        var index = new FullTextIndexDefinition(TableName, "data") { TsVectorExpression = Weighted };
+
+        index.IndexedTsVector.ShouldBe($"({Weighted})");
+
+        index.TsVectorExpression = "   ";
+
+        index.TsVectorExpression.ShouldBeNull();
+        index.IndexedTsVector.ShouldBe("to_tsvector('english',data)");
+    }
+
+    /// <summary>
+    ///     The whole reason for a second property rather than a reinterpretation of the first: every
+    ///     existing definition has to emit the same bytes it always did. A changed index expression
+    ///     makes Weasel drop and recreate the index, which on a large table is an outage rather than
+    ///     a migration — so a diff here would be charged to people who never opted in.
+    /// </summary>
+    [Theory]
+    [InlineData("data", null)]
+    [InlineData("data", "italian")]
+    [InlineData("(data ->> 'AnotherString' || ' ' || 'test')", null)]
+    [InlineData("((data ->> 'FirstName') || ' ' || (data ->> 'LastName'))", "french")]
+    public void an_untouched_definition_emits_exactly_what_it_always_did(string documentConfig, string? regConfig)
+    {
+        var index = new FullTextIndexDefinition(TableName, documentConfig, regConfig);
+
+        var expectedRegConfig = regConfig ?? FullTextIndexDefinition.DefaultRegConfig;
+        var expectedName = regConfig == null
+            ? $"{TableName.Name}_idx_fts"
+            : $"{TableName.Name}_{regConfig}_idx_fts";
+
+        index.ToDDL(parent).ShouldBe(
+            $"CREATE INDEX {expectedName} ON {TableName.QualifiedName} USING gin (to_tsvector('{expectedRegConfig}',{documentConfig}));");
+    }
+}

--- a/src/Weasel.Postgresql.Tests/Tables/Indexes/prebuilt_tsvector_index_deltas.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/Indexes/prebuilt_tsvector_index_deltas.cs
@@ -1,0 +1,111 @@
+using Shouldly;
+using Weasel.Core;
+using Weasel.Postgresql.Tables.Indexes;
+using Xunit;
+
+namespace Weasel.Postgresql.Tests.Tables.Indexes;
+
+/// <summary>
+///     weasel#541 against a real server. The unit tests say what DDL comes out; these say PostgreSQL
+///     accepts it, and that Weasel reads it back as the same index rather than as a change.
+/// </summary>
+/// <remarks>
+///     Both halves matter. A weighted index is built with <c>||</c>, and PostgreSQL lets an index
+///     expression go bare only when it is a function call or a column reference — so the DDL is a
+///     syntax error unless the expression carries parentheses of its own. And an index Weasel
+///     re-reads as different is dropped and recreated on every single migration, which on a table
+///     big enough to want ranked search is the expensive kind of wrong.
+/// </remarks>
+[Collection("fts_tsvector_deltas")]
+public class prebuilt_tsvector_index_deltas(): IndexDeltasDetectionContext("fts_tsvector_deltas", "achievements")
+{
+    private const string Weighted =
+        "setweight(to_tsvector('english', coalesce(data ->> 'Title', '')), 'A') || " +
+        "setweight(to_tsvector('english', coalesce(data ->> 'Description', '')), 'C')";
+
+    [PgVersionTargetedFact(MinimumVersion = "10.0")]
+    public Task a_weighted_tsvector_index_is_accepted_and_round_trips()
+    {
+        theTable.Indexes.Add(FullTextIndexDefinition.ForTsVector(
+            PostgresqlObjectName.From(theTable.Identifier), Weighted));
+
+        return AssertNoDeltasAfterPatching();
+    }
+
+    /// <summary>
+    ///     A single <c>setweight</c> — a function call at the top level, so it would be legal
+    ///     unparenthesized too. Here to prove the wrapping does not break the case that never needed
+    ///     it.
+    /// </summary>
+    [PgVersionTargetedFact(MinimumVersion = "10.0")]
+    public Task a_single_weighted_member_round_trips()
+    {
+        theTable.Indexes.Add(FullTextIndexDefinition.ForTsVector(
+            PostgresqlObjectName.From(theTable.Identifier),
+            "setweight(to_tsvector('english', coalesce(data ->> 'Title', '')), 'A')"));
+
+        return AssertNoDeltasAfterPatching();
+    }
+
+    /// <summary>
+    ///     An expression the caller already parenthesized must not be double-counted into a
+    ///     difference.
+    /// </summary>
+    [PgVersionTargetedFact(MinimumVersion = "10.0")]
+    public Task an_already_parenthesized_expression_round_trips()
+    {
+        theTable.Indexes.Add(FullTextIndexDefinition.ForTsVector(
+            PostgresqlObjectName.From(theTable.Identifier), $"({Weighted})"));
+
+        return AssertNoDeltasAfterPatching();
+    }
+
+    /// <summary>
+    ///     Changing the weights is a real change and has to be seen as one — that is the whole point
+    ///     of the expression being readable back off the definition.
+    /// </summary>
+    [PgVersionTargetedFact(MinimumVersion = "10.0")]
+    public async Task changing_a_weight_is_detected_as_an_update()
+    {
+        var name = PostgresqlObjectName.From(theTable.Identifier);
+        theTable.Indexes.Add(FullTextIndexDefinition.ForTsVector(name, Weighted));
+
+        await CreateSchemaObjectInDatabase(theTable);
+
+        theTable.Indexes.Clear();
+        theTable.Indexes.Add(FullTextIndexDefinition.ForTsVector(
+            name, Weighted.Replace("'C')", "'B')")));
+
+        await AssertIndexUpdate($"{theTable.Identifier.Name}_idx_fts");
+    }
+
+    /// <summary>
+    ///     The weighting actually works once the index is there — <c>ts_rank</c> puts a title match
+    ///     above a description match. Without this the tests would prove only that Weasel emits and
+    ///     re-reads a string, not that the string means what weasel#541 was raised to make it mean.
+    /// </summary>
+    [PgVersionTargetedFact(MinimumVersion = "10.0")]
+    public async Task the_weighting_ranks_a_title_match_above_a_description_match()
+    {
+        theTable.Indexes.Add(FullTextIndexDefinition.ForTsVector(
+            PostgresqlObjectName.From(theTable.Identifier), Weighted));
+
+        await CreateSchemaObjectInDatabase(theTable);
+
+        await theConnection.CreateCommand(
+                $"insert into {theTable.Identifier} (id, data) values (1, '{{\"Title\": \"ordinary\", \"Description\": \"marmot sighting\"}}'::jsonb)")
+            .ExecuteNonQueryAsync();
+        await theConnection.CreateCommand(
+                $"insert into {theTable.Identifier} (id, data) values (2, '{{\"Title\": \"marmot\", \"Description\": \"ordinary\"}}'::jsonb)")
+            .ExecuteNonQueryAsync();
+
+        var indexed = ((FullTextIndexDefinition)theTable.Indexes[0]).IndexedTsVector;
+
+        var ranked = await theConnection.CreateCommand(
+                $"select id from {theTable.Identifier} where {indexed} @@ plainto_tsquery('english', 'marmot') "
+                + $"order by ts_rank({indexed}, plainto_tsquery('english', 'marmot')) desc")
+            .FetchListAsync<int>();
+
+        ranked.ShouldBe(new[] { 2, 1 });
+    }
+}

--- a/src/Weasel.Postgresql/Tables/IndexDefinition.cs
+++ b/src/Weasel.Postgresql/Tables/IndexDefinition.cs
@@ -935,6 +935,12 @@ public class IndexDefinition: ITableIndex
             .Replace("INDEX CONCURRENTLY", "INDEX")
             .Replace("::text", "")
             .Replace("::regconfig", "")
+            // setweight's second argument is of type "char", and PostgreSQL renders the cast
+            // explicitly when it gives an index expression back. Same class of automatic cast as
+            // ::text and ::regconfig above: it is in the actual and never in the expected, so
+            // without this a weighted full text index reads as changed on every migration and is
+            // dropped and recreated every time (weasel#541).
+            .Replace("::\"char\"", "")
             .Replace(" ->> ", "->>")
             .Replace(" -> ", "->")
             .Replace(IndexCreationBeginComment, "")

--- a/src/Weasel.Postgresql/Tables/Indexes/FullTextIndexDefinition.cs
+++ b/src/Weasel.Postgresql/Tables/Indexes/FullTextIndexDefinition.cs
@@ -12,6 +12,7 @@ public class FullTextIndexDefinition: IndexDefinition
     private readonly string? indexPrefix;
 
     private string regConfig;
+    private string? tsVectorExpression;
 
     public FullTextIndexDefinition(
         PostgresqlObjectName tableName,
@@ -27,6 +28,139 @@ public class FullTextIndexDefinition: IndexDefinition
         this.indexPrefix = indexPrefix;
 
         Method = IndexMethod.gin;
+    }
+
+    /// <summary>
+    ///     An index over an expression that is <em>already</em> a <c>tsvector</c>, rather than over
+    ///     text for this definition to convert.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         The case this exists for is per-member weighting. PostgreSQL's <c>setweight</c> labels
+    ///         a vector, so weighting works by converting each member separately and concatenating
+    ///         the <em>vectors</em> — not by concatenating the text and converting once:
+    ///     </para>
+    ///     <code>
+    ///     setweight(to_tsvector('english', coalesce(data ->> 'Title', '')), 'A') ||
+    ///     setweight(to_tsvector('english', coalesce(data ->> 'Body', '')), 'B')
+    ///     </code>
+    ///     <para>
+    ///         That expression is a <c>tsvector</c> at the top level. Handing it to
+    ///         <see cref="DocumentConfig" /> would wrap it in another <c>to_tsvector</c>, which is a
+    ///         type error rather than a weighted index — so weighting was unreachable through this
+    ///         type (weasel#541, for JasperFx/marten#5298).
+    ///     </para>
+    ///     <para>
+    ///         When this is set it wins outright: <see cref="DocumentConfig" /> and
+    ///         <see cref="RegConfig" /> take no part in the DDL, because a pre-built vector already
+    ///         carries its own text search configuration inside the expression. Leave it unset — the
+    ///         default — and this definition behaves exactly as it always has, down to the byte. That
+    ///         matters: a changed index expression makes Weasel drop and recreate the index, which on
+    ///         a large table is an outage rather than a migration.
+    ///     </para>
+    ///     <para>
+    ///         Whitespace-only is treated as unset. Read <see cref="IndexedTsVector" /> rather than
+    ///         this property to find out what is actually indexed.
+    ///     </para>
+    /// </remarks>
+    public string? TsVectorExpression
+    {
+        get => tsVectorExpression;
+        set => tsVectorExpression = string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+    }
+
+    /// <summary>
+    ///     The <c>tsvector</c> expression this index is actually built over, whichever way it was
+    ///     configured.
+    /// </summary>
+    /// <remarks>
+    ///     The DDL is generated from this and nothing else, so a consumer building the query-side
+    ///     filter should read it from here too. Marten's <c>FullTextWhereFragment</c> reads the
+    ///     expression back off the index definition for exactly this reason, and ranking makes the
+    ///     coupling stricter still: a <c>ts_rank</c> computed over a different vector than the one
+    ///     <c>@@</c> filtered on is silently wrong rather than merely slow.
+    /// </remarks>
+    public string IndexedTsVector =>
+        tsVectorExpression == null
+            ? $"to_tsvector('{regConfig}',{DocumentConfig.Trim()})"
+            : parenthesize(tsVectorExpression);
+
+    /// <summary>
+    ///     Wrap the expression unless it already carries its own outermost pair.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Not cosmetic. PostgreSQL lets an index expression go bare only when it is a function
+    ///         call or a simple column reference; anything built with an operator needs parentheses
+    ///         of its own. The weighting case is built with <c>||</c>, and
+    ///         <c>IndexDefinition.correctedExpression</c> supplies exactly one pair — which the
+    ///         <c>USING gin (…)</c> argument list consumes — so an unwrapped
+    ///         <c>setweight(…) || setweight(…)</c> reaches the server as a syntax error.
+    ///     </para>
+    ///     <para>
+    ///         Delta detection is unaffected either way: <see cref="CanonicizeDdl(string, string)" />
+    ///         strips every parenthesis before comparing.
+    ///     </para>
+    /// </remarks>
+    private static string parenthesize(string expression)
+    {
+        if (!expression.StartsWith('(') || !expression.EndsWith(')'))
+        {
+            return $"({expression})";
+        }
+
+        // The leading '(' must be the one the trailing ')' closes, or the expression is something
+        // like "(a) || (b)" -- already balanced, but not wrapped.
+        var depth = 0;
+        for (var i = 0; i < expression.Length; i++)
+        {
+            if (expression[i] == '(')
+            {
+                depth++;
+            }
+            else if (expression[i] == ')')
+            {
+                depth--;
+
+                if (depth == 0)
+                {
+                    return i == expression.Length - 1 ? expression : $"({expression})";
+                }
+            }
+        }
+
+        return $"({expression})";
+    }
+
+    /// <summary>
+    ///     An index over an expression that is already a <c>tsvector</c>. See
+    ///     <see cref="TsVectorExpression" /> for why this is not just a different
+    ///     <see cref="DocumentConfig" />.
+    /// </summary>
+    /// <remarks>
+    ///     A factory rather than a constructor overload: the existing constructor already takes a
+    ///     <c>string</c> in that position followed by three optional <c>string?</c>s, so an overload
+    ///     would be ambiguous at every call site that omits the optional arguments — and would
+    ///     silently pick the wrong one where it was not.
+    /// </remarks>
+    public static FullTextIndexDefinition ForTsVector(
+        PostgresqlObjectName tableName,
+        string tsVectorExpression,
+        string? indexName = null,
+        string? indexPrefix = null)
+    {
+        if (string.IsNullOrWhiteSpace(tsVectorExpression))
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(tsVectorExpression),
+                "A tsvector expression is required. To index text for Weasel to convert, use the constructor and DocumentConfig instead.");
+        }
+
+        return new FullTextIndexDefinition(tableName, DataDocumentConfig, indexName: indexName,
+            indexPrefix: indexPrefix)
+        {
+            TsVectorExpression = tsVectorExpression
+        };
     }
 
     public string? RegConfig
@@ -46,7 +180,7 @@ public class FullTextIndexDefinition: IndexDefinition
 
     public override string[] Columns
     {
-        get => new[] { $"to_tsvector('{regConfig}',{DocumentConfig.Trim()})" };
+        get => new[] { IndexedTsVector };
         set
         {
             // nothing


### PR DESCRIPTION
Closes #541. Raised from JasperFx/marten#5298.

## The constraint

`FullTextIndexDefinition.Columns` unconditionally wrapped whatever it was given:

```csharp
get => new[] { $"to_tsvector('{regConfig}',{DocumentConfig.Trim()})" };
```

So `DocumentConfig` was always *text to be converted*, and there was no way to hand the type an expression that is already a `tsvector`. PostgreSQL's weighting works by labelling each member's vector and concatenating the **vectors**, not the text — so the expression is a `tsvector` at the top level, and passing it as `DocumentConfig` produced `to_tsvector('english', setweight(…) || setweight(…))`: a type error, not a weighted index.

## The shape

`TsVectorExpression`, consumed by `Columns` without the `to_tsvector` wrapping, plus a `ForTsVector` factory. A factory rather than a constructor overload — the existing constructor takes a `string` in that position followed by three optional `string?`s, so an overload would be ambiguous wherever the optionals are omitted and would silently pick wrong where they are not.

```csharp
var weighted =
    "setweight(to_tsvector('english', coalesce(data ->> 'Title', '')), 'A') || " +
    "setweight(to_tsvector('english', coalesce(data ->> 'Body', '')), 'B')";

var index = FullTextIndexDefinition.ForTsVector(tableName, weighted);
```

**Nothing changes for anyone who does not opt in.** Left unset, every existing definition emits the byte-identical DDL it always did — pinned by a theory over four `DocumentConfig`/`RegConfig` combinations, because a changed index expression means Weasel drops and recreates the index, which on a large table is an outage rather than a migration.

## One property, so the vectors cannot drift

The issue's actual requirement. `IndexedTsVector` yields the vector this index is built over whichever way it was configured, and the DDL is generated from it and nothing else:

```csharp
public string IndexedTsVector =>
    tsVectorExpression == null
        ? $"to_tsvector('{regConfig}',{DocumentConfig.Trim()})"
        : parenthesize(tsVectorExpression);
```

Marten's `FullTextWhereFragment` reads the expression back off the index definition for exactly this reason, and ranking makes the coupling stricter: a `ts_rank` computed over a different vector than the one `@@` filtered on is silently wrong rather than merely slow. A test asserts `IndexedTsVector` is exactly what lands in the DDL for both configurations.

## Two things only a real server showed

Both were caught by integration tests, not by reading the code.

**1. The DDL was a syntax error.** `setweight(…) || setweight(…)` is an operator expression, and PostgreSQL lets an index expression go bare only when it is a function call or a column reference. `IndexDefinition.correctedExpression` supplies exactly one pair of parentheses, which the `USING gin (…)` argument list consumes — so the expression needs its own. It is now parenthesized on the way in, unless the caller already did it. Canonicalization strips parentheses entirely, so delta detection is unaffected either way.

**2. A weighted index re-read as changed on every migration.** PostgreSQL renders `setweight`'s weight argument with an explicit cast when it gives the index expression back:

```
expected: … setweightto_tsvector'english',coalescedata->>'title','','a' || …
actual:   … setweightto_tsvector'english',coalescedata->>'title','','a'::"char" || …
```

That cast is in the actual and never in the expected, so the index would have been dropped and recreated on every single migration — on a table big enough to want ranked search, the expensive kind of wrong. `CanonicizeDdl` now strips `::"char"` alongside the `::text` and `::regconfig` it already handled; this is the same class of automatic cast the existing `fts_index_comparison_must_take_into_account_automatic_cast` test was written for.

## Tests

Verified against PostgreSQL 17 in a dedicated database.

`full_text_index_over_a_prebuilt_tsvector.cs` (unit) — DDL shape, no double conversion, name derivation and prefixing, `IndexedTsVector` for both configurations and its equality with what lands in the DDL, empty expression refused, clearing the expression falling back cleanly, and the byte-identical theory for untouched definitions.

`prebuilt_tsvector_index_deltas.cs` (integration) — the weighted index is accepted by the server and round-trips with no delta; a single `setweight` (legal unparenthesized) still round-trips, so the wrapping does not break the case that never needed it; an already-parenthesized expression round-trips; a changed weight is still detected as an update; and `ts_rank` actually puts a title match above a description match, so the tests prove the expression *means* what the issue was raised to make it mean rather than merely that Weasel emits and re-reads a string.

Full `Weasel.Postgresql.Tests` (971) and `Weasel.Core.Tests` (320) green.

## Docs

`docs/postgresql/tables.md` gains a Full Text Indexes section with a weighting subsection, from compilable mdsnippets in `src/DocSamples`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)