### PR TITLE
Detect a widened character column in the schema differ

### DIFF
--- a/src/Weasel.Core.Tests/CharacterColumnLengthTests.cs
+++ b/src/Weasel.Core.Tests/CharacterColumnLengthTests.cs
@@ -1,0 +1,79 @@
+using Shouldly;
+using Weasel.Core;
+using Xunit;
+
+namespace Weasel.Core.Tests;
+
+public class CharacterColumnLengthTests
+{
+    [Theory]
+    [InlineData("varchar(255)", 255)]
+    [InlineData("VARCHAR(1000)", 1000)]
+    [InlineData("nvarchar(50)", 50)]
+    [InlineData("char(1)", 1)]
+    [InlineData("varbinary(16)", 16)]
+    [InlineData("VARCHAR2(500)", 500)]
+    // Oracle spells the semantics out; the number is still the length.
+    [InlineData("VARCHAR2(100 CHAR)", 100)]
+    [InlineData("VARCHAR2(100 BYTE)", 100)]
+    [InlineData("varchar(max)", CharacterColumnLength.Unbounded)]
+    public void reads_the_declared_length(string type, int expected)
+    {
+        CharacterColumnLength.TryParse(type).ShouldBe(expected);
+    }
+
+    [Theory]
+    // No length declared at all.
+    [InlineData("varchar")]
+    [InlineData("text")]
+    [InlineData(null)]
+    // The parenthesised part is not a character length, and comparing it is what produces drift on
+    // tables nobody touched -- a MySQL INT display width the catalog invented, a decimal precision and
+    // scale, a fractional-seconds precision.
+    [InlineData("int(11)")]
+    [InlineData("decimal(18,2)")]
+    [InlineData("datetime(6)")]
+    [InlineData("NUMBER(10)")]
+    [InlineData("timestamp(3) with time zone")]
+    public void reads_nothing_from_a_type_whose_size_is_not_a_character_length(string? type)
+    {
+        CharacterColumnLength.TryParse(type).ShouldBeNull();
+    }
+
+    [Fact]
+    public void a_widened_character_column_differs()
+    {
+        CharacterColumnLength.Differ("varchar(1000)", "varchar(255)").ShouldBeTrue();
+        CharacterColumnLength.Differ("VARCHAR2(1000)", "varchar2(500)").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void the_same_length_does_not_differ()
+    {
+        CharacterColumnLength.Differ("varchar(255)", "VARCHAR(255)").ShouldBeFalse();
+        CharacterColumnLength.Differ("varchar(max)", "VARCHAR(MAX)").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void an_unbounded_column_differs_from_a_bounded_one()
+    {
+        CharacterColumnLength.Differ("varchar(max)", "varchar(500)").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void a_length_on_only_one_side_is_not_a_difference()
+    {
+        // "Cannot tell" must never report drift: a model that declares a bare type keeps comparing the
+        // way it always has, against whatever the catalog reports.
+        CharacterColumnLength.Differ("varchar", "varchar(255)").ShouldBeFalse();
+        CharacterColumnLength.Differ("varchar(255)", "varchar").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void sizes_that_are_not_character_lengths_are_never_a_difference()
+    {
+        CharacterColumnLength.Differ("int(11)", "int").ShouldBeFalse();
+        CharacterColumnLength.Differ("decimal(18,2)", "decimal(10,4)").ShouldBeFalse();
+        CharacterColumnLength.Differ("datetime(6)", "datetime(3)").ShouldBeFalse();
+    }
+}

--- a/src/Weasel.Core/CharacterColumnLength.cs
+++ b/src/Weasel.Core/CharacterColumnLength.cs
@@ -1,0 +1,103 @@
+using System.Globalization;
+
+namespace Weasel.Core;
+
+/// <summary>
+///     Reads the declared length out of a character or binary column type so that column comparison can
+///     tell <c>varchar(255)</c> from <c>varchar(1000)</c>.
+/// </summary>
+/// <remarks>
+///     Every provider's <c>TableColumn</c> comparison strips the parenthesised part of a type before
+///     comparing, because for most types it is not a length that a model is expected to reproduce: MySQL
+///     reports an <c>INT</c> display width the catalog invented, <c>DECIMAL</c> carries a precision and a
+///     scale, <c>DATETIME</c> a fractional-seconds precision. Comparing those wholesale produces drift on
+///     every schema check for tables nobody touched.
+///     <para>
+///     Character and binary lengths are the exception. They are declared by the model, reported faithfully
+///     by every catalog, and the difference is load-bearing -- a column narrower than the value being
+///     written fails the insert. Before this, widening a <c>varchar</c> in a model was invisible to the
+///     differ, so an existing database silently kept the old width forever and only a hand-written ALTER
+///     fixed it. See JasperFx/wolverine#4246, where a MySQL <c>varchar(255)</c> that should have been
+///     wider failed node-record inserts with "Data too long for column".
+///     </para>
+/// </remarks>
+public static class CharacterColumnLength
+{
+    /// <summary>
+    ///     Sentinel for the unbounded forms -- SQL Server's <c>varchar(max)</c>. Compares equal only to
+    ///     another unbounded declaration, and greater than any explicit length.
+    /// </summary>
+    public const int Unbounded = int.MaxValue;
+
+    // Deliberately only the types whose single parenthesised argument is a character or byte length.
+    // Anything else keeps the existing size-insensitive comparison.
+    private static readonly HashSet<string> LengthBearingTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "CHAR",
+        "VARCHAR",
+        "NCHAR",
+        "NVARCHAR",
+        "CHARACTER",
+        "VARCHAR2",
+        "NVARCHAR2",
+        "BINARY",
+        "VARBINARY",
+        "RAW"
+    };
+
+    /// <summary>
+    ///     True when a length declared on this type names a character or byte count.
+    /// </summary>
+    public static bool IsLengthBearing(string? rawType)
+        => rawType != null && LengthBearingTypes.Contains(rawType.Trim());
+
+    /// <summary>
+    ///     The declared length of <paramref name="type" />, or null when the type carries none or is not a
+    ///     type whose length is comparable. A null on either side of a comparison means "cannot tell", and
+    ///     the caller should fall back to comparing the bare type -- never report drift on a guess.
+    /// </summary>
+    public static int? TryParse(string? type)
+    {
+        if (type == null) return null;
+
+        var open = type.IndexOf('(');
+        if (open < 0) return null;
+
+        var close = type.IndexOf(')', open);
+        if (close < 0) return null;
+
+        if (!IsLengthBearing(type[..open])) return null;
+
+        var inner = type[(open + 1)..close].Trim();
+
+        // Oracle spells the length semantics out: VARCHAR2(100 CHAR) and VARCHAR2(100 BYTE) are both
+        // 100 as far as a model is concerned, and the catalog reports the byte count either way.
+        var space = inner.IndexOf(' ');
+        if (space > 0)
+        {
+            inner = inner[..space];
+        }
+
+        if (inner.Equals("max", StringComparison.OrdinalIgnoreCase)) return Unbounded;
+
+        return int.TryParse(inner, NumberStyles.Integer, CultureInfo.InvariantCulture, out var length)
+            ? length
+            : null;
+    }
+
+    /// <summary>
+    ///     True when the two type declarations disagree about a character length that both of them state.
+    ///     False whenever either side declares none, so a model that omits a length keeps comparing the way
+    ///     it always has.
+    /// </summary>
+    public static bool Differ(string? expected, string? actual)
+    {
+        var expectedLength = TryParse(expected);
+        if (expectedLength == null) return false;
+
+        var actualLength = TryParse(actual);
+        if (actualLength == null) return false;
+
+        return expectedLength != actualLength;
+    }
+}

--- a/src/Weasel.MySql.Tests/Tables/TableColumnTests.cs
+++ b/src/Weasel.MySql.Tests/Tables/TableColumnTests.cs
@@ -113,13 +113,29 @@ public class TableColumnTests
     }
 
     [Fact]
-    public void is_equivalent_ignores_size_differences()
+    public void is_equivalent_catches_a_character_length_difference()
     {
         var column1 = new TableColumn("email", "VARCHAR(100)");
         var column2 = new TableColumn("email", "VARCHAR(255)");
 
-        // RawType() comparison means they are equivalent
-        column1.IsEquivalentTo(column2).ShouldBeTrue();
+        // This asserted the opposite until JasperFx/wolverine#4246. RawType() still throws the
+        // parenthesised part away, but a character length is declared by the model, reported faithfully
+        // by the catalog, and load-bearing -- a column narrower than the value fails the insert. Widening
+        // a varchar used to be invisible here, so the differ never emitted the MODIFY COLUMN and an
+        // existing table kept the narrow column forever.
+        column1.IsEquivalentTo(column2).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void is_equivalent_still_ignores_sizes_that_are_not_character_lengths()
+    {
+        // The reason sizes are stripped in the first place: MySQL 8 reports a bare INT for a column
+        // declared int(11), and a DECIMAL carries a precision and a scale rather than a length.
+        new TableColumn("count", "INT(11)")
+            .IsEquivalentTo(new TableColumn("count", "INT")).ShouldBeTrue();
+
+        new TableColumn("amount", "DECIMAL(18,2)")
+            .IsEquivalentTo(new TableColumn("amount", "DECIMAL(10,4)")).ShouldBeTrue();
     }
 
     [Fact]

--- a/src/Weasel.MySql.Tests/Tables/detecting_widened_character_columns.cs
+++ b/src/Weasel.MySql.Tests/Tables/detecting_widened_character_columns.cs
@@ -1,0 +1,85 @@
+using Shouldly;
+using Weasel.Core;
+using Weasel.MySql.Tables;
+using Xunit;
+
+namespace Weasel.MySql.Tests.Tables;
+
+/// <summary>
+/// A widened character column used to be invisible to the differ: TableColumn.RawType() strips the
+/// parenthesised part before comparing, so varchar(255) and varchar(1000) looked identical and an
+/// existing table kept the narrow column forever, with only a hand-written ALTER to fix it. Reported
+/// downstream as JasperFx/wolverine#4246, where a defaulted MySQL varchar(255) failed inserts with
+/// "Data too long for column" and migrating the application did not widen it.
+/// </summary>
+public class detecting_widened_character_columns: IntegrationContext
+{
+    [Fact]
+    public async Task detect_a_widened_varchar()
+    {
+        await DropTableAsync("`weasel_testing`.`widened_varchar`");
+
+        var actual = new Table("weasel_testing.widened_varchar");
+        actual.AddColumn<int>("id").AsPrimaryKey();
+        actual.AddColumn("description", "varchar(255)");
+        await actual.CreateAsync(theConnection);
+
+        var expected = new Table("weasel_testing.widened_varchar");
+        expected.AddColumn<int>("id").AsPrimaryKey();
+        expected.AddColumn("description", "varchar(1000)");
+
+        var delta = await expected.FindDeltaAsync(theConnection);
+
+        delta.Difference.ShouldBe(SchemaPatchDifference.Update);
+    }
+
+    [Fact]
+    public async Task patching_widens_the_column_in_place()
+    {
+        await DropTableAsync("`weasel_testing`.`widened_varchar_patch`");
+
+        var actual = new Table("weasel_testing.widened_varchar_patch");
+        actual.AddColumn<int>("id").AsPrimaryKey();
+        actual.AddColumn("description", "varchar(255)");
+        await actual.CreateAsync(theConnection);
+
+        await using (var seed = theConnection.CreateCommand(
+                         "insert into `weasel_testing`.`widened_varchar_patch` (id, description) values (1, 'still here')"))
+        {
+            await seed.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+        }
+
+        var expected = new Table("weasel_testing.widened_varchar_patch");
+        expected.AddColumn<int>("id").AsPrimaryKey();
+        expected.AddColumn("description", "varchar(1000)");
+
+        await expected.ApplyChangesAsync(theConnection);
+
+        var afterwards = await expected.FetchExistingAsync(theConnection);
+        afterwards!.ColumnFor("description")!.Type.ToUpperInvariant().ShouldBe("VARCHAR(1000)");
+
+        // MODIFY COLUMN, not a rebuild -- the rows are still there.
+        await using var check = theConnection.CreateCommand(
+            "select description from `weasel_testing`.`widened_varchar_patch` where id = 1");
+        (await check.ExecuteScalarAsync(TestContext.Current.CancellationToken)).ShouldBe("still here");
+
+        (await expected.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task an_int_display_width_is_still_not_a_difference()
+    {
+        // The reason the size was stripped wholesale in the first place: MySQL 8 reports a bare INT for
+        // a column declared int(11), so comparing sizes indiscriminately drifts on every schema check.
+        await DropTableAsync("`weasel_testing`.`int_display_width`");
+
+        var actual = new Table("weasel_testing.int_display_width");
+        actual.AddColumn<int>("id").AsPrimaryKey();
+        await actual.CreateAsync(theConnection);
+
+        var expected = new Table("weasel_testing.int_display_width");
+        expected.AddColumn("id", "int(11)").AsPrimaryKey();
+
+        (await expected.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+}

--- a/src/Weasel.MySql/Tables/TableColumn.cs
+++ b/src/Weasel.MySql/Tables/TableColumn.cs
@@ -94,6 +94,15 @@ public class TableColumn: ITableColumn
             return false;
         }
 
+        // RawType() throws the parenthesised part away, which is right for an INT display width the
+        // catalog invented and wrong for a character length the model declared. See
+        // CharacterColumnLength: a widened varchar used to be invisible here, so an existing table kept
+        // the narrow column forever.
+        if (CharacterColumnLength.Differ(Type, other.Type))
+        {
+            return false;
+        }
+
         // Compare nullability only for non-primary key columns
         if (!IsPrimaryKey && !other.IsPrimaryKey)
         {

--- a/src/Weasel.Oracle.Tests/Tables/detecting_widened_character_columns.cs
+++ b/src/Weasel.Oracle.Tests/Tables/detecting_widened_character_columns.cs
@@ -1,0 +1,71 @@
+using Shouldly;
+using Weasel.Core;
+using Weasel.Oracle.Tables;
+using Xunit;
+
+namespace Weasel.Oracle.Tests.Tables;
+
+/// <summary>
+/// The Oracle twin of the MySQL and SQL Server tests by the same name. TableColumn.RawType() strips the
+/// parenthesised part before comparing, so a model widened from VARCHAR2(500) to VARCHAR2(1000) used to
+/// compare equal to the existing column and the differ never emitted the ALTER ... MODIFY. Reported
+/// downstream as JasperFx/wolverine#4246.
+/// </summary>
+public class detecting_widened_character_columns: IntegrationContext
+{
+    public detecting_widened_character_columns() : base("widened")
+    {
+    }
+
+    [Fact]
+    public async Task detect_a_widened_varchar2()
+    {
+        await ResetSchema();
+
+        var actual = new Table("widened.WIDENED_VARCHAR");
+        actual.AddColumn<int>("id").AsPrimaryKey();
+        actual.AddColumn("description", "VARCHAR2(500)");
+        await CreateSchemaObjectInDatabase(actual);
+
+        var expected = new Table("widened.WIDENED_VARCHAR");
+        expected.AddColumn<int>("id").AsPrimaryKey();
+        expected.AddColumn("description", "VARCHAR2(1000)");
+
+        (await expected.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.Update);
+    }
+
+    [Fact]
+    public async Task patching_widens_the_column_and_settles()
+    {
+        await ResetSchema();
+
+        var actual = new Table("widened.WIDENED_PATCH");
+        actual.AddColumn<int>("id").AsPrimaryKey();
+        actual.AddColumn("description", "VARCHAR2(500)");
+        await CreateSchemaObjectInDatabase(actual);
+
+        var expected = new Table("widened.WIDENED_PATCH");
+        expected.AddColumn<int>("id").AsPrimaryKey();
+        expected.AddColumn("description", "VARCHAR2(1000)");
+
+        await expected.ApplyChangesAsync(theConnection);
+
+        (await expected.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task a_number_precision_is_still_not_a_difference()
+    {
+        // The reason sizes are stripped in the first place -- NUMBER carries a precision, not a length.
+        await ResetSchema();
+
+        var actual = new Table("widened.NUMBER_PRECISION");
+        actual.AddColumn("id", "NUMBER(10)").AsPrimaryKey();
+        await CreateSchemaObjectInDatabase(actual);
+
+        var expected = new Table("widened.NUMBER_PRECISION");
+        expected.AddColumn("id", "NUMBER").AsPrimaryKey();
+
+        (await expected.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+}

--- a/src/Weasel.Oracle/Tables/TableColumn.cs
+++ b/src/Weasel.Oracle/Tables/TableColumn.cs
@@ -105,6 +105,14 @@ public class TableColumn: ITableColumn
 
     protected bool Equals(TableColumn other)
     {
+        // RawType() throws the parenthesised part away, which is right for a NUMBER precision and wrong
+        // for a VARCHAR2 length the model declared. See CharacterColumnLength: a widened VARCHAR2 used to
+        // be invisible here, so an existing table kept the narrow column forever.
+        if (CharacterColumnLength.Differ(Type, other.Type))
+        {
+            return false;
+        }
+
         return string.Equals(QuotedName, other.QuotedName, StringComparison.OrdinalIgnoreCase) &&
                string.Equals(OracleProvider.Instance.ConvertSynonyms(RawType()),
                    OracleProvider.Instance.ConvertSynonyms(other.RawType()), StringComparison.OrdinalIgnoreCase);
@@ -154,7 +162,32 @@ public class TableColumn: ITableColumn
 
     public virtual string AlterColumnTypeSql(Table table, TableColumn changeActual)
     {
-        return $"ALTER TABLE {table.Identifier} MODIFY {changeActual.ToDeclaration()}";
+        // Two things were wrong here, and neither showed until character lengths started being compared
+        // (see CharacterColumnLength) -- before that a column type delta was almost never detected at all.
+        //
+        // First, the side: the SQL Server and PostgreSQL twins both emit the receiver, which is the shape
+        // the column is moving TO. This emitted changeActual, the shape it is moving FROM, so the
+        // statement altered the column to what it already was. Both call sites in TableDelta pass the
+        // target as the receiver, so reading the receiver is what they always meant.
+        //
+        // Second, the nullability: Oracle rejects a MODIFY that restates the nullability a column already
+        // has -- ORA-01451 "column to be modified to NULL cannot be modified to NULL", and ORA-01442 for
+        // the NOT NULL direction. So the clause is emitted only when it is actually changing, which is
+        // what changeActual is for.
+        var parts = new List<string> { QuotedName, Type };
+
+        if (DefaultExpression.IsNotEmpty())
+        {
+            parts.Add("DEFAULT " + DefaultExpression);
+        }
+
+        var allowsNulls = !IsPrimaryKey && AllowNulls;
+        if (allowsNulls != (!changeActual.IsPrimaryKey && changeActual.AllowNulls))
+        {
+            parts.Add(allowsNulls ? "NULL" : "NOT NULL");
+        }
+
+        return $"ALTER TABLE {table.Identifier} MODIFY {parts.Join(" ")}";
     }
 
     public string DropColumnSql(Table table)

--- a/src/Weasel.SqlServer.Tests/Tables/detecting_widened_character_columns.cs
+++ b/src/Weasel.SqlServer.Tests/Tables/detecting_widened_character_columns.cs
@@ -1,0 +1,77 @@
+using Shouldly;
+using Weasel.Core;
+using Weasel.SqlServer.Tables;
+using Xunit;
+
+namespace Weasel.SqlServer.Tests.Tables;
+
+/// <summary>
+/// The SQL Server twin of the MySQL test by the same name. TableColumn.RawType() strips the
+/// parenthesised part before comparing, so a model widened from varchar(500) to varchar(1000) used to
+/// compare equal to the existing column and the differ never emitted the ALTER. Reported downstream as
+/// JasperFx/wolverine#4246.
+/// </summary>
+[Collection("integration")]
+public class detecting_widened_character_columns: IntegrationContext
+{
+    public detecting_widened_character_columns() : base("widened")
+    {
+    }
+
+    [Fact]
+    public async Task detect_a_widened_varchar()
+    {
+        await ResetSchema();
+
+        var actual = new Table("widened.widened_varchar");
+        actual.AddColumn<int>("id").AsPrimaryKey();
+        actual.AddColumn("description", "varchar(500)");
+        await CreateSchemaObjectInDatabase(actual);
+
+        var expected = new Table("widened.widened_varchar");
+        expected.AddColumn<int>("id").AsPrimaryKey();
+        expected.AddColumn("description", "varchar(1000)");
+
+        var delta = await expected.FindDeltaAsync(theConnection);
+
+        delta.Difference.ShouldBe(SchemaPatchDifference.Update);
+    }
+
+    [Fact]
+    public async Task patching_widens_the_column_and_settles()
+    {
+        await ResetSchema();
+
+        var actual = new Table("widened.widened_varchar_patch");
+        actual.AddColumn<int>("id").AsPrimaryKey();
+        actual.AddColumn("description", "varchar(500)");
+        await CreateSchemaObjectInDatabase(actual);
+
+        var expected = new Table("widened.widened_varchar_patch");
+        expected.AddColumn<int>("id").AsPrimaryKey();
+        expected.AddColumn("description", "varchar(1000)");
+
+        await expected.ApplyChangesAsync(theConnection);
+
+        (await expected.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
+    [Fact]
+    public async Task a_decimal_precision_is_still_not_a_difference()
+    {
+        // The reason the size is stripped wholesale: comparing every parenthesised size indiscriminately
+        // would drift on precisions and scales the model spells differently from the catalog.
+        await ResetSchema();
+
+        var actual = new Table("widened.decimal_precision");
+        actual.AddColumn<int>("id").AsPrimaryKey();
+        actual.AddColumn("amount", "decimal(18,2)");
+        await CreateSchemaObjectInDatabase(actual);
+
+        var expected = new Table("widened.decimal_precision");
+        expected.AddColumn<int>("id").AsPrimaryKey();
+        expected.AddColumn("amount", "decimal");
+
+        (await expected.FindDeltaAsync(theConnection)).Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+}

--- a/src/Weasel.SqlServer/Tables/TableColumn.cs
+++ b/src/Weasel.SqlServer/Tables/TableColumn.cs
@@ -167,6 +167,14 @@ public class TableColumn: ITableColumn
 
     protected bool Equals(TableColumn other)
     {
+        // RawType() throws the parenthesised part away, which is right for a decimal precision or a
+        // datetime2 scale and wrong for a character length the model declared. See CharacterColumnLength:
+        // a widened varchar used to be invisible here, so an existing table kept the narrow column forever.
+        if (CharacterColumnLength.Differ(Type, other.Type))
+        {
+            return false;
+        }
+
         return string.Equals(QuotedName, other.QuotedName, StringComparison.OrdinalIgnoreCase) &&
                string.Equals(SqlServerProvider.Instance.ConvertSynonyms(RawType()),
                    SqlServerProvider.Instance.ConvertSynonyms(other.RawType()));


### PR DESCRIPTION
`TableColumn.RawType()` strips the parenthesised part of a type before comparing, on MySQL, SQL Server and Oracle alike. For most types that is right: MySQL 8 reports a bare `INT` for a column declared `int(11)`, a `DECIMAL` carries a precision and a scale, a `DATETIME` a fractional-seconds precision. Comparing those wholesale drifts on every schema check for tables nobody touched -- that is what JasperFx/wolverine#3839 ran into.

Character and binary lengths are the exception. They are declared by the model, reported faithfully by every catalog, and load-bearing: a column narrower than the value being written fails the insert. Widening a `varchar` in a model was invisible to the differ, so an existing database kept the old width forever and only a hand-written `ALTER` fixed it.

Reported downstream as JasperFx/wolverine#4246, where a MySQL `varchar(255)` that should have been wider failed node-record inserts with `Data too long for column 'description'`. Widening the model there is not enough on its own -- I confirmed on both MySQL and SQL Server that `MigrateAsync` against an existing table leaves the old width in place.

## The rule

`CharacterColumnLength` carries it for all three providers. A length is compared only for the types whose single parenthesised argument really is a character or byte count (`CHAR`, `VARCHAR`, `NCHAR`, `NVARCHAR`, `CHARACTER`, `VARCHAR2`, `NVARCHAR2`, `BINARY`, `VARBINARY`, `RAW`), and only when both sides state one -- "cannot tell" never reports drift, so a model that declares a bare type keeps comparing the way it always has. `varchar(max)` is handled as an unbounded sentinel, and Oracle's `VARCHAR2(100 CHAR)` / `(100 BYTE)` both read as 100.

## Two Oracle defects that surfaced with it

Both in `AlterColumnTypeSql`, neither reachable before, because a column type delta was almost never detected in the first place:

- It emitted `changeActual`, the shape the column is moving **from**, where the SQL Server and PostgreSQL twins both emit the receiver, the shape it is moving **to**. Both `TableDelta` call sites pass the target as the receiver, so the statement altered the column to what it already was.
- It restated the column's nullability, which Oracle rejects when it is not changing: ORA-01451 for `NULL`, ORA-01442 for `NOT NULL`.

## Scope

PostgreSQL and SQLite are deliberately untouched. PostgreSQL spells the type `character varying`, which is not in the set, so its comparison is unchanged; SQLite is effectively typeless for this. Adding PostgreSQL would widen the blast radius into Marten's most-used provider for no benefit to the reported issue -- worth doing separately and deliberately if wanted.

## Behaviour change worth a deliberate decision

Once character lengths are compared, every consumer -- Marten included -- starts seeing `ALTER`s for width drift that was previously invisible, **in both directions**. A model *narrower* than an existing column will now emit a narrowing `ALTER` that can fail on real data. That is the correct contract (the model is the truth, and the differ makes the database match it), and it is exactly what makes the downstream fix work, but it is a real change in what an existing database does on its next migration.

`is_equivalent_ignores_size_differences` asserted the behaviour this reverses for exactly the varchar case; it is updated and renamed, with a companion pinning that non-character sizes are still ignored.

## Verification

All green, run locally against real databases:

| Suite | Result |
|---|---|
| Weasel.Core.Tests | 349 passed |
| Weasel.MySql.Tests | 299 passed |
| Weasel.SqlServer.Tests | 550 passed, 8 skipped |
| Weasel.Oracle.Tests | 316 passed |
| `weasel.slnx` build, `-f net9.0` | clean |

The new per-provider tests were confirmed to go red without the change: `detect_a_widened_varchar` and `patching_widens_the_column_in_place` both fail on the unpatched comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)