### PR TITLE
Lift the STJ serializer shared by Polecat and Fisher into Weasel

### DIFF
--- a/src/Weasel.Core.Tests/Weasel.Core.Tests.csproj
+++ b/src/Weasel.Core.Tests/Weasel.Core.Tests.csproj
@@ -12,6 +12,9 @@
 
     <ItemGroup>
       <ProjectReference Include="..\Weasel.Core\Weasel.Core.csproj" />
+      <!-- Referenced for the StorageSerializerAdapter / IStorageSerializer seam tests
+           (weasel#555). Pure in-memory serialization; no database, no containers. -->
+      <ProjectReference Include="..\Weasel.Storage\Weasel.Storage.csproj" />
       <!-- Referenced for the cross-provider identifier conformance suite. Pure string logic;
            no database, no containers. -->
       <ProjectReference Include="..\Weasel.MySql\Weasel.MySql.csproj" />

--- a/src/Weasel.Core.Tests/storage_serializer_adapter_tests.cs
+++ b/src/Weasel.Core.Tests/storage_serializer_adapter_tests.cs
@@ -1,0 +1,126 @@
+using System.Buffers;
+using System.Text;
+using Microsoft.Data.Sqlite;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Storage;
+using Xunit;
+
+namespace Weasel.Core.Tests;
+
+/// <summary>
+///     Covers <see cref="StorageSerializerAdapter" />, lifted out of Polecat's and Fisher's
+///     byte-identical per-store copies alongside the serializer itself (weasel#555). The adapter
+///     derives the <see cref="IStorageSerializer" /> seam-only members from the shared
+///     <see cref="ISerializer" /> members every serializer already carries.
+/// </summary>
+public class storage_serializer_adapter_tests
+{
+    public class TestDoc
+    {
+        public string? Name { get; set; }
+        public int Number { get; set; }
+    }
+
+    /// <summary>
+    ///     The store-shaped subclass: this is the whole of what Polecat and Fisher keep locally
+    ///     after adopting the lifted serializer — a namespace of their own plus the seam
+    ///     declaration, satisfied entirely by inherited members.
+    /// </summary>
+    private sealed class StoreStyleSerializer : SystemTextJsonSerializer, IStorageSerializer;
+
+    private readonly SystemTextJsonSerializer theInner = new();
+
+    private IStorageSerializer theAdapter => StorageSerializerAdapter.For(theInner);
+
+    [Fact]
+    public void a_serializer_already_implementing_the_seam_is_returned_unwrapped()
+    {
+        var native = new StoreStyleSerializer();
+
+        StorageSerializerAdapter.For(native).ShouldBeSameAs(native);
+    }
+
+    [Fact]
+    public void a_core_only_serializer_is_wrapped()
+    {
+        theAdapter.ShouldBeOfType<StorageSerializerAdapter>();
+    }
+
+    [Fact]
+    public void to_json_delegates_and_maps_null_to_the_json_null_literal()
+    {
+        theAdapter.ToJson(new TestDoc { Name = "adapted" })
+            .ShouldBe(theInner.ToJson(new TestDoc { Name = "adapted" }));
+
+        theAdapter.ToJson(null).ShouldBe("null");
+    }
+
+    [Fact]
+    public void clean_json_is_plain_json()
+    {
+        var doc = new TestDoc { Name = "clean", Number = 2 };
+
+        theAdapter.ToCleanJson(doc).ShouldBe(theAdapter.ToJson(doc));
+    }
+
+    [Fact]
+    public void write_to_produces_the_utf8_bytes_of_the_json()
+    {
+        var doc = new TestDoc { Name = "buffered", Number = 4 };
+        var writer = new ArrayBufferWriter<byte>();
+
+        theAdapter.WriteTo(writer, doc);
+
+        writer.WrittenSpan.ToArray().ShouldBe(Encoding.UTF8.GetBytes(theInner.ToJson(doc)));
+    }
+
+    [Fact]
+    public void write_to_parameter_binds_json_as_a_string_and_null_as_dbnull()
+    {
+        var parameter = new SqliteParameter();
+
+        theAdapter.WriteToParameter(parameter, new TestDoc { Name = "bound" });
+        parameter.Value.ShouldBeOfType<string>().ShouldContain("\"name\":\"bound\"");
+
+        theAdapter.WriteToParameter(parameter, null);
+        parameter.Value.ShouldBe(DBNull.Value);
+    }
+
+    [Fact]
+    public async Task the_stream_reads_delegate_to_the_inner_serializer()
+    {
+        var bytes = Encoding.UTF8.GetBytes(theInner.ToJson(new TestDoc { Name = "streamed", Number = 6 }));
+
+        theAdapter.FromJson<TestDoc>(new MemoryStream(bytes)).Name.ShouldBe("streamed");
+        theAdapter.FromJson(typeof(TestDoc), new MemoryStream(bytes))
+            .ShouldBeOfType<TestDoc>().Number.ShouldBe(6);
+
+        (await theAdapter.FromJsonAsync<TestDoc>(new MemoryStream(bytes))).Name.ShouldBe("streamed");
+        (await theAdapter.FromJsonAsync(typeof(TestDoc), new MemoryStream(bytes)))
+            .ShouldBeOfType<TestDoc>().Number.ShouldBe(6);
+    }
+
+    [Fact]
+    public async Task reads_json_from_a_data_reader_column_sync_and_async()
+    {
+        await using var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+
+        var command = connection.CreateCommand();
+        command.CommandText = "select '{\"name\":\"row\",\"number\":13}'";
+
+        await using var reader = await command.ExecuteReaderAsync();
+        (await reader.ReadAsync()).ShouldBeTrue();
+
+        theAdapter.FromJson<TestDoc>(reader, 0).Name.ShouldBe("row");
+        theAdapter.FromJson(typeof(TestDoc), reader, 0)
+            .ShouldBeOfType<TestDoc>().Number.ShouldBe(13);
+
+        // The async reader reads route through the reader's stream rather than the
+        // RUC-annotated string overloads.
+        (await theAdapter.FromJsonAsync<TestDoc>(reader, 0)).Name.ShouldBe("row");
+        (await theAdapter.FromJsonAsync(typeof(TestDoc), reader, 0))
+            .ShouldBeOfType<TestDoc>().Number.ShouldBe(13);
+    }
+}

--- a/src/Weasel.Core.Tests/system_text_json_serializer_tests.cs
+++ b/src/Weasel.Core.Tests/system_text_json_serializer_tests.cs
@@ -1,0 +1,238 @@
+using System.Buffers;
+using System.Text;
+using Microsoft.Data.Sqlite;
+using Shouldly;
+using Weasel.Core;
+using Xunit;
+
+namespace Weasel.Core.Tests;
+
+/// <summary>
+///     Covers the shared System.Text.Json serializer lifted out of Polecat's and Fisher's
+///     byte-identical per-store copies (weasel#555). Pure relocation, so these tests pin the
+///     behavior the stores already rely on: defaults, casing/enum-storage/non-public-member
+///     options, and the DbDataReader/DbParameter members of the storage seam.
+/// </summary>
+public class system_text_json_serializer_tests
+{
+    public class TestDoc
+    {
+        public string? Name { get; set; }
+        public int Number { get; set; }
+        public string? MaybeNull { get; set; }
+        public TestColor Color { get; set; }
+    }
+
+    public enum TestColor
+    {
+        DarkBlue,
+        LightGreen
+    }
+
+    public class SnakeDoc
+    {
+        public string? FirstName { get; set; }
+    }
+
+    public class GuardedDoc
+    {
+        public GuardedDoc()
+        {
+        }
+
+        public GuardedDoc(string name)
+        {
+            Name = name;
+        }
+
+        public string? Name { get; private set; }
+    }
+
+    private readonly SystemTextJsonSerializer theSerializer = new();
+
+    [Fact]
+    public void a_null_options_argument_is_refused()
+    {
+        Should.Throw<ArgumentNullException>(() => new SystemTextJsonSerializer(null!));
+    }
+
+    [Fact]
+    public void default_configuration_is_camel_case_integer_enums_null_ignoring()
+    {
+        theSerializer.Casing.ShouldBe(Casing.CamelCase);
+        theSerializer.EnumStorage.ShouldBe(EnumStorage.AsInteger);
+        theSerializer.CollectionStorage.ShouldBe(CollectionStorage.Default);
+        theSerializer.NonPublicMembersStorage.ShouldBe(NonPublicMembersStorage.Default);
+
+        var json = theSerializer.ToJson(new TestDoc { Name = "weasel", Number = 3, Color = TestColor.LightGreen });
+
+        json.ShouldBe("{\"name\":\"weasel\",\"number\":3,\"color\":1}");
+    }
+
+    [Fact]
+    public void round_trips_through_the_string_overloads()
+    {
+        var doc = new TestDoc { Name = "weasel", Number = 42, Color = TestColor.DarkBlue };
+
+        var typed = theSerializer.FromJson<TestDoc>(theSerializer.ToJson(doc));
+        typed.Name.ShouldBe("weasel");
+        typed.Number.ShouldBe(42);
+        typed.Color.ShouldBe(TestColor.DarkBlue);
+
+        var untyped = theSerializer.FromJson(typeof(TestDoc), theSerializer.ToJson(doc))
+            .ShouldBeOfType<TestDoc>();
+        untyped.Name.ShouldBe("weasel");
+        untyped.Number.ShouldBe(42);
+    }
+
+    [Fact]
+    public async Task round_trips_through_the_stream_overloads()
+    {
+        var doc = new TestDoc { Name = "streamed", Number = 7 };
+        var bytes = Encoding.UTF8.GetBytes(theSerializer.ToJson(doc));
+
+        theSerializer.FromJson<TestDoc>(new MemoryStream(bytes)).Name.ShouldBe("streamed");
+        theSerializer.FromJson(typeof(TestDoc), new MemoryStream(bytes))
+            .ShouldBeOfType<TestDoc>().Name.ShouldBe("streamed");
+
+        (await theSerializer.FromJsonAsync<TestDoc>(new MemoryStream(bytes))).Name.ShouldBe("streamed");
+        (await theSerializer.FromJsonAsync(typeof(TestDoc), new MemoryStream(bytes)))
+            .ShouldBeOfType<TestDoc>().Name.ShouldBe("streamed");
+    }
+
+    [Fact]
+    public void serializing_null_yields_the_json_null_literal()
+    {
+        theSerializer.ToJson(null).ShouldBe("null");
+    }
+
+    [Fact]
+    public void serializes_by_runtime_type_rather_than_declared_type()
+    {
+        object doc = new TestDoc { Name = "runtime" };
+
+        theSerializer.ToJson(doc).ShouldContain("\"name\":\"runtime\"");
+    }
+
+    [Fact]
+    public void to_clean_json_is_identical_to_to_json()
+    {
+        var doc = new TestDoc { Name = "clean", Number = 9 };
+
+        theSerializer.ToCleanJson(doc).ShouldBe(theSerializer.ToJson(doc));
+    }
+
+    [Fact]
+    public void write_to_produces_the_same_bytes_as_to_json()
+    {
+        var doc = new TestDoc { Name = "buffered", Number = 5, Color = TestColor.LightGreen };
+        var writer = new ArrayBufferWriter<byte>();
+
+        theSerializer.WriteTo(writer, doc);
+
+        writer.WrittenSpan.ToArray().ShouldBe(Encoding.UTF8.GetBytes(theSerializer.ToJson(doc)));
+    }
+
+    [Fact]
+    public void write_to_parameter_binds_json_as_a_string_and_null_as_dbnull()
+    {
+        var parameter = new SqliteParameter();
+
+        theSerializer.WriteToParameter(parameter, new TestDoc { Name = "bound" });
+        parameter.Value.ShouldBeOfType<string>().ShouldContain("\"name\":\"bound\"");
+
+        theSerializer.WriteToParameter(parameter, null);
+        parameter.Value.ShouldBe(DBNull.Value);
+    }
+
+    [Fact]
+    public void snake_casing_is_applied_when_selected()
+    {
+        theSerializer.Casing = Casing.SnakeCase;
+
+        theSerializer.ToJson(new SnakeDoc { FirstName = "wendell" })
+            .ShouldBe("{\"first_name\":\"wendell\"}");
+
+        theSerializer.FromJson<SnakeDoc>("{\"first_name\":\"wendell\"}")
+            .FirstName.ShouldBe("wendell");
+    }
+
+    [Fact]
+    public void default_casing_keeps_the_member_names_as_declared()
+    {
+        theSerializer.Casing = Casing.Default;
+
+        theSerializer.ToJson(new SnakeDoc { FirstName = "exact" })
+            .ShouldBe("{\"FirstName\":\"exact\"}");
+    }
+
+    [Fact]
+    public void enums_as_strings_respect_the_naming_policy_and_round_trip()
+    {
+        theSerializer.EnumStorage = EnumStorage.AsString;
+
+        var json = theSerializer.ToJson(new TestDoc { Name = "e", Color = TestColor.DarkBlue });
+        json.ShouldContain("\"color\":\"darkBlue\"");
+
+        theSerializer.FromJson<TestDoc>(json).Color.ShouldBe(TestColor.DarkBlue);
+    }
+
+    [Fact]
+    public void switching_enum_storage_back_to_integers_removes_the_converter()
+    {
+        theSerializer.EnumStorage = EnumStorage.AsString;
+        theSerializer.EnumStorage = EnumStorage.AsInteger;
+
+        theSerializer.ToJson(new TestDoc { Name = "e", Color = TestColor.LightGreen })
+            .ShouldContain("\"color\":1");
+    }
+
+    [Fact]
+    public void non_public_setters_are_ignored_by_default()
+    {
+        var json = theSerializer.ToJson(new GuardedDoc("hidden"));
+        json.ShouldContain("\"name\":\"hidden\"");
+
+        theSerializer.FromJson<GuardedDoc>(json).Name.ShouldBeNull();
+    }
+
+    [Fact]
+    public void non_public_setters_are_used_when_opted_into()
+    {
+        theSerializer.NonPublicMembersStorage = NonPublicMembersStorage.NonPublicSetters;
+
+        var json = theSerializer.ToJson(new GuardedDoc("restored"));
+
+        theSerializer.FromJson<GuardedDoc>(json).Name.ShouldBe("restored");
+    }
+
+    [Fact]
+    public async Task reads_json_from_a_data_reader_column()
+    {
+        await using var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+
+        var command = connection.CreateCommand();
+        command.CommandText = "select '{\"name\":\"row\",\"number\":11}'";
+
+        await using var reader = await command.ExecuteReaderAsync();
+        (await reader.ReadAsync()).ShouldBeTrue();
+
+        theSerializer.FromJson<TestDoc>(reader, 0).Name.ShouldBe("row");
+        theSerializer.FromJson(typeof(TestDoc), reader, 0)
+            .ShouldBeOfType<TestDoc>().Number.ShouldBe(11);
+
+        (await theSerializer.FromJsonAsync<TestDoc>(reader, 0)).Name.ShouldBe("row");
+        (await theSerializer.FromJsonAsync(typeof(TestDoc), reader, 0))
+            .ShouldBeOfType<TestDoc>().Number.ShouldBe(11);
+    }
+
+    [Fact]
+    public void configure_reaches_the_underlying_options()
+    {
+        theSerializer.Configure(o => o.WriteIndented = true);
+
+        theSerializer.Options.WriteIndented.ShouldBeTrue();
+        theSerializer.ToJson(new TestDoc { Name = "pretty" }).ShouldContain("\n");
+    }
+}

--- a/src/Weasel.Core/SystemTextJsonSerializer.cs
+++ b/src/Weasel.Core/SystemTextJsonSerializer.cs
@@ -1,0 +1,315 @@
+using System.Buffers;
+using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+
+namespace Weasel.Core;
+
+/// <summary>
+///     Default serializer implementation using System.Text.Json, shared by the Critter Stack
+///     document stores (Polecat, Fisher). Lifted from their byte-identical per-store copies
+///     (weasel#555); each store keeps a small subclass in its own namespace for back-compat.
+/// </summary>
+/// <remarks>
+///     Also carries every member of <c>Weasel.Storage.IStorageSerializer</c> — the dialect-neutral
+///     serializer seam of the shared closed-shape storage runtime (weasel#329/#331,
+///     JasperFx/polecat#273) — with BCL-typed signatures only, so a store's subclass can declare
+///     that interface and satisfy it entirely through these inherited members. The interface itself
+///     lives in Weasel.Storage, which references Weasel.Core, so it cannot be declared here.
+/// </remarks>
+public class SystemTextJsonSerializer : ISerializer
+{
+    private JsonSerializerOptions _options;
+    private EnumStorage _enumStorage = EnumStorage.AsInteger;
+    private Casing _casing = Casing.CamelCase;
+    private CollectionStorage _collectionStorage = CollectionStorage.Default;
+    private NonPublicMembersStorage _nonPublicMembersStorage = NonPublicMembersStorage.Default;
+
+    public SystemTextJsonSerializer() : this(DefaultOptions())
+    {
+    }
+
+    public SystemTextJsonSerializer(JsonSerializerOptions options)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+    }
+
+    /// <summary>
+    ///     Provides access to the underlying JsonSerializerOptions for advanced configuration.
+    /// </summary>
+    public JsonSerializerOptions Options => _options;
+
+    public EnumStorage EnumStorage
+    {
+        get => _enumStorage;
+        set
+        {
+            _enumStorage = value;
+            ApplyEnumStorage();
+        }
+    }
+
+    public Casing Casing
+    {
+        get => _casing;
+        set
+        {
+            _casing = value;
+            ApplyCasing();
+        }
+    }
+
+    public CollectionStorage CollectionStorage
+    {
+        get => _collectionStorage;
+        set => _collectionStorage = value;
+    }
+
+    public NonPublicMembersStorage NonPublicMembersStorage
+    {
+        get => _nonPublicMembersStorage;
+        set
+        {
+            _nonPublicMembersStorage = value;
+            ApplyNonPublicMembers();
+        }
+    }
+
+    /// <summary>
+    ///     Apply custom configuration to the underlying JsonSerializerOptions.
+    /// </summary>
+    public void Configure(Action<JsonSerializerOptions> configure)
+    {
+        configure(_options);
+    }
+
+    // polecat#273: the shared members inherited from Weasel.Core.ISerializer are intentionally
+    // unannotated (Marten parity), so their reflection-based STJ bodies suppress the RUC/RDC warnings
+    // here rather than propagating a caller-facing contract the base doesn't declare. AOT consumers
+    // supply a source-generator-backed ISerializer. The two string-based overloads below are
+    // store-level extensions (Polecat and Fisher declare them on their own ISerializer interfaces,
+    // not on the shared base), so they keep the propagating
+    // [RequiresUnreferencedCode]/[RequiresDynamicCode].
+    private const string SharedSerializerSuppression =
+        "Reflection-based STJ serialize/deserialize is the Critter Stack stores' documented default; the shared Weasel.Core.ISerializer base is intentionally unannotated for Marten parity, so RUC/RDC is not propagated. AOT consumers supply a source-generator-backed ISerializer.";
+
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification = SharedSerializerSuppression)]
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = SharedSerializerSuppression)]
+    public string ToJson(object? document)
+    {
+        // object? satisfies both Weasel.Core.ISerializer.ToJson(object) and the wider
+        // Weasel.Storage.IStorageSerializer.ToJson(object?) with a single implementation.
+        return JsonSerializer.Serialize(document, document?.GetType() ?? typeof(object), _options);
+    }
+
+    // ---- Weasel.Storage.IStorageSerializer additions (beyond the Weasel.Core.ISerializer base) ----
+
+    /// <summary>
+    ///     STJ has no type-metadata pollution to strip, so "clean" JSON is identical to
+    ///     <see cref="ToJson" />. (The distinction exists on the shared seam for Newtonsoft's
+    ///     TypeNameHandling.)
+    /// </summary>
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification = SharedSerializerSuppression)]
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = SharedSerializerSuppression)]
+    public string ToCleanJson(object? document)
+    {
+        return ToJson(document);
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification = SharedSerializerSuppression)]
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = SharedSerializerSuppression)]
+    public void WriteTo(IBufferWriter<byte> writer, object? value)
+    {
+        using var jsonWriter = new Utf8JsonWriter(writer);
+        JsonSerializer.Serialize(jsonWriter, value, value?.GetType() ?? typeof(object), _options);
+    }
+
+    /// <summary>
+    ///     Writes the value's JSON to a database parameter as a plain string value. Every store
+    ///     using this serializer binds JSON as string parameter values throughout (SQL Server 2025's
+    ///     native JSON column type accepts nvarchar input; SQLite's json1 functions accept TEXT), so
+    ///     this stays dialect-neutral with no provider-specific typing.
+    /// </summary>
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification = SharedSerializerSuppression)]
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = SharedSerializerSuppression)]
+    public void WriteToParameter(DbParameter parameter, object? value)
+    {
+        parameter.Value = value is null ? DBNull.Value : ToJson(value);
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification = SharedSerializerSuppression)]
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = SharedSerializerSuppression)]
+    public async ValueTask<T> FromJsonAsync<T>(DbDataReader reader, int index,
+        CancellationToken cancellationToken = default)
+    {
+        var json = await reader.GetFieldValueAsync<string>(index, cancellationToken).ConfigureAwait(false);
+        return FromJson<T>(json);
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification = SharedSerializerSuppression)]
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = SharedSerializerSuppression)]
+    public async ValueTask<object> FromJsonAsync(Type type, DbDataReader reader, int index,
+        CancellationToken cancellationToken = default)
+    {
+        var json = await reader.GetFieldValueAsync<string>(index, cancellationToken).ConfigureAwait(false);
+        return FromJson(type, json);
+    }
+
+    [RequiresUnreferencedCode("STJ JsonSerializer.Deserialize<T> uses reflection over T.")]
+    [RequiresDynamicCode("STJ JsonSerializer.Deserialize requires runtime code generation for non-source-generated types.")]
+    public T FromJson<T>(string json)
+    {
+        return JsonSerializer.Deserialize<T>(json, _options)!;
+    }
+
+    [RequiresUnreferencedCode("STJ JsonSerializer.Deserialize uses reflection over the supplied type.")]
+    [RequiresDynamicCode("STJ JsonSerializer.Deserialize requires runtime code generation for non-source-generated types.")]
+    public object FromJson(Type type, string json)
+    {
+        return JsonSerializer.Deserialize(json, type, _options)!;
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification = SharedSerializerSuppression)]
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = SharedSerializerSuppression)]
+    public T FromJson<T>(Stream stream)
+    {
+        return JsonSerializer.Deserialize<T>(stream, _options)!;
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification = SharedSerializerSuppression)]
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = SharedSerializerSuppression)]
+    public object FromJson(Type type, Stream stream)
+    {
+        return JsonSerializer.Deserialize(stream, type, _options)!;
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification = SharedSerializerSuppression)]
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = SharedSerializerSuppression)]
+    public T FromJson<T>(DbDataReader reader, int index)
+    {
+        var json = reader.GetString(index);
+        return FromJson<T>(json);
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification = SharedSerializerSuppression)]
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = SharedSerializerSuppression)]
+    public object FromJson(Type type, DbDataReader reader, int index)
+    {
+        var json = reader.GetString(index);
+        return FromJson(type, json);
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification = SharedSerializerSuppression)]
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = SharedSerializerSuppression)]
+    public async ValueTask<T> FromJsonAsync<T>(Stream stream, CancellationToken cancellationToken = default)
+    {
+        return (await JsonSerializer.DeserializeAsync<T>(stream, _options, cancellationToken).ConfigureAwait(false))!;
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification = SharedSerializerSuppression)]
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = SharedSerializerSuppression)]
+    public async ValueTask<object> FromJsonAsync(Type type, Stream stream,
+        CancellationToken cancellationToken = default)
+    {
+        return (await JsonSerializer.DeserializeAsync(stream, type, _options, cancellationToken).ConfigureAwait(false))!;
+    }
+
+    public static JsonSerializerOptions DefaultOptions()
+    {
+        return new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            WriteIndented = false
+        };
+    }
+
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+        Justification = "JsonStringEnumConverter(JsonNamingPolicy, bool) requires runtime code generation for non-source-generated enum types. The default serializer is reflection-based by design; AOT consumers should supply a custom ISerializer with the generic JsonStringEnumConverter<TEnum> per-enum.")]
+    private void ApplyEnumStorage()
+    {
+        // Remove any existing JsonStringEnumConverter
+        for (var i = _options.Converters.Count - 1; i >= 0; i--)
+        {
+            if (_options.Converters[i] is JsonStringEnumConverter)
+            {
+                _options.Converters.RemoveAt(i);
+            }
+        }
+
+        if (_enumStorage == EnumStorage.AsString)
+        {
+            _options.Converters.Add(new JsonStringEnumConverter(_options.PropertyNamingPolicy));
+        }
+    }
+
+    private void ApplyCasing()
+    {
+        _options.PropertyNamingPolicy = _casing switch
+        {
+            Casing.CamelCase => JsonNamingPolicy.CamelCase,
+            Casing.SnakeCase => JsonNamingPolicy.SnakeCaseLower,
+            Casing.Default => null,
+            _ => null
+        };
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+        Justification = "DefaultJsonTypeInfoResolver uses reflection. The whole NonPublicMembers feature is reflection-driven by intent; AOT consumers should supply a custom ISerializer with an STJ source-generator context.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+        Justification = "Same as IL2026.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2075:DynamicallyAccessedMembers",
+        Justification = "Falls back to scanning typeInfo.Type.GetProperties when the JSON property has no usable AttributeProvider. Reflection on user types — keeping public/non-public properties alive is the user's responsibility when opting into NonPublicMembers.")]
+    private void ApplyNonPublicMembers()
+    {
+        if (_nonPublicMembersStorage == NonPublicMembersStorage.Default)
+        {
+            return;
+        }
+
+        var resolver = new DefaultJsonTypeInfoResolver();
+
+        if (_nonPublicMembersStorage.HasFlag(NonPublicMembersStorage.NonPublicSetters))
+        {
+            resolver.Modifiers.Add(typeInfo =>
+            {
+                if (typeInfo.Kind != JsonTypeInfoKind.Object) return;
+
+                foreach (var property in typeInfo.Properties)
+                {
+                    if (property.Set == null)
+                    {
+                        // property.Name is the JSON name (e.g. "name" in camelCase), so look up
+                        // by AttributeProvider which gives us the actual PropertyInfo
+                        var clrProperty = property.AttributeProvider as System.Reflection.PropertyInfo;
+                        if (clrProperty == null)
+                        {
+                            // Fallback: search all properties by case-insensitive match
+                            clrProperty = typeInfo.Type.GetProperties(
+                                    System.Reflection.BindingFlags.Public |
+                                    System.Reflection.BindingFlags.NonPublic |
+                                    System.Reflection.BindingFlags.Instance)
+                                .FirstOrDefault(p => string.Equals(p.Name, property.Name,
+                                    StringComparison.OrdinalIgnoreCase));
+                        }
+
+                        if (clrProperty?.GetSetMethod(true) != null)
+                        {
+                            property.Set = (obj, value) => clrProperty.GetSetMethod(true)!.Invoke(obj, [value]);
+                        }
+                    }
+                }
+            });
+        }
+
+        _options.TypeInfoResolver = resolver;
+
+        if (_nonPublicMembersStorage.HasFlag(NonPublicMembersStorage.NonPublicDefaultConstructor) ||
+            _nonPublicMembersStorage.HasFlag(NonPublicMembersStorage.NonPublicConstructor))
+        {
+            _options.PreferredObjectCreationHandling = JsonObjectCreationHandling.Populate;
+        }
+    }
+}

--- a/src/Weasel.Storage/StorageSerializerAdapter.cs
+++ b/src/Weasel.Storage/StorageSerializerAdapter.cs
@@ -1,0 +1,97 @@
+#nullable enable
+using System;
+using System.Buffers;
+using System.Data.Common;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Weasel.Core;
+
+namespace Weasel.Storage;
+
+/// <summary>
+///     Adapts any <see cref="ISerializer" /> (the shared Weasel.Core serialization base) to the
+///     dialect-neutral <see cref="IStorageSerializer" /> seam of the shared closed-shape storage
+///     runtime (JasperFx/polecat#273). A store's default serializer (derived from
+///     <see cref="SystemTextJsonSerializer" /> and declaring the seam) implements it natively and
+///     never needs this; the adapter covers user-supplied serializers, deriving the seam-only
+///     members (<c>ToCleanJson</c>, <c>WriteTo</c>, <c>WriteToParameter</c>, async reader reads)
+///     from the shared <c>Weasel.Core.ISerializer</c> members every serializer already carries.
+///     Lifted from Polecat's and Fisher's byte-identical per-store copies (weasel#555).
+/// </summary>
+public sealed class StorageSerializerAdapter : IStorageSerializer
+{
+    private readonly ISerializer _inner;
+
+    private StorageSerializerAdapter(ISerializer inner)
+    {
+        _inner = inner;
+    }
+
+    /// <summary>
+    ///     Returns the serializer itself when it already implements the seam, otherwise wraps it.
+    /// </summary>
+    public static IStorageSerializer For(ISerializer serializer)
+    {
+        return serializer as IStorageSerializer ?? new StorageSerializerAdapter(serializer);
+    }
+
+    public string ToJson(object? document)
+    {
+        return document is null ? "null" : _inner.ToJson(document);
+    }
+
+    /// <summary>
+    ///     The STJ-only stores have no type-metadata pollution to strip; "clean" JSON is plain JSON.
+    /// </summary>
+    public string ToCleanJson(object? document) => ToJson(document);
+
+    public void WriteTo(IBufferWriter<byte> writer, object? value)
+    {
+        var json = ToJson(value);
+        writer.Write(Encoding.UTF8.GetBytes(json));
+    }
+
+    /// <summary>
+    ///     The stores using this seam bind JSON as string parameter values throughout (SQL Server
+    ///     2025's native JSON column type accepts nvarchar input; SQLite's json1 functions accept
+    ///     TEXT), so this stays dialect-neutral.
+    /// </summary>
+    public void WriteToParameter(DbParameter parameter, object? value)
+    {
+        parameter.Value = value is null ? DBNull.Value : ToJson(value);
+    }
+
+    public T FromJson<T>(Stream stream) => _inner.FromJson<T>(stream);
+
+    public object FromJson(Type type, Stream stream) => _inner.FromJson(type, stream);
+
+    public T FromJson<T>(DbDataReader reader, int index) => _inner.FromJson<T>(reader, index);
+
+    public object FromJson(Type type, DbDataReader reader, int index) => _inner.FromJson(type, reader, index);
+
+    public ValueTask<T> FromJsonAsync<T>(Stream stream, CancellationToken cancellationToken = default)
+        => _inner.FromJsonAsync<T>(stream, cancellationToken);
+
+    public ValueTask<object> FromJsonAsync(Type type, Stream stream, CancellationToken cancellationToken = default)
+        => _inner.FromJsonAsync(type, stream, cancellationToken);
+
+    public async ValueTask<T> FromJsonAsync<T>(DbDataReader reader, int index,
+        CancellationToken cancellationToken = default)
+    {
+        // Route through the unannotated Stream overload rather than the RUC-annotated
+        // string overloads so the adapter adds no trim/AOT surface of its own.
+        await Task.CompletedTask.ConfigureAwait(false); // row is already buffered; stream access is synchronous
+        await using var stream = reader.GetStream(index);
+        return _inner.FromJson<T>(stream);
+    }
+
+    public async ValueTask<object> FromJsonAsync(Type type, DbDataReader reader, int index,
+        CancellationToken cancellationToken = default)
+    {
+        await Task.CompletedTask.ConfigureAwait(false);
+        await using var stream = reader.GetStream(index);
+        return _inner.FromJson(type, stream);
+    }
+}


### PR DESCRIPTION
Closes #555.

Polecat and Fisher each carry a byte-identical (modulo namespace and store-name doc prose) System.Text.Json serializer trio — `Serializer.cs`, `ISerializer.cs`, `StorageSerializerAdapter.cs`. This PR lifts the two store-neutral pieces into Weasel as a **pure relocation**; the store-side adoption (deleting the copies, re-pointing at these types) is a separate step gated on the Weasel publish.

## Where the classes landed, and why

- **`Weasel.Core.SystemTextJsonSerializer`** — the concrete reflection-based STJ serializer: `Casing` / `EnumStorage` / `CollectionStorage` / `NonPublicMembersStorage` options, string/stream/`DbDataReader` reads, and the full BCL-typed member set of the `IStorageSerializer` seam (`ToCleanJson`, `WriteTo`, `WriteToParameter`, async reader reads). It sits beside the `ISerializer` abstraction it implements. It deliberately does **not** declare `Weasel.Storage.IStorageSerializer`: the dependency direction is Weasel.Storage → Weasel.Core, so Weasel.Core cannot name that interface. Every seam member is present with a BCL-typed signature, so a store's back-compat subclass is one line — `public class Serializer : SystemTextJsonSerializer, ISerializer, IStorageSerializer;` — with the seam satisfied entirely by inherited members. That pattern is pinned by a test.
- **`Weasel.Storage.StorageSerializerAdapter`** — adapts any `Weasel.Core.ISerializer` (it calls only shared-base members on the wrapped serializer, so it is fully store-neutral) to the `IStorageSerializer` seam. It lands in Weasel.Storage rather than Weasel.Core because it *implements* the seam interface, which only Weasel.Storage can name — the same dependency-direction argument. It becomes `public` (the store copies were `internal`) so both stores can drop theirs.

## Drift check

The six store files were compared before lifting: the Polecat and Fisher copies are identical apart from namespace and store-name prose. The only prose seam was each store's `WriteToParameter` doc comment describing per-provider JSON parameter binding — both bind JSON as plain string parameter values (SQL Server 2025 native JSON accepts nvarchar; SQLite json1 accepts TEXT), so there is no behavioral seam and the lifted comment says both. Suppression justification strings were likewise neutralized ("the Critter Stack stores' documented default").

The store-local `ISerializer` interfaces (the two string-based `FromJson` overloads) stay in the stores: `Weasel.Core.ISerializer` is deliberately the Marten-parity intersection, and the concrete class carries those overloads with the propagating `[RequiresUnreferencedCode]`/`[RequiresDynamicCode]` either way.

## Not a behavior change

No read/write behavior moves — reads stay string-based (the stream-read perf work is a separate follow-up). The only edits beyond renaming and doc prose are two `ConfigureAwait(false)` additions required by Weasel's VSTHRD111 analyzer (errors in Weasel.Storage), which are unobservable.

## Tests

25 new tests in `Weasel.Core.Tests` (which gains a `Weasel.Storage` project reference for the adapter/seam tests — pure in-memory, no database beyond an in-memory SQLite connection for the `DbDataReader`/`DbParameter` members):

- serialization round-trips through string, stream, and data-reader overloads; defaults (camelCase, integer enums, null-ignoring)
- `Casing` (camel/snake/default), `EnumStorage` (string with naming policy, converter removal on switch-back), `NonPublicMembersStorage.NonPublicSetters` on/off
- `ToCleanJson` ≡ `ToJson`, `WriteTo` byte-parity with `ToJson`, `WriteToParameter` string/`DBNull` binding
- adapter: unwrap-when-native vs wrap, `null` → `"null"`, seam-only member derivation, async reader reads through the reader's stream

`dotnet build Weasel.slnx` clean (including the `Weasel.Core.AotSmoke` trim/AOT gate); `Weasel.Core.Tests` 405/405 green on net9.0 and net10.0.

Stoat plan `internals-lifting-2026-09`, node `weasel-stj-serializer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)