### PR TITLE
Price the introspection parameter budget from the real render, not a probe pass

### DIFF
--- a/src/Weasel.Core.Tests/introspection_renders_once.cs
+++ b/src/Weasel.Core.Tests/introspection_renders_once.cs
@@ -1,0 +1,131 @@
+using System.Data.Common;
+using Microsoft.Data.Sqlite;
+using Shouldly;
+using Weasel.Core;
+using Xunit;
+
+namespace Weasel.Core.Tests;
+
+/// <summary>
+///     Pricing the parameter budget used to be a separate pass: a throwaway
+///     <see cref="DbCommandBuilder" /> per schema object, running the object's whole
+///     <c>ConfigureQueryCommand</c> just to read <c>Parameters.Count</c> off it, before the real
+///     pass rendered everything again (weasel#557). The costs are now recorded off the render
+///     that has to happen anyway, so a set that fits the budget renders exactly once, and only a
+///     set that genuinely needs splitting renders twice.
+///     <para>
+///     Runs against an in-memory SQLite connection — a real execution path, no containers.
+///     </para>
+/// </summary>
+public class introspection_renders_once
+{
+    private static async Task<SqliteConnection> openConnectionAsync()
+    {
+        var conn = new SqliteConnection("Data Source=:memory:");
+        await conn.OpenAsync();
+        return conn;
+    }
+
+    private static CountingSchemaObject[] objects(int count)
+        => Enumerable.Range(0, count).Select(i => new CountingSchemaObject($"thing{i}")).ToArray();
+
+    [Fact]
+    public async Task a_set_within_the_budget_configures_every_object_exactly_once()
+    {
+        await using var conn = await openConnectionAsync();
+        var all = objects(10);
+
+        // 10 objects * 1 parameter each, well within the budget
+        var migration = await SchemaMigration.DetermineAsync(conn, default, 2000,
+            all.Cast<ISchemaObject>().ToArray());
+
+        migration.Deltas.Count.ShouldBe(10);
+        all.ShouldAllBe(x => x.ConfigureCount == 1);
+    }
+
+    [Fact]
+    public async Task a_set_over_the_budget_still_batches_and_configures_at_most_twice()
+    {
+        await using var conn = await openConnectionAsync();
+        var all = objects(10);
+
+        // 1 parameter per object against a budget of 3: forced to split into batches of 3
+        var migration = await SchemaMigration.DetermineAsync(conn, default, 3,
+            all.Cast<ISchemaObject>().ToArray());
+
+        migration.Deltas.Count.ShouldBe(10);
+
+        // Once for the pricing render that was discarded, once inside its own batch -- never more
+        all.ShouldAllBe(x => x.ConfigureCount == 2);
+    }
+
+    [Fact]
+    public async Task deltas_come_back_in_order_whichever_path_runs()
+    {
+        await using var conn = await openConnectionAsync();
+
+        foreach (var budget in new[] { 2000, 3 })
+        {
+            var all = objects(7);
+
+            var migration = await SchemaMigration.DetermineAsync(conn, default, budget,
+                all.Cast<ISchemaObject>().ToArray());
+
+            migration.Deltas.Select(x => x.SchemaObject).ShouldBe(all);
+        }
+    }
+
+    [Fact]
+    public void recorded_costs_batch_identically_to_the_priced_func()
+    {
+        var all = objects(9).Cast<ISchemaObject>().ToArray();
+        var costs = new[] { 2, 2, 2, 5, 1, 1, 1, 1, 4 };
+
+        var byArray = SchemaMigration.BatchByParameterBudget(all, costs, 6)
+            .Select(b => b.Length).ToArray();
+        var byFunc = SchemaMigration.BatchByParameterBudget(all, x => costs[Array.IndexOf(all, x)], 6)
+            .Select(b => b.Length).ToArray();
+
+        byArray.ShouldBe(byFunc);
+
+        // 2+2+2 = 6 | 5+1 = 6 | 1+1+1 = 3 (a 4 would overflow) | 4
+        byArray.ShouldBe(new[] { 3, 2, 3, 1 });
+    }
+
+    /// <summary>
+    ///     A real, executable schema object: binds one parameter, reads one count row — the same
+    ///     shape as the "exists / does not exist" objects — and counts how many times its query
+    ///     was rendered.
+    /// </summary>
+    private class CountingSchemaObject(string name): ISchemaObject
+    {
+        public int ConfigureCount { get; private set; }
+
+        public DbObjectName Identifier { get; } = new("main", name);
+
+        public void ConfigureQueryCommand(DbCommandBuilder builder)
+        {
+            ConfigureCount++;
+
+            var param = builder.AddParameter(Identifier.Name).ParameterName;
+            builder.Append($"select count(*) from sqlite_master where name = @{param};");
+        }
+
+        public async Task<ISchemaObjectDelta> CreateDeltaAsync(DbDataReader reader, CancellationToken ct = default)
+        {
+            await reader.ReadAsync(ct);
+            var count = await reader.GetFieldValueAsync<long>(0, ct);
+
+            return new SchemaObjectDelta(this,
+                count == 0 ? SchemaPatchDifference.Create : SchemaPatchDifference.None);
+        }
+
+        public void WriteCreateStatement(Migrator migrator, TextWriter writer) => throw new NotSupportedException();
+        public void WriteDropStatement(Migrator rules, TextWriter writer) => throw new NotSupportedException();
+
+        public IEnumerable<DbObjectName> AllNames()
+        {
+            yield return Identifier;
+        }
+    }
+}

--- a/src/Weasel.Core/SchemaMigration.cs
+++ b/src/Weasel.Core/SchemaMigration.cs
@@ -216,19 +216,33 @@ public class SchemaMigration
             return new SchemaMigration(deltas);
         }
 
-        // Priced against a throwaway builder, which costs no round trip: the parameter count an
-        // object binds is a property of its query, not of the builder it is handed.
-        int cost(ISchemaObject schemaObject)
-        {
-            var probe = new DbCommandBuilder(conn);
-            schemaObject.ConfigureQueryCommand(probe);
-            using var command = probe.Command;
-            return command.Parameters.Count;
-        }
+        // A Migrator subclass that does not answer -- a test double, most often -- would otherwise
+        // put every object in a batch of its own and turn one round trip into hundreds.
+        var budget = parameterBudget > 0 ? parameterBudget : DefaultParameterBudget;
 
-        foreach (var batch in BatchByParameterBudget(schemaObjects, cost, parameterBudget))
+        // Render everything once into the real builder, recording what each object binds as it
+        // lands. Pricing used to be a separate pass -- a throwaway builder per object, running the
+        // object's whole ConfigureQueryCommand just to read Parameters.Count off it -- which
+        // rendered every introspection query twice on every determination (weasel#557).
+        var builder = newBuilder();
+        var costs = configureBatch(builder, schemaObjects);
+
+        if (costs.Sum() <= budget)
         {
-            await determineBatchAsync(conn, newBuilder(), batch, deltas, ct).ConfigureAwait(false);
+            // The whole set fits in one command, so the builder just configured is the one that
+            // executes: one render, no probes. This is the overwhelmingly common case.
+            await executeBatchAsync(conn, builder, schemaObjects, deltas, ct).ConfigureAwait(false);
+        }
+        else
+        {
+            // Only a set too large for one command pays for a second render, and it is the case
+            // that used to fail outright before batching existed.
+            builder.Command.Dispose();
+
+            foreach (var batch in BatchByParameterBudget(schemaObjects, costs, budget))
+            {
+                await determineBatchAsync(conn, newBuilder(), batch, deltas, ct).ConfigureAwait(false);
+            }
         }
 
         // Once over the complete delta set rather than per batch, so a delta can still look across
@@ -256,6 +270,18 @@ public class SchemaMigration
         ISchemaObject[] schemaObjects,
         Func<ISchemaObject, int> parameterCost,
         int parameterBudget
+    ) => BatchByParameterBudget(schemaObjects, schemaObjects.Select(parameterCost).ToArray(), parameterBudget);
+
+    /// <summary>
+    ///     Group the objects into batches whose combined parameter count stays within the budget,
+    ///     with each object's cost supplied by position. This is what the migration path calls:
+    ///     the costs were recorded while the objects rendered, so pricing by position rather than
+    ///     by a lookup keeps duplicate instances in the set unambiguous.
+    /// </summary>
+    internal static IEnumerable<ISchemaObject[]> BatchByParameterBudget(
+        ISchemaObject[] schemaObjects,
+        int[] parameterCosts,
+        int parameterBudget
     )
     {
         // A Migrator subclass that does not answer -- a test double, most often -- would otherwise
@@ -265,9 +291,9 @@ public class SchemaMigration
         var current = new List<ISchemaObject>();
         var used = 0;
 
-        foreach (var schemaObject in schemaObjects)
+        for (var i = 0; i < schemaObjects.Length; i++)
         {
-            var cost = parameterCost(schemaObject);
+            var cost = parameterCosts[i];
 
             // current.Count is what keeps an object costing more than the entire budget from
             // yielding an empty batch forever; it goes into a batch of its own instead.
@@ -278,7 +304,7 @@ public class SchemaMigration
                 used = 0;
             }
 
-            current.Add(schemaObject);
+            current.Add(schemaObjects[i]);
             used += cost;
         }
 
@@ -296,6 +322,26 @@ public class SchemaMigration
         CancellationToken ct
     )
     {
+        configureBatch(builder, schemaObjects);
+
+        await executeBatchAsync(conn, builder, schemaObjects, deltas, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    ///     Render every object's introspection query into the builder, and record what each one
+    ///     bound as it landed.
+    /// </summary>
+    /// <returns>
+    ///     Per-object parameter counts, by position. Reading them off the builder's live command —
+    ///     whose parameter collection accumulates across <see cref="DbCommandBuilder.StartNewCommand" />
+    ///     boundaries on every provider, Oracle's splitting builder included — is what lets the
+    ///     budget be priced from the render that has to happen anyway (weasel#557).
+    /// </returns>
+    private static int[] configureBatch(DbCommandBuilder builder, ISchemaObject[] schemaObjects)
+    {
+        var costs = new int[schemaObjects.Length];
+        var bound = 0;
+
         for (var i = 0; i < schemaObjects.Length; i++)
         {
             // Between objects, not before the first: a builder that splits on this boundary would
@@ -303,8 +349,23 @@ public class SchemaMigration
             if (i > 0) builder.StartNewCommand();
 
             schemaObjects[i].ConfigureQueryCommand(builder);
+
+            var total = builder.Command.Parameters.Count;
+            costs[i] = total - bound;
+            bound = total;
         }
 
+        return costs;
+    }
+
+    private static async Task executeBatchAsync(
+        DbConnection conn,
+        DbCommandBuilder builder,
+        ISchemaObject[] schemaObjects,
+        List<ISchemaObjectDelta> deltas,
+        CancellationToken ct
+    )
+    {
         await using var reader = await conn.ExecuteReaderAsync(builder, ct).ConfigureAwait(false);
 
         deltas.Add(await schemaObjects[0].CreateDeltaAsync(reader, ct).ConfigureAwait(false));


### PR DESCRIPTION
Closes #557. Stoat plan `critter-performance-2026-09`, node `weasel-introspection-probe`.

## What

`SchemaMigration.determineBatchedAsync` priced each schema object against the parameter budget by constructing a throwaway `DbCommandBuilder` per object and running the object's entire `ConfigureQueryCommand` — rendering all of its introspection SQL and allocating all of its parameters — just to read `Parameters.Count` off the result. The real pass then rendered everything again, so every migration determination was O(2 × all schema objects) renders plus one throwaway `DbCommand`/`DbCommandBuilder` per object. Startup-only, but amplified by stores that re-trigger migration determination per document type.

Now the set renders **once** into the real builder, with each object's parameter count recorded off the builder's live command as it lands. When the recorded total fits the budget — the overwhelmingly common case — that same builder is the one that executes: one render, zero probes, zero throwaway commands. Only a set too large for one command (the >~1000-table case that motivated batching) pays for a second render, re-batched by the costs already recorded.

## Why this option

The plan node offered three shapes; this is option (b), chosen because:

- **(a)** a declared-parameter-count interface member would need a correct override on every `ISchemaObject` implementation across five providers — and any drift between an override and its `ConfigureQueryCommand` silently breaks the budget arithmetic. Third-party implementations (Marten's custom feature objects) would still fall back to a probe anyway.
- **(c)** memoizing the probe per type is unsound as a blanket rule: nothing in the `ISchemaObject` contract promises a type-stable count, and the contract is implemented outside this repo.
- **(b)** needs no contract change at all, keeps a single source of truth (the render itself), and makes the common case strictly cheaper than either alternative — the pricing information is free because the render had to happen anyway. Recording cumulative `Parameters.Count` works on every provider including Oracle's splitting builder, whose parameter collection accumulates across `StartNewCommand` boundaries until `CompileCommands`.

`ISchemaObject`, `Migrator`, and every public `DetermineAsync` overload are untouched; `BatchByParameterBudget` gains an internal by-position overload (the existing `Func`-based one delegates to it, and its tests are unchanged).

## Tests

New `introspection_renders_once` suite in `Weasel.Core.Tests`, executing the real path against in-memory SQLite: a set within budget configures every object exactly once; an over-budget set still batches correctly and configures at most twice; delta ordering holds on both paths; and the by-position batching matches the `Func`-based arithmetic.

- `Weasel.Core.Tests` (net9.0, no database): 384 passed, 0 failed
- `Weasel.Sqlite.Tests` (no database): 569 passed
- `Weasel.Postgresql.Tests` (docker): 974 passed, 3 skipped
- `Weasel.SqlServer.Tests` (docker): 555 passed, 8 skipped
- Full `Weasel.slnx` builds with 0 errors (Oracle/MySql compile; no local Oracle/MySql databases were available to run those suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)