### PR TITLE
Precompute positional parameter names (no more "p" + count per parameter)

### DIFF
--- a/src/Weasel.Core.Tests/parameter_name_precomputation.cs
+++ b/src/Weasel.Core.Tests/parameter_name_precomputation.cs
@@ -1,0 +1,37 @@
+using Shouldly;
+using Weasel.Core;
+using Xunit;
+
+namespace Weasel.Core.Tests;
+
+/// <summary>
+///     The positional parameter names the builders stamp onto parameters come from a precomputed
+///     table instead of a per-parameter string concatenation (weasel#556). The names must be
+///     byte-for-byte what <c>"p" + position</c> produced before, at every position — inside the
+///     table, at its edges, and past its end — so that no generated SQL text changes.
+/// </summary>
+public class parameter_name_precomputation
+{
+    [Fact]
+    public void names_are_identical_to_the_concatenation_they_replace()
+    {
+        // Well past any plausible table size, so the fallback path is exercised too
+        for (var i = 0; i < 5000; i++)
+        {
+            ParameterNames.ForPosition(i).ShouldBe("p" + i);
+        }
+    }
+
+    [Fact]
+    public void positions_within_the_table_do_not_allocate()
+    {
+        ParameterNames.ForPosition(0).ShouldBeSameAs(ParameterNames.ForPosition(0));
+        ParameterNames.ForPosition(511).ShouldBeSameAs(ParameterNames.ForPosition(511));
+    }
+
+    [Fact]
+    public void the_first_position_past_the_table_still_answers_correctly()
+    {
+        ParameterNames.ForPosition(512).ShouldBe("p512");
+    }
+}

--- a/src/Weasel.Core/CommandBuilderBase.cs
+++ b/src/Weasel.Core/CommandBuilderBase.cs
@@ -187,7 +187,7 @@ public class CommandBuilderBase<TCommand, TParameter, TParameterType>: ICommandB
     /// <returns></returns>
     public virtual TParameter AddParameter(object? value, TParameterType? dbType = null)
     {
-        var name = "p" + _command.Parameters.Count;
+        var name = ParameterNames.ForPosition(_command.Parameters.Count);
 
         var parameter = (TParameter)_command.CreateParameter();
         parameter.ParameterName = name;

--- a/src/Weasel.Core/DatabaseProvider.cs
+++ b/src/Weasel.Core/DatabaseProvider.cs
@@ -281,7 +281,7 @@ public abstract class DatabaseProvider<TCommand, TParameter, TParameterType>
 
     public TParameter AddParameter(TCommand command, object? value, TParameterType? dbType = null)
     {
-        var name = "p" + command.Parameters.Count;
+        var name = ParameterNames.ForPosition(command.Parameters.Count);
 
         var parameter = (TParameter)command.CreateParameter();
         parameter.ParameterName = name;

--- a/src/Weasel.Core/ParameterNames.cs
+++ b/src/Weasel.Core/ParameterNames.cs
@@ -1,0 +1,43 @@
+namespace Weasel.Core;
+
+/// <summary>
+///     Precomputed positional parameter names — "p0", "p1", … — for the builders that name
+///     parameters by their position in the command. Naming by position is a per-parameter
+///     string allocation on every append path; the overwhelming majority of commands bind
+///     far fewer parameters than the table holds, so the common case allocates nothing
+///     (weasel#556).
+/// </summary>
+/// <remarks>
+///     The names are byte-for-byte what <c>"p" + position</c> produced before, and past the
+///     end of the table that concatenation is exactly what happens, so no SQL text changes
+///     at any position.
+/// </remarks>
+public static class ParameterNames
+{
+    private const int TableSize = 512;
+
+    private static readonly string[] _names = precompute();
+
+    private static string[] precompute()
+    {
+        var names = new string[TableSize];
+        for (var i = 0; i < names.Length; i++)
+        {
+            names[i] = "p" + i;
+        }
+
+        return names;
+    }
+
+    /// <summary>
+    ///     The name of the parameter at the given zero-based position: "p0", "p1", … Allocation-free
+    ///     for the positions any sane command reaches; identical to <c>"p" + position</c> beyond them.
+    /// </summary>
+    /// <param name="position">
+    ///     Zero-based position, typically the parameter collection's count at the moment of the add.
+    /// </param>
+    public static string ForPosition(int position)
+    {
+        return (uint)position < TableSize ? _names[position] : "p" + position;
+    }
+}

--- a/src/Weasel.SqlServer.Tests/BatchBuilderParameterNameTests.cs
+++ b/src/Weasel.SqlServer.Tests/BatchBuilderParameterNameTests.cs
@@ -1,0 +1,82 @@
+using System.Data;
+using Shouldly;
+using Xunit;
+
+namespace Weasel.SqlServer.Tests;
+
+/// <summary>
+///     Pure unit tests — no database. The parameter names the SQL Server BatchBuilder stamps
+///     onto its parameters now come from the precomputed table in Weasel.Core (weasel#556);
+///     these pin down that the names, and the SQL text that embeds them, are exactly what the
+///     old per-parameter concatenation produced.
+/// </summary>
+public class BatchBuilderParameterNameTests
+{
+    [Fact]
+    public void every_append_parameter_overload_names_by_position()
+    {
+        var builder = new BatchBuilder();
+
+        builder.Append("select ");
+        builder.AppendParameter("one");                          // AppendParameter<T>(T)
+        builder.Append(", ");
+        builder.AppendParameter("two", SqlDbType.NVarChar);      // AppendParameter<T>(T, SqlDbType)
+        builder.Append(", ");
+        builder.AppendParameter((object)3);                      // AppendParameter(object)
+        builder.Append(", ");
+        builder.AppendParameter((object)4, SqlDbType.Int);       // AppendParameter(object?, SqlDbType?)
+
+        var batch = builder.Compile();
+        var command = batch.BatchCommands[0];
+
+        command.CommandText.ShouldBe("select @p0, @p1, @p2, @p3");
+
+        command.Parameters.Count.ShouldBe(4);
+        for (var i = 0; i < command.Parameters.Count; i++)
+        {
+            command.Parameters[i].ParameterName.ShouldBe("p" + i);
+        }
+    }
+
+    [Fact]
+    public void numbering_restarts_with_each_new_command()
+    {
+        var builder = new BatchBuilder();
+
+        builder.Append("select ");
+        builder.AppendParameter(1);
+        builder.StartNewCommand();
+        builder.Append("select ");
+        builder.AppendParameter(2);
+        builder.Append(", ");
+        builder.AppendParameter(3);
+
+        var batch = builder.Compile();
+
+        batch.BatchCommands[0].Parameters[0].ParameterName.ShouldBe("p0");
+        batch.BatchCommands[1].Parameters[0].ParameterName.ShouldBe("p0");
+        batch.BatchCommands[1].Parameters[1].ParameterName.ShouldBe("p1");
+        batch.BatchCommands[1].CommandText.ShouldBe("select @p0, @p1");
+    }
+
+    [Fact]
+    public void names_stay_correct_past_the_precomputed_table()
+    {
+        var builder = new BatchBuilder();
+
+        builder.Append("select ");
+        builder.AppendParameter(0);
+        for (var i = 1; i < 600; i++)
+        {
+            builder.Append(", ");
+            builder.AppendParameter(i);
+        }
+
+        var batch = builder.Compile();
+        var command = batch.BatchCommands[0];
+
+        command.Parameters.Count.ShouldBe(600);
+        command.Parameters[599].ParameterName.ShouldBe("p599");
+        command.CommandText.ShouldEndWith("@p598, @p599");
+    }
+}

--- a/src/Weasel.SqlServer/BatchBuilder.cs
+++ b/src/Weasel.SqlServer/BatchBuilder.cs
@@ -53,7 +53,7 @@ public class BatchBuilder: ICommandBuilder
     public SqlParameter AppendParameter<T>(T value)
     {
         _current ??= appendCommand();
-        var name = "p" + _current.Parameters.Count;
+        var name = Weasel.Core.ParameterNames.ForPosition(_current.Parameters.Count);
         var param = new SqlParameter
         {
             ParameterName = name,
@@ -71,7 +71,7 @@ public class BatchBuilder: ICommandBuilder
     public SqlParameter AppendParameter<T>(T value, SqlDbType dbType)
     {
         _current ??= appendCommand();
-        var name = "p" + _current.Parameters.Count;
+        var name = Weasel.Core.ParameterNames.ForPosition(_current.Parameters.Count);
         var param = new SqlParameter
         {
             ParameterName = name,
@@ -90,7 +90,7 @@ public class BatchBuilder: ICommandBuilder
     public SqlParameter AppendParameter(object value)
     {
         _current ??= appendCommand();
-        var name = "p" + _current.Parameters.Count;
+        var name = Weasel.Core.ParameterNames.ForPosition(_current.Parameters.Count);
         var param = new SqlParameter
         {
             ParameterName = name,
@@ -108,7 +108,7 @@ public class BatchBuilder: ICommandBuilder
     public SqlParameter AppendParameter(object? value, SqlDbType? dbType)
     {
         _current ??= appendCommand();
-        var name = "p" + _current.Parameters.Count;
+        var name = Weasel.Core.ParameterNames.ForPosition(_current.Parameters.Count);
         var param = new SqlParameter
         {
             ParameterName = name,


### PR DESCRIPTION
Closes #556. Stoat plan `critter-performance-2026-09`, node `weasel-parameter-names`.

## What

Every parameter appended through the hot builder paths allocated a fresh string for its positional name:

- `Weasel.SqlServer/BatchBuilder.cs` — all four `AppendParameter` overloads
- `Weasel.Core/CommandBuilderBase.cs` — `AddParameter`
- `Weasel.Core/DatabaseProvider.cs` — `AddParameter(TCommand, ...)`

Those six sites now read from a precomputed `static readonly string[]` table in the new `Weasel.Core.ParameterNames` ("p0" .. "p511"), falling back to the old concatenation past the end of the table. These are the only occurrences of the pattern in the repo (Postgres's `BatchBuilder` uses positional `$N` placeholders and never names parameters; Sqlite/MySql/Oracle name through the shared Core paths).

## No SQL text changes

The names are byte-for-byte what `"p" + count` produced, at every position — pinned by tests that sweep positions 0..5000 across the table boundary, plus SqlServer `BatchBuilder` unit tests asserting the exact `@p0, @p1, ...` command text, per-command restart of the numbering, and correctness past the table.

## Tests

- `Weasel.Core.Tests` (net9.0, no database): 383 passed, 0 failed — includes the new `parameter_name_precomputation` tests
- `Weasel.SqlServer.Tests` filtered to the new `BatchBuilderParameterNameTests` (pure unit, no database): 3 passed
- Full `Weasel.slnx` builds with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)