### PR TITLE
Lift a generic ITransactionParticipant<TConnection, TTransaction> into Weasel.Storage

### DIFF
--- a/src/Weasel.Core.Tests/Weasel.Core.Tests.csproj
+++ b/src/Weasel.Core.Tests/Weasel.Core.Tests.csproj
@@ -19,6 +19,10 @@
       <ProjectReference Include="..\Weasel.Sqlite\Weasel.Sqlite.csproj" />
       <ProjectReference Include="..\Weasel.Postgresql\Weasel.Postgresql.csproj" />
       <ProjectReference Include="..\Weasel.Oracle\Weasel.Oracle.csproj" />
+      <!-- Referenced for the transaction-participant contract tests (weasel#561). The concrete
+           connection/transaction pair those tests close the generic over is Microsoft.Data.Sqlite's,
+           which arrives transitively through Weasel.Sqlite — in-memory, no containers. -->
+      <ProjectReference Include="..\Weasel.Storage\Weasel.Storage.csproj" />
     </ItemGroup>
 
     <Import Project="../../Tests.Build.props" />

--- a/src/Weasel.Core.Tests/transaction_participant_contract.cs
+++ b/src/Weasel.Core.Tests/transaction_participant_contract.cs
@@ -1,0 +1,161 @@
+using System.Data.Common;
+using Microsoft.Data.Sqlite;
+using Shouldly;
+using Weasel.Storage;
+using Xunit;
+
+namespace Weasel.Core.Tests;
+
+/// <summary>
+///     The shape of <see cref="ITransactionParticipant{TConnection,TTransaction}" /> (weasel#561) —
+///     the generic transaction-participant contract lifted out of Marten, Polecat, and Fisher, each
+///     of which declared the same interface closed over its own provider types. What is pinned here
+///     is exactly what the stores' aliasing depends on: a store can expose a derived interface
+///     closing the generics without breaking implementors written against the old provider-typed
+///     signature, and Fisher's default-implemented <c>AfterCommitAsync</c> is part of the shared
+///     contract so a participant that does not need it declares one member, as before.
+/// </summary>
+/// <remarks>
+///     The concrete pair the tests close the generic over is Microsoft.Data.Sqlite's, purely
+///     because it is the one provider in this repository that needs no server — nothing here is
+///     about SQLite.
+/// </remarks>
+public class transaction_participant_contract
+{
+    /// <summary>
+    ///     A store's own <c>ITransactionParticipant</c> becomes a derived interface closing the
+    ///     generics — this is the shape each of the three stores will alias with.
+    /// </summary>
+    public interface IStoreTransactionParticipant: ITransactionParticipant<SqliteConnection, SqliteTransaction>;
+
+    [Fact]
+    public async Task after_commit_defaults_to_a_completed_no_op()
+    {
+        // A participant declaring only BeforeCommitAsync — the pre-lift Marten/Polecat shape —
+        // compiles, and the default AfterCommitAsync completes without doing anything.
+        ITransactionParticipant<SqliteConnection, SqliteTransaction> participant = new BeforeOnlyParticipant();
+
+        var task = participant.AfterCommitAsync(CancellationToken.None);
+
+        task.IsCompletedSuccessfully.ShouldBeTrue();
+        await task;
+    }
+
+    [Fact]
+    public async Task an_overridden_after_commit_is_reached_through_the_contract()
+    {
+        // The default must not shadow an implementation that does override it — a store invoking
+        // participants through the shared contract has to reach the override.
+        var participant = new RecordingParticipant();
+        ITransactionParticipant<SqliteConnection, SqliteTransaction> contract = participant;
+
+        await contract.AfterCommitAsync(CancellationToken.None);
+
+        participant.AfterCommitCalls.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task a_participant_of_a_derived_store_interface_is_invoked_through_the_generic_member()
+    {
+        // The aliasing story in one test: an implementor of the store-shaped derived interface,
+        // written with the provider-typed signature it always had, satisfies the generic member
+        // implicitly — so a store's commit path can hold participants as the closed generic and
+        // invoke them without knowing the derived interface exists.
+        var participant = new StoreShapedParticipant();
+        ITransactionParticipant<SqliteConnection, SqliteTransaction> contract = participant;
+
+        await using var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+
+        await using (var creating = connection.BeginTransaction())
+        {
+            var create = connection.CreateCommand();
+            create.Transaction = creating;
+            create.CommandText = "create table participant_rows(id integer primary key)";
+            await create.ExecuteNonQueryAsync();
+            await creating.CommitAsync();
+        }
+
+        await using (var transaction = connection.BeginTransaction())
+        {
+            await contract.BeforeCommitAsync(connection, transaction, CancellationToken.None);
+            await transaction.CommitAsync();
+        }
+
+        var count = connection.CreateCommand();
+        count.CommandText = "select count(*) from participant_rows";
+        (await count.ExecuteScalarAsync()).ShouldBe(1L);
+    }
+
+    [Fact]
+    public void a_provider_neutral_participant_satisfies_a_closed_shape()
+    {
+        // The contravariance the interface declares: a participant written once against the base
+        // DbConnection/DbTransaction pair is usable wherever any store's closed shape is expected.
+        ITransactionParticipant<DbConnection, DbTransaction> neutral = new ProviderNeutralParticipant();
+
+        ITransactionParticipant<SqliteConnection, SqliteTransaction> closed = neutral;
+
+        closed.ShouldBeSameAs(neutral);
+    }
+
+    [Fact]
+    public void the_type_parameters_are_constrained_to_the_ado_net_base_types()
+    {
+        // The constraints are the contract's floor — a store cannot close the generics over
+        // something that is not an ADO.NET connection/transaction pair, and a participant can
+        // always fall back to the DbConnection/DbTransaction members.
+        var arguments = typeof(ITransactionParticipant<,>).GetGenericArguments();
+
+        arguments[0].GetGenericParameterConstraints().ShouldContain(typeof(DbConnection));
+        arguments[1].GetGenericParameterConstraints().ShouldContain(typeof(DbTransaction));
+    }
+
+    private class BeforeOnlyParticipant: ITransactionParticipant<SqliteConnection, SqliteTransaction>
+    {
+        public Task BeforeCommitAsync(SqliteConnection connection, SqliteTransaction transaction,
+            CancellationToken token)
+        {
+            return Task.CompletedTask;
+        }
+    }
+
+    private class RecordingParticipant: ITransactionParticipant<SqliteConnection, SqliteTransaction>
+    {
+        public int AfterCommitCalls { get; private set; }
+
+        public Task BeforeCommitAsync(SqliteConnection connection, SqliteTransaction transaction,
+            CancellationToken token)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task AfterCommitAsync(CancellationToken token)
+        {
+            AfterCommitCalls++;
+            return Task.CompletedTask;
+        }
+    }
+
+    private class StoreShapedParticipant: IStoreTransactionParticipant
+    {
+        public async Task BeforeCommitAsync(SqliteConnection connection, SqliteTransaction transaction,
+            CancellationToken token)
+        {
+            // Writes on the connection it was handed, inside the transaction it was handed —
+            // the one rule the contract's docs call the point.
+            var command = connection.CreateCommand();
+            command.Transaction = transaction;
+            command.CommandText = "insert into participant_rows(id) values (1)";
+            await command.ExecuteNonQueryAsync(token);
+        }
+    }
+
+    private class ProviderNeutralParticipant: ITransactionParticipant<DbConnection, DbTransaction>
+    {
+        public Task BeforeCommitAsync(DbConnection connection, DbTransaction transaction, CancellationToken token)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Weasel.Storage/ITransactionParticipant.cs
+++ b/src/Weasel.Storage/ITransactionParticipant.cs
@@ -1,0 +1,76 @@
+#nullable enable
+using System.Data.Common;
+
+namespace Weasel.Storage;
+
+/// <summary>
+///     Something else writing on the owning store's connection, inside the store's transaction,
+///     committed (or rolled back) with it. Allows external components — an EF Core
+///     <c>DbContext</c>, Dapper, hand-written ADO.NET — to flush their pending work into the
+///     same transaction the store uses for its own batch operations, so "my rows and the
+///     store's, or neither" holds atomically.
+/// </summary>
+/// <typeparam name="TConnection">The owning store's ADO.NET connection type.</typeparam>
+/// <typeparam name="TTransaction">The owning store's ADO.NET transaction type.</typeparam>
+/// <remarks>
+///     <para>
+///         Each Critter Stack store closes this over its own provider types and exposes the
+///         closed shape as its own <c>ITransactionParticipant</c>, so participant code is
+///         written against the provider the store actually uses. The interface is
+///         contravariant in both type parameters, so a participant written against the base
+///         <see cref="DbConnection" /> / <see cref="DbTransaction" /> pair satisfies any
+///         store's closed shape.
+///     </para>
+///     <para>
+///         <b>The connection is the point.</b> A participant must write on the connection it
+///         is handed, not open one of its own to the same database — a parallel connection is
+///         outside the transaction at best, and on an embedded store (one writer per database
+///         file) it is a self-deadlock that presents as a hang rather than an error. That is
+///         why the connection is a parameter rather than something the participant is
+///         expected to find.
+///     </para>
+/// </remarks>
+public interface ITransactionParticipant<in TConnection, in TTransaction>
+    where TConnection : DbConnection
+    where TTransaction : DbTransaction
+{
+    /// <summary>
+    ///     Write, on the supplied connection and inside the supplied transaction. Called after
+    ///     the store's own operations have executed but before the transaction is committed,
+    ///     so nothing written here is visible to anyone else until the store commits, and
+    ///     throwing here rolls back the store's work along with the participant's.
+    /// </summary>
+    /// <remarks>
+    ///     <b>This may be called more than once for one unit of work</b>, and a participant
+    ///     has to survive it. A store whose commit runs inside a resilience pipeline (e.g. a
+    ///     retried <c>SQLITE_BUSY</c> on Fisher) re-executes the whole write delegate, so
+    ///     whatever this writes must still be pending on the second attempt. The failed
+    ///     attempt's transaction rolled back, so re-writing is correct; <em>not</em>
+    ///     re-writing is the silent failure, because the store's own work commits either way.
+    ///     See <see cref="AfterCommitAsync" /> for the other half of that.
+    /// </remarks>
+    Task BeforeCommitAsync(TConnection connection, TTransaction transaction, CancellationToken token);
+
+    /// <summary>
+    ///     Reconcile whatever <see cref="BeforeCommitAsync" /> left pending, now that the
+    ///     write is durable. Does nothing unless a participant overrides it.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <b>This is not a post-commit side-effect hook</b> — a store's session listener
+    ///         seam is still the place for those, with the "everyone can see this now"
+    ///         semantics an application wants. This exists for the narrower job the retry rule
+    ///         above creates: a participant that has to keep its writes replayable across
+    ///         attempts needs one place to stop keeping them, and only the store knows when
+    ///         the commit happened.
+    ///     </para>
+    ///     <para>
+    ///         Runs <b>outside</b> any resilience pipeline the store's commit uses, so it
+    ///         fires once for a transaction that committed rather than once per attempt. It
+    ///         does not fire for a session enlisted in a transaction the caller owns — there
+    ///         the commit is the caller's and the store is never told it happened, so a
+    ///         participant has nothing to reconcile until the caller commits.
+    ///     </para>
+    /// </remarks>
+    Task AfterCommitAsync(CancellationToken token) => Task.CompletedTask;
+}


### PR DESCRIPTION
Closes #561. Stoat plan `internals-lifting-2026-09`, node `weasel-transaction-participant`.

## What

Adds `Weasel.Storage.ITransactionParticipant<TConnection, TTransaction>` — the shared shape of the transaction-participant interface Marten, Polecat, and Fisher each declare today, closed over their own provider types (`NpgsqlConnection`/`NpgsqlTransaction`, `SqlConnection`/`SqlTransaction`, `SqliteConnection`/`SqliteTransaction`).

- `BeforeCommitAsync(TConnection, TTransaction, CancellationToken)` — the member all three stores have, with the doc intent from all three copies preserved: called after the store's own operations, before the commit; throwing rolls back both; **may be called more than once for one unit of work** when the store's commit runs inside a resilience pipeline; and the write must go on the supplied connection, not a parallel one.
- `AfterCommitAsync(CancellationToken)` with a no-op default — lifted from Fisher, where a retried `SQLITE_BUSY` re-runs the whole write delegate so a participant keeping its writes replayable across attempts needs one place to stop. Marten and Polecat lack the member today but have the same retry story, so it is part of the shared contract rather than a Fisher extension; the default means the common one-member participant is unchanged.
- Constrained `where TConnection : DbConnection, TTransaction : DbTransaction`, and **contravariant in both**, so a provider-neutral participant written against the base pair satisfies any store's closed shape.

## Why Weasel.Storage

All three stores already reference Weasel.Storage — it is the dialect-neutral closed-shape session/commit runtime (`IStorageSession`, `IStorageDatabase` live there and already deal in `DbConnection`), which is exactly the layer a "join the store's commit" seam belongs to. Weasel.Core sits below the session seams (ADO.NET helpers, schema migration) and carries no unit-of-work semantics; the dialect packages (`Weasel.Postgresql`/`Weasel.SqlServer`/`Weasel.Sqlite`) reference only Weasel.Core and are per-provider, which is the opposite of what a shared contract wants.

## Store adoption (later, gated — not in this PR)

Each store's existing interface becomes a derived interface closing the generics, e.g.:

```csharp
public interface ITransactionParticipant
    : Weasel.Storage.ITransactionParticipant<NpgsqlConnection, NpgsqlTransaction>;
```

No consumer breaks: an existing implementor's provider-typed `BeforeCommitAsync` already satisfies the closed generic member implicitly, and Fisher's `AfterCommitAsync` (default + overrides) carries over unchanged. This is pinned by `a_participant_of_a_derived_store_interface_is_invoked_through_the_generic_member` in the new contract tests.

## Tests

`Weasel.Core.Tests/transaction_participant_contract.cs` — five facts covering the default `AfterCommitAsync` no-op, that an override is reached through the contract, the derived-interface aliasing shape (invoked through the generic member against a real in-memory SQLite connection/transaction), contravariance, and the generic constraints. The concrete pair is Microsoft.Data.Sqlite purely because it needs no server; Weasel.Core.Tests gains a `Weasel.Storage` project reference for it.

- Full `Weasel.slnx` build: 0 errors
- `Weasel.Core.Tests`: 385/385 passed on net9.0 and net10.0 (includes the 5 new)
- `Weasel.Sqlite.Tests`: 569/569 passed on net9.0 and net10.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)