### PR TITLE
Lift the flat-table projection DSL into Weasel.Storage

### DIFF
--- a/src/Weasel.Core.Tests/Flattened/ReferenceFlatTableDialects.cs
+++ b/src/Weasel.Core.Tests/Flattened/ReferenceFlatTableDialects.cs
@@ -1,0 +1,181 @@
+using System.Globalization;
+using Weasel.Postgresql;
+using Weasel.Postgresql.Functions;
+using Weasel.Sqlite;
+using Weasel.Storage.Flattened;
+
+namespace Weasel.Core.Tests.Flattened;
+
+/// <summary>
+///     One reference <see cref="IFlatTableSqlDialect" /> per upsert form the Critter Stack stores
+///     actually emit, reproducing the SQL each store's own flat-table code produces today.
+/// </summary>
+/// <remarks>
+///     <para>
+///         These live in the test project on purpose. <c>Weasel.Storage</c> references no provider
+///         assembly, and each store already owns the rest of its flat-table plumbing — so shipping
+///         the dialects here is what proves the seam can express all three shapes without
+///         prejudging where a store chooses to put its own implementation.
+///     </para>
+///     <para>
+///         The SQL Server one is Polecat's <c>MERGE</c>, the SQLite one Fisher's
+///         <c>INSERT … ON CONFLICT DO UPDATE</c>, and the PostgreSQL one Marten's generated upsert
+///         <em>function</em> — the shape that does not fit an inline statement at all, and therefore
+///         the one that decides whether the abstraction is wide enough.
+///     </para>
+/// </remarks>
+internal static class ReferenceFlatTableDialects
+{
+    public static readonly SqlServerFlatTableDialect SqlServer = new();
+    public static readonly SqliteFlatTableDialect Sqlite = new();
+    public static readonly PostgresqlFlatTableDialect Postgresql = new();
+}
+
+/// <summary>Polecat's shape: a <c>MERGE</c> with the pre-update row reached through <c>target</c>.</summary>
+internal sealed class SqlServerFlatTableDialect: InlineFlatTableSqlDialect
+{
+    /// <remarks>
+    ///     Weasel.SqlServer ships no <see cref="IDdlSyntaxStrategy" /> yet, so the bracket rule is
+    ///     spelled out here. Doubling an embedded <c>]</c> is not optional — it would otherwise close
+    ///     the bracket early (polecat#390 / weasel#416).
+    /// </remarks>
+    public override string QuoteIdentifier(string name) => string.Concat("[", name.Replace("]", "]]"), "]");
+
+    public override string ExistingRowReference(DbObjectName table, string columnName)
+        => $"target.{QuoteIdentifier(columnName)}";
+
+    protected override FlatTableUpsert WriteUpsert(FlatTableUpsertRequest request, FlatTableUpsertClauses clauses)
+    {
+        // UPDLOCK/HOLDLOCK: the daemon applies slices concurrently, so two slices touching the same
+        // row race the probe and both insert on the primary key without it (polecat#500).
+        var sql = $"""
+                   MERGE {TableReference(request.Identifier)} WITH (UPDLOCK, HOLDLOCK) AS target
+                   USING (SELECT {clauses.PrimaryKeyParameter} AS {clauses.QuotedPrimaryKey}) AS source ON target.{clauses.QuotedPrimaryKey} = source.{clauses.QuotedPrimaryKey}
+                   WHEN MATCHED THEN UPDATE SET {clauses.UpdateAssignmentList}
+                   WHEN NOT MATCHED THEN INSERT ({clauses.InsertColumnList}) VALUES ({clauses.InsertValueList});
+                   """;
+
+        return FlatTableUpsert.Statement(sql);
+    }
+
+    public override string BuildDelete(DbObjectName table, string primaryKeyColumn)
+        => $"DELETE FROM {TableReference(table)} WHERE {QuoteIdentifier(primaryKeyColumn)} = {ParameterName(0)};";
+}
+
+/// <summary>
+///     Fisher's shape: one <c>INSERT … ON CONFLICT DO UPDATE</c>, where an unqualified column on the
+///     right of an assignment <em>is</em> the pre-update row.
+/// </summary>
+internal sealed class SqliteFlatTableDialect: InlineFlatTableSqlDialect
+{
+    public SqliteFlatTableDialect(): base(SqliteDdlSyntax.Instance)
+    {
+    }
+
+    /// <remarks>SQLite has no schemas; the logical schema is folded into the table name instead.</remarks>
+    public override string TableReference(DbObjectName table) => QuoteIdentifier(table.Name);
+
+    /// <remarks>
+    ///     Bare, not <c>excluded."c"</c> — that would be the value the insert branch would have
+    ///     written, which turns every increment into a self-assignment.
+    /// </remarks>
+    public override string ExistingRowReference(DbObjectName table, string columnName)
+        => QuoteIdentifier(columnName);
+
+    protected override FlatTableUpsert WriteUpsert(FlatTableUpsertRequest request, FlatTableUpsertClauses clauses)
+    {
+        var sql = $"""
+                   insert into {TableReference(request.Identifier)} ({clauses.InsertColumnList})
+                   values ({clauses.InsertValueList})
+                   on conflict ({clauses.QuotedPrimaryKey}) do update set {clauses.UpdateAssignmentList};
+                   """;
+
+        return FlatTableUpsert.Statement(sql);
+    }
+}
+
+/// <summary>
+///     Marten's shape: a generated <c>plpgsql</c> upsert function per event type, called by the
+///     runtime statement.
+/// </summary>
+/// <remarks>
+///     The one form that is not a single inline statement, so it derives from the bare
+///     <see cref="FlatTableSqlDialectBase" /> rather than from
+///     <see cref="InlineFlatTableSqlDialect" /> and returns the function alongside the call. Its
+///     parameters are the function's own named arguments rather than positional placeholders, which
+///     is why the inline clause composition does not fit.
+/// </remarks>
+internal sealed class PostgresqlFlatTableDialect: FlatTableSqlDialectBase
+{
+    public PostgresqlFlatTableDialect(): base(PostgresqlDdlSyntax.Instance)
+    {
+    }
+
+    /// <remarks>
+    ///     Inside <c>ON CONFLICT DO UPDATE</c>, PostgreSQL names the pre-update row by the table's own
+    ///     name.
+    /// </remarks>
+    public override string ExistingRowReference(DbObjectName table, string columnName)
+        => $"{QuoteIdentifier(table.Name)}.{QuoteIdentifier(columnName)}";
+
+    /// <remarks>Weasel's command builders translate <c>?</c> into the provider's placeholder.</remarks>
+    public override string ParameterName(int index) => "?";
+
+    public override FlatTableUpsert BuildUpsert(FlatTableUpsertRequest request)
+    {
+        var context = new FlatTableColumnContext(this, request.Identifier);
+
+        var arguments = new List<string> { ArgumentDeclaration(request, request.PrimaryKeyColumn) };
+        var insertColumns = new List<string> { QuoteIdentifier(request.PrimaryKeyColumn) };
+        var insertValues = new List<string> { ArgumentName(request.PrimaryKeyColumn) };
+        var updates = new List<string>();
+
+        foreach (var map in request.Columns)
+        {
+            var argument = string.Empty;
+
+            if (map.RequiresInput)
+            {
+                argument = ArgumentName(map.ColumnName);
+                arguments.Add(ArgumentDeclaration(request, map.ColumnName));
+            }
+
+            insertColumns.Add(QuoteIdentifier(map.ColumnName));
+            insertValues.Add(map.InsertExpression(context, argument));
+            updates.Add(map.UpdateExpression(context, argument));
+        }
+
+        var identifier = FunctionName(request);
+
+        var body = $"""
+                    CREATE OR REPLACE FUNCTION {identifier.QualifiedName}({string.Join(", ", arguments)}) RETURNS void LANGUAGE plpgsql
+                    AS $function$
+                    BEGIN
+                    INSERT INTO {TableReference(request.Identifier)} ({string.Join(", ", insertColumns)}) VALUES ({string.Join(", ", insertValues)})
+                      ON CONFLICT ON CONSTRAINT {request.Table.PrimaryKeyName}
+                      DO UPDATE SET {string.Join(", ", updates)};
+                    END;
+                    $function$;
+                    """;
+
+        var call =
+            $"select {identifier.QualifiedName}({string.Join(", ", Enumerable.Repeat("?", arguments.Count))})";
+
+        return FlatTableUpsert.CallingInto(call, new Function(identifier, body));
+    }
+
+    private static DbObjectName FunctionName(FlatTableUpsertRequest request)
+        => new PostgresqlObjectName(request.Identifier.Schema,
+            $"mt_upsert_{request.Identifier.Name.ToLower(CultureInfo.InvariantCulture)}_"
+            + $"{request.EventType.Name.ToLower(CultureInfo.InvariantCulture)}");
+
+    private static string ArgumentName(string columnName) => "p_" + columnName;
+
+    private string ArgumentDeclaration(FlatTableUpsertRequest request, string columnName)
+    {
+        var column = request.Table.Columns.FirstOrDefault(x =>
+            string.Equals(x.Name, columnName, StringComparison.OrdinalIgnoreCase));
+
+        return $"{ArgumentName(columnName)} {column?.Type ?? "text"}";
+    }
+}

--- a/src/Weasel.Core.Tests/Flattened/flat_table_column_map_rendering.cs
+++ b/src/Weasel.Core.Tests/Flattened/flat_table_column_map_rendering.cs
@@ -1,0 +1,166 @@
+using Shouldly;
+using Weasel.Postgresql;
+using Weasel.Sqlite;
+using Weasel.SqlServer;
+using Weasel.Storage.Flattened;
+using Xunit;
+
+namespace Weasel.Core.Tests.Flattened;
+
+/// <summary>
+///     What each column map renders to, per dialect shape.
+/// </summary>
+/// <remarks>
+///     <para>
+///         This is the load-bearing half of the lift and the half that fails silently. An
+///         <c>Increment</c> whose update assignment reads the <em>would-be-inserted</em> value rather
+///         than the pre-update row is a self-assignment: valid SQL, no error, and a counter that
+///         never moves past its first event. The three spellings of "the row as it stands" —
+///         <c>target.c</c> inside a <c>MERGE</c>, an unqualified <c>c</c> inside SQLite's
+///         <c>DO UPDATE</c> (where <c>excluded.c</c> would be the would-be-inserted value instead),
+///         and <c>tbl.c</c> inside PostgreSQL's — are what these tests pin.
+///     </para>
+///     <para>
+///         Every expectation here is the SQL the corresponding store emits today, so a fragment that
+///         changes shape at adoption shows up as a failure rather than as a behaviour difference
+///         nobody looked for. Note that only SQL Server's brackets are unconditional: Weasel's SQLite
+///         and PostgreSQL identifier rules quote a name only when it has to be quoted, so the
+///         ordinary expectations below are bare and the last two tests are where quoting appears.
+///     </para>
+/// </remarks>
+public class flat_table_column_map_rendering
+{
+    private static readonly DbObjectName SqlServerTable = new SqlServerObjectName("dbo", "flat");
+    private static readonly DbObjectName SqliteTable = new SqliteObjectName("main", "flat");
+    private static readonly DbObjectName PostgresqlTable = new PostgresqlObjectName("public", "flat");
+
+    private static FlatTableColumnContext SqlServer =>
+        new(ReferenceFlatTableDialects.SqlServer, SqlServerTable);
+
+    private static FlatTableColumnContext Sqlite =>
+        new(ReferenceFlatTableDialects.Sqlite, SqliteTable);
+
+    private static FlatTableColumnContext Postgresql =>
+        new(ReferenceFlatTableDialects.Postgresql, PostgresqlTable);
+
+    [Fact]
+    public void member_map_assigns_the_parameter()
+    {
+        var map = new MemberMap("amount", typeof(decimal));
+
+        map.UpdateExpression(SqlServer, "@p1").ShouldBe("[amount] = @p1");
+        map.UpdateExpression(Sqlite, "@p1").ShouldBe("amount = @p1");
+        map.UpdateExpression(Postgresql, "p_amount").ShouldBe("amount = p_amount");
+
+        map.InsertExpression(SqlServer, "@p1").ShouldBe("@p1");
+        map.InsertExpression(Sqlite, "@p1").ShouldBe("@p1");
+        map.InsertExpression(Postgresql, "p_amount").ShouldBe("p_amount");
+    }
+
+    [Fact]
+    public void incrementing_by_a_member_reads_the_pre_update_row()
+    {
+        var map = new IncrementMemberMap("amount", typeof(int));
+
+        map.UpdateExpression(SqlServer, "@p1").ShouldBe("[amount] = target.[amount] + @p1");
+        map.UpdateExpression(Sqlite, "@p1").ShouldBe("amount = amount + @p1");
+        map.UpdateExpression(Postgresql, "p_amount").ShouldBe("amount = flat.amount + p_amount");
+    }
+
+    [Fact]
+    public void incrementing_by_a_member_inserts_the_value_itself()
+    {
+        // A row that does not exist yet starts at the increment, not at zero-plus-it.
+        var map = new IncrementMemberMap("amount", typeof(int));
+
+        map.InsertExpression(SqlServer, "@p1").ShouldBe("@p1");
+        map.InsertExpression(Sqlite, "@p1").ShouldBe("@p1");
+        map.InsertExpression(Postgresql, "p_amount").ShouldBe("p_amount");
+    }
+
+    [Fact]
+    public void decrementing_by_a_member_reads_the_pre_update_row()
+    {
+        var map = new DecrementMemberMap("amount", typeof(int));
+
+        map.UpdateExpression(SqlServer, "@p1").ShouldBe("[amount] = target.[amount] - @p1");
+        map.UpdateExpression(Sqlite, "@p1").ShouldBe("amount = amount - @p1");
+        map.UpdateExpression(Postgresql, "p_amount").ShouldBe("amount = flat.amount - p_amount");
+    }
+
+    [Fact]
+    public void increment_by_one_needs_no_parameter()
+    {
+        var map = new IncrementMap("count");
+
+        map.RequiresInput.ShouldBeFalse();
+        map.ColumnType.ShouldBe(typeof(int));
+
+        map.UpdateExpression(SqlServer, string.Empty).ShouldBe("[count] = target.[count] + 1");
+        map.UpdateExpression(Sqlite, string.Empty).ShouldBe("count = count + 1");
+        map.UpdateExpression(Postgresql, string.Empty).ShouldBe("count = flat.count + 1");
+
+        map.InsertExpression(SqlServer, string.Empty).ShouldBe("1");
+    }
+
+    [Fact]
+    public void decrement_by_one_needs_no_parameter()
+    {
+        var map = new DecrementMap("count");
+
+        map.RequiresInput.ShouldBeFalse();
+
+        map.UpdateExpression(SqlServer, string.Empty).ShouldBe("[count] = target.[count] - 1");
+        map.UpdateExpression(Sqlite, string.Empty).ShouldBe("count = count - 1");
+        map.UpdateExpression(Postgresql, string.Empty).ShouldBe("count = flat.count - 1");
+
+        map.InsertExpression(SqlServer, string.Empty).ShouldBe("0");
+    }
+
+    [Fact]
+    public void a_set_string_value_is_a_literal_and_is_escaped()
+    {
+        // The value is fixed at configuration time, so it is baked in rather than parameterized —
+        // which makes escaping mandatory. An undoubled quote closes the literal and the remainder of
+        // the value is parsed as SQL (polecat#390).
+        var map = new SetStringValueMap("status", "O'Brien");
+
+        map.RequiresInput.ShouldBeFalse();
+
+        map.UpdateExpression(SqlServer, string.Empty).ShouldBe("[status] = 'O''Brien'");
+        map.UpdateExpression(Sqlite, string.Empty).ShouldBe("status = 'O''Brien'");
+        map.UpdateExpression(Postgresql, string.Empty).ShouldBe("status = 'O''Brien'");
+
+        map.InsertExpression(Sqlite, string.Empty).ShouldBe("'O''Brien'");
+    }
+
+    [Fact]
+    public void a_set_int_value_is_a_literal()
+    {
+        var map = new SetIntValueMap("status", -5);
+
+        map.UpdateExpression(SqlServer, string.Empty).ShouldBe("[status] = -5");
+        map.InsertExpression(SqlServer, string.Empty).ShouldBe("-5");
+    }
+
+    [Fact]
+    public void an_identifier_that_would_close_its_own_quoting_is_escaped()
+    {
+        // Nothing upstream of a column map is a sanitizing boundary — DbObjectName validates
+        // nothing and the mapping API takes the name the caller wrote.
+        new MemberMap("od]d", typeof(int)).UpdateExpression(SqlServer, "@p1")
+            .ShouldBe("[od]]d] = @p1");
+
+        new MemberMap("od\"d", typeof(int)).UpdateExpression(Sqlite, "@p1")
+            .ShouldBe("\"od\"\"d\" = @p1");
+    }
+
+    [Fact]
+    public void a_reserved_word_column_is_quoted_on_postgresql()
+    {
+        // PostgresqlDdlSyntax quotes only what has to be quoted, which is why the ordinary
+        // expectations above are bare — and why this one is not.
+        new MemberMap("order", typeof(int)).UpdateExpression(Postgresql, "p_order")
+            .ShouldBe("\"order\" = p_order");
+    }
+}

--- a/src/Weasel.Core.Tests/Flattened/flat_table_member_mapping.cs
+++ b/src/Weasel.Core.Tests/Flattened/flat_table_member_mapping.cs
@@ -1,0 +1,101 @@
+using System.Linq.Expressions;
+using JasperFx.Events;
+using Shouldly;
+using Weasel.Storage.Flattened;
+using Xunit;
+
+namespace Weasel.Core.Tests.Flattened;
+
+/// <summary>
+///     Reading a mapping lambda: the column it names by default, and the value it pulls off an event.
+/// </summary>
+public class flat_table_member_mapping
+{
+    public record Address(string City);
+
+    public record Shipped(decimal Amount, Guid CustomerId, Address Destination);
+
+    private static Shipped AnEvent() => new(12.5m, Guid.Parse("22222222-2222-2222-2222-222222222222"),
+        new Address("Austin"));
+
+    [Theory]
+    [InlineData("MemberCount", "member_count")]
+    [InlineData("A", "a")]
+    [InlineData("Amount", "amount")]
+    [InlineData("CustomerId", "customer_id")]
+    public void snake_case(string member, string expected)
+        => FlatTableMembers.SnakeCase(member).ShouldBe(expected);
+
+    [Fact]
+    public void the_default_column_name_of_a_nested_path_joins_the_whole_path()
+    {
+        // A leaf-only name would silently collide whenever two mapped paths end in the same member.
+        var path = FlatTableMembers.MemberPath(
+            (Expression<Func<Shipped, object>>)(x => x.Destination.City))!;
+
+        FlatTableMembers.DefaultColumnName(path).ShouldBe("destination_city");
+    }
+
+    [Fact]
+    public void the_default_column_name_of_a_single_member()
+    {
+        var member = FlatTableMembers.MemberOf((Shipped x) => x.Amount);
+
+        FlatTableMembers.DefaultColumnName([member]).ShouldBe("amount");
+    }
+
+    [Fact]
+    public void an_expression_that_is_not_a_member_access_is_refused_by_name()
+    {
+        var ex = Should.Throw<ArgumentException>(() =>
+            FlatTableMembers.MemberOf((Shipped x) => x.Amount + 1));
+
+        ex.Message.ShouldContain("member access");
+    }
+
+    [Fact]
+    public void a_member_setter_reads_the_event_body()
+    {
+        var setter = FlatTableParameterSetters.ForMember((Shipped x) => x.Amount);
+
+        setter.ValueFor(new Event<Shipped>(AnEvent())).ShouldBe(12.5m);
+    }
+
+    [Fact]
+    public void a_member_setter_walks_a_nested_path()
+    {
+        var path = FlatTableMembers.MemberPath(
+            (Expression<Func<Shipped, object>>)(x => x.Destination.City))!;
+
+        FlatTableParameterSetters.ForMembers<Shipped>(path)
+            .ValueFor(new Event<Shipped>(AnEvent()))
+            .ShouldBe("Austin");
+    }
+
+    [Fact]
+    public void the_store_supplied_conversion_is_applied()
+    {
+        // SQLite has to write a Guid as lowercase canonical text and SQL Server has to unwrap a
+        // strong-typed id; neither is Weasel's decision, so the conversion is the store's to supply.
+        var setter = FlatTableParameterSetters.ForMember((Shipped x) => x.CustomerId,
+            value => value?.ToString());
+
+        setter.ValueFor(new Event<Shipped>(AnEvent()))
+            .ShouldBe("22222222-2222-2222-2222-222222222222");
+    }
+
+    [Fact]
+    public void a_stream_keyed_table_takes_its_key_from_the_stores_stream_identity()
+    {
+        var streamId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+
+        var @event = new Event<Shipped>(AnEvent()) { StreamId = streamId, StreamKey = "shipment-1" };
+
+        FlatTableParameterSetters.ForStream(StreamIdentity.AsGuid).ValueFor(@event).ShouldBe(streamId);
+        FlatTableParameterSetters.ForStream(StreamIdentity.AsString).ValueFor(@event).ShouldBe("shipment-1");
+
+        FlatTableParameterSetters.ForStream(StreamIdentity.AsGuid, value => value?.ToString())
+            .ValueFor(@event)
+            .ShouldBe("11111111-1111-1111-1111-111111111111");
+    }
+}

--- a/src/Weasel.Core.Tests/Flattened/flat_table_statement_composition.cs
+++ b/src/Weasel.Core.Tests/Flattened/flat_table_statement_composition.cs
@@ -1,0 +1,251 @@
+using Shouldly;
+using Weasel.Postgresql;
+using Weasel.Sqlite;
+using Weasel.SqlServer;
+using Weasel.Storage.Flattened;
+using Xunit;
+using PostgresqlTable = Weasel.Postgresql.Tables.Table;
+using SqlServerTable = Weasel.SqlServer.Tables.Table;
+using SqliteTable = Weasel.Sqlite.Tables.Table;
+
+namespace Weasel.Core.Tests.Flattened;
+
+/// <summary>
+///     The whole statement, per upsert form — and the parameter numbering it has to agree with.
+/// </summary>
+/// <remarks>
+///     The column list, the value list and the parameter order are one contract: the caller binds
+///     parameter 0 to the key and 1..N to the maps that read from the event, in declaration order. A
+///     map that takes no parameter must not consume a number, which is the single easiest thing to
+///     get wrong here and shows up as every column after it holding the wrong value.
+/// </remarks>
+public class flat_table_statement_composition
+{
+    private record Deposit(decimal Amount);
+
+    private static IReadOnlyList<IColumnMap> Columns() =>
+    [
+        new MemberMap("amount", typeof(decimal)),
+        new IncrementMap("deposit_count"),
+        new IncrementMemberMap("total", typeof(decimal)),
+        new SetStringValueMap("status", "open")
+    ];
+
+    private static SqlServerTable SqlServer()
+    {
+        var table = new SqlServerTable(new SqlServerObjectName("dbo", "account"));
+        ((ITable)table).AddPrimaryKeyColumn("id", typeof(Guid));
+
+        return table;
+    }
+
+    private static SqliteTable Sqlite()
+    {
+        var table = new SqliteTable(new SqliteObjectName("main", "account"));
+        ((ITable)table).AddPrimaryKeyColumn("id", typeof(Guid));
+
+        return table;
+    }
+
+    private static PostgresqlTable Postgresql()
+    {
+        var table = new PostgresqlTable(new PostgresqlObjectName("public", "account"));
+        ((ITable)table).AddPrimaryKeyColumn("id", typeof(Guid));
+
+        return table;
+    }
+
+    private static void Resolve(ITable table, IReadOnlyList<IColumnMap> columns)
+    {
+        foreach (var column in columns)
+        {
+            FlatTableStatementBuilder.ResolveColumn(table, column);
+        }
+    }
+
+    [Fact]
+    public void merge_is_composed_the_way_polecat_composes_it()
+    {
+        var table = SqlServer();
+        var columns = Columns();
+        Resolve(table, columns);
+
+        var upsert = FlatTableStatementBuilder.Upsert(ReferenceFlatTableDialects.SqlServer, table,
+            typeof(Deposit), columns);
+
+        upsert.SchemaObjects.ShouldBeEmpty();
+
+        upsert.Sql.ShouldBe("""
+                            MERGE [dbo].[account] WITH (UPDLOCK, HOLDLOCK) AS target
+                            USING (SELECT @p0 AS [id]) AS source ON target.[id] = source.[id]
+                            WHEN MATCHED THEN UPDATE SET [amount] = @p1, [deposit_count] = target.[deposit_count] + 1, [total] = target.[total] + @p2, [status] = 'open'
+                            WHEN NOT MATCHED THEN INSERT ([id], [amount], [deposit_count], [total], [status]) VALUES (@p0, @p1, 1, @p2, 'open');
+                            """);
+    }
+
+    [Fact]
+    public void on_conflict_is_composed_the_way_fisher_composes_it()
+    {
+        var table = Sqlite();
+        var columns = Columns();
+        Resolve(table, columns);
+
+        var upsert = FlatTableStatementBuilder.Upsert(ReferenceFlatTableDialects.Sqlite, table,
+            typeof(Deposit), columns);
+
+        upsert.SchemaObjects.ShouldBeEmpty();
+
+        // Unquoted because Weasel's SQLite identifier rules quote only what has to be quoted — the
+        // same rule Fisher's own flat table goes through.
+        upsert.Sql.ShouldBe("""
+                            insert into account (id, amount, deposit_count, total, status)
+                            values (@p0, @p1, 1, @p2, 'open')
+                            on conflict (id) do update set amount = @p1, deposit_count = deposit_count + 1, total = total + @p2, status = 'open';
+                            """);
+    }
+
+    [Fact]
+    public void the_function_form_returns_the_function_alongside_the_call()
+    {
+        var table = Postgresql();
+        var columns = Columns();
+        Resolve(table, columns);
+
+        var upsert = FlatTableStatementBuilder.Upsert(ReferenceFlatTableDialects.Postgresql, table,
+            typeof(Deposit), columns);
+
+        // The shape the seam exists to accommodate: the runtime statement is a call, and the object
+        // it calls comes back with it to be created by the caller's migration.
+        upsert.Sql.ShouldBe("select public.mt_upsert_account_deposit(?, ?, ?)");
+
+        var function = upsert.SchemaObjects.ShouldHaveSingleItem();
+        function.Identifier.Name.ShouldBe("mt_upsert_account_deposit");
+
+        var body = WriteCreateStatement(function);
+
+        body.ShouldContain("ON CONFLICT ON CONSTRAINT pkey_account_id");
+        body.ShouldContain(
+            "DO UPDATE SET amount = p_amount, deposit_count = account.deposit_count + 1, "
+            + "total = account.total + p_total, status = 'open';");
+        body.ShouldContain(
+            "INSERT INTO public.account (id, amount, deposit_count, total, status) "
+            + "VALUES (p_id, p_amount, 1, p_total, 'open')");
+    }
+
+    [Fact]
+    public void only_the_maps_that_read_the_event_consume_a_parameter()
+    {
+        var table = Sqlite();
+
+        // Two literal maps sandwiched between the member maps: the numbering must skip them, or the
+        // caller's setters bind to the wrong slots.
+        IReadOnlyList<IColumnMap> columns =
+        [
+            new SetIntValueMap("a", 0),
+            new MemberMap("b", typeof(int)),
+            new IncrementMap("c"),
+            new MemberMap("d", typeof(int))
+        ];
+
+        Resolve(table, columns);
+
+        var sql = FlatTableStatementBuilder
+            .Upsert(ReferenceFlatTableDialects.Sqlite, table, typeof(Deposit), columns).Sql;
+
+        sql.ShouldContain("values (@p0, 0, @p1, 1, @p2)");
+        sql.ShouldContain("do update set a = 0, b = @p1, c = c + 1, d = @p2;");
+    }
+
+    [Fact]
+    public void delete_is_keyed_on_parameter_zero()
+    {
+        FlatTableStatementBuilder.Delete(ReferenceFlatTableDialects.Sqlite, Sqlite())
+            .ShouldBe("delete from account where id = @p0;");
+
+        FlatTableStatementBuilder.Delete(ReferenceFlatTableDialects.SqlServer, SqlServer())
+            .ShouldBe("DELETE FROM [dbo].[account] WHERE [id] = @p0;");
+    }
+
+    [Fact]
+    public void a_table_with_no_primary_key_is_refused_by_name()
+    {
+        var table = new SqliteTable(new SqliteObjectName("main", "account"));
+        ((ITable)table).AddColumn("amount", typeof(decimal));
+
+        var ex = Should.Throw<InvalidOperationException>(() =>
+            FlatTableStatementBuilder.Upsert(ReferenceFlatTableDialects.Sqlite, table, typeof(Deposit),
+                [new MemberMap("amount", typeof(decimal))]));
+
+        ex.Message.ShouldContain("account");
+        ex.Message.ShouldContain("AsPrimaryKey");
+    }
+
+    [Fact]
+    public void mapping_no_columns_at_all_is_refused()
+    {
+        // An empty update branch is a syntax error, not a no-op. Name it here, where the projection
+        // is still identifiable, rather than at the first event.
+        Should.Throw<InvalidOperationException>(() =>
+                FlatTableStatementBuilder.Upsert(ReferenceFlatTableDialects.Sqlite, Sqlite(),
+                    typeof(Deposit), []))
+            .Message.ShouldContain("at least one column");
+    }
+
+    [Fact]
+    public void a_column_named_twice_in_different_casings_is_one_column()
+    {
+        // Identifiers are case-insensitive where values are not, so two Project<T> handlers naming
+        // "Amount" and "amount" mean one column — and adding both emits DDL the database rejects as
+        // a duplicate (polecat#45).
+        var table = Sqlite();
+
+        FlatTableStatementBuilder.ResolveColumn(table, new MemberMap("Amount", typeof(decimal)));
+        FlatTableStatementBuilder.ResolveColumn(table, new MemberMap("amount", typeof(decimal)));
+
+        table.Columns.Count(x => string.Equals(x.Name, "amount", StringComparison.OrdinalIgnoreCase))
+            .ShouldBe(1);
+    }
+
+    [Fact]
+    public void an_explicit_column_type_rule_wins_over_the_providers_own()
+    {
+        // The hook a store needs where it has an opinion the provider's type map does not carry —
+        // a strong-typed id stored as its inner primitive, for instance.
+        var table = Sqlite();
+
+        FlatTableStatementBuilder.ResolveColumn(table, new MemberMap("amount", typeof(decimal)),
+            _ => "NUMERIC(19,4)");
+
+        table.ColumnFor("amount")!.Type.ShouldBe("NUMERIC(19,4)");
+    }
+
+    [Fact]
+    public void the_insert_branch_follows_polecat_and_fisher_where_the_three_stores_disagree()
+    {
+        // Pinned as a decision rather than left to be discovered at adoption. Marten's equivalents
+        // insert 0 for Increment(column) and negate the parameter for Decrement(member); Polecat's
+        // and Fisher's, which are byte-for-byte the same as each other, do neither. The lifted maps
+        // take the two-store majority, so Marten's adoption is a behaviour change to make
+        // deliberately.
+        var table = Sqlite();
+
+        IReadOnlyList<IColumnMap> columns =
+        [
+            new IncrementMap("hits"),
+            new DecrementMemberMap("balance", typeof(decimal))
+        ];
+
+        Resolve(table, columns);
+
+        FlatTableStatementBuilder.Upsert(ReferenceFlatTableDialects.Sqlite, table, typeof(Deposit), columns)
+            .Sql.ShouldContain("values (@p0, 1, @p1)");
+    }
+
+    private static string WriteCreateStatement(ISchemaObject schemaObject)
+    {
+        var writer = new StringWriter();
+        schemaObject.WriteCreateStatement(new PostgresqlMigrator(), writer);
+
+        return writer.ToString();
+    }
+}

--- a/src/Weasel.Core.Tests/Weasel.Core.Tests.csproj
+++ b/src/Weasel.Core.Tests/Weasel.Core.Tests.csproj
@@ -22,6 +22,10 @@
       <ProjectReference Include="..\Weasel.Sqlite\Weasel.Sqlite.csproj" />
       <ProjectReference Include="..\Weasel.Postgresql\Weasel.Postgresql.csproj" />
       <ProjectReference Include="..\Weasel.Oracle\Weasel.Oracle.csproj" />
+      <!-- Weasel.Storage has no test project of its own; its flat-table lift is verified here
+           because the reference dialects need the provider assemblies this project already
+           references. Still pure string logic — no database. -->
+      <ProjectReference Include="..\Weasel.Storage\Weasel.Storage.csproj" />
       <!-- Referenced for the transaction-participant contract tests (weasel#561). The concrete
            connection/transaction pair those tests close the generic over is Microsoft.Data.Sqlite's,
            which arrives transitively through Weasel.Sqlite — in-memory, no containers. -->

--- a/src/Weasel.Storage/Flattened/ColumnMaps.cs
+++ b/src/Weasel.Storage/Flattened/ColumnMaps.cs
@@ -1,0 +1,209 @@
+using System.Globalization;
+
+namespace Weasel.Storage.Flattened;
+
+/// <summary>Writes an event member straight onto the column.</summary>
+public sealed class MemberMap: IColumnMap
+{
+    public MemberMap(string columnName, Type columnType)
+    {
+        ColumnName = columnName;
+        ColumnType = columnType;
+    }
+
+    /// <inheritdoc />
+    public string ColumnName { get; }
+
+    /// <inheritdoc />
+    public Type ColumnType { get; }
+
+    /// <inheritdoc />
+    public bool RequiresInput => true;
+
+    /// <inheritdoc />
+    public string UpdateExpression(in FlatTableColumnContext context, string parameterName)
+        => $"{context.Quote(ColumnName)} = {parameterName}";
+
+    /// <inheritdoc />
+    public string InsertExpression(in FlatTableColumnContext context, string parameterName)
+        => parameterName;
+}
+
+/// <summary>Adds an event member's value to the column.</summary>
+public sealed class IncrementMemberMap: IColumnMap
+{
+    public IncrementMemberMap(string columnName, Type columnType)
+    {
+        ColumnName = columnName;
+        ColumnType = columnType;
+    }
+
+    /// <inheritdoc />
+    public string ColumnName { get; }
+
+    /// <inheritdoc />
+    public Type ColumnType { get; }
+
+    /// <inheritdoc />
+    public bool RequiresInput => true;
+
+    /// <inheritdoc />
+    public string UpdateExpression(in FlatTableColumnContext context, string parameterName)
+        => $"{context.Quote(ColumnName)} = {context.Existing(ColumnName)} + {parameterName}";
+
+    /// <summary>
+    ///     A row that does not exist yet starts at the increment itself, not at zero-plus-it.
+    /// </summary>
+    public string InsertExpression(in FlatTableColumnContext context, string parameterName)
+        => parameterName;
+}
+
+/// <summary>Subtracts an event member's value from the column.</summary>
+public sealed class DecrementMemberMap: IColumnMap
+{
+    public DecrementMemberMap(string columnName, Type columnType)
+    {
+        ColumnName = columnName;
+        ColumnType = columnType;
+    }
+
+    /// <inheritdoc />
+    public string ColumnName { get; }
+
+    /// <inheritdoc />
+    public Type ColumnType { get; }
+
+    /// <inheritdoc />
+    public bool RequiresInput => true;
+
+    /// <inheritdoc />
+    public string UpdateExpression(in FlatTableColumnContext context, string parameterName)
+        => $"{context.Quote(ColumnName)} = {context.Existing(ColumnName)} - {parameterName}";
+
+    /// <summary>
+    ///     Polecat's and Fisher's shape: a first sighting inserts the value as given. Marten's
+    ///     equivalent inserts <c>-value</c> instead — see the type's remarks in the lift's PR; the
+    ///     divergence is preserved here as the two-store majority rather than reconciled silently.
+    /// </summary>
+    public string InsertExpression(in FlatTableColumnContext context, string parameterName)
+        => parameterName;
+}
+
+/// <summary>Adds one to the column, with nothing read from the event.</summary>
+public sealed class IncrementMap: IColumnMap
+{
+    public IncrementMap(string columnName)
+    {
+        ColumnName = columnName;
+    }
+
+    /// <inheritdoc />
+    public string ColumnName { get; }
+
+    /// <inheritdoc />
+    public Type ColumnType => typeof(int);
+
+    /// <inheritdoc />
+    public bool RequiresInput => false;
+
+    /// <inheritdoc />
+    public string UpdateExpression(in FlatTableColumnContext context, string parameterName)
+        => $"{context.Quote(ColumnName)} = {context.Existing(ColumnName)} + 1";
+
+    /// <summary>
+    ///     A first sighting counts once, so the row starts at 1. Marten's equivalent inserts 0 — see
+    ///     the lift's PR; the divergence is preserved here as the two-store majority.
+    /// </summary>
+    public string InsertExpression(in FlatTableColumnContext context, string parameterName) => "1";
+}
+
+/// <summary>Subtracts one from the column, with nothing read from the event.</summary>
+public sealed class DecrementMap: IColumnMap
+{
+    public DecrementMap(string columnName)
+    {
+        ColumnName = columnName;
+    }
+
+    /// <inheritdoc />
+    public string ColumnName { get; }
+
+    /// <inheritdoc />
+    public Type ColumnType => typeof(int);
+
+    /// <inheritdoc />
+    public bool RequiresInput => false;
+
+    /// <inheritdoc />
+    public string UpdateExpression(in FlatTableColumnContext context, string parameterName)
+        => $"{context.Quote(ColumnName)} = {context.Existing(ColumnName)} - 1";
+
+    /// <summary>All three stores insert 0 here; it is not the mirror of <see cref="IncrementMap" />.</summary>
+    public string InsertExpression(in FlatTableColumnContext context, string parameterName) => "0";
+}
+
+/// <summary>Sets the column to a configured string.</summary>
+/// <remarks>
+///     The value lands in a SQL string literal rather than a parameter, because it is fixed at
+///     configuration time and baking it in keeps the parameter list aligned with the maps that
+///     genuinely read from the event. Escaping is therefore the dialect's job and not optional — an
+///     embedded quote that is not doubled terminates the literal and the remainder is parsed as SQL
+///     (polecat#390).
+/// </remarks>
+public sealed class SetStringValueMap: IColumnMap
+{
+    private readonly string _value;
+
+    public SetStringValueMap(string columnName, string value)
+    {
+        ColumnName = columnName;
+        _value = value;
+    }
+
+    /// <inheritdoc />
+    public string ColumnName { get; }
+
+    /// <inheritdoc />
+    public Type ColumnType => typeof(string);
+
+    /// <inheritdoc />
+    public bool RequiresInput => false;
+
+    /// <inheritdoc />
+    public string UpdateExpression(in FlatTableColumnContext context, string parameterName)
+        => $"{context.Quote(ColumnName)} = {context.Literal(_value)}";
+
+    /// <inheritdoc />
+    public string InsertExpression(in FlatTableColumnContext context, string parameterName)
+        => context.Literal(_value);
+}
+
+/// <summary>Sets the column to a configured integer.</summary>
+public sealed class SetIntValueMap: IColumnMap
+{
+    private readonly string _literal;
+
+    public SetIntValueMap(string columnName, int value)
+    {
+        ColumnName = columnName;
+
+        // Invariant, so a column literal never picks up a locale's digit or sign formatting.
+        _literal = value.ToString(CultureInfo.InvariantCulture);
+    }
+
+    /// <inheritdoc />
+    public string ColumnName { get; }
+
+    /// <inheritdoc />
+    public Type ColumnType => typeof(int);
+
+    /// <inheritdoc />
+    public bool RequiresInput => false;
+
+    /// <inheritdoc />
+    public string UpdateExpression(in FlatTableColumnContext context, string parameterName)
+        => $"{context.Quote(ColumnName)} = {_literal}";
+
+    /// <inheritdoc />
+    public string InsertExpression(in FlatTableColumnContext context, string parameterName) => _literal;
+}

--- a/src/Weasel.Storage/Flattened/FlatTableMembers.cs
+++ b/src/Weasel.Storage/Flattened/FlatTableMembers.cs
@@ -1,0 +1,104 @@
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text;
+
+namespace Weasel.Storage.Flattened;
+
+/// <summary>
+///     The reflection and naming odds and ends the flat-table mapping API needs, so that
+///     <c>Map(x =&gt; x.MemberCount)</c> means the same column on every store.
+/// </summary>
+public static class FlatTableMembers
+{
+    /// <summary>The member a single-member-access lambda reads.</summary>
+    /// <exception cref="ArgumentException">The lambda is not a member access.</exception>
+    public static MemberInfo MemberOf<TSource, TValue>(Expression<Func<TSource, TValue>> expression)
+    {
+        ArgumentNullException.ThrowIfNull(expression);
+
+        var body = Unwrap(expression.Body);
+
+        return body is MemberExpression member
+            ? member.Member
+            : throw new ArgumentException(
+                $"'{expression}' is not a member access. A flat table mapping has to name a property or "
+                + "field of the event, such as x => x.Amount.", nameof(expression));
+    }
+
+    /// <summary>
+    ///     The chain of members a possibly-nested member-access lambda reads, outermost first, or
+    ///     <see langword="null" /> when the expression names none.
+    /// </summary>
+    public static MemberInfo[]? MemberPath(LambdaExpression? expression)
+    {
+        if (expression is null)
+        {
+            return null;
+        }
+
+        var body = Unwrap(expression.Body);
+        var members = new List<MemberInfo>();
+
+        while (body is MemberExpression member)
+        {
+            members.Insert(0, member.Member);
+            body = member.Expression!;
+        }
+
+        return members.Count > 0 ? members.ToArray() : null;
+    }
+
+    /// <summary>
+    ///     The default column name for a mapped member path: each member snake-cased and joined with
+    ///     <c>_</c>, so <c>MemberCount</c> becomes <c>member_count</c> and <c>Shipping.City</c>
+    ///     becomes <c>shipping_city</c>.
+    /// </summary>
+    public static string DefaultColumnName(IReadOnlyList<MemberInfo> members)
+    {
+        ArgumentNullException.ThrowIfNull(members);
+
+        if (members.Count == 1)
+        {
+            return SnakeCase(members[0].Name);
+        }
+
+        var builder = new StringBuilder();
+
+        for (var i = 0; i < members.Count; i++)
+        {
+            if (i > 0)
+            {
+                builder.Append('_');
+            }
+
+            builder.Append(SnakeCase(members[i].Name));
+        }
+
+        return builder.ToString();
+    }
+
+    /// <summary>
+    ///     <c>MemberCount</c> to <c>member_count</c>, <c>A</c> to <c>a</c>.
+    /// </summary>
+    public static string SnakeCase(string name)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+
+        var builder = new StringBuilder(name.Length + 4);
+
+        for (var i = 0; i < name.Length; i++)
+        {
+            if (i > 0 && char.IsUpper(name[i]))
+            {
+                builder.Append('_');
+            }
+
+            builder.Append(char.ToLowerInvariant(name[i]));
+        }
+
+        return builder.ToString();
+    }
+
+    private static Expression Unwrap(Expression body)
+        => body is UnaryExpression unary ? unary.Operand : body;
+}

--- a/src/Weasel.Storage/Flattened/FlatTableParameterSetters.cs
+++ b/src/Weasel.Storage/Flattened/FlatTableParameterSetters.cs
@@ -1,0 +1,152 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+using System.Reflection;
+using JasperFx.Events;
+
+namespace Weasel.Storage.Flattened;
+
+/// <summary>
+///     How a store converts a CLR value into what its database should actually hold.
+/// </summary>
+/// <remarks>
+///     Supplied by the store rather than assumed here, because the conversions are genuinely
+///     store-shaped: SQLite has to write a Guid as lowercase canonical text and a bool as 0/1, SQL
+///     Server has to unwrap a strong-typed id to its inner primitive, and PostgreSQL needs neither.
+///     The default is to hand the value over untouched.
+/// </remarks>
+public delegate object? FlatTableValueConversion(object? value);
+
+/// <summary>
+///     Pulls one parameter value out of an event for a flat-table statement.
+/// </summary>
+/// <remarks>
+///     Deliberately provider-neutral: it yields the value rather than setting it on a provider's
+///     parameter type, so the same setters serve a store that binds
+///     <see cref="System.Data.Common.DbParameter" /> objects and one that hands a dictionary to a
+///     command builder.
+/// </remarks>
+public interface IFlatTableParameterSetter
+{
+    /// <summary>The value this setter contributes for <paramref name="source" />.</summary>
+    object? ValueFor(IEvent source);
+}
+
+/// <summary>Reads a member off the event body through a compiled accessor.</summary>
+public sealed class EventMemberParameterSetter<TEvent>: IFlatTableParameterSetter
+{
+    private readonly Func<TEvent, object?> _accessor;
+    private readonly FlatTableValueConversion? _conversion;
+
+    public EventMemberParameterSetter(Func<TEvent, object?> accessor, FlatTableValueConversion? conversion = null)
+    {
+        _accessor = accessor ?? throw new ArgumentNullException(nameof(accessor));
+        _conversion = conversion;
+    }
+
+    /// <inheritdoc />
+    public object? ValueFor(IEvent source)
+    {
+        var value = _accessor((TEvent)source.Data);
+
+        return _conversion is null ? value : _conversion(value);
+    }
+}
+
+/// <summary>The stream's Guid identity, for a table keyed on the stream.</summary>
+public sealed class StreamIdParameterSetter: IFlatTableParameterSetter
+{
+    private readonly FlatTableValueConversion? _conversion;
+
+    public StreamIdParameterSetter(FlatTableValueConversion? conversion = null)
+    {
+        _conversion = conversion;
+    }
+
+    /// <inheritdoc />
+    public object? ValueFor(IEvent source)
+        => _conversion is null ? source.StreamId : _conversion(source.StreamId);
+}
+
+/// <summary>The stream's string identity, for a store configured <c>AsString</c>.</summary>
+public sealed class StreamKeyParameterSetter: IFlatTableParameterSetter
+{
+    private readonly FlatTableValueConversion? _conversion;
+
+    public StreamKeyParameterSetter(FlatTableValueConversion? conversion = null)
+    {
+        _conversion = conversion;
+    }
+
+    /// <inheritdoc />
+    public object? ValueFor(IEvent source)
+        => _conversion is null ? source.StreamKey : _conversion(source.StreamKey);
+}
+
+/// <summary>
+///     Factories for the setters a flat-table mapping needs.
+/// </summary>
+[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+    Justification =
+        "Class-level: compiles member-access lambdas over event types supplied at projection registration, "
+        + "which are preserved per the AOT publishing guide.")]
+public static class FlatTableParameterSetters
+{
+    /// <summary>
+    ///     A setter that walks <paramref name="members" /> from the event body.
+    /// </summary>
+    /// <remarks>
+    ///     The accessor is compiled to <c>Func&lt;TEvent, object?&gt;</c> rather than to the member's
+    ///     own type, so nothing here has to close a generic over a type only known at runtime. The
+    ///     value is boxed either way — <see cref="IFlatTableParameterSetter.ValueFor" /> yields
+    ///     <see cref="object" />.
+    /// </remarks>
+    public static IFlatTableParameterSetter ForMembers<TEvent>(IReadOnlyList<MemberInfo> members,
+        FlatTableValueConversion? conversion = null)
+    {
+        ArgumentNullException.ThrowIfNull(members);
+
+        if (members.Count == 0)
+        {
+            throw new ArgumentException("At least one member is required.", nameof(members));
+        }
+
+        var parameter = Expression.Parameter(typeof(TEvent), "x");
+        Expression body = parameter;
+
+        foreach (var member in members)
+        {
+            body = Expression.MakeMemberAccess(body, member);
+        }
+
+        if (body.Type != typeof(object))
+        {
+            body = Expression.Convert(body, typeof(object));
+        }
+
+        var accessor = Expression.Lambda<Func<TEvent, object?>>(body, parameter).Compile();
+
+        return new EventMemberParameterSetter<TEvent>(accessor, conversion);
+    }
+
+    /// <summary>
+    ///     A setter reading the member a mapping lambda names.
+    /// </summary>
+    public static IFlatTableParameterSetter ForMember<TEvent, TValue>(
+        Expression<Func<TEvent, TValue>> expression, FlatTableValueConversion? conversion = null)
+    {
+        ArgumentNullException.ThrowIfNull(expression);
+
+        var compiled = expression.Compile();
+
+        return new EventMemberParameterSetter<TEvent>(e => compiled(e), conversion);
+    }
+
+    /// <summary>
+    ///     The setter for a table keyed on the stream rather than on a member of the event.
+    /// </summary>
+    public static IFlatTableParameterSetter ForStream(StreamIdentity identity,
+        FlatTableValueConversion? conversion = null)
+        => identity == StreamIdentity.AsGuid
+            ? new StreamIdParameterSetter(conversion)
+            : new StreamKeyParameterSetter(conversion);
+}

--- a/src/Weasel.Storage/Flattened/FlatTableSqlDialectBase.cs
+++ b/src/Weasel.Storage/Flattened/FlatTableSqlDialectBase.cs
@@ -1,0 +1,134 @@
+using System.Globalization;
+using Weasel.Core;
+
+namespace Weasel.Storage.Flattened;
+
+/// <summary>
+///     Base class for a flat-table dialect, carrying the quoting, table-naming, parameter-naming and
+///     literal rules that are the same shape on every provider even where the tokens differ.
+/// </summary>
+/// <remarks>
+///     A dialect whose upsert is a single inline statement — a <c>MERGE</c> or an
+///     <c>INSERT … ON CONFLICT DO UPDATE</c> — should derive from
+///     <see cref="InlineFlatTableSqlDialect" /> instead, which additionally composes the clauses.
+///     This class is what is left for a dialect whose upsert is not one statement at all, such as one
+///     that generates an upsert function per event type and calls it.
+/// </remarks>
+public abstract class FlatTableSqlDialectBase: IFlatTableSqlDialect
+{
+    private readonly IDdlSyntaxStrategy? _syntax;
+
+    /// <param name="syntax">
+    ///     The provider's DDL syntax strategy, when it has one — its
+    ///     <see cref="IDdlSyntaxStrategy.QuoteIdentifier" /> then becomes this dialect's quoting rule,
+    ///     so the two cannot drift. Pass <see langword="null" /> and override
+    ///     <see cref="QuoteIdentifier" /> for a provider that does not ship one.
+    /// </param>
+    protected FlatTableSqlDialectBase(IDdlSyntaxStrategy? syntax = null)
+    {
+        _syntax = syntax;
+    }
+
+    /// <inheritdoc />
+    public virtual string QuoteIdentifier(string name)
+        => _syntax?.QuoteIdentifier(name)
+           ?? throw new InvalidOperationException(
+               $"{GetType().FullName} was constructed without an {nameof(IDdlSyntaxStrategy)}, so it has to "
+               + $"override {nameof(QuoteIdentifier)} itself.");
+
+    /// <inheritdoc />
+    /// <remarks>Schema-qualified and quoted; override for a provider without schemas.</remarks>
+    public virtual string TableReference(DbObjectName table)
+        => $"{QuoteIdentifier(table.Schema)}.{QuoteIdentifier(table.Name)}";
+
+    /// <inheritdoc />
+    public virtual string ParameterName(int index) => "@p" + index.ToString(CultureInfo.InvariantCulture);
+
+    /// <inheritdoc />
+    /// <remarks>
+    ///     Doubling the single quote is the rule on every provider Weasel supports. Override where a
+    ///     provider needs more — a backslash-escaping mode, say.
+    /// </remarks>
+    public virtual string StringLiteral(string value)
+        => string.Concat("'", value.Replace("'", "''"), "'");
+
+    /// <inheritdoc />
+    public abstract string ExistingRowReference(DbObjectName table, string columnName);
+
+    /// <inheritdoc />
+    public abstract FlatTableUpsert BuildUpsert(FlatTableUpsertRequest request);
+
+    /// <inheritdoc />
+    public virtual string BuildDelete(DbObjectName table, string primaryKeyColumn)
+        => $"delete from {TableReference(table)} where {QuoteIdentifier(primaryKeyColumn)} = {ParameterName(0)};";
+}
+
+/// <summary>
+///     Base class for a flat-table dialect whose upsert is a single inline statement.
+/// </summary>
+/// <remarks>
+///     The parameter numbering, the walk over the column maps and the insert / update clause
+///     composition are identical between a <c>MERGE</c> and an <c>INSERT … ON CONFLICT DO UPDATE</c>,
+///     so a concrete dialect is left with <see cref="FlatTableSqlDialectBase.ExistingRowReference" />
+///     and <see cref="WriteUpsert" /> — plus whatever quoting it does not get for free from an
+///     <see cref="IDdlSyntaxStrategy" />.
+/// </remarks>
+public abstract class InlineFlatTableSqlDialect: FlatTableSqlDialectBase
+{
+    protected InlineFlatTableSqlDialect(IDdlSyntaxStrategy? syntax = null): base(syntax)
+    {
+    }
+
+    /// <inheritdoc />
+    public override FlatTableUpsert BuildUpsert(FlatTableUpsertRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        // An event type mapped to no columns renders an update branch with nothing on the left of it,
+        // which is a syntax error rather than a no-op. Say so here, where the projection can still be
+        // named, instead of at the first event.
+        if (request.Columns.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"No columns are mapped for the flat table '{request.Identifier}'. A Project<T>(...) "
+                + "registration has to map at least one column.");
+        }
+
+        var context = new FlatTableColumnContext(this, request.Identifier);
+
+        var quotedKey = QuoteIdentifier(request.PrimaryKeyColumn);
+        var keyParameter = ParameterName(0);
+
+        var insertColumns = new List<string>(request.Columns.Count + 1) { quotedKey };
+        var insertValues = new List<string>(request.Columns.Count + 1) { keyParameter };
+        var updateAssignments = new List<string>(request.Columns.Count);
+
+        // Parameter 0 is the key; the maps that read from the event take 1..N in declaration order,
+        // which is the order the caller's parameter setters are built in.
+        var nextParameter = 1;
+
+        foreach (var map in request.Columns)
+        {
+            var parameterName = string.Empty;
+
+            if (map.RequiresInput)
+            {
+                parameterName = ParameterName(nextParameter++);
+            }
+
+            insertColumns.Add(QuoteIdentifier(map.ColumnName));
+            insertValues.Add(map.InsertExpression(context, parameterName));
+            updateAssignments.Add(map.UpdateExpression(context, parameterName));
+        }
+
+        var clauses = new FlatTableUpsertClauses(quotedKey, keyParameter, insertColumns, insertValues,
+            updateAssignments);
+
+        return WriteUpsert(request, clauses);
+    }
+
+    /// <summary>
+    ///     String the composed clauses together into this dialect's upsert statement.
+    /// </summary>
+    protected abstract FlatTableUpsert WriteUpsert(FlatTableUpsertRequest request, FlatTableUpsertClauses clauses);
+}

--- a/src/Weasel.Storage/Flattened/FlatTableStatementBuilder.cs
+++ b/src/Weasel.Storage/Flattened/FlatTableStatementBuilder.cs
@@ -1,0 +1,91 @@
+using Weasel.Core;
+
+namespace Weasel.Storage.Flattened;
+
+/// <summary>
+///     The dialect-neutral half of a flat-table projection: resolving the columns a set of mappings
+///     names, and handing them to a dialect to be rendered.
+/// </summary>
+/// <remarks>
+///     Everything here works against <see cref="ITable" /> rather than a provider's concrete
+///     <c>Table</c>, which is what lets one implementation serve every store. A store's own
+///     <c>StatementMap</c> keeps only what genuinely cannot be lifted: returning its provider's
+///     fluent <c>ColumnExpression</c>, building its parameter binding, and queueing its
+///     <c>IStorageOperation</c>.
+/// </remarks>
+public static class FlatTableStatementBuilder
+{
+    /// <summary>
+    ///     The single column a flat table's rows are keyed on.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    ///     The table declares no primary key, which is a configuration mistake worth naming at
+    ///     compile time rather than meeting as a duplicate-row bug later.
+    /// </exception>
+    public static string PrimaryKeyColumn(ITable table)
+    {
+        ArgumentNullException.ThrowIfNull(table);
+
+        var primaryKey = table.PrimaryKeyColumns.FirstOrDefault();
+
+        return primaryKey ?? throw new InvalidOperationException(
+            $"The flat table '{table.Identifier}' has no primary key column. Declare one in the "
+            + "projection's constructor with Table.AddColumn(...).AsPrimaryKey() before mapping events.");
+    }
+
+    /// <summary>
+    ///     Build the upsert for one event type's mappings.
+    /// </summary>
+    public static FlatTableUpsert Upsert(IFlatTableSqlDialect dialect, ITable table, Type eventType,
+        IReadOnlyList<IColumnMap> columns)
+    {
+        ArgumentNullException.ThrowIfNull(dialect);
+
+        return dialect.BuildUpsert(
+            new FlatTableUpsertRequest(table, eventType, PrimaryKeyColumn(table), columns));
+    }
+
+    /// <summary>
+    ///     Build the statement that removes a flat table's row, keyed on parameter 0.
+    /// </summary>
+    public static string Delete(IFlatTableSqlDialect dialect, ITable table)
+    {
+        ArgumentNullException.ThrowIfNull(dialect);
+
+        return dialect.BuildDelete(table.Identifier, PrimaryKeyColumn(table));
+    }
+
+    /// <summary>
+    ///     Find or add the column a mapping writes.
+    /// </summary>
+    /// <param name="table">The flat table being shaped.</param>
+    /// <param name="map">The mapping naming the column.</param>
+    /// <param name="columnTypeFor">
+    ///     An optional CLR-type-to-column-type rule. Supply one where a store has an opinion the
+    ///     provider's own type map does not carry — a strong-typed id stored as its inner primitive,
+    ///     for instance. Omit it to take the provider's mapping.
+    /// </param>
+    /// <remarks>
+    ///     Matched case-insensitively on every provider, including the ones that compare
+    ///     <em>values</em> case-sensitively: identifiers are the exception, so two mappings naming
+    ///     <c>Amount</c> and <c>amount</c> mean one column and adding both would emit DDL the database
+    ///     rejects as a duplicate (polecat#45).
+    /// </remarks>
+    public static ITableColumn ResolveColumn(ITable table, IColumnMap map, Func<Type, string>? columnTypeFor = null)
+    {
+        ArgumentNullException.ThrowIfNull(table);
+        ArgumentNullException.ThrowIfNull(map);
+
+        foreach (var column in table.Columns)
+        {
+            if (string.Equals(column.Name, map.ColumnName, StringComparison.OrdinalIgnoreCase))
+            {
+                return column;
+            }
+        }
+
+        return columnTypeFor is null
+            ? table.AddColumn(map.ColumnName, map.ColumnType)
+            : table.AddColumn(map.ColumnName, columnTypeFor(map.ColumnType));
+    }
+}

--- a/src/Weasel.Storage/Flattened/FlatTableUpsertRequest.cs
+++ b/src/Weasel.Storage/Flattened/FlatTableUpsertRequest.cs
@@ -1,0 +1,150 @@
+using Weasel.Core;
+
+namespace Weasel.Storage.Flattened;
+
+/// <summary>
+///     Everything a dialect needs to render the upsert for one event type's column mappings.
+/// </summary>
+/// <remarks>
+///     The whole <see cref="ITable" /> is carried rather than just its identifier because a
+///     function-emitting dialect has to declare an argument per input column, and an argument
+///     declaration needs the column's declared type.
+/// </remarks>
+public sealed class FlatTableUpsertRequest
+{
+    public FlatTableUpsertRequest(ITable table, Type eventType, string primaryKeyColumn,
+        IReadOnlyList<IColumnMap> columns)
+    {
+        Table = table ?? throw new ArgumentNullException(nameof(table));
+        EventType = eventType ?? throw new ArgumentNullException(nameof(eventType));
+        PrimaryKeyColumn = primaryKeyColumn ?? throw new ArgumentNullException(nameof(primaryKeyColumn));
+        Columns = columns ?? throw new ArgumentNullException(nameof(columns));
+    }
+
+    /// <summary>The flat table being written.</summary>
+    public ITable Table { get; }
+
+    /// <summary>
+    ///     The event type these mappings were declared for. Carried because a dialect that generates
+    ///     one upsert function per event type has to name it after something, and the table alone is
+    ///     shared by every event type the projection handles.
+    /// </summary>
+    public Type EventType { get; }
+
+    /// <summary>Shorthand for <c>Table.Identifier</c>.</summary>
+    public DbObjectName Identifier => Table.Identifier;
+
+    /// <summary>
+    ///     The single column the row is keyed on. A flat table's key is the stream (or an explicitly
+    ///     named member of the event), which is one value; composite keys are out of scope because
+    ///     the runtime binds exactly one key parameter.
+    /// </summary>
+    public string PrimaryKeyColumn { get; }
+
+    /// <summary>The column mappings declared for this event type, in declaration order.</summary>
+    public IReadOnlyList<IColumnMap> Columns { get; }
+
+    /// <summary>
+    ///     How many of the mappings read a value off the event, and therefore take a parameter.
+    /// </summary>
+    public int InputCount
+    {
+        get
+        {
+            var count = 0;
+            for (var i = 0; i < Columns.Count; i++)
+            {
+                if (Columns[i].RequiresInput)
+                {
+                    count++;
+                }
+            }
+
+            return count;
+        }
+    }
+}
+
+/// <summary>
+///     What a dialect produces for an upsert: the statement the runtime executes, plus any schema
+///     objects that statement depends on.
+/// </summary>
+/// <remarks>
+///     <see cref="SchemaObjects" /> is empty for an inline form (<c>MERGE</c>,
+///     <c>INSERT … ON CONFLICT</c>) and carries the generated function for a dialect that emits one.
+///     That is the whole of what makes the function shape expressible without every caller having to
+///     know which shape it is dealing with — the caller executes <see cref="Sql" /> and contributes
+///     <see cref="SchemaObjects" /> to its migration.
+/// </remarks>
+public sealed class FlatTableUpsert
+{
+    private static readonly ISchemaObject[] None = [];
+
+    public FlatTableUpsert(string sql, IReadOnlyList<ISchemaObject> schemaObjects)
+    {
+        Sql = sql ?? throw new ArgumentNullException(nameof(sql));
+        SchemaObjects = schemaObjects ?? throw new ArgumentNullException(nameof(schemaObjects));
+    }
+
+    /// <summary>The statement the projection executes per matching event.</summary>
+    public string Sql { get; }
+
+    /// <summary>Schema objects the statement depends on; empty for an inline upsert.</summary>
+    public IReadOnlyList<ISchemaObject> SchemaObjects { get; }
+
+    /// <summary>An inline upsert that depends on nothing but the table itself.</summary>
+    public static FlatTableUpsert Statement(string sql) => new(sql, None);
+
+    /// <summary>An upsert whose statement calls generated schema objects.</summary>
+    public static FlatTableUpsert CallingInto(string sql, params ISchemaObject[] schemaObjects) =>
+        new(sql, schemaObjects);
+}
+
+/// <summary>
+///     The rendered pieces of an inline upsert, composed once by
+///     <see cref="FlatTableSqlDialectBase" /> so that a <c>MERGE</c> dialect and an
+///     <c>ON CONFLICT</c> dialect differ only in how they are strung together.
+/// </summary>
+public sealed class FlatTableUpsertClauses
+{
+    public FlatTableUpsertClauses(
+        string quotedPrimaryKey,
+        string primaryKeyParameter,
+        IReadOnlyList<string> insertColumns,
+        IReadOnlyList<string> insertValues,
+        IReadOnlyList<string> updateAssignments)
+    {
+        QuotedPrimaryKey = quotedPrimaryKey;
+        PrimaryKeyParameter = primaryKeyParameter;
+        InsertColumns = insertColumns;
+        InsertValues = insertValues;
+        UpdateAssignments = updateAssignments;
+    }
+
+    /// <summary>The key column, quoted.</summary>
+    public string QuotedPrimaryKey { get; }
+
+    /// <summary>The placeholder the key value binds to — parameter 0.</summary>
+    public string PrimaryKeyParameter { get; }
+
+    /// <summary>The insert column list, key first, each quoted.</summary>
+    public IReadOnlyList<string> InsertColumns { get; }
+
+    /// <summary>The insert value expressions, aligned with <see cref="InsertColumns" />.</summary>
+    public IReadOnlyList<string> InsertValues { get; }
+
+    /// <summary>
+    ///     The update-branch assignments. The key is deliberately absent — it is what the row was
+    ///     matched on, so assigning it would be a no-op at best.
+    /// </summary>
+    public IReadOnlyList<string> UpdateAssignments { get; }
+
+    /// <summary>The insert column list as comma-separated SQL.</summary>
+    public string InsertColumnList => string.Join(", ", InsertColumns);
+
+    /// <summary>The insert value list as comma-separated SQL.</summary>
+    public string InsertValueList => string.Join(", ", InsertValues);
+
+    /// <summary>The update assignments as comma-separated SQL.</summary>
+    public string UpdateAssignmentList => string.Join(", ", UpdateAssignments);
+}

--- a/src/Weasel.Storage/Flattened/IColumnMap.cs
+++ b/src/Weasel.Storage/Flattened/IColumnMap.cs
@@ -1,0 +1,88 @@
+using Weasel.Core;
+
+namespace Weasel.Storage.Flattened;
+
+/// <summary>
+///     How one column of a flat table participates in the upsert for a single event type.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Both branches are described here, and they are deliberately not derived from each other:
+///         an <c>Increment</c> <em>inserts</em> a starting value but <em>updates</em> by adding to
+///         what is already there, and that asymmetry is the entire point of the model.
+///     </para>
+///     <para>
+///         Nothing here renders a dialect's SQL directly — every fragment goes through the
+///         <see cref="FlatTableColumnContext" /> it is handed, which is what lets one set of maps
+///         serve a <c>MERGE</c>, an <c>INSERT … ON CONFLICT</c> and a generated upsert function.
+///     </para>
+/// </remarks>
+public interface IColumnMap
+{
+    /// <summary>The column this mapping writes.</summary>
+    string ColumnName { get; }
+
+    /// <summary>
+    ///     The CLR type the column holds, used to declare the column when the table does not already
+    ///     have one by that name.
+    /// </summary>
+    Type ColumnType { get; }
+
+    /// <summary>
+    ///     True when the column's value comes from the event and therefore needs a bound parameter.
+    ///     False for <c>Increment(name)</c>, <c>Decrement(name)</c> and <c>SetValue</c>, which are
+    ///     entirely determined at configuration time.
+    /// </summary>
+    bool RequiresInput { get; }
+
+    /// <summary>
+    ///     The assignment for the update branch — the <c>SET</c> clause of a <c>MERGE</c>'s
+    ///     <c>WHEN MATCHED</c>, or of an <c>ON CONFLICT … DO UPDATE</c>.
+    /// </summary>
+    /// <param name="context">The dialect and table this fragment is being rendered against.</param>
+    /// <param name="parameterName">
+    ///     The placeholder bound to this column's value, or an empty string when
+    ///     <see cref="RequiresInput" /> is false.
+    /// </param>
+    string UpdateExpression(in FlatTableColumnContext context, string parameterName);
+
+    /// <summary>The value expression for the insert branch.</summary>
+    /// <param name="context">The dialect and table this fragment is being rendered against.</param>
+    /// <param name="parameterName">
+    ///     The placeholder bound to this column's value, or an empty string when
+    ///     <see cref="RequiresInput" /> is false.
+    /// </param>
+    string InsertExpression(in FlatTableColumnContext context, string parameterName);
+}
+
+/// <summary>
+///     What a column map is rendered against: the dialect, and the table whose row is being written.
+/// </summary>
+/// <remarks>
+///     The table travels with the dialect because the pre-update row reference needs it —
+///     PostgreSQL's <c>ON CONFLICT DO UPDATE</c> names the target row by the table's own name, where
+///     a <c>MERGE</c> names it by the alias the statement gave it.
+/// </remarks>
+public readonly struct FlatTableColumnContext
+{
+    public FlatTableColumnContext(IFlatTableSqlDialect dialect, DbObjectName table)
+    {
+        Dialect = dialect;
+        Table = table;
+    }
+
+    /// <summary>The dialect supplying the SQL fragments.</summary>
+    public IFlatTableSqlDialect Dialect { get; }
+
+    /// <summary>The table being written.</summary>
+    public DbObjectName Table { get; }
+
+    /// <summary>The column, quoted for an assignment target or an insert column list.</summary>
+    public string Quote(string columnName) => Dialect.QuoteIdentifier(columnName);
+
+    /// <summary>The column's value <em>before</em> this statement runs.</summary>
+    public string Existing(string columnName) => Dialect.ExistingRowReference(Table, columnName);
+
+    /// <summary>A configured string baked into the statement as a literal.</summary>
+    public string Literal(string value) => Dialect.StringLiteral(value);
+}

--- a/src/Weasel.Storage/Flattened/IFlatTableSqlDialect.cs
+++ b/src/Weasel.Storage/Flattened/IFlatTableSqlDialect.cs
@@ -1,0 +1,96 @@
+using Weasel.Core;
+
+namespace Weasel.Storage.Flattened;
+
+/// <summary>
+///     The dialect seam for flat-table projections — the three provider-specific decisions a
+///     flat-table upsert needs, and nothing else.
+/// </summary>
+/// <remarks>
+///     <para>
+///         The flat-table DSL (<c>Project&lt;T&gt;(map =&gt; map.Map(x =&gt; x.Prop))</c>,
+///         <c>Increment</c>, <c>Decrement</c>, <c>SetValue</c>, <c>Delete&lt;T&gt;()</c>) is the same
+///         mapping model on every store. What differs is only the SQL it renders to:
+///     </para>
+///     <list type="number">
+///         <item>
+///             <description>
+///                 <b>Identifier quoting</b> — <c>[c]</c> on SQL Server, <c>"c"</c> on SQLite and
+///                 PostgreSQL. See <see cref="QuoteIdentifier" />; a provider that ships an
+///                 <see cref="IDdlSyntaxStrategy" /> can simply hand it to
+///                 <see cref="FlatTableSqlDialectBase" /> rather than reimplementing the rule.
+///             </description>
+///         </item>
+///         <item>
+///             <description>
+///                 <b>The upsert form</b> — a <c>MERGE</c>, an <c>INSERT … ON CONFLICT DO UPDATE</c>,
+///                 or a generated upsert <em>function</em> the statement then calls. See
+///                 <see cref="BuildUpsert" />, whose result carries both the runtime SQL and any
+///                 schema objects the form needs created, so the function-based shape fits without
+///                 the caller knowing which shape it got.
+///             </description>
+///         </item>
+///         <item>
+///             <description>
+///                 <b>The "pre-update row" reference</b> — how the update branch names the value a
+///                 column held <em>before</em> this statement. <c>target.[c]</c> inside a
+///                 <c>MERGE</c>, a bare <c>"c"</c> inside SQLite's <c>DO UPDATE</c> (where
+///                 <c>excluded."c"</c> would be the would-be-inserted value instead), and
+///                 <c>tbl.c</c> inside PostgreSQL's. See <see cref="ExistingRowReference" />; this is
+///                 what makes <c>Increment</c> an increment rather than a self-assignment, so getting
+///                 it wrong is silent.
+///             </description>
+///         </item>
+///     </list>
+///     <para>
+///         This is deliberately <em>not</em> folded onto <see cref="IStorageDialect" />. That
+///         interface is about materializing provider <see cref="System.Data.Common.DbCommand" /> /
+///         <see cref="System.Data.Common.DbParameter" /> objects for the closed-shape document
+///         runtime; everything here is pure SQL-text composition with no ADO.NET types in sight, and
+///         a store may want one without the other. The precedent is
+///         <see cref="IEventStoreSqlDialect" />, which was given its own seam for the same reason.
+///     </para>
+/// </remarks>
+public interface IFlatTableSqlDialect
+{
+    /// <summary>
+    ///     Quote a column or table identifier per the provider's rules, escaping whatever character
+    ///     would otherwise terminate the quoting early.
+    /// </summary>
+    string QuoteIdentifier(string name);
+
+    /// <summary>
+    ///     How the table is named in a DML statement — schema-qualified and quoted where the provider
+    ///     has schemas, the bare quoted name where it does not (SQLite folds its logical schema into
+    ///     the table name instead).
+    /// </summary>
+    string TableReference(DbObjectName table);
+
+    /// <summary>
+    ///     The placeholder for the parameter at <paramref name="index" />. Index 0 is always the
+    ///     primary key; the column maps that read from the event take 1..N in declaration order.
+    /// </summary>
+    string ParameterName(int index);
+
+    /// <summary>
+    ///     <paramref name="value" /> as a complete, quoted SQL string literal with the provider's
+    ///     escaping applied. Used by <c>SetValue(column, "literal")</c>, which is fixed at
+    ///     configuration time and therefore baked into the statement rather than parameterized.
+    /// </summary>
+    string StringLiteral(string value);
+
+    /// <summary>
+    ///     How the update branch refers to <paramref name="columnName" />'s <em>pre-update</em> value.
+    /// </summary>
+    string ExistingRowReference(DbObjectName table, string columnName);
+
+    /// <summary>
+    ///     Build the upsert for one event type's column mappings.
+    /// </summary>
+    FlatTableUpsert BuildUpsert(FlatTableUpsertRequest request);
+
+    /// <summary>
+    ///     Build the statement that removes a flat table's row, keyed on parameter 0.
+    /// </summary>
+    string BuildDelete(DbObjectName table, string primaryKeyColumn);
+}


### PR DESCRIPTION
Closes #568. Stoat plan `internals-lifting-2026-09`, node `weasel-flat-table`.

The flat-table projection DSL is implemented three times with the same public shape. Polecat's and Fisher's `IColumnMap.cs` are the *same* interface with the *same* four implementations, differing only in the SQL produced; Marten's diverges further because it emits a per-event upsert *function* rather than an inline statement.

This is the Weasel side only — store adoption is a separate, gated step, and nothing in marten / polecat / fisher is touched here.

## The seam

New namespace `Weasel.Storage.Flattened`, with `IFlatTableSqlDialect` carrying exactly the three provider decisions:

| Seam | SQL Server | SQLite | PostgreSQL |
|---|---|---|---|
| identifier quoting | `[c]`, always | `"c"`, only when required | `"c"`, only when required |
| upsert form | `MERGE` | `INSERT … ON CONFLICT DO UPDATE` | generated `plpgsql` function + a call |
| pre-update row | `target.[c]` | unqualified `c` | `tbl.c` |

### Why not `IStorageDialect`

`IStorageDialect` is about materializing provider `DbCommand` / `DbParameter` objects for the closed-shape document runtime — every member on it names an ADO.NET type. Everything here is pure SQL-text composition with no ADO.NET in sight, and a store may want one without the other. `IEventStoreSqlDialect` is the precedent: it was given its own seam for the same reason, rather than being folded in.

### Why the upsert form needs a result type rather than a string

Marten's shape is the one that decides whether the abstraction is wide enough: its statement is `select fn(?, ?, ?)`, and the object it calls has to be created by the caller's migration. So `BuildUpsert` returns a `FlatTableUpsert` carrying **both** the runtime SQL and any `ISchemaObject`s that statement depends on — empty for the two inline forms. That is the whole of what makes the function shape expressible without every caller knowing which shape it got.

`InlineFlatTableSqlDialect` composes the clauses for the two inline forms (parameter numbering, the walk over the maps, the insert/update lists), leaving a `MERGE` dialect and an `ON CONFLICT` dialect ~15 lines each. A function-emitting dialect derives from the bare `FlatTableSqlDialectBase` and overrides `BuildUpsert`.

### Quoting reuses `IDdlSyntaxStrategy`

Rather than inventing a second quoting rule, `FlatTableSqlDialectBase` takes the provider's `IDdlSyntaxStrategy` and routes `QuoteIdentifier` through it, so the two cannot drift. SQLite and PostgreSQL ship one; SQL Server does not yet (#270 step 9), so that dialect overrides the one method. Adding `SqlServerDdlSyntax` was deliberately left out of scope here.

## What else came with it

Everything else that was duplicated verbatim and is not bound to a provider's concrete `Table`:

- the seven column maps (`MemberMap`, `IncrementMemberMap`, `DecrementMemberMap`, `IncrementMap`, `DecrementMap`, `SetStringValueMap`, `SetIntValueMap`)
- `FlatTableStatementBuilder` — primary-key resolution, case-insensitive find-or-add column resolution, and the upsert/delete entry points, working against `Weasel.Core`'s `ITable` so one implementation serves every provider
- `FlatTableMembers` — the member-path reflection and the snake-case column naming
- `FlatTableParameterSetters` — the event-member / stream-id / stream-key setters, provider-neutral (they yield the value rather than setting it on a provider parameter type), with the store's own value conversion supplied as a `FlatTableValueConversion` delegate

What stays store-side, and why: the concrete `Table` and its fluent `ColumnExpression`, the `IStorageOperation` the projection queues, the `EventGraph` that decides stream identity, and each store's own value conversions. A store's `StatementMap<TEvent>` becomes bookkeeping plus a dialect.

## Drift found between the three copies

Worth recording, because the lift had to choose:

1. **`Increment(column)`'s insert value.** Marten inserts `0`; Polecat and Fisher insert `1`. So the same DSL call counts a stream's first event on two stores and not on the third. Lifted code takes the two-store majority.
2. **`Decrement(member)`'s insert value.** Marten inserts `-value`; Polecat and Fisher insert `value` — i.e. a first sighting *increases* the column on two of the three. Lifted code again takes the majority, but this one looks more like Marten being right than the other two.
3. **String literal escaping.** Polecat (polecat#390) and Fisher double an embedded `'`; Marten's `SetStringValueMap` interpolates the raw value into `'{_value}'`. Lifted code escapes through the dialect, so Marten gains the fix on adoption.
4. **Integer literal formatting.** Fisher renders invariant; Polecat calls `_value.ToString()` under the ambient culture. Lifted code is invariant.
5. **Identifier escaping.** Polecat's `MemberMap` interpolates `[{ColumnName}]` directly, bypassing its own `SqlEscaping.QuoteIdentifier` that the `SetValue` maps use — so a `]` in a column name terminates the bracket. Lifted code has one quoting path.
6. **Nested column naming.** Marten joins the whole member path (`shipping_city`); Polecat and Fisher use the leaf only, so two mapped paths ending in the same member silently collide. `FlatTableMembers.DefaultColumnName` joins the path, which is identical for the single-member case those two support.
7. **An event type mapped to no columns** renders an update branch with nothing on its left — a syntax error at the first event, guarded by none of the three. Now refused at compile time, naming the table.

Items 1 and 2 are behaviour changes for Marten at adoption and are pinned by a test that says so, rather than left to be discovered.

## Tests

`Weasel.Storage` has no test project of its own, so these live in `Weasel.Core.Tests/Flattened/`, which already references every provider assembly for the identifier conformance suite. Pure string logic — no database, no containers.

- `flat_table_column_map_rendering` — every map's update and insert fragment, per dialect shape. This is the half that fails silently: an `Increment` whose update assignment reads the would-be-inserted value instead of the pre-update row is a self-assignment — valid SQL, no error, and a counter that never moves past its first event.
- `flat_table_statement_composition` — the whole statement per form, including that the function form returns its function alongside the call; that a map taking no parameter does not consume a number (otherwise every column after it binds the wrong value); the case-insensitive column resolution; and the two refusals.
- `flat_table_member_mapping` — default column naming and the parameter setters, including that the store-supplied conversion is applied.
- `ReferenceFlatTableDialects` — the three reference dialects, reproducing the SQL each store emits today.

## Validation

- `dotnet build Weasel.slnx` — 0 errors.
- `Weasel.Core.Tests` — 448 passed, 0 failed, on net9.0 and net10.0.
- `Weasel.Sqlite.Tests` — 582 passed, **1 failed**, on both TFMs: `TypeMappingIntegrationTests.all_types_together`. Pre-existing and unrelated — it reproduces identically on unmodified `master`, and is a UTC/local day-boundary assertion (`DateTime.Parse` of an `"o"`-formatted UTC value compared against the local day) that fails whenever the machine's local date is behind UTC's.

GitHub Actions is stalled org-wide, so CI is not a gate on this one; the above is local validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)