### PR TITLE
docs(core): attach the local-identifiers doc block to the type it describes

### DIFF
--- a/src/Weasel.Core/ISchemaObject.cs
+++ b/src/Weasel.Core/ISchemaObject.cs
@@ -30,19 +30,6 @@ public interface ISchemaObjectWithPostProcessing : ISchemaObject
 }
 
 /// <summary>
-///     Schema objects that write identifiers into their DDL which are not themselves named
-///     database objects — a table's column names, its primary key constraint name, its check
-///     constraint names. <see cref="ISchemaObject.AllNames" /> cannot carry these: it yields
-///     <see cref="DbObjectName" />, and callers read the schema off every name it returns
-///     (<c>SchemaMigration.Schemas</c>, <c>DatabaseBase.ApplyAllConfiguredChangesToDatabaseAsync</c>),
-///     so a column name would arrive there claiming to be an object in a schema.
-/// </summary>
-/// <remarks>
-///     The migration path validates these alongside <see cref="ISchemaObject.AllNames" />
-///     (weasel#448). Before that, a table's identifier, index names and foreign key names were
-///     checked and everything else went straight into the DDL unexamined.
-/// </remarks>
-/// <summary>
 ///     A delta that reports <see cref="SchemaPatchDifference.Invalid" /> because the change cannot
 ///     be made in place, but which knows how to make it anyway without losing the data.
 /// </summary>
@@ -76,6 +63,19 @@ public interface ISchemaObjectDeltaWithRebuild : ISchemaObjectDelta
     bool CanRebuildInPlace { get; }
 }
 
+/// <summary>
+///     Schema objects that write identifiers into their DDL which are not themselves named
+///     database objects — a table's column names, its primary key constraint name, its check
+///     constraint names. <see cref="ISchemaObject.AllNames" /> cannot carry these: it yields
+///     <see cref="DbObjectName" />, and callers read the schema off every name it returns
+///     (<c>SchemaMigration.Schemas</c>, <c>DatabaseBase.ApplyAllConfiguredChangesToDatabaseAsync</c>),
+///     so a column name would arrive there claiming to be an object in a schema.
+/// </summary>
+/// <remarks>
+///     The migration path validates these alongside <see cref="ISchemaObject.AllNames" />
+///     (weasel#448). Before that, a table's identifier, index names and foreign key names were
+///     checked and everything else went straight into the DDL unexamined.
+/// </remarks>
 public interface ISchemaObjectWithLocalIdentifiers : ISchemaObject
 {
     /// <summary>


### PR DESCRIPTION
Two XML doc comment blocks had stacked up back-to-back above a single type declaration in `src/Weasel.Core/ISchemaObject.cs`.

The first block — schema objects that write identifiers into their DDL which are not themselves named database objects (a table's column names, PK constraint name, check constraint names), with the `<remarks>` citing weasel#448 — is written for `ISchemaObjectWithLocalIdentifiers`: it talks about `ISchemaObject.AllNames`, `DbObjectName` and `LocalIdentifiers()`. But it sat directly above the block for `ISchemaObjectDeltaWithRebuild`, which is the type actually declared next.

The result was `ISchemaObjectDeltaWithRebuild` carrying two `<summary>` elements and `ISchemaObjectWithLocalIdentifiers` carrying none.

This moves the block down so it sits immediately above `public interface ISchemaObjectWithLocalIdentifiers : ISchemaObject`. Pure relocation — no wording changed, no behaviour change.

`dotnet build src/Weasel.Core/Weasel.Core.csproj -f net9.0` succeeds with the same 9 pre-existing warnings; none are in this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)