### PR TITLE
View body comparison

### DIFF
--- a/src/Weasel.Core.Tests/ViewSqlNormalizerTests.cs
+++ b/src/Weasel.Core.Tests/ViewSqlNormalizerTests.cs
@@ -1,0 +1,86 @@
+using Shouldly;
+using Xunit;
+
+namespace Weasel.Core.Tests;
+
+public class ViewSqlNormalizerTests
+{
+    [Theory]
+    [InlineData("select id, name from users", "select id,name from users")]
+    [InlineData("select id, name from users", "SELECT ID, NAME FROM USERS")]
+    [InlineData("select id from users", "select id\r\n\tfrom\tusers")]
+    [InlineData("select 1", "select 1;")]
+    [InlineData("select 1", "  select 1 ;;  ")]
+    public void equal_outside_string_literals(string left, string right)
+        => ViewSqlNormalizer.Normalize(left).ShouldBe(ViewSqlNormalizer.Normalize(right));
+
+    [Theory]
+    [InlineData("where name = 'active'", "where name = 'ACTIVE'")]
+    [InlineData("where name = 'a b'", "where name = 'ab'")]
+    [InlineData("where name = 'a\tb'", "where name = 'ab'")]
+    [InlineData("where name = 'it''s'", "where name = 'IT''S'")]
+    [InlineData("select 'x' as tag", "select 'X' as tag")]
+    public void different_inside_string_literals(string left, string right)
+        => ViewSqlNormalizer.Normalize(left).ShouldNotBe(ViewSqlNormalizer.Normalize(right));
+
+    [Fact]
+    public void literal_contents_survive_verbatim()
+        => ViewSqlNormalizer.Normalize("select 'a b' as tag").ShouldBe("SELECT'a b'ASTAG");
+
+    [Fact]
+    public void an_escaped_quote_does_not_end_the_literal()
+        => ViewSqlNormalizer.Normalize("select 'it''s a b'").ShouldBe("SELECT'it''s a b'");
+
+    [Fact]
+    public void an_unterminated_literal_is_copied_rather_than_folded()
+        => ViewSqlNormalizer.Normalize("select 'a b").ShouldBe("SELECT'a b");
+
+    [Fact]
+    public void a_trailing_semicolon_inside_a_literal_is_kept()
+        => ViewSqlNormalizer.Normalize("select ';'").ShouldBe("SELECT';'");
+
+    [Theory]
+    [InlineData("select id -- don't fold this\nfrom users", "select id -- don't fold this\n  from  users")]
+    [InlineData("select id /* don't */ from users", "select id /* don't */    from users")]
+    public void a_quote_in_a_comment_does_not_open_a_literal(string left, string right)
+        => ViewSqlNormalizer.Normalize(left).ShouldBe(ViewSqlNormalizer.Normalize(right));
+
+    [Fact]
+    public void a_comment_does_not_swallow_a_following_literal()
+        => ViewSqlNormalizer.Normalize("select 1 /* c */ , 'a b'").ShouldBe("SELECT1/*C*/,'a b'");
+
+    [Theory]
+    [InlineData("select total as [Customer's Total] , id from t", "select total as [Customer's Total], id from t")]
+    [InlineData("select \"o'brien\" , id from t", "select \"o'brien\", id from t")]
+    [InlineData("select [a]]b] , id from t", "select [a]]b], id from t")]
+    [InlineData("select \"a\"\"b\" , id from t", "select \"a\"\"b\", id from t")]
+    [InlineData("select `o'brien` , id from t", "select `o'brien`, id from t")]
+    [InlineData("select `a``b` , id from t", "select `a``b`, id from t")]
+    [InlineData("select [Name] from t", "select [name]   from   t")]
+    public void an_apostrophe_in_a_delimited_identifier_does_not_open_a_literal(string left, string right)
+        => ViewSqlNormalizer.Normalize(left).ShouldBe(ViewSqlNormalizer.Normalize(right));
+
+    [Theory]
+    [InlineData("select [Customer's Name] from t where s = 'active'",
+        "select [Customer's Name] from t where s = 'ACTIVE'")]
+    [InlineData("select \"o'brien\" from t where s = 'a b'", "select \"o'brien\" from t where s = 'ab'")]
+    [InlineData("select `o'brien` from t where s = 'active'", "select `o'brien` from t where s = 'ACTIVE'")]
+    public void a_delimited_identifier_does_not_hide_drift_in_a_later_literal(string left, string right)
+        => ViewSqlNormalizer.Normalize(left).ShouldNotBe(ViewSqlNormalizer.Normalize(right));
+
+    [Fact]
+    public void a_delimited_identifier_is_folded_like_any_text_outside_a_literal()
+        => ViewSqlNormalizer.Normalize("select [Customer's Total] from t").ShouldBe("SELECT[CUSTOMER'STOTAL]FROMT");
+
+    [Fact]
+    public void a_bracket_inside_a_literal_is_still_literal_text()
+        => ViewSqlNormalizer.Normalize("select 'a [b] c'").ShouldBe("SELECT'a [b] c'");
+
+    [Fact]
+    public void an_unterminated_delimited_identifier_is_folded_to_the_end()
+        => ViewSqlNormalizer.Normalize("select [a b").ShouldBe("SELECT[AB");
+
+    [Fact]
+    public void empty_sql_normalizes_to_empty()
+        => ViewSqlNormalizer.Normalize("").ShouldBe("");
+}

--- a/src/Weasel.Core/ViewSqlNormalizer.cs
+++ b/src/Weasel.Core/ViewSqlNormalizer.cs
@@ -1,0 +1,162 @@
+using System.Text;
+
+namespace Weasel.Core;
+
+/// <summary>
+///     Normalizes a view body for comparison against the text a database hands back.
+///     Inside a literal, every character is copied verbatim: <c>'active'</c> and <c>'ACTIVE'</c>
+///     select different rows, and so do <c>'a b'</c> and <c>'ab'</c>.
+/// </summary>
+/// <remarks>
+///     Delimited identifiers and comments get their own branches for one reason only: an
+///     apostrophe is ordinary text inside <c>[Customer's Name]</c>, <c>"o'brien"</c>,
+///     <c>`o'brien`</c> and prose, and must not open a literal there. Their contents are folded
+///     like any other text outside a literal, so identifier case and spacing keep comparing equal
+///     as they always have.
+/// </remarks>
+public static class ViewSqlNormalizer
+{
+    public static string Normalize(string sql)
+    {
+        if (string.IsNullOrEmpty(sql))
+        {
+            return string.Empty;
+        }
+
+        var builder = new StringBuilder(sql.Length);
+
+        for (var i = 0; i < sql.Length; i++)
+        {
+            var c = sql[i];
+
+            if (c == '\'')
+            {
+                i = appendLiteral(sql, i, builder);
+                continue;
+            }
+
+            if (c == '"' || c == '[' || c == '`')
+            {
+                i = appendDelimitedIdentifier(sql, i, builder);
+                continue;
+            }
+
+            if (c == '-' && i + 1 < sql.Length && sql[i + 1] == '-')
+            {
+                i = appendLineComment(sql, i, builder);
+                continue;
+            }
+
+            if (c == '/' && i + 1 < sql.Length && sql[i + 1] == '*')
+            {
+                i = appendBlockComment(sql, i, builder);
+                continue;
+            }
+
+            appendOutsideLiteral(builder, c);
+        }
+
+        return builder.ToString().TrimEnd(';');
+    }
+
+    private static void appendOutsideLiteral(StringBuilder builder, char c)
+    {
+        if (!char.IsWhiteSpace(c))
+        {
+            builder.Append(char.ToUpperInvariant(c));
+        }
+    }
+
+    private static int appendLiteral(string sql, int start, StringBuilder builder)
+    {
+        builder.Append('\'');
+
+        var i = start + 1;
+        while (i < sql.Length)
+        {
+            if (sql[i] == '\'')
+            {
+                if (i + 1 < sql.Length && sql[i + 1] == '\'')
+                {
+                    builder.Append("''");
+                    i += 2;
+                    continue;
+                }
+
+                builder.Append('\'');
+                return i;
+            }
+
+            builder.Append(sql[i]);
+            i++;
+        }
+
+        return sql.Length - 1;
+    }
+
+    private static int appendDelimitedIdentifier(string sql, int start, StringBuilder builder)
+    {
+        var open = sql[start];
+        var close = open == '[' ? ']' : open;
+
+        builder.Append(open);
+
+        var i = start + 1;
+        while (i < sql.Length)
+        {
+            if (sql[i] == close)
+            {
+                builder.Append(close);
+
+                if (i + 1 < sql.Length && sql[i + 1] == close)
+                {
+                    builder.Append(close);
+                    i += 2;
+                    continue;
+                }
+
+                return i;
+            }
+
+            appendOutsideLiteral(builder, sql[i]);
+            i++;
+        }
+
+        return sql.Length - 1;
+    }
+
+    /// <summary>
+    ///     Comment bodies are folded like any other text outside a literal, but a quote inside one
+    ///     must not open a literal — an apostrophe in prose would otherwise swallow the rest of the
+    ///     statement.
+    /// </summary>
+    private static int appendLineComment(string sql, int start, StringBuilder builder)
+    {
+        var i = start;
+        while (i < sql.Length && sql[i] != '\n' && sql[i] != '\r')
+        {
+            appendOutsideLiteral(builder, sql[i]);
+            i++;
+        }
+
+        return i - 1;
+    }
+
+    private static int appendBlockComment(string sql, int start, StringBuilder builder)
+    {
+        var i = start;
+        while (i < sql.Length)
+        {
+            appendOutsideLiteral(builder, sql[i]);
+
+            if (i > start + 2 && sql[i] == '/' && sql[i - 1] == '*')
+            {
+                return i;
+            }
+
+            i++;
+        }
+
+        return sql.Length - 1;
+    }
+}

--- a/src/Weasel.SqlServer.Tests/Views/ViewTests.cs
+++ b/src/Weasel.SqlServer.Tests/Views/ViewTests.cs
@@ -165,6 +165,84 @@ FROM views.source");
     }
 
     [Fact]
+    public async Task a_case_change_inside_a_string_literal_is_drift()
+    {
+        await ResetSchema();
+        await createSourceTableAsync("source");
+
+        await CreateSchemaObjectInDatabase(
+            new View("views.literal_case", "select id from views.source where name = 'active'"));
+
+        var changed = new View("views.literal_case", "select id from views.source where name = 'ACTIVE'");
+
+        (await changed.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.Update);
+
+        await changed.ApplyChangesAsync(theConnection);
+
+        (await changed.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task a_whitespace_change_inside_a_string_literal_is_drift()
+    {
+        await ResetSchema();
+        await createSourceTableAsync("source");
+
+        await CreateSchemaObjectInDatabase(
+            new View("views.literal_space", "select id from views.source where name = 'a b'"));
+
+        var changed = new View("views.literal_space", "select id from views.source where name = 'ab'");
+
+        (await changed.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.Update);
+    }
+
+    [Fact]
+    public async Task reformatting_around_an_unchanged_literal_is_not_drift()
+    {
+        await ResetSchema();
+        await createSourceTableAsync("source");
+
+        await CreateSchemaObjectInDatabase(
+            new View("views.literal_stable", "select id, name from views.source where name = 'a b'"));
+
+        var reformatted = new View("views.literal_stable", @"SELECT id,name
+FROM   views.source
+WHERE  name = 'a b'");
+
+        (await reformatted.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task reformatting_around_an_apostrophe_in_a_bracketed_identifier_is_not_drift()
+    {
+        await ResetSchema();
+        await createSourceTableAsync("source");
+
+        await CreateSchemaObjectInDatabase(
+            new View("views.bracket_stable", "select quantity as [Customer's Total] , id from views.source"));
+
+        var reformatted = new View("views.bracket_stable",
+            "select quantity as [Customer's Total], id from views.source");
+
+        (await reformatted.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task an_apostrophe_in_a_bracketed_identifier_does_not_hide_literal_drift()
+    {
+        await ResetSchema();
+        await createSourceTableAsync("source");
+
+        await CreateSchemaObjectInDatabase(new View("views.bracket_drift",
+            "select name as [Customer's Name] from views.source where name = 'active'"));
+
+        var changed = new View("views.bracket_drift",
+            "select name as [Customer's Name] from views.source where name = 'ACTIVE'");
+
+        (await changed.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.Update);
+    }
+
+    [Fact]
     public async Task a_view_over_a_join_round_trips()
     {
         await ResetSchema();

--- a/src/Weasel.SqlServer/Views/View.cs
+++ b/src/Weasel.SqlServer/Views/View.cs
@@ -113,17 +113,11 @@ public class View: ViewBase
     private const string SqlServerIdentifierDelimiters = "[\"";
 
     /// <summary>
-    ///     Whitespace-insensitive and case-insensitive, because <c>sys.sql_modules</c> hands back
-    ///     the text as it was submitted and callers reformat freely.
+    ///     Whitespace-insensitive and case-insensitive outside string literals, because
+    ///     <c>sys.sql_modules</c> hands back the text as it was submitted and callers reformat
+    ///     freely. Literal contents are compared exactly.
     /// </summary>
     internal static string NormalizeSql(string sql)
-        => sql.Replace("\r\n", "")
-            .Replace("\n", "")
-            .Replace("\r", "")
-            .Replace("\t", "")
-            .Replace(" ", "")
-            .Trim()
-            .TrimEnd(';')
-            .ToUpperInvariant();
+        => ViewSqlNormalizer.Normalize(sql);
 
 }

--- a/src/Weasel.Sqlite.Tests/Views/ViewDeltaTests.cs
+++ b/src/Weasel.Sqlite.Tests/Views/ViewDeltaTests.cs
@@ -161,6 +161,63 @@ FROM users");
     }
 
     [Fact]
+    public void a_case_change_inside_a_string_literal_is_drift()
+    {
+        var expected = new View("test_view", "SELECT id FROM users WHERE name = 'active'");
+        var actual = new View("test_view", "SELECT id FROM users WHERE name = 'ACTIVE'");
+
+        var delta = new ViewDelta(expected, actual);
+
+        delta.Difference.ShouldBe(SchemaPatchDifference.Update);
+    }
+
+    [Fact]
+    public void a_whitespace_change_inside_a_string_literal_is_drift()
+    {
+        var expected = new View("test_view", "SELECT id FROM users WHERE name = 'a b'");
+        var actual = new View("test_view", "SELECT id FROM users WHERE name = 'ab'");
+
+        var delta = new ViewDelta(expected, actual);
+
+        delta.Difference.ShouldBe(SchemaPatchDifference.Update);
+    }
+
+    [Fact]
+    public void reformatting_around_an_unchanged_literal_is_not_drift()
+    {
+        var expected = new View("test_view", "SELECT id, name FROM users WHERE name = 'a b'");
+        var actual = new View("test_view", @"select id,name
+  from users
+  where NAME = 'a b'");
+
+        var delta = new ViewDelta(expected, actual);
+
+        delta.Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public void reformatting_around_an_apostrophe_in_a_quoted_identifier_is_not_drift()
+    {
+        var expected = new View("test_view", "SELECT amount AS \"customer's total\" , id FROM orders");
+        var actual = new View("test_view", "SELECT amount AS \"customer's total\", id FROM orders");
+
+        var delta = new ViewDelta(expected, actual);
+
+        delta.Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public void an_apostrophe_in_a_quoted_identifier_does_not_hide_literal_drift()
+    {
+        var expected = new View("test_view", "SELECT \"o'brien\" FROM users WHERE name = 'active'");
+        var actual = new View("test_view", "SELECT \"o'brien\" FROM users WHERE name = 'ACTIVE'");
+
+        var delta = new ViewDelta(expected, actual);
+
+        delta.Difference.ShouldBe(SchemaPatchDifference.Update);
+    }
+
+    [Fact]
     public void difference_is_case_insensitive()
     {
         var expected = new View("test_view", "SELECT id FROM users");

--- a/src/Weasel.Sqlite.Tests/Views/ViewIntegrationTests.cs
+++ b/src/Weasel.Sqlite.Tests/Views/ViewIntegrationTests.cs
@@ -82,6 +82,28 @@ public class ViewIntegrationTests
         await rebuild.ExecuteNonQueryAsync();
     }
 
+    private static async Task ExecuteCreateAsync(SqliteConnection connection, View view)
+    {
+        var writer = new StringWriter();
+        view.WriteCreateStatement(new SqliteMigrator(), writer);
+
+        var cmd = connection.CreateCommand();
+        cmd.CommandText = writer.ToString();
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private static async Task<SchemaPatchDifference> DifferenceAsync(SqliteConnection connection, View view)
+    {
+        var queryCmd = connection.CreateCommand();
+        var builder = new Core.DbCommandBuilder(queryCmd);
+        view.ConfigureQueryCommand(builder);
+        builder.Compile();
+
+        await using var reader = await queryCmd.ExecuteReaderAsync();
+        var delta = await view.CreateDeltaAsync(reader, CancellationToken.None);
+        return delta.Difference;
+    }
+
     [Fact]
     public async Task create_simple_view()
     {
@@ -374,5 +396,79 @@ public class ViewIntegrationTests
 
         category.ShouldBe("gadgets");
         price.ShouldBe(19.99);
+    }
+
+    [Fact]
+    public async Task a_case_change_inside_a_string_literal_is_drift()
+    {
+        await using var connection = await OpenConnectionAsync();
+        await CreateUsersTable(connection);
+
+        await ExecuteCreateAsync(connection, new View("by_name", "SELECT id FROM users WHERE name = 'active'"));
+
+        var changed = new View("by_name", "SELECT id FROM users WHERE name = 'ACTIVE'");
+
+        (await DifferenceAsync(connection, changed)).ShouldBe(SchemaPatchDifference.Update);
+
+        await ExecuteCreateAsync(connection, changed);
+
+        (await DifferenceAsync(connection, changed)).ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task a_whitespace_change_inside_a_string_literal_is_drift()
+    {
+        await using var connection = await OpenConnectionAsync();
+        await CreateUsersTable(connection);
+
+        await ExecuteCreateAsync(connection, new View("by_name", "SELECT id FROM users WHERE name = 'a b'"));
+
+        var changed = new View("by_name", "SELECT id FROM users WHERE name = 'ab'");
+
+        (await DifferenceAsync(connection, changed)).ShouldBe(SchemaPatchDifference.Update);
+    }
+
+    [Fact]
+    public async Task reformatting_around_an_apostrophe_in_a_backtick_identifier_is_not_drift()
+    {
+        await using var connection = await OpenConnectionAsync();
+        await CreateUsersTable(connection);
+
+        await ExecuteCreateAsync(connection,
+            new View("by_name", "SELECT name AS `customer's name` , id FROM users"));
+
+        var reformatted = new View("by_name", "SELECT name AS `customer's name`, id FROM users");
+
+        (await DifferenceAsync(connection, reformatted)).ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task an_apostrophe_in_a_backtick_identifier_does_not_hide_literal_drift()
+    {
+        await using var connection = await OpenConnectionAsync();
+        await CreateUsersTable(connection);
+
+        await ExecuteCreateAsync(connection,
+            new View("by_name", "SELECT name AS `o'brien` FROM users WHERE name = 'active'"));
+
+        var changed = new View("by_name", "SELECT name AS `o'brien` FROM users WHERE name = 'ACTIVE'");
+
+        (await DifferenceAsync(connection, changed)).ShouldBe(SchemaPatchDifference.Update);
+    }
+
+    [Fact]
+    public async Task reformatting_around_an_unchanged_literal_is_not_drift()
+    {
+        await using var connection = await OpenConnectionAsync();
+        await CreateUsersTable(connection);
+
+        await ExecuteCreateAsync(connection,
+            new View("by_name", "SELECT id, name FROM users WHERE name = 'a b'"));
+
+        var reformatted = new View("by_name", @"select id,name
+  FROM users
+  where NAME = 'a b'");
+
+        (await DifferenceAsync(connection, reformatted)).ShouldBe(SchemaPatchDifference.None);
     }
 }

--- a/src/Weasel.Sqlite/Views/View.cs
+++ b/src/Weasel.Sqlite/Views/View.cs
@@ -91,7 +91,7 @@ public class View : ViewBase
                 var normalizedExisting = NormalizeSql(existingBody);
                 var normalizedExpected = NormalizeSql(ViewSql);
 
-                if (string.Equals(normalizedExisting, normalizedExpected, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(normalizedExisting, normalizedExpected, StringComparison.Ordinal))
                 {
                     return new SchemaObjectDelta(this, SchemaPatchDifference.None);
                 }
@@ -144,19 +144,12 @@ public class View : ViewBase
         return null;
     }
 
+    /// <summary>
+    ///     Whitespace-insensitive and case-insensitive outside string literals; literal contents
+    ///     are compared exactly, so callers must compare the results with
+    ///     <see cref="StringComparison.Ordinal" />.
+    /// </summary>
     internal static string NormalizeSql(string sql)
-    {
-        // Remove all whitespace for comparison purposes
-        var normalized = sql
-            .Replace("\r\n", "")
-            .Replace("\n", "")
-            .Replace("\r", "")
-            .Replace("\t", "")
-            .Replace(" ", "")
-            .Trim()
-            .TrimEnd(';');
-
-        return normalized;
-    }
+        => ViewSqlNormalizer.Normalize(sql);
 
 }

--- a/src/Weasel.Sqlite/Views/ViewDelta.cs
+++ b/src/Weasel.Sqlite/Views/ViewDelta.cs
@@ -37,7 +37,7 @@ public class ViewDelta : SchemaObjectDelta<View>
         var expectedSql = View.NormalizeSql(expected.ViewSql);
         var actualSql = View.NormalizeSql(actual.ViewSql);
 
-        if (string.Equals(expectedSql, actualSql, StringComparison.OrdinalIgnoreCase))
+        if (string.Equals(expectedSql, actualSql, StringComparison.Ordinal))
         {
             return SchemaPatchDifference.None;
         }


### PR DESCRIPTION
View bodies are compared with all whitespace stripped and case folded — including inside string literals:

where name = 'active' and where name = 'ACTIVE' 
where name = 'a b' and where name = 'ab'

compare equal, so a view that selects different rows reports no drift.