### PR TITLE
Scope SQLite PRAGMAs by connection vs database file and precompute the batches

### DIFF
--- a/src/Weasel.Sqlite.Tests/SqlitePragmaScopeTests.cs
+++ b/src/Weasel.Sqlite.Tests/SqlitePragmaScopeTests.cs
@@ -1,0 +1,326 @@
+using Microsoft.Data.Sqlite;
+using Shouldly;
+using Xunit;
+
+namespace Weasel.Sqlite.Tests;
+
+/// <summary>
+///     Tests for the split between connection-scoped and database-file-scoped PRAGMAs,
+///     the precomputed batch SQL caching, and SqliteDataSource applying the file-scoped
+///     batch only once per data source. See JasperFx/weasel#562.
+/// </summary>
+public class SqlitePragmaScopeTests
+{
+    [Fact]
+    public void connection_batch_contains_only_connection_scoped_pragmas()
+    {
+        var sql = SqlitePragmaSettings.Default.ConnectionPragmaSql;
+
+        sql.ShouldContain("PRAGMA busy_timeout = 5000");
+        sql.ShouldContain("PRAGMA synchronous = NORMAL");
+        sql.ShouldContain("PRAGMA cache_size = -64000");
+        sql.ShouldContain("PRAGMA temp_store = 2");
+        sql.ShouldContain("PRAGMA mmap_size = 268435456");
+        sql.ShouldContain("PRAGMA foreign_keys = ON");
+        sql.ShouldContain("PRAGMA secure_delete = OFF");
+        sql.ShouldContain("PRAGMA case_sensitive_like = OFF");
+
+        // database-file scoped PRAGMAs do not belong in the per-connection batch
+        sql.ShouldNotContain("page_size");
+        sql.ShouldNotContain("auto_vacuum");
+        sql.ShouldNotContain("journal_mode");
+    }
+
+    [Fact]
+    public void database_batch_contains_only_file_scoped_pragmas()
+    {
+        var sql = SqlitePragmaSettings.Default.DatabasePragmaSql;
+
+        sql.ShouldContain("PRAGMA page_size = 4096");
+        sql.ShouldContain("PRAGMA auto_vacuum = 2");
+        sql.ShouldContain("PRAGMA journal_mode = WAL");
+
+        sql.ShouldNotContain("busy_timeout");
+        sql.ShouldNotContain("foreign_keys");
+        sql.ShouldNotContain("synchronous");
+    }
+
+    [Fact]
+    public void busy_timeout_leads_the_connection_batch()
+    {
+        // so that any later statement that has to take a file lock benefits from the timeout
+        SqlitePragmaSettings.Default.ConnectionPragmaSql
+            .ShouldStartWith("PRAGMA busy_timeout = ");
+    }
+
+    [Fact]
+    public void page_size_precedes_wal_in_the_database_batch()
+    {
+        // page_size cannot change once a new database has entered WAL mode
+        var sql = SqlitePragmaSettings.Default.DatabasePragmaSql;
+        sql.IndexOf("page_size", StringComparison.Ordinal)
+            .ShouldBeLessThan(sql.IndexOf("journal_mode", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void non_wal_journal_mode_is_a_connection_scoped_pragma()
+    {
+        // DELETE/TRUNCATE/PERSIST/MEMORY/OFF are per-connection settings, not persisted in the file
+        var settings = new SqlitePragmaSettings { JournalMode = JournalMode.MEMORY };
+
+        settings.ConnectionPragmaSql.ShouldContain("PRAGMA journal_mode = MEMORY");
+        settings.DatabasePragmaSql.ShouldNotContain("journal_mode");
+    }
+
+    [Fact]
+    public void wal_autocheckpoint_is_a_connection_scoped_pragma()
+    {
+        // wal_autocheckpoint maps to sqlite3_wal_autocheckpoint, a per-connection setting
+        var settings = new SqlitePragmaSettings { JournalMode = JournalMode.WAL, WalAutoCheckpoint = 1500 };
+
+        settings.ConnectionPragmaSql.ShouldContain("PRAGMA wal_autocheckpoint = 1500");
+        settings.DatabasePragmaSql.ShouldNotContain("wal_autocheckpoint");
+    }
+
+    [Fact]
+    public void batch_sql_is_computed_once_and_cached()
+    {
+        var settings = SqlitePragmaSettings.Default;
+
+        ReferenceEquals(settings.ConnectionPragmaSql, settings.ConnectionPragmaSql).ShouldBeTrue();
+        ReferenceEquals(settings.DatabasePragmaSql, settings.DatabasePragmaSql).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void mutating_a_setting_invalidates_the_cached_batches()
+    {
+        var settings = SqlitePragmaSettings.Default;
+        var before = settings.ConnectionPragmaSql;
+        before.ShouldContain("PRAGMA busy_timeout = 5000");
+
+        settings.BusyTimeout = 12345;
+
+        settings.ConnectionPragmaSql.ShouldContain("PRAGMA busy_timeout = 12345");
+        settings.ConnectionPragmaSql.ShouldNotContain("PRAGMA busy_timeout = 5000");
+
+        var databaseBefore = settings.DatabasePragmaSql;
+        settings.PageSize = 8192;
+        settings.DatabasePragmaSql.ShouldNotBe(databaseBefore);
+        settings.DatabasePragmaSql.ShouldContain("PRAGMA page_size = 8192");
+    }
+
+    [Fact]
+    public async Task data_source_applies_database_pragmas_only_once_per_data_source()
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), $"pragma_scope_{Guid.NewGuid():N}.db");
+        var settings = new CountingPragmaSettings();
+
+        try
+        {
+            await using (var dataSource = new SqliteDataSource($"Data Source={tempFile}", settings))
+            {
+                await using (var conn1 = await dataSource.OpenConnectionAsync())
+                {
+                    var cmd = conn1.CreateCommand();
+                    cmd.CommandText = "CREATE TABLE t (id INTEGER PRIMARY KEY)";
+                    await cmd.ExecuteNonQueryAsync();
+                }
+
+                await using (await dataSource.OpenConnectionAsync())
+                {
+                }
+
+                using ((SqliteConnection)dataSource.OpenConnection())
+                {
+                }
+
+                settings.DatabaseApplications.ShouldBe(1);
+                settings.ConnectionApplications.ShouldBe(3);
+            }
+        }
+        finally
+        {
+            cleanUp(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task new_connections_see_wal_without_reapplication()
+    {
+        // journal_mode = WAL is persisted in the database file header, so a second connection
+        // must observe WAL even though the data source only issued the PRAGMA once
+        var tempFile = Path.Combine(Path.GetTempPath(), $"pragma_scope_{Guid.NewGuid():N}.db");
+        var settings = new CountingPragmaSettings();
+
+        try
+        {
+            await using (var dataSource = new SqliteDataSource($"Data Source={tempFile}", settings))
+            {
+                await using (var conn1 = await dataSource.OpenConnectionAsync())
+                {
+                    // force the database file to actually be created
+                    var create = conn1.CreateCommand();
+                    create.CommandText = "CREATE TABLE t (id INTEGER PRIMARY KEY)";
+                    await create.ExecuteNonQueryAsync();
+                }
+
+                await using var conn2 = await dataSource.OpenConnectionAsync();
+                var cmd = conn2.CreateCommand();
+                cmd.CommandText = "PRAGMA journal_mode";
+                var mode = await cmd.ExecuteScalarAsync();
+                mode!.ToString()!.ToUpperInvariant().ShouldBe("WAL");
+
+                settings.DatabaseApplications.ShouldBe(1);
+            }
+        }
+        finally
+        {
+            cleanUp(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task connection_pragmas_are_still_applied_on_every_open()
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), $"pragma_scope_{Guid.NewGuid():N}.db");
+        var settings = new SqlitePragmaSettings { BusyTimeout = 7321, ForeignKeys = true };
+
+        try
+        {
+            await using (var dataSource = new SqliteDataSource($"Data Source={tempFile}", settings))
+            {
+                await using (await dataSource.OpenConnectionAsync())
+                {
+                }
+
+                // busy_timeout and foreign_keys are connection-local, so a later connection only
+                // has them because the data source applied the per-connection batch again
+                await using var conn2 = await dataSource.OpenConnectionAsync();
+                (await pragmaValueAsync((SqliteConnection)conn2, "busy_timeout")).ShouldBe("7321");
+                (await pragmaValueAsync((SqliteConnection)conn2, "foreign_keys")).ShouldBe("1");
+            }
+        }
+        finally
+        {
+            cleanUp(tempFile);
+        }
+    }
+
+    [Fact]
+    public void synchronous_open_applies_pragmas_without_blocking_on_async()
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), $"pragma_scope_{Guid.NewGuid():N}.db");
+        var settings = new SqlitePragmaSettings { BusyTimeout = 4444 };
+
+        try
+        {
+            using var dataSource = new SqliteDataSource($"Data Source={tempFile}", settings);
+            using var conn = (SqliteConnection)dataSource.OpenConnection();
+
+            var cmd = conn.CreateCommand();
+            cmd.CommandText = "PRAGMA busy_timeout";
+            cmd.ExecuteScalar()!.ToString().ShouldBe("4444");
+
+            cmd.CommandText = "PRAGMA journal_mode";
+            cmd.ExecuteScalar()!.ToString()!.ToUpperInvariant().ShouldBe("WAL");
+        }
+        finally
+        {
+            cleanUp(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task in_memory_data_source_applies_database_pragmas_per_connection()
+    {
+        // a private :memory: database is a brand-new database per connection, so the
+        // file-scoped batch cannot be skipped after the first open
+        var settings = new CountingPragmaSettings();
+        await using var dataSource = new SqliteDataSource("Data Source=:memory:", settings);
+
+        await using (await dataSource.OpenConnectionAsync())
+        {
+        }
+
+        await using (await dataSource.OpenConnectionAsync())
+        {
+        }
+
+        settings.DatabaseApplications.ShouldBe(2);
+        settings.ConnectionApplications.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task full_apply_to_connection_still_covers_both_scopes()
+    {
+        // ApplyToConnectionAsync keeps its historical "apply everything" semantics
+        await using var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+
+        var settings = new SqlitePragmaSettings { BusyTimeout = 9999, ForeignKeys = true };
+        await settings.ApplyToConnectionAsync(connection);
+
+        (await pragmaValueAsync(connection, "busy_timeout")).ShouldBe("9999");
+        (await pragmaValueAsync(connection, "foreign_keys")).ShouldBe("1");
+    }
+
+    private static async Task<string> pragmaValueAsync(SqliteConnection connection, string pragmaName)
+    {
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = $"PRAGMA {pragmaName}";
+        var result = await cmd.ExecuteScalarAsync();
+        return result?.ToString() ?? "";
+    }
+
+    private static void cleanUp(string tempFile)
+    {
+        SqliteConnection.ClearAllPools();
+        foreach (var file in new[] { tempFile, tempFile + "-wal", tempFile + "-shm" })
+        {
+            try
+            {
+                if (File.Exists(file)) File.Delete(file);
+            }
+            catch
+            {
+                // ignore cleanup errors
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Spy that counts how often each scope of PRAGMAs is applied.
+    /// </summary>
+    private sealed class CountingPragmaSettings : SqlitePragmaSettings
+    {
+        private int _connectionApplications;
+        private int _databaseApplications;
+
+        public int ConnectionApplications => _connectionApplications;
+        public int DatabaseApplications => _databaseApplications;
+
+        public override Task ApplyConnectionPragmasAsync(SqliteConnection connection, CancellationToken ct = default)
+        {
+            Interlocked.Increment(ref _connectionApplications);
+            return base.ApplyConnectionPragmasAsync(connection, ct);
+        }
+
+        public override void ApplyConnectionPragmas(SqliteConnection connection)
+        {
+            Interlocked.Increment(ref _connectionApplications);
+            base.ApplyConnectionPragmas(connection);
+        }
+
+        public override Task ApplyDatabasePragmasAsync(SqliteConnection connection, CancellationToken ct = default)
+        {
+            Interlocked.Increment(ref _databaseApplications);
+            return base.ApplyDatabasePragmasAsync(connection, ct);
+        }
+
+        public override void ApplyDatabasePragmas(SqliteConnection connection)
+        {
+            Interlocked.Increment(ref _databaseApplications);
+            base.ApplyDatabasePragmas(connection);
+        }
+    }
+}

--- a/src/Weasel.Sqlite/SqliteDataSource.cs
+++ b/src/Weasel.Sqlite/SqliteDataSource.cs
@@ -10,6 +10,20 @@ namespace Weasel.Sqlite;
 ///
 /// For in-memory databases with Cache=Shared, this class maintains a keep-alive connection
 /// to prevent the database from being destroyed when all other connections close.
+///
+/// PRAGMAs are applied by scope: connection-scoped PRAGMAs (busy_timeout, foreign_keys,
+/// synchronous, ...) are applied to every connection, while database-file-scoped PRAGMAs
+/// (page_size, auto_vacuum, and journal_mode = WAL, which is persisted in the file header)
+/// are applied only on the first connection this data source opens. Re-issuing
+/// "PRAGMA journal_mode = WAL" on every open forces SQLite to take file locks to verify the
+/// journal mode and can return SQLITE_BUSY under a concurrent writer.
+///
+/// Assumption: for a database file that is not being modified externally, applying the
+/// file-scoped PRAGMAs once gives the same guarantee as re-applying them per open (the per-open
+/// reapplication was a no-op after the first open anyway). Multiple data sources pointed at the
+/// same file each apply the file-scoped PRAGMAs once, which is harmless — WAL conversion of an
+/// already-WAL file is a cheap verification. A file deleted and recreated underneath a live data
+/// source is not supported, exactly as before.
 /// </summary>
 public class SqliteDataSource : DbDataSource
 {
@@ -17,6 +31,7 @@ public class SqliteDataSource : DbDataSource
     private readonly SqlitePragmaSettings _pragmaSettings;
     private SqliteConnection? _keepAliveConnection;
     private readonly bool _isInMemory;
+    private volatile bool _databasePragmasApplied;
 
     public SqliteDataSource(string connectionString, SqlitePragmaSettings? pragmaSettings = null)
     {
@@ -42,8 +57,18 @@ public class SqliteDataSource : DbDataSource
     {
         EnsureKeepAlive();
         var conn = new SqliteConnection(_connectionString);
-        await conn.OpenAsync(cancellationToken).ConfigureAwait(false);
-        await _pragmaSettings.ApplyToConnectionAsync(conn, cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await conn.OpenAsync(cancellationToken).ConfigureAwait(false);
+            await _pragmaSettings.ApplyConnectionPragmasAsync(conn, cancellationToken).ConfigureAwait(false);
+            await EnsureDatabasePragmasAsync(conn, cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            await conn.DisposeAsync().ConfigureAwait(false);
+            throw;
+        }
+
         return conn;
     }
 
@@ -51,14 +76,41 @@ public class SqliteDataSource : DbDataSource
     {
         EnsureKeepAlive();
         var conn = new SqliteConnection(_connectionString);
-        conn.Open();
+        try
+        {
+            conn.Open();
 
-        // Apply PRAGMAs synchronously — this is safe because SQLite PRAGMAs
-        // execute locally with no async I/O.
-#pragma warning disable VSTHRD002
-        _pragmaSettings.ApplyToConnectionAsync(conn).GetAwaiter().GetResult();
-#pragma warning restore VSTHRD002
+            // PRAGMAs execute locally with no async I/O, so a genuinely synchronous
+            // execution is safe here and avoids blocking on async machinery
+            _pragmaSettings.ApplyConnectionPragmas(conn);
+            if (_isInMemory || !_databasePragmasApplied)
+            {
+                _pragmaSettings.ApplyDatabasePragmas(conn);
+                _databasePragmasApplied = true;
+            }
+        }
+        catch
+        {
+            conn.Dispose();
+            throw;
+        }
+
         return conn;
+    }
+
+    /// <summary>
+    /// Apply the database-file-scoped PRAGMAs the first time this data source successfully opens
+    /// a connection. A benign race between concurrent first opens can apply them more than once,
+    /// which is harmless — it is exactly what every open used to do. In-memory databases without
+    /// shared cache are a distinct database per connection, so for in-memory data sources the
+    /// batch is still applied on every open (where it is lock-free and cheap anyway).
+    /// </summary>
+    private async ValueTask EnsureDatabasePragmasAsync(SqliteConnection conn, CancellationToken cancellationToken)
+    {
+        if (!_isInMemory && _databasePragmasApplied) return;
+
+        await _pragmaSettings.ApplyDatabasePragmasAsync(conn, cancellationToken).ConfigureAwait(false);
+        _databasePragmasApplied = true;
     }
 
     /// <summary>

--- a/src/Weasel.Sqlite/SqlitePragmaSettings.cs
+++ b/src/Weasel.Sqlite/SqlitePragmaSettings.cs
@@ -4,8 +4,52 @@ namespace Weasel.Sqlite;
 /// Configuration for SQLite PRAGMA settings optimized for performance and reliability.
 /// These settings are applied when creating or opening a database connection.
 /// </summary>
+/// <remarks>
+///     <para>
+///         PRAGMAs are split by their actual scope:
+///     </para>
+///     <list type="bullet">
+///         <item>
+///             <b>Database-file scoped</b> (<see cref="DatabasePragmaSql" />): <c>page_size</c> and
+///             <c>auto_vacuum</c> are properties of the database file that can only take effect before
+///             the file is first written (or via VACUUM), and <c>journal_mode = WAL</c> is persisted in
+///             the database file header. These only need to be issued once per database file —
+///             re-issuing <c>journal_mode = WAL</c> on every connection open forces SQLite to take
+///             locks to verify/convert the journal mode and can return SQLITE_BUSY under a concurrent
+///             writer.
+///         </item>
+///         <item>
+///             <b>Connection scoped</b> (<see cref="ConnectionPragmaSql" />): everything else,
+///             including non-WAL journal modes (DELETE/TRUNCATE/PERSIST/MEMORY/OFF are per-connection
+///             settings) and <c>wal_autocheckpoint</c> (a per-connection setting even though it
+///             operates on the WAL file). These must be applied to every new connection.
+///         </item>
+///     </list>
+///     <para>
+///         Both batch strings are computed lazily and cached; mutating any setting invalidates the
+///         cache, so opening a connection does not rebuild the PRAGMA SQL from scratch each time.
+///     </para>
+/// </remarks>
 public class SqlitePragmaSettings
 {
+    private JournalMode _journalMode = JournalMode.WAL;
+    private SynchronousMode _synchronous = SynchronousMode.NORMAL;
+    private int _cacheSize = -64000;
+    private TempStoreMode _tempStore = TempStoreMode.MEMORY;
+    private long _mmapSize = 268435456; // 256MB
+    private int _pageSize = 4096;
+    private bool _foreignKeys = true;
+    private AutoVacuumMode _autoVacuum = AutoVacuumMode.INCREMENTAL;
+    private int _busyTimeout = 5000;
+    private bool _secureDelete;
+    private bool _caseSensitiveLike;
+    private int? _walAutoCheckpoint;
+
+    // Cached batch SQL, invalidated whenever a setting is mutated. Reads/writes of a
+    // reference are atomic, so the worst case under concurrent mutation is a redundant rebuild.
+    private string? _connectionPragmaSql;
+    private string? _databasePragmaSql;
+
     /// <summary>
     /// Default optimized settings for general-purpose applications.
     /// </summary>
@@ -63,77 +107,203 @@ public class SqlitePragmaSettings
     /// <summary>
     /// Journal mode controls how transactions are stored.
     /// WAL (Write-Ahead Logging) is recommended for most use cases.
+    /// WAL is persisted in the database file and only needs to be set once per database;
+    /// all other journal modes are per-connection settings.
     /// </summary>
-    public JournalMode JournalMode { get; set; } = JournalMode.WAL;
+    public JournalMode JournalMode
+    {
+        get => _journalMode;
+        set { _journalMode = value; invalidateCache(); }
+    }
 
     /// <summary>
     /// Controls how often SQLite syncs to disk.
     /// NORMAL is a good balance between safety and performance.
     /// </summary>
-    public SynchronousMode Synchronous { get; set; } = SynchronousMode.NORMAL;
+    public SynchronousMode Synchronous
+    {
+        get => _synchronous;
+        set { _synchronous = value; invalidateCache(); }
+    }
 
     /// <summary>
     /// Cache size in kibibytes (negative) or pages (positive).
     /// Negative values specify size in KiB (e.g., -64000 = 64MB).
     /// </summary>
-    public int CacheSize { get; set; } = -64000;
+    public int CacheSize
+    {
+        get => _cacheSize;
+        set { _cacheSize = value; invalidateCache(); }
+    }
 
     /// <summary>
     /// Where temporary tables and indices are stored.
     /// MEMORY is fastest for most operations.
     /// </summary>
-    public TempStoreMode TempStore { get; set; } = TempStoreMode.MEMORY;
+    public TempStoreMode TempStore
+    {
+        get => _tempStore;
+        set { _tempStore = value; invalidateCache(); }
+    }
 
     /// <summary>
     /// Maximum size of memory-mapped I/O in bytes.
     /// Can significantly improve read performance.
     /// </summary>
-    public long MmapSize { get; set; } = 268435456; // 256MB
+    public long MmapSize
+    {
+        get => _mmapSize;
+        set { _mmapSize = value; invalidateCache(); }
+    }
 
     /// <summary>
     /// Database page size in bytes. Must be a power of 2 between 512 and 65536.
     /// 4096 is optimal for most modern systems.
     /// Can only be set before the database is created.
     /// </summary>
-    public int PageSize { get; set; } = 4096;
+    public int PageSize
+    {
+        get => _pageSize;
+        set { _pageSize = value; invalidateCache(); }
+    }
 
     /// <summary>
     /// Enable foreign key constraints. Strongly recommended.
     /// </summary>
-    public bool ForeignKeys { get; set; } = true;
+    public bool ForeignKeys
+    {
+        get => _foreignKeys;
+        set { _foreignKeys = value; invalidateCache(); }
+    }
 
     /// <summary>
     /// Auto-vacuum mode for automatically reclaiming space.
     /// INCREMENTAL is a good balance.
+    /// Can only take effect before the database file is created (or via VACUUM).
     /// </summary>
-    public AutoVacuumMode AutoVacuum { get; set; } = AutoVacuumMode.INCREMENTAL;
+    public AutoVacuumMode AutoVacuum
+    {
+        get => _autoVacuum;
+        set { _autoVacuum = value; invalidateCache(); }
+    }
 
     /// <summary>
     /// Timeout in milliseconds when database is locked.
     /// </summary>
-    public int BusyTimeout { get; set; } = 5000;
+    public int BusyTimeout
+    {
+        get => _busyTimeout;
+        set { _busyTimeout = value; invalidateCache(); }
+    }
 
     /// <summary>
     /// Whether to securely delete data (overwrite with zeros).
     /// Slower but more secure.
     /// </summary>
-    public bool SecureDelete { get; set; } = false;
+    public bool SecureDelete
+    {
+        get => _secureDelete;
+        set { _secureDelete = value; invalidateCache(); }
+    }
 
     /// <summary>
     /// Whether LIKE operator is case-sensitive.
     /// Default is case-insensitive for ASCII characters.
     /// </summary>
-    public bool CaseSensitiveLike { get; set; } = false;
+    public bool CaseSensitiveLike
+    {
+        get => _caseSensitiveLike;
+        set { _caseSensitiveLike = value; invalidateCache(); }
+    }
 
     /// <summary>
     /// WAL auto-checkpoint threshold (number of pages).
     /// NULL means use default (1000 pages).
     /// </summary>
-    public int? WalAutoCheckpoint { get; set; }
+    public int? WalAutoCheckpoint
+    {
+        get => _walAutoCheckpoint;
+        set { _walAutoCheckpoint = value; invalidateCache(); }
+    }
+
+    private void invalidateCache()
+    {
+        _connectionPragmaSql = null;
+        _databasePragmaSql = null;
+    }
 
     /// <summary>
-    /// Apply these PRAGMA settings to a connection.
-    /// All PRAGMA statements are executed in a single batch for better performance.
+    ///     The batch of connection-scoped PRAGMA statements that must be applied to every new
+    ///     connection. Computed once and cached until a setting is mutated.
+    /// </summary>
+    public string ConnectionPragmaSql => _connectionPragmaSql ??= buildBatchSql(connectionPragmas());
+
+    /// <summary>
+    ///     The batch of database-file-scoped PRAGMA statements (<c>page_size</c>, <c>auto_vacuum</c>,
+    ///     and <c>journal_mode</c> when WAL) that only need to be issued once per database file.
+    ///     Computed once and cached until a setting is mutated.
+    /// </summary>
+    public string DatabasePragmaSql => _databasePragmaSql ??= buildBatchSql(databasePragmas());
+
+    /// <summary>
+    ///     The database-file-scoped PRAGMA statements. <c>page_size</c> is deliberately ordered
+    ///     before <c>journal_mode = WAL</c>: the page size of a brand-new database cannot be changed
+    ///     once the database has entered WAL mode.
+    /// </summary>
+    private IEnumerable<string> databasePragmas()
+    {
+        yield return $"PRAGMA page_size = {PageSize}";
+        yield return $"PRAGMA auto_vacuum = {(int)AutoVacuum}";
+
+        if (JournalMode == JournalMode.WAL)
+        {
+            // WAL is persisted in the database file header, so it is a property of the
+            // database file rather than of any one connection
+            yield return "PRAGMA journal_mode = WAL";
+        }
+    }
+
+    /// <summary>
+    ///     The connection-scoped PRAGMA statements. <c>busy_timeout</c> comes first so that any
+    ///     subsequent statement that has to take a file lock benefits from it.
+    /// </summary>
+    private IEnumerable<string> connectionPragmas()
+    {
+        yield return $"PRAGMA busy_timeout = {BusyTimeout}";
+
+        if (JournalMode != JournalMode.WAL)
+        {
+            // DELETE/TRUNCATE/PERSIST/MEMORY/OFF are per-connection settings and are not
+            // persisted in the database file, so they have to be applied on every open
+            yield return $"PRAGMA journal_mode = {JournalMode.ToString().ToUpperInvariant()}";
+        }
+
+        yield return $"PRAGMA synchronous = {Synchronous.ToString().ToUpperInvariant()}";
+        yield return $"PRAGMA cache_size = {CacheSize}";
+        yield return $"PRAGMA temp_store = {(int)TempStore}";
+        yield return $"PRAGMA mmap_size = {MmapSize}";
+        yield return $"PRAGMA foreign_keys = {(ForeignKeys ? "ON" : "OFF")}";
+        yield return $"PRAGMA secure_delete = {(SecureDelete ? "ON" : "OFF")}";
+        yield return $"PRAGMA case_sensitive_like = {(CaseSensitiveLike ? "ON" : "OFF")}";
+
+        if (WalAutoCheckpoint.HasValue && JournalMode == JournalMode.WAL)
+        {
+            // wal_autocheckpoint is a per-connection setting (sqlite3_wal_autocheckpoint)
+            // even though it operates on the shared WAL file
+            yield return $"PRAGMA wal_autocheckpoint = {WalAutoCheckpoint.Value}";
+        }
+    }
+
+    private static string buildBatchSql(IEnumerable<string> pragmas)
+    {
+        return string.Join(";\n", pragmas) + ";";
+    }
+
+    /// <summary>
+    /// Apply all of these PRAGMA settings — database-file scoped and connection scoped — to a
+    /// connection. All PRAGMA statements are executed in a single batch for better performance.
+    /// Prefer <see cref="SqliteDataSource" />, which applies the database-file-scoped PRAGMAs only
+    /// once instead of on every open.
     /// </summary>
     public async Task ApplyToConnectionAsync(Microsoft.Data.Sqlite.SqliteConnection connection, CancellationToken ct = default)
     {
@@ -142,33 +312,90 @@ public class SqlitePragmaSettings
             throw new ArgumentNullException(nameof(connection));
         }
 
-        // Build all PRAGMA statements
-        var pragmas = new List<string>
-        {
-            $"PRAGMA journal_mode = {JournalMode.ToString().ToUpperInvariant()}",
-            $"PRAGMA synchronous = {Synchronous.ToString().ToUpperInvariant()}",
-            $"PRAGMA cache_size = {CacheSize}",
-            $"PRAGMA temp_store = {(int)TempStore}",
-            $"PRAGMA mmap_size = {MmapSize}",
-            $"PRAGMA page_size = {PageSize}",
-            $"PRAGMA foreign_keys = {(ForeignKeys ? "ON" : "OFF")}",
-            $"PRAGMA auto_vacuum = {(int)AutoVacuum}",
-            $"PRAGMA busy_timeout = {BusyTimeout}",
-            $"PRAGMA secure_delete = {(SecureDelete ? "ON" : "OFF")}",
-            $"PRAGMA case_sensitive_like = {(CaseSensitiveLike ? "ON" : "OFF")}"
-        };
+        // Connection PRAGMAs first so busy_timeout is in force before the journal-mode
+        // conversion in the database batch has to take file locks
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = ConnectionPragmaSql + "\n" + DatabasePragmaSql;
+        await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+    }
 
-        if (WalAutoCheckpoint.HasValue && JournalMode == JournalMode.WAL)
+    /// <summary>
+    /// Synchronous equivalent of <see cref="ApplyToConnectionAsync" />. PRAGMA statements execute
+    /// locally with no network I/O, so a genuinely synchronous execution is safe and avoids
+    /// blocking on async machinery.
+    /// </summary>
+    public void ApplyToConnection(Microsoft.Data.Sqlite.SqliteConnection connection)
+    {
+        if (connection == null)
         {
-            pragmas.Add($"PRAGMA wal_autocheckpoint = {WalAutoCheckpoint.Value}");
+            throw new ArgumentNullException(nameof(connection));
         }
 
-        // Execute all PRAGMAs in a single batch
-        var batchSql = string.Join(";\n", pragmas) + ";";
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = ConnectionPragmaSql + "\n" + DatabasePragmaSql;
+        cmd.ExecuteNonQuery();
+    }
+
+    /// <summary>
+    /// Apply only the connection-scoped PRAGMA settings. Used by <see cref="SqliteDataSource" />
+    /// on every connection open.
+    /// </summary>
+    public virtual async Task ApplyConnectionPragmasAsync(Microsoft.Data.Sqlite.SqliteConnection connection, CancellationToken ct = default)
+    {
+        if (connection == null)
+        {
+            throw new ArgumentNullException(nameof(connection));
+        }
 
         await using var cmd = connection.CreateCommand();
-        cmd.CommandText = batchSql;
+        cmd.CommandText = ConnectionPragmaSql;
         await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Synchronous equivalent of <see cref="ApplyConnectionPragmasAsync" />.
+    /// </summary>
+    public virtual void ApplyConnectionPragmas(Microsoft.Data.Sqlite.SqliteConnection connection)
+    {
+        if (connection == null)
+        {
+            throw new ArgumentNullException(nameof(connection));
+        }
+
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = ConnectionPragmaSql;
+        cmd.ExecuteNonQuery();
+    }
+
+    /// <summary>
+    /// Apply only the database-file-scoped PRAGMA settings. Used by <see cref="SqliteDataSource" />
+    /// once per data source rather than on every connection open.
+    /// </summary>
+    public virtual async Task ApplyDatabasePragmasAsync(Microsoft.Data.Sqlite.SqliteConnection connection, CancellationToken ct = default)
+    {
+        if (connection == null)
+        {
+            throw new ArgumentNullException(nameof(connection));
+        }
+
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = DatabasePragmaSql;
+        await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Synchronous equivalent of <see cref="ApplyDatabasePragmasAsync" />.
+    /// </summary>
+    public virtual void ApplyDatabasePragmas(Microsoft.Data.Sqlite.SqliteConnection connection)
+    {
+        if (connection == null)
+        {
+            throw new ArgumentNullException(nameof(connection));
+        }
+
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = DatabasePragmaSql;
+        cmd.ExecuteNonQuery();
     }
 
     /// <summary>
@@ -177,26 +404,9 @@ public class SqlitePragmaSettings
     /// </summary>
     public string ToSqlScript()
     {
-        var lines = new List<string>
-        {
-            "-- SQLite PRAGMA Settings",
-            $"PRAGMA journal_mode = {JournalMode.ToString().ToUpperInvariant()};",
-            $"PRAGMA synchronous = {Synchronous.ToString().ToUpperInvariant()};",
-            $"PRAGMA cache_size = {CacheSize};",
-            $"PRAGMA temp_store = {(int)TempStore};",
-            $"PRAGMA mmap_size = {MmapSize};",
-            $"PRAGMA page_size = {PageSize};",
-            $"PRAGMA foreign_keys = {(ForeignKeys ? "ON" : "OFF")};",
-            $"PRAGMA auto_vacuum = {(int)AutoVacuum};",
-            $"PRAGMA busy_timeout = {BusyTimeout};",
-            $"PRAGMA secure_delete = {(SecureDelete ? "ON" : "OFF")};",
-            $"PRAGMA case_sensitive_like = {(CaseSensitiveLike ? "ON" : "OFF")};"
-        };
-
-        if (WalAutoCheckpoint.HasValue && JournalMode == JournalMode.WAL)
-        {
-            lines.Add($"PRAGMA wal_autocheckpoint = {WalAutoCheckpoint.Value};");
-        }
+        var lines = new List<string> { "-- SQLite PRAGMA Settings" };
+        lines.AddRange(connectionPragmas().Select(p => p + ";"));
+        lines.AddRange(databasePragmas().Select(p => p + ";"));
 
         return string.Join(Environment.NewLine, lines);
     }


### PR DESCRIPTION
Closes #562. Part of Stoat plan `critter-performance-2026-09`, node `weasel-pragma-scope`.

## What changed

**PRAGMAs are now classified by their actual scope** (verified against the SQLite pragma docs):

| Scope | PRAGMAs | Why |
|---|---|---|
| Database file — applied **once per data source** | `page_size`, `auto_vacuum`, `journal_mode` *when WAL* | `page_size`/`auto_vacuum` only take effect before the file is first written (or via VACUUM); WAL is persisted in the database file header. Re-issuing `journal_mode = WAL` on every open forces SQLite to take file locks to verify/convert the mode and can return SQLITE_BUSY under a concurrent writer — manufacturing the very contention downstream resilience pipelines then retry. |
| Connection — applied **on every open** | `busy_timeout` (first), `journal_mode` *when not WAL*, `synchronous`, `cache_size`, `temp_store`, `mmap_size`, `foreign_keys`, `secure_delete`, `case_sensitive_like`, `wal_autocheckpoint` | All per-connection settings. Non-WAL journal modes (DELETE/TRUNCATE/PERSIST/MEMORY/OFF) are connection-local and not persisted in the file; `wal_autocheckpoint` maps to `sqlite3_wal_autocheckpoint`, a per-connection setting despite operating on the WAL file; `secure_delete` is likewise a per-connection flag. |

**Other changes**

- Both batch SQL strings are precomputed and cached on `SqlitePragmaSettings`; mutating any setting invalidates the cache, so opening a connection no longer rebuilds a `List<string>` of interpolated statements (with `ToUpperInvariant()` calls) per open.
- `busy_timeout` now leads the per-connection batch so anything that later takes a file lock benefits from it.
- `page_size` is ordered *before* `journal_mode = WAL` in the database batch — previously the batch entered WAL first, so the configured page size was silently ignored for brand-new databases (page size cannot change once in WAL mode).
- `SqliteDataSource.OpenDbConnection()` now executes the PRAGMA batch with genuinely synchronous command execution instead of `ApplyToConnectionAsync(...).GetAwaiter().GetResult()` behind a `VSTHRD002` suppression, and both open paths dispose the connection if PRAGMA application fails.
- `ApplyToConnectionAsync` keeps its historical apply-everything semantics for existing callers (SqliteHelper-style usage, DocSamples, Fisher).

## Semantics

- Applying file-scoped PRAGMAs once per data source gives the same guarantee as the old per-open reapplication for a file that isn't modified externally — the reapplication was a no-op after the first open anyway. Multiple data sources on one file each apply the batch once, which is a cheap verification for an already-WAL file. A file deleted and recreated underneath a live data source is unsupported, exactly as before.
- In-memory data sources still apply the database batch per open, because each private `:memory:` connection is a brand-new database (and there is no file lock to contend on).
- A benign race between concurrent first opens can apply the database batch more than once; that's harmless (it's what every open used to do) and avoids a lock on the hot path.

## Tests

New `SqlitePragmaScopeTests` (12 tests): batch content/classification, statement ordering (`busy_timeout` first, `page_size` before WAL), cache stability (`ReferenceEquals`) and invalidation on mutation, once-per-data-source application via a counting spy, WAL visible on new connections without reapplication, per-open connection PRAGMAs, sync open path, in-memory per-open behavior, and full-apply back-compat.

`Weasel.Sqlite.Tests`: 583/583 passed (net9.0 and net10.0). `Weasel.Core.Tests`: 380/380 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)