### PR TITLE
9.29.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>9.29.0</Version>
+        <Version>9.29.1</Version>
         <LangVersion>13.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>


### PR DESCRIPTION
Fix bump for release. Three fixes on top of 9.29.0.

- **#550** -- the schema differ compares character lengths, so a widened `varchar` is no longer invisible to it. Before this an existing database kept the narrow column forever and only a hand-written `ALTER` fixed it. Reported downstream as JasperFx/wolverine#4246, a MySQL `varchar(255)` failing node-record inserts with `Data too long for column`. Sizes that are *not* character lengths -- a MySQL `int(11)` display width, a decimal precision, a datetime fsp -- are still ignored, so the false drift that stripping avoided stays avoided.

  Also fixes two Oracle defects in `AlterColumnTypeSql` that the new detection made reachable: it emitted the shape the column was moving *from* rather than *to*, and it restated a nullability Oracle rejects (ORA-01451 / ORA-01442).

- **#549** -- a SQLite rebuild migration no longer mutates the caller's table model.
- **#548** -- view bodies compare without normalizing away string literals.

## Note for consumers

Comparing character lengths means width drift that was previously invisible now generates `ALTER`s **in both directions**. A model *narrower* than an existing column will emit a narrowing `ALTER` that can fail on real data. That is the intended contract -- the model is the truth and the differ makes the database match it -- and it is what makes the downstream Wolverine fix reach existing databases, but it is a real change in what an existing database does on its next migration after taking this patch.

Merging this and dispatching `publish_nuget.yml` ships all 8 packages at 9.29.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)