### PR TITLE
Lift a dialect-neutral EventLoaderBase into Weasel.Storage

### DIFF
--- a/src/Weasel.Core.Tests/event_loader_base.cs
+++ b/src/Weasel.Core.Tests/event_loader_base.cs
@@ -1,0 +1,677 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Microsoft.Data.Sqlite;
+using Shouldly;
+using Weasel.Storage;
+using Xunit;
+
+namespace Weasel.Core.Tests;
+
+/// <summary>
+/// The lifted <see cref="EventLoaderBase"/> (weasel#566), exercised over a real SQLite events table
+/// so the paging, the SQL-level event-type filter and the ceiling arithmetic are checked against a
+/// database rather than against a mock that agrees with them.
+/// </summary>
+/// <remarks>
+/// SQLite is used because it needs no server, not because the base is SQLite-specific — the base
+/// only ever touches <see cref="DbConnection"/> and <see cref="DbDataReader"/>, and the dialect
+/// here renders the SQL the way a store's would.
+/// </remarks>
+public class event_loader_base: IDisposable
+{
+    private readonly string _path = Path.Combine(Path.GetTempPath(), $"weasel_loader_{Guid.NewGuid():n}.db");
+    private readonly string _connectionString;
+
+    public event_loader_base()
+    {
+        _connectionString = $"Data Source={_path}";
+
+        using var conn = new SqliteConnection(_connectionString);
+        conn.Open();
+
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            create table events (
+                seq_id integer primary key,
+                type text not null,
+                is_archived integer not null default 0,
+                tenant_id text not null default '*DEFAULT*'
+            );
+            """;
+        cmd.ExecuteNonQuery();
+    }
+
+    public void Dispose()
+    {
+        SqliteConnection.ClearPool(new SqliteConnection(_connectionString));
+        if (File.Exists(_path)) File.Delete(_path);
+        GC.SuppressFinalize(this);
+    }
+
+    private void Append(params (long Sequence, string Type)[] rows) =>
+        Append(rows.Select(x => (x.Sequence, x.Type, false, "*DEFAULT*")).ToArray());
+
+    private void Append(params (long Sequence, string Type, bool Archived, string TenantId)[] rows)
+    {
+        using var conn = new SqliteConnection(_connectionString);
+        conn.Open();
+
+        foreach (var row in rows)
+        {
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText =
+                "insert into events (seq_id, type, is_archived, tenant_id) values (@s, @t, @a, @tenant)";
+            cmd.Parameters.AddWithValue("@s", row.Sequence);
+            cmd.Parameters.AddWithValue("@t", row.Type);
+            cmd.Parameters.AddWithValue("@a", row.Archived ? 1 : 0);
+            cmd.Parameters.AddWithValue("@tenant", row.TenantId);
+            cmd.ExecuteNonQuery();
+        }
+    }
+
+    private static EventRequest RequestFor(long floor, long highWater, int batchSize = 10,
+        bool skipUnknown = false, bool skipSerialization = false) => new()
+    {
+        Floor = floor,
+        HighWater = highWater,
+        BatchSize = batchSize,
+        ErrorOptions = new ErrorHandlingOptions
+        {
+            SkipUnknownEvents = skipUnknown, SkipSerializationErrors = skipSerialization
+        }
+    };
+
+    private TestLoader LoaderFor(EventLoaderOptions? options = null) =>
+        new(_connectionString, options);
+
+    // ----------------------------------------------------------------------------------------
+    // The ordinary page read
+    // ----------------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task reads_the_range_in_sequence_order()
+    {
+        Append((1, "a"), (2, "b"), (3, "c"), (4, "d"));
+
+        var page = await LoaderFor().LoadAsync(RequestFor(0, 10), CancellationToken.None);
+
+        page.Select(x => x.Sequence).ShouldBe([1, 2, 3, 4]);
+    }
+
+    [Fact]
+    public async Task the_floor_is_exclusive_and_the_ceiling_is_inclusive()
+    {
+        Append((1, "a"), (2, "b"), (3, "c"), (4, "d"));
+
+        var page = await LoaderFor().LoadAsync(RequestFor(1, 3), CancellationToken.None);
+
+        // Not 1 (the floor is where the shard already got to), and 3 is included.
+        page.Select(x => x.Sequence).ShouldBe([2, 3]);
+    }
+
+    [Fact]
+    public async Task archived_events_are_excluded_unless_asked_for()
+    {
+        Append((1, "a", false, "*DEFAULT*"), (2, "b", true, "*DEFAULT*"), (3, "c", false, "*DEFAULT*"));
+
+        var excluded = await LoaderFor().LoadAsync(RequestFor(0, 10), CancellationToken.None);
+        excluded.Select(x => x.Sequence).ShouldBe([1, 3]);
+
+        var included = await LoaderFor(new EventLoaderOptions { IncludeArchivedEvents = true })
+            .LoadAsync(RequestFor(0, 10), CancellationToken.None);
+        included.Select(x => x.Sequence).ShouldBe([1, 2, 3]);
+    }
+
+    [Fact]
+    public async Task a_tenant_scoped_loader_reads_only_that_tenant()
+    {
+        Append((1, "a", false, "blue"), (2, "a", false, "green"), (3, "a", false, "blue"));
+
+        var page = await LoaderFor(new EventLoaderOptions { TenantId = "blue" })
+            .LoadAsync(RequestFor(0, 10), CancellationToken.None);
+
+        page.Select(x => x.Sequence).ShouldBe([1, 3]);
+    }
+
+    // ----------------------------------------------------------------------------------------
+    // The event-type filter has to be SQL. See EventTypeAllowList.
+    // ----------------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task the_event_type_filter_is_applied_in_sql_not_after_hydration()
+    {
+        Append((1, "wanted"), (2, "unwanted"), (3, "wanted"), (4, "unwanted"));
+
+        var loader = LoaderFor(new EventLoaderOptions { EventTypes = AllowList("wanted") });
+
+        var page = await loader.LoadAsync(RequestFor(0, 10), CancellationToken.None);
+
+        page.Select(x => x.Sequence).ShouldBe([1, 3]);
+
+        // The discriminating assertion: the loader never hydrated a filtered row. A client-side
+        // filter would produce the same page having read and discarded both "unwanted" rows, which
+        // is exactly the regression polecat and fisher#153 exist to prevent.
+        loader.HydratedTypes.ShouldBe(["wanted", "wanted"]);
+    }
+
+    [Fact]
+    public async Task an_empty_allow_list_means_every_event_type()
+    {
+        Append((1, "a"), (2, "b"));
+
+        EventTypeAllowList.All.IsEmpty.ShouldBeTrue();
+
+        var page = await LoaderFor(new EventLoaderOptions { EventTypes = EventTypeAllowList.All })
+            .LoadAsync(RequestFor(0, 10), CancellationToken.None);
+
+        page.Count.ShouldBe(2);
+    }
+
+    // ----------------------------------------------------------------------------------------
+    // Skip accounting and the ceiling
+    // ----------------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task a_page_that_does_not_fill_the_batch_claims_the_high_water_mark()
+    {
+        Append((1, "a"), (2, "b"));
+
+        var page = await LoaderFor().LoadAsync(RequestFor(0, 500, batchSize: 10), CancellationToken.None);
+
+        page.Ceiling.ShouldBe(500);
+    }
+
+    [Fact]
+    public async Task a_full_page_claims_only_the_last_event_it_read()
+    {
+        Append((1, "a"), (2, "b"), (3, "c"), (4, "d"), (5, "e"));
+
+        var page = await LoaderFor().LoadAsync(RequestFor(0, 500, batchSize: 3), CancellationToken.None);
+
+        page.Count.ShouldBe(3);
+        page.Ceiling.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task a_skipped_event_still_counts_toward_the_batch()
+    {
+        // Three rows, batch size three, one of which is skipped: the batch was saturated even
+        // though only two events survived, so the ceiling must not claim the high-water mark.
+        Append((1, "a"), (2, TestLoader.UnknownType), (3, "c"), (4, "d"));
+
+        var page = await LoaderFor()
+            .LoadAsync(RequestFor(0, 500, batchSize: 3, skipUnknown: true), CancellationToken.None);
+
+        page.Count.ShouldBe(2);
+        page.Ceiling.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task an_unknown_event_type_throws_when_the_shard_does_not_skip_them()
+    {
+        Append((1, "a"), (2, TestLoader.UnknownType));
+
+        var ex = await Should.ThrowAsync<TestUnknownEventTypeException>(
+            () => LoaderFor().LoadAsync(RequestFor(0, 10), CancellationToken.None));
+
+        ex.Sequence.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task a_null_event_is_treated_as_an_unresolved_type()
+    {
+        // Fisher's row reader returns null rather than throwing; both spellings have to reach the
+        // same SkipUnknownEvents decision.
+        Append((1, "a"), (2, TestLoader.UnresolvableType), (3, "c"));
+
+        var skipped = await LoaderFor()
+            .LoadAsync(RequestFor(0, 10, skipUnknown: true), CancellationToken.None);
+        skipped.Select(x => x.Sequence).ShouldBe([1, 3]);
+
+        await Should.ThrowAsync<TestUnknownEventTypeException>(
+            () => LoaderFor().LoadAsync(RequestFor(0, 10), CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task a_serialization_failure_is_governed_by_its_own_option()
+    {
+        Append((1, "a"), (2, TestLoader.PoisonType), (3, "c"));
+
+        // SkipUnknownEvents does not cover it — the categories are deliberately separate, because
+        // the operator response differs.
+        await Should.ThrowAsync<TestDeserializationException>(
+            () => LoaderFor().LoadAsync(RequestFor(0, 10, skipUnknown: true), CancellationToken.None));
+
+        var page = await LoaderFor()
+            .LoadAsync(RequestFor(0, 10, skipSerialization: true), CancellationToken.None);
+        page.Select(x => x.Sequence).ShouldBe([1, 3]);
+    }
+
+    [Fact]
+    public async Task a_skipped_event_is_reported_to_the_store()
+    {
+        Append((1, "a"), (2, TestLoader.PoisonType));
+
+        var loader = LoaderFor();
+        await loader.LoadAsync(RequestFor(0, 10, skipSerialization: true), CancellationToken.None);
+
+        loader.Skipped.Count.ShouldBe(1);
+        loader.Skipped.Single().ShouldBeOfType<TestDeserializationException>();
+    }
+
+    [Fact]
+    public async Task classification_walks_the_inner_exception_chain()
+    {
+        // A store's exception transformer may have wrapped the exception that knows its category.
+        // Inspecting only the outermost one is how marten#4720's timeout detection missed every
+        // wrapped case for as long as it did.
+        var wrapped = new InvalidOperationException("wrapped by the store",
+            new TestDeserializationException(7));
+
+        EventLoaderBase.Classify(wrapped).ShouldBe(ShardFailureCategory.EventSerialization);
+        EventLoaderBase.Classify(new InvalidOperationException("nothing to see")).ShouldBeNull();
+        EventLoaderBase.Classify(null).ShouldBeNull();
+    }
+
+    // ----------------------------------------------------------------------------------------
+    // Skip-ahead
+    // ----------------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task the_probe_finds_the_first_matching_sequence_above_the_floor()
+    {
+        Append((1, "wanted"), (2, "unwanted"), (3, "unwanted"), (4, "wanted"));
+
+        var loader = LoaderFor(new EventLoaderOptions { EventTypes = AllowList("wanted") });
+
+        (await loader.ProbeAsync(0, 10)).ShouldBe(1);
+        (await loader.ProbeAsync(1, 10)).ShouldBe(4);
+        (await loader.ProbeAsync(4, 10)).ShouldBeNull();
+
+        // Bounded above as well as below: the probe must not report a match outside the range it
+        // was asked about.
+        (await loader.ProbeAsync(1, 3)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task skip_ahead_jumps_the_floor_to_the_first_match()
+    {
+        Append((1, "unwanted"), (2, "unwanted"), (3, "unwanted"), (4, "wanted"), (5, "wanted"));
+
+        var loader = LoaderFor(new EventLoaderOptions { EventTypes = AllowList("wanted") });
+
+        var page = await loader.SkipAheadAsync(RequestFor(0, 500));
+
+        page.Select(x => x.Sequence).ShouldBe([4, 5]);
+
+        // The page's floor moves with the query's, because the probe PROVED there is no matching
+        // event between the request's floor and the match.
+        page.Floor.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task skip_ahead_over_a_range_with_no_match_returns_an_empty_page_at_the_high_water_mark()
+    {
+        Append((1, "unwanted"), (2, "unwanted"));
+
+        var loader = LoaderFor(new EventLoaderOptions { EventTypes = AllowList("wanted") });
+
+        var page = await loader.SkipAheadAsync(RequestFor(0, 500));
+
+        page.ShouldBeEmpty();
+        page.Ceiling.ShouldBe(500);
+    }
+
+    // ----------------------------------------------------------------------------------------
+    // Window-step. The ceiling is the whole point — marten#5239.
+    // ----------------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task window_step_reports_the_window_it_scanned_not_the_high_water_mark()
+    {
+        Append((5, "a"));
+
+        var page = await LoaderFor().WindowAsync(RequestFor(0, 10_000, batchSize: 100), windowSize: 100);
+
+        page.Select(x => x.Sequence).ShouldBe([5]);
+
+        // 100, not 10_000. The query was bounded by the window, so that is the most this page can
+        // honestly claim to have scanned; claiming the high-water mark would write durable progress
+        // past every matching event between 100 and 10_000 and skip them permanently.
+        page.Ceiling.ShouldBe(100);
+
+        // And the page keeps the request's floor, unlike skip-ahead: this walk proved nothing about
+        // the range below, it simply read it in slices.
+        page.Floor.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task window_step_walks_over_empty_windows_until_it_finds_rows()
+    {
+        Append((450, "a"), (451, "b"));
+
+        var loader = LoaderFor();
+        var page = await loader.WindowAsync(RequestFor(0, 10_000, batchSize: 100), windowSize: 100);
+
+        page.Select(x => x.Sequence).ShouldBe([450, 451]);
+        page.Ceiling.ShouldBe(500);
+
+        // Five windows: (0,100], (100,200], (200,300], (300,400], (400,500].
+        loader.PageQueries.Count.ShouldBe(5);
+    }
+
+    [Fact]
+    public async Task window_step_returns_on_any_row_read_even_when_every_row_was_skipped()
+    {
+        // A window whose rows were all skipped may still have had matching events truncated by the
+        // batch limit further up the same window, so advancing past it would drop them.
+        Append((50, TestLoader.UnknownType), (150, "a"));
+
+        var page = await LoaderFor().WindowAsync(
+            RequestFor(0, 10_000, batchSize: 100, skipUnknown: true), windowSize: 100);
+
+        page.ShouldBeEmpty();
+        page.Ceiling.ShouldBe(100);
+    }
+
+    [Fact]
+    public async Task an_exhausted_window_walk_claims_the_high_water_mark()
+    {
+        // Nothing anywhere in range: the walk really did scan every window, so claiming the
+        // high-water mark here — as the loop must not — is honest.
+        var page = await LoaderFor().WindowAsync(RequestFor(0, 500, batchSize: 100), windowSize: 100);
+
+        page.ShouldBeEmpty();
+        page.Ceiling.ShouldBe(500);
+    }
+
+    // ----------------------------------------------------------------------------------------
+    // Strategy layering. The reason the base is primitives rather than one algorithm.
+    // ----------------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task a_store_can_layer_a_strategy_progression_over_the_primitives()
+    {
+        Append((1, "unwanted"), (2, "unwanted"), (3, "unwanted"), (4, "wanted"));
+
+        var loader = new AdaptiveTestLoader(_connectionString,
+            new EventLoaderOptions { EventTypes = AllowList("wanted") });
+
+        // Normal: fails, escalates to skip-ahead.
+        var page = await loader.LoadAsync(RequestFor(0, 500), CancellationToken.None);
+
+        loader.Strategies.ShouldBe(["Normal", "SkipAhead"]);
+        page.Select(x => x.Sequence).ShouldBe([4]);
+    }
+
+    // ----------------------------------------------------------------------------------------
+    // Cancellation
+    // ----------------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task a_provider_error_under_cancellation_is_reported_as_cancellation()
+    {
+        // The daemon cancels a load mid-flight as a matter of course, and a provider does not
+        // necessarily surface that as a clean OperationCanceledException. Reporting the raw
+        // provider exception makes the daemon's recorder treat a routine shutdown as a shard error.
+        Append((1, "a"));
+
+        using var source = new CancellationTokenSource();
+        var loader = new ThrowingLoader(_connectionString, source);
+
+        await Should.ThrowAsync<OperationCanceledException>(
+            () => loader.LoadAsync(RequestFor(0, 10), source.Token));
+    }
+
+    [Fact]
+    public async Task an_error_with_no_cancellation_is_left_alone()
+    {
+        Append((1, "a"));
+
+        var loader = new ThrowingLoader(_connectionString, cancelFirst: null);
+
+        await Should.ThrowAsync<InvalidOperationException>(
+            () => loader.LoadAsync(RequestFor(0, 10), CancellationToken.None));
+    }
+
+    // ----------------------------------------------------------------------------------------
+
+    private static EventTypeAllowList AllowList(params string[] aliases)
+    {
+        var registry = new StubRegistry(aliases);
+        return EventTypeAllowList.For(registry, aliases.Select((_, i) => StubRegistry.TypeAt(i)).ToList());
+    }
+
+    #region test doubles
+
+    private sealed record TestEvent(string Type);
+
+    /// <summary>Maps a handful of marker CLR types onto caller-chosen aliases.</summary>
+    private sealed class StubRegistry: EventRegistry
+    {
+        private static readonly Type[] _types =
+            [typeof(Marker0), typeof(Marker1), typeof(Marker2), typeof(Marker3)];
+
+        private readonly string[] _aliases;
+
+        public StubRegistry(string[] aliases) => _aliases = aliases;
+
+        public static Type TypeAt(int index) => _types[index];
+
+        public override IEventType EventMappingFor(Type eventType)
+        {
+            var index = Array.IndexOf(_types, eventType);
+            return new EventTypeData<object>
+            {
+                EventTypeName = _aliases[index], DotNetTypeName = $"dotnet::{_aliases[index]}"
+            };
+        }
+
+        private sealed record Marker0;
+        private sealed record Marker1;
+        private sealed record Marker2;
+        private sealed record Marker3;
+    }
+
+    /// <summary>Renders SQLite SQL for the base's two commands.</summary>
+    private sealed class SqliteTestDialect: IEventPagingDialect
+    {
+        public List<EventPageQuery> Queries { get; } = [];
+
+        public EventPageCommand BuildPageCommand(EventPageQuery query)
+        {
+            Queries.Add(query);
+            var (where, parameters) = Filters(query);
+
+            return new EventPageCommand(
+                $"select seq_id, type from events where {where} order by seq_id limit @batch",
+                [.. parameters, new EventPageParameter("@batch", query.BatchSize, DbType.Int32)]);
+        }
+
+        public EventPageCommand BuildNextMatchingSequenceCommand(EventPageQuery query)
+        {
+            var (where, parameters) = Filters(query);
+
+            // order by / limit 1, never min() -- see IEventPagingDialect.
+            return new EventPageCommand(
+                $"select seq_id from events where {where} order by seq_id limit 1", parameters);
+        }
+
+        private static (string Where, List<EventPageParameter> Parameters) Filters(EventPageQuery query)
+        {
+            var clauses = new List<string> { "seq_id > @floor", "seq_id <= @ceiling" };
+            var parameters = new List<EventPageParameter>
+            {
+                new("@floor", query.Floor, DbType.Int64), new("@ceiling", query.Ceiling, DbType.Int64)
+            };
+
+            if (!query.IncludeArchivedEvents)
+            {
+                clauses.Add("is_archived = 0");
+            }
+
+            if (query.TenantId is not null)
+            {
+                clauses.Add("tenant_id = @tenant");
+                parameters.Add(new EventPageParameter("@tenant", query.TenantId));
+            }
+
+            if (!query.EventTypes.IsEmpty)
+            {
+                // In SQL, never after hydration.
+                var names = query.EventTypes.Aliases
+                    .Select((_, i) => $"@type{i}")
+                    .ToArray();
+                clauses.Add($"type in ({string.Join(", ", names)})");
+                parameters.AddRange(query.EventTypes.Aliases
+                    .Select((alias, i) => new EventPageParameter($"@type{i}", alias)));
+            }
+
+            return (string.Join(" and ", clauses), parameters);
+        }
+    }
+
+    private class TestLoader: EventLoaderBase
+    {
+        public const string UnknownType = "!unknown";
+        public const string UnresolvableType = "!unresolvable";
+        public const string PoisonType = "!poison";
+
+        private readonly string _connectionString;
+        private readonly SqliteTestDialect _dialect;
+
+        public TestLoader(string connectionString, EventLoaderOptions? options)
+            : this(connectionString, new SqliteTestDialect(), options)
+        {
+        }
+
+        private TestLoader(string connectionString, SqliteTestDialect dialect, EventLoaderOptions? options)
+            : base(dialect, options)
+        {
+            _connectionString = connectionString;
+            _dialect = dialect;
+        }
+
+        public List<string> HydratedTypes { get; } = [];
+        public List<Exception> Skipped { get; } = [];
+        public IReadOnlyList<EventPageQuery> PageQueries => _dialect.Queries;
+
+        public Task<long?> ProbeAsync(long floor, long ceiling) =>
+            ProbeNextMatchingSequenceAsync(floor, ceiling, 10, CancellationToken.None);
+
+        public Task<EventPage> SkipAheadAsync(EventRequest request) =>
+            LoadWithSkipAheadAsync(request, CancellationToken.None);
+
+        public Task<EventPage> WindowAsync(EventRequest request, long windowSize) =>
+            LoadByWindowAsync(request, windowSize, CancellationToken.None);
+
+        protected override async ValueTask<DbConnection> OpenConnectionAsync(CancellationToken token)
+        {
+            var conn = new SqliteConnection(_connectionString);
+            await conn.OpenAsync(token);
+            return conn;
+        }
+
+        protected override ValueTask<IEvent?> ReadEventAsync(DbDataReader reader, CancellationToken token)
+        {
+            var sequence = reader.GetInt64(0);
+            var type = reader.GetString(1);
+
+            HydratedTypes.Add(type);
+
+            return type switch
+            {
+                UnknownType => throw new TestUnknownEventTypeException(sequence),
+                PoisonType => throw new TestDeserializationException(sequence),
+                UnresolvableType => ValueTask.FromResult<IEvent?>(null),
+                _ => ValueTask.FromResult<IEvent?>(
+                    new Event<TestEvent>(new TestEvent(type)) { Sequence = sequence, EventTypeName = type })
+            };
+        }
+
+        protected override Exception UnresolvedEventTypeException(DbDataReader reader, long sequence) =>
+            new TestUnknownEventTypeException(sequence);
+
+        protected override ValueTask RecordSkippedEventAsync(
+            Exception ex, EventRequest request, CancellationToken token)
+        {
+            Skipped.Add(ex);
+            return default;
+        }
+    }
+
+    /// <summary>
+    /// A store layering an escalation strategy over the base's primitives — the shape Marten's
+    /// loader has and the other two do not. Nothing about paging, skip accounting or the ceiling is
+    /// reimplemented here.
+    /// </summary>
+    private sealed class AdaptiveTestLoader(string connectionString, EventLoaderOptions options)
+        : TestLoader(connectionString, options)
+    {
+        public List<string> Strategies { get; } = [];
+
+        public override async Task<EventPage> LoadAsync(EventRequest request, CancellationToken token)
+        {
+            Strategies.Add("Normal");
+
+            try
+            {
+                throw new TimeoutException("statement timeout");
+            }
+            catch (TimeoutException)
+            {
+                Strategies.Add("SkipAhead");
+                return await LoadWithSkipAheadAsync(request, token);
+            }
+        }
+    }
+
+    private sealed class ThrowingLoader(string connectionString, CancellationTokenSource? cancelFirst)
+        : TestLoader(connectionString, null)
+    {
+        protected override ValueTask<IEvent?> ReadEventAsync(DbDataReader reader, CancellationToken token)
+        {
+            // Stand in for a provider that reports a cancelled command as its own exception type
+            // rather than as an OperationCanceledException.
+            cancelFirst?.Cancel();
+            throw new InvalidOperationException("Operation cancelled by user.");
+        }
+    }
+
+    private sealed class TestUnknownEventTypeException(long sequence)
+        : Exception($"Unknown event type at {sequence}"), IEventFailureContext
+    {
+        public ShardFailureCategory Category => ShardFailureCategory.UnknownEventType;
+        public long Sequence { get; } = sequence;
+        public string? EventTypeName => null;
+        public Guid? EventId => null;
+        public Guid? StreamId => null;
+        public string? StreamKey => null;
+        public string? TenantId => null;
+        public long? Version => null;
+    }
+
+    private sealed class TestDeserializationException(long sequence)
+        : Exception($"Could not deserialize the event at {sequence}"), IEventFailureContext
+    {
+        public ShardFailureCategory Category => ShardFailureCategory.EventSerialization;
+        public long Sequence { get; } = sequence;
+        public string? EventTypeName => null;
+        public Guid? EventId => null;
+        public Guid? StreamId => null;
+        public string? StreamKey => null;
+        public string? TenantId => null;
+        public long? Version => null;
+    }
+
+    #endregion
+}

--- a/src/Weasel.Storage/Events/Daemon/EventLoaderBase.cs
+++ b/src/Weasel.Storage/Events/Daemon/EventLoaderBase.cs
@@ -1,0 +1,467 @@
+#nullable enable
+using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// The dialect-neutral inner event loader for the async daemon. Pages an events table by sequence,
+/// hydrates each row, honours the shard's skip policy and reports an honest ceiling — the shape
+/// Marten, Polecat and Fisher each carried a copy of (weasel#566).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>This is the bare inner loader.</b> Retry and load metrics are layered on by JasperFx's
+/// <c>ResilientEventLoader</c> decorator when a store builds its loader, so nothing here handles
+/// either.
+/// </para>
+/// <para>
+/// <b>The base is a set of primitives, not a single algorithm.</b> Marten's loader escalates
+/// through three strategies when the ordinary query times out — normal, then skip-ahead, then
+/// window-step — and Polecat and Fisher have nothing of the kind. A base that only offered "load
+/// one page" would have left Marten unable to adopt it, which is the store the duplication costs
+/// the most. So <see cref="LoadAsync"/> is virtual and does the simple thing, and the pieces the
+/// progression is built from are protected and composable:
+/// </para>
+/// <list type="bullet">
+/// <item><see cref="LoadRangeAsync(EventRequest,long,long,CancellationToken)"/> — one bounded page.</item>
+/// <item><see cref="ProbeNextMatchingSequenceAsync"/> — the skip-ahead probe.</item>
+/// <item><see cref="LoadByWindowAsync"/> — the window-step walk, written over the other two.</item>
+/// </list>
+/// <para>
+/// A store adds escalation by overriding <see cref="LoadAsync"/> and choosing between them; it
+/// never has to reimplement paging, skip accounting or the ceiling calculation underneath.
+/// </para>
+/// <para>
+/// <b>The event-type filter is SQL.</b> See <see cref="EventTypeAllowList"/>: the allow list is
+/// handed to the dialect and rendered into the WHERE clause. This class never filters a hydrated
+/// event, because doing so would quietly undo the work polecat and fisher#153 did.
+/// </para>
+/// </remarks>
+public abstract class EventLoaderBase: IEventLoader
+{
+    /// <summary>
+    /// The window a <see cref="LoadByWindowAsync"/> walk advances by when the caller does not name
+    /// one. Marten's value, and the reasoning is the same: small enough that a window cannot time
+    /// out on a store where the ordinary query already did.
+    /// </summary>
+    public const long DefaultWindowSize = 10_000;
+
+    /// <param name="dialect">Renders this store's page and probe SQL.</param>
+    /// <param name="options">The shard's scope — tenant, event types, archived events.</param>
+    protected EventLoaderBase(IEventPagingDialect dialect, EventLoaderOptions? options = null)
+    {
+        Dialect = dialect ?? throw new ArgumentNullException(nameof(dialect));
+        Options = options ?? new EventLoaderOptions();
+    }
+
+    /// <summary>The SQL seam.</summary>
+    public IEventPagingDialect Dialect { get; }
+
+    /// <summary>What this shard is scoped to read.</summary>
+    public EventLoaderOptions Options { get; }
+
+    /// <summary>
+    /// Load one page for the request. The default implementation reads the whole
+    /// <c>(Floor, HighWater]</c> range in one query; override to layer a strategy progression over
+    /// the primitives below.
+    /// </summary>
+    public virtual async Task<EventPage> LoadAsync(EventRequest request, CancellationToken token)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        try
+        {
+            return await LoadRangeAsync(request, request.Floor, request.HighWater, token)
+                .ConfigureAwait(false);
+        }
+        catch (Exception e) when (ShouldTranslateToCancellation(e, token))
+        {
+            throw AsCancellation(e, token);
+        }
+    }
+
+    /// <summary>
+    /// Read one page bounded by <c>(floor, ceiling]</c>. The page reports its floor as
+    /// <paramref name="floor"/>.
+    /// </summary>
+    protected Task<EventPage> LoadRangeAsync(
+        EventRequest request, long floor, long ceiling, CancellationToken token)
+        => LoadRangeAsync(request, floor, ceiling, floor, token);
+
+    /// <summary>
+    /// Read one page bounded by <c>(floor, ceiling]</c>, reporting the page's floor as
+    /// <paramref name="pageFloor"/>.
+    /// </summary>
+    /// <remarks>
+    /// The two floors come apart on exactly the strategies that move the query's floor without the
+    /// shard having moved: a skip-ahead probe lands the query just below the first matching event
+    /// and the page's floor moves with it, because the probe <em>proved</em> there was nothing in
+    /// between; a window-step walk keeps the page on the request's original floor, because it has
+    /// proved nothing — it is simply reading a narrower slice at a time.
+    /// </remarks>
+    protected async Task<EventPage> LoadRangeAsync(
+        EventRequest request, long floor, long ceiling, long pageFloor, CancellationToken token)
+    {
+        var (page, _) = await loadRangeAsync(request, floor, ceiling, pageFloor, token).ConfigureAwait(false);
+        return page;
+    }
+
+    /// <summary>
+    /// The lowest sequence above <paramref name="floor"/> and at or below <paramref name="ceiling"/>
+    /// matching this shard's filters, or null when there is none.
+    /// </summary>
+    /// <remarks>
+    /// The skip-ahead primitive. Its value is entirely in what it lets a caller <em>not</em> read:
+    /// on a store where matching events are sparse, jumping the query's floor to the next match
+    /// turns a scan of a large sequence range into a page read.
+    /// </remarks>
+    protected async Task<long?> ProbeNextMatchingSequenceAsync(
+        long floor, long ceiling, int batchSize, CancellationToken token)
+    {
+        var command = Dialect.BuildNextMatchingSequenceCommand(QueryFor(floor, ceiling, batchSize));
+
+        await using var connection = await OpenConnectionAsync(token).ConfigureAwait(false);
+        await using var cmd = CreateCommand(connection, command);
+        await using var reader = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+
+        // A single-row probe, so "no row" is the no-match answer. Do not test IsDBNull here: that
+        // was the shape a min() probe needed, and min() is exactly what the dialect contract says
+        // not to render.
+        long? sequence = await reader.ReadAsync(token).ConfigureAwait(false)
+            ? reader.GetInt64(0)
+            : null;
+
+        await reader.CloseAsync().ConfigureAwait(false);
+        return sequence;
+    }
+
+    /// <summary>
+    /// Skip-ahead: probe for the next matching sequence and read a page from just below it. Returns
+    /// an empty page at the high-water mark when nothing in range matches.
+    /// </summary>
+    protected async Task<EventPage> LoadWithSkipAheadAsync(EventRequest request, CancellationToken token)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var next = await ProbeNextMatchingSequenceAsync(
+            request.Floor, request.HighWater, request.BatchSize, token).ConfigureAwait(false);
+
+        if (next is null)
+        {
+            // Nothing matches anywhere in the range, so the shard really has consumed all of it.
+            return EmptyPage(request, request.Floor, request.HighWater);
+        }
+
+        // The floor is exclusive, so start one below the match to include it.
+        return await LoadRangeAsync(request, next.Value - 1, request.HighWater, token).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Window-step: advance through the sequence in fixed windows until a window returns rows.
+    /// Each window is narrow enough to survive on a store where the full-range query times out.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>The page's ceiling is the window's, never the high-water mark</b>, and that is the whole
+    /// correctness content of this method (marten#5239). <c>CalculateCeiling</c>'s contract is "if
+    /// the page did not fill the batch, the query exhausted everything up to this bound" — and the
+    /// query was bounded by the window. Claiming the high-water mark asserts an exhaustion that
+    /// never happened, and since the consumer writes the ceiling as durable projection progress,
+    /// every matching event above the window is skipped permanently. A window returning fewer than
+    /// a full batch is the ordinary case here, not an edge case: the window is wide and this
+    /// strategy exists because matching events are sparse.
+    /// </para>
+    /// <para>
+    /// <b>It returns on any row read, not on any event added.</b> A window whose rows were all
+    /// skipped may still have had matching events truncated by the batch limit further up the same
+    /// window; advancing past it would drop them exactly as the ceiling bug did.
+    /// </para>
+    /// </remarks>
+    protected async Task<EventPage> LoadByWindowAsync(
+        EventRequest request, long windowSize, CancellationToken token)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(windowSize);
+
+        var currentFloor = request.Floor;
+
+        while (currentFloor < request.HighWater)
+        {
+            var windowCeiling = Math.Min(currentFloor + windowSize, request.HighWater);
+
+            // The page keeps the request's floor: this walk has not proved anything about the range
+            // below the current window, it is only reading it in slices.
+            var (page, rowsRead) = await loadRangeAsync(
+                request, currentFloor, windowCeiling, request.Floor, token).ConfigureAwait(false);
+
+            if (rowsRead > 0)
+            {
+                return page;
+            }
+
+            // No rows at all, so nothing in this window was elided by the batch limit and stepping
+            // over it is safe.
+            currentFloor = windowCeiling;
+        }
+
+        // The walk really did scan every window up to the high-water mark, so claiming it here — as
+        // the loop above must not — is honest.
+        return EmptyPage(request, request.Floor, request.HighWater);
+    }
+
+    /// <summary>
+    /// Build the query for one bounded read, folding in this shard's tenant, event-type and
+    /// archived-event scope. Override to add a store-specific dimension.
+    /// </summary>
+    protected virtual EventPageQuery QueryFor(long floor, long ceiling, int batchSize) => new()
+    {
+        Floor = floor,
+        Ceiling = ceiling,
+        BatchSize = batchSize,
+        TenantId = Options.TenantId,
+        EventTypes = Options.EventTypes,
+        IncludeArchivedEvents = Options.IncludeArchivedEvents
+    };
+
+    /// <summary>Open a connection to read from. The base disposes whatever it is given.</summary>
+    protected abstract ValueTask<DbConnection> OpenConnectionAsync(CancellationToken token);
+
+    /// <summary>
+    /// Hydrate the reader's current row into an event, or return null when the row's stored .NET
+    /// type resolves to nothing in this deployment.
+    /// </summary>
+    /// <remarks>
+    /// Returning null and throwing a <see cref="IEventFailureContext"/> exception with
+    /// <see cref="ShardFailureCategory.UnknownEventType"/> mean the same thing to the base; both
+    /// spellings exist because the three stores use both. Either way the shard's
+    /// <see cref="ErrorHandlingOptions.SkipUnknownEvents"/> decides what happens, because a daemon
+    /// that silently skipped an event it could not resolve would leave the projection permanently
+    /// wrong with nothing to signal it.
+    /// </remarks>
+    protected abstract ValueTask<IEvent?> ReadEventAsync(DbDataReader reader, CancellationToken token);
+
+    /// <summary>
+    /// Read the sequence of the reader's current row. Defaults to ordinal 0, which is where all
+    /// three stores put it; override if the dialect's column list does not.
+    /// </summary>
+    /// <remarks>
+    /// The base reads this for every row, including rows it goes on to skip, because a page whose
+    /// rows were all skipped still has to be able to say how far its query actually got.
+    /// </remarks>
+    protected virtual long ReadSequence(DbDataReader reader) => reader.GetInt64(0);
+
+    /// <summary>
+    /// The exception to throw for a row whose <see cref="ReadEventAsync"/> returned null while
+    /// <see cref="ErrorHandlingOptions.SkipUnknownEvents"/> is off.
+    /// </summary>
+    /// <remarks>
+    /// Override to return the store's own exception, which should implement
+    /// <see cref="IEventFailureContext"/> so the daemon can report
+    /// <see cref="ShardFailureCategory.UnknownEventType"/> with the offending sequence rather than
+    /// classifying the pause as <see cref="ShardFailureCategory.Other"/> with no detail.
+    /// </remarks>
+    protected virtual Exception UnresolvedEventTypeException(DbDataReader reader, long sequence)
+        => new InvalidOperationException(
+            $"Unable to resolve the .NET type of the event at sequence {sequence}. Register the event type, or turn on ErrorHandlingOptions.SkipUnknownEvents to skip it.");
+
+    /// <summary>
+    /// Should a hydration failure be skipped rather than thrown, given the shard's error policy?
+    /// </summary>
+    /// <remarks>
+    /// Classification goes through <see cref="IEventFailureContext.Category"/> — the store's own
+    /// exception declares its kind, exactly as jasperfx#565 intended, so nothing here sniffs
+    /// exception type names.
+    /// </remarks>
+    protected virtual bool ShouldSkip(Exception ex, ErrorHandlingOptions options) =>
+        Classify(ex) switch
+        {
+            ShardFailureCategory.UnknownEventType => options.SkipUnknownEvents,
+            ShardFailureCategory.EventSerialization => options.SkipSerializationErrors,
+            _ => false
+        };
+
+    /// <summary>
+    /// The failure category an exception declares, or null when it declares none.
+    /// </summary>
+    /// <remarks>
+    /// Walks the inner-exception chain, because a store's exception transformer may have wrapped
+    /// the one that knows — inspecting only the outermost exception is how marten#4720's timeout
+    /// detection missed every wrapped case for as long as it did.
+    /// </remarks>
+    public static ShardFailureCategory? Classify(Exception? ex)
+    {
+        while (ex is not null)
+        {
+            if (ex is IEventFailureContext context)
+            {
+                return context.Category;
+            }
+
+            ex = ex.InnerException;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Called for each row the loader skipped. The default does nothing; override to record a dead
+    /// letter or log, as Marten does for a suppressed serialization failure.
+    /// </summary>
+    protected virtual ValueTask RecordSkippedEventAsync(
+        Exception ex, EventRequest request, CancellationToken token) => default;
+
+    /// <summary>
+    /// Should this exception be reported as cooperative cancellation?
+    /// </summary>
+    /// <remarks>
+    /// The daemon cancels a load mid-flight as a matter of course — shutting a shard down after
+    /// <c>CatchUpAsync</c> reaches the high-water mark, for one — and an ADO.NET provider does not
+    /// necessarily surface that as a clean <see cref="OperationCanceledException"/>. SqlClient
+    /// reports it as a <c>SqlException</c> ("Operation cancelled by user"), which the daemon's
+    /// recorder would otherwise treat as a real shard error.
+    /// </remarks>
+    protected virtual bool ShouldTranslateToCancellation(Exception ex, CancellationToken token)
+        => token.IsCancellationRequested && ex is not OperationCanceledException;
+
+    /// <summary>The cancellation exception to raise in place of a provider's own.</summary>
+    protected virtual Exception AsCancellation(Exception ex, CancellationToken token)
+        => new OperationCanceledException("Event loading was cancelled.", ex, token);
+
+    /// <summary>
+    /// Tell the page how far its query actually got, whether or not any row survived into it.
+    /// </summary>
+    /// <param name="page">The page about to have its ceiling calculated.</param>
+    /// <param name="lastObservedSequence">
+    /// The sequence of the last row the reader saw, or null when the query returned no rows at all.
+    /// </param>
+    /// <remarks>
+    /// <para>
+    /// The default does nothing. <c>EventPage.LastObservedSequence</c> (jasperfx#667) is what this
+    /// is for — a full batch whose every row was skipped has no last event to take a ceiling from,
+    /// and claiming the high-water mark there writes durable progress past rows nobody read. But it
+    /// arrived after the JasperFx.Events floor this package builds against, so the base tracks the
+    /// value and hands it over here rather than setting it directly.
+    /// </para>
+    /// <para>
+    /// A store on a new enough JasperFx.Events should override this with
+    /// <c>page.LastObservedSequence = lastObservedSequence;</c> — one line, and it closes the case
+    /// that matters most: a whole event type that stopped resolving, which is exactly what fills a
+    /// batch with skips.
+    /// </para>
+    /// </remarks>
+    protected virtual void ReportLastObservedSequence(EventPage page, long? lastObservedSequence)
+    {
+    }
+
+    /// <summary>
+    /// An empty page whose ceiling claims everything up to <paramref name="ceiling"/> was scanned.
+    /// </summary>
+    protected static EventPage EmptyPage(EventRequest request, long pageFloor, long ceiling)
+    {
+        var page = new EventPage(pageFloor);
+        page.CalculateCeiling(request.BatchSize, ceiling, 0);
+        return page;
+    }
+
+    [SuppressMessage("Reliability", "CA2100:Review SQL queries for security vulnerabilities",
+        Justification = "The SQL is rendered by the store's own dialect from an EventPageQuery whose only free values are bound as parameters.")]
+    private DbCommand CreateCommand(DbConnection connection, EventPageCommand command)
+    {
+        var cmd = connection.CreateCommand();
+        cmd.CommandText = command.Sql;
+
+        foreach (var parameter in command.Parameters)
+        {
+            var dbParameter = cmd.CreateParameter();
+            dbParameter.ParameterName = parameter.Name;
+            dbParameter.Value = parameter.Value ?? DBNull.Value;
+
+            if (parameter.DbType.HasValue)
+            {
+                dbParameter.DbType = parameter.DbType.Value;
+            }
+
+            cmd.Parameters.Add(dbParameter);
+        }
+
+        ConfigureCommand(cmd);
+        return cmd;
+    }
+
+    /// <summary>
+    /// Last look at the command before it executes — a store's command timeout, or enlisting it in
+    /// a transaction it already holds.
+    /// </summary>
+    protected virtual void ConfigureCommand(DbCommand command)
+    {
+    }
+
+    private async Task<(EventPage Page, int RowsRead)> loadRangeAsync(
+        EventRequest request, long floor, long ceiling, long pageFloor, CancellationToken token)
+    {
+        var page = new EventPage(pageFloor);
+        var skipped = 0;
+        var rowsRead = 0;
+        long? lastObserved = null;
+
+        var command = Dialect.BuildPageCommand(QueryFor(floor, ceiling, request.BatchSize));
+
+        await using var connection = await OpenConnectionAsync(token).ConfigureAwait(false);
+        await using var cmd = CreateCommand(connection, command);
+        await using var reader = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+
+        try
+        {
+            while (await reader.ReadAsync(token).ConfigureAwait(false))
+            {
+                rowsRead++;
+
+                // Read off the row rather than out of a failure, so it is available for exactly the
+                // page that most needs it: one whose every row was skipped because a whole event
+                // type stopped resolving. See EventPage.LastObservedSequence.
+                lastObserved = ReadSequence(reader);
+
+                IEvent? @event;
+                try
+                {
+                    @event = await ReadEventAsync(reader, token).ConfigureAwait(false);
+                }
+                catch (Exception e) when (ShouldSkip(e, request.ErrorOptions))
+                {
+                    skipped++;
+                    await RecordSkippedEventAsync(e, request, token).ConfigureAwait(false);
+                    continue;
+                }
+
+                if (@event is null)
+                {
+                    if (request.ErrorOptions.SkipUnknownEvents)
+                    {
+                        skipped++;
+                        continue;
+                    }
+
+                    throw UnresolvedEventTypeException(reader, lastObserved.Value);
+                }
+
+                page.Add(@event);
+            }
+        }
+        finally
+        {
+            await reader.CloseAsync().ConfigureAwait(false);
+        }
+
+        ReportLastObservedSequence(page, lastObserved);
+
+        // The ceiling is calculated against the bound this query actually carried, which is not
+        // necessarily the shard's high-water mark — see LoadByWindowAsync.
+        page.CalculateCeiling(request.BatchSize, ceiling, skipped);
+
+        return (page, rowsRead);
+    }
+}

--- a/src/Weasel.Storage/Events/Daemon/EventLoaderOptions.cs
+++ b/src/Weasel.Storage/Events/Daemon/EventLoaderOptions.cs
@@ -1,0 +1,34 @@
+#nullable enable
+namespace Weasel.Storage;
+
+/// <summary>
+/// What one daemon shard's loader is scoped to read. Fixed when the store builds the loader, and
+/// folded into every <see cref="EventPageQuery"/> the loader issues.
+/// </summary>
+public sealed class EventLoaderOptions
+{
+    /// <summary>
+    /// Restrict the load to one tenant. Set on a per-tenant rebuild or subscription shard so it
+    /// reads only that tenant's bounded sequence range rather than the whole store; null (the
+    /// default) is store-global.
+    /// </summary>
+    /// <remarks>
+    /// Worth setting even where the store is not partitioned by tenant. On a per-tenant rebuild it
+    /// is not only an optimisation: without it the execution sees other tenants' events and routes
+    /// their document writes by <c>IEvent.TenantId</c>, so a rebuild for one tenant writes another
+    /// tenant's documents.
+    /// </remarks>
+    public string? TenantId { get; init; }
+
+    /// <summary>
+    /// The event types this shard reads, rendered into the query's WHERE clause by the dialect.
+    /// Defaults to <see cref="EventTypeAllowList.All"/>.
+    /// </summary>
+    public EventTypeAllowList EventTypes { get; init; } = EventTypeAllowList.All;
+
+    /// <summary>
+    /// Whether archived events are in scope. False by default, which is what an ordinary shard
+    /// wants and what each store's <c>(is_archived, seq_id)</c> index is shaped for.
+    /// </summary>
+    public bool IncludeArchivedEvents { get; init; }
+}

--- a/src/Weasel.Storage/Events/Daemon/EventPageQuery.cs
+++ b/src/Weasel.Storage/Events/Daemon/EventPageQuery.cs
@@ -1,0 +1,59 @@
+#nullable enable
+namespace Weasel.Storage;
+
+/// <summary>
+/// One bounded read of the events table, described without any SQL in it. This is the whole of what
+/// <see cref="EventLoaderBase"/> asks an <see cref="IEventPagingDialect"/> for, and it is the same
+/// question in all three Critter Stack stores: the events in <c>(Floor, Ceiling]</c>, in sequence
+/// order, at most <see cref="BatchSize"/> of them, excluding archived events unless asked for, and
+/// restricted to one tenant and/or one set of event types when the shard is scoped that way.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b><see cref="Floor"/> is exclusive and <see cref="Ceiling"/> is inclusive</b> — the daemon's
+/// progression is "the last sequence I have processed", so the next page starts strictly above it.
+/// Every store already spells this <c>seq_id &gt; @floor and seq_id &lt;= @ceiling</c>; a dialect
+/// that rendered it any other way would double-process or skip an event at each page boundary.
+/// </para>
+/// <para>
+/// <see cref="Ceiling"/> is not necessarily the shard's high-water mark. A store layering a
+/// window-stepping strategy over the base (see <see cref="EventLoaderBase.LoadByWindowAsync"/>)
+/// asks for a much narrower range, and the page it gets back reports its ceiling against the window
+/// it actually scanned rather than against the high-water mark it did not.
+/// </para>
+/// </remarks>
+public sealed record EventPageQuery
+{
+    /// <summary>Exclusive lower bound on <c>seq_id</c>.</summary>
+    public required long Floor { get; init; }
+
+    /// <summary>Inclusive upper bound on <c>seq_id</c>.</summary>
+    public required long Ceiling { get; init; }
+
+    /// <summary>
+    /// Maximum rows to return. Rendered as <c>TOP(@n)</c>, <c>LIMIT @n</c> or <c>FETCH FIRST</c>
+    /// depending on the dialect — this is one of only two things that genuinely differ between the
+    /// three stores' loaders, the other being row hydration.
+    /// </summary>
+    public required int BatchSize { get; init; }
+
+    /// <summary>
+    /// When set, restrict the read to one tenant. Non-null only on a per-tenant rebuild or
+    /// subscription shard (Marten's #4596, Polecat's #163); null means store-global.
+    /// </summary>
+    public string? TenantId { get; init; }
+
+    /// <summary>
+    /// The event types this shard reads. <b>The dialect must render this into the WHERE clause</b>
+    /// — see <see cref="EventTypeAllowList"/> for why filtering after hydration is not an
+    /// acceptable substitute.
+    /// </summary>
+    public EventTypeAllowList EventTypes { get; init; } = EventTypeAllowList.All;
+
+    /// <summary>
+    /// False (the default) excludes archived events, which is what every ordinary shard wants and
+    /// what each store's <c>(is_archived, seq_id)</c> index is shaped for. True is the deliberate
+    /// "replay everything including archived streams" case.
+    /// </summary>
+    public bool IncludeArchivedEvents { get; init; }
+}

--- a/src/Weasel.Storage/Events/Daemon/EventTypeAllowList.cs
+++ b/src/Weasel.Storage/Events/Daemon/EventTypeAllowList.cs
@@ -1,0 +1,114 @@
+#nullable enable
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// The set of event types an async daemon shard is allowed to read, in both of the spellings a
+/// store's events table can carry: the short type alias (Marten's and Fisher's <c>type</c> column)
+/// and the assembly-qualified .NET type name (Polecat's <c>dotnet_type</c> column). Both are
+/// supplied so the dialect can filter on whichever column it actually indexes, rather than the base
+/// class picking one and forcing two of the three stores to translate.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>This exists to be rendered into SQL, never applied after hydration.</b> Both Polecat and
+/// Fisher moved their event-type filter from a client-side <c>HashSet</c> check into the query
+/// (polecat, fisher#153) for the obvious reason: a subscription that names three event types on a
+/// store holding thirty should not read, deserialize and discard the other twenty-seven. A dialect
+/// that ignored <see cref="IsEmpty"/> and let <see cref="EventLoaderBase"/> filter afterwards would
+/// silently undo that, and the only symptom would be throughput.
+/// </para>
+/// <para>
+/// An empty allow list means "every event type", which is the daemon's default — an
+/// <see cref="EventFilterable"/> with no <see cref="EventFilterable.IncludedEventTypes"/> is asking
+/// for everything, not for nothing.
+/// </para>
+/// </remarks>
+public sealed class EventTypeAllowList
+{
+    /// <summary>An allow list that admits every event type.</summary>
+    public static EventTypeAllowList All { get; } = new([], []);
+
+    private EventTypeAllowList(IReadOnlyList<string> aliases, IReadOnlyList<string> dotNetTypeNames)
+    {
+        Aliases = aliases;
+        DotNetTypeNames = dotNetTypeNames;
+    }
+
+    /// <summary>
+    /// The stores' short type aliases (e.g. <c>trip_started</c>), matching the <c>type</c> column.
+    /// Prefer these where the column is indexed: an alias survives a CLR type being renamed or
+    /// moved, where the assembly-qualified name does not.
+    /// </summary>
+    public IReadOnlyList<string> Aliases { get; }
+
+    /// <summary>
+    /// The assembly-qualified .NET type names, matching a <c>dotnet_type</c> column.
+    /// </summary>
+    public IReadOnlyList<string> DotNetTypeNames { get; }
+
+    /// <summary>True when no filtering applies and every event type should be read.</summary>
+    public bool IsEmpty => Aliases.Count == 0;
+
+    /// <summary>
+    /// Build the allow list for a projection or subscription's declared event types. Returns
+    /// <see cref="All"/> when the filterable names none, which is what an unfiltered shard wants.
+    /// </summary>
+    /// <remarks>
+    /// Takes the concrete <see cref="EventFilterable"/> rather than <see cref="IEventFilterable"/>
+    /// deliberately: the interface declares the <c>IncludeType</c> writers and
+    /// <see cref="IEventFilterable.IncludeArchivedEvents"/>, but the
+    /// <see cref="EventFilterable.IncludedEventTypes"/> collection this reads lives only on the
+    /// class. That is also the type all three stores' loaders already accept.
+    /// </remarks>
+    public static EventTypeAllowList For(IEventRegistry registry, EventFilterable? filtering)
+    {
+        ArgumentNullException.ThrowIfNull(registry);
+
+        if (filtering?.IncludedEventTypes is not { Count: > 0 } included)
+        {
+            return All;
+        }
+
+        return For(registry, included);
+    }
+
+    /// <summary>
+    /// Build the allow list for an explicit set of event types.
+    /// </summary>
+    public static EventTypeAllowList For(IEventRegistry registry, IReadOnlyList<Type> eventTypes)
+    {
+        ArgumentNullException.ThrowIfNull(registry);
+        ArgumentNullException.ThrowIfNull(eventTypes);
+
+        if (eventTypes.Count == 0)
+        {
+            return All;
+        }
+
+        // Ordinal-distinct rather than a plain projection: two registered CLR types can legitimately
+        // share an alias through an upcast chain, and a duplicate would render as a redundant term in
+        // the IN list.
+        var aliases = new List<string>(eventTypes.Count);
+        var dotNetTypeNames = new List<string>(eventTypes.Count);
+
+        foreach (var eventType in eventTypes)
+        {
+            var mapping = registry.EventMappingFor(eventType);
+
+            if (!aliases.Contains(mapping.EventTypeName, StringComparer.Ordinal))
+            {
+                aliases.Add(mapping.EventTypeName);
+            }
+
+            if (!dotNetTypeNames.Contains(mapping.DotNetTypeName, StringComparer.Ordinal))
+            {
+                dotNetTypeNames.Add(mapping.DotNetTypeName);
+            }
+        }
+
+        return new EventTypeAllowList(aliases, dotNetTypeNames);
+    }
+}

--- a/src/Weasel.Storage/Events/Daemon/IEventPagingDialect.cs
+++ b/src/Weasel.Storage/Events/Daemon/IEventPagingDialect.cs
@@ -1,0 +1,88 @@
+#nullable enable
+using System.Data.Common;
+
+namespace Weasel.Storage;
+
+/// <summary>
+/// The SQL half of the async daemon's event loader. A store's dialect renders an
+/// <see cref="EventPageQuery"/> into a command; <see cref="EventLoaderBase"/> owns everything
+/// around it — paging, skip accounting, the ceiling calculation, and cancellation.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Deliberately separate from <see cref="IEventStoreSqlDialect"/>'s append-side descriptors, and
+/// reached through <see cref="IEventStoreSqlDialect.EventPaging"/> so a dialect can adopt the
+/// loader without also being ready to hand over its append SQL. That matters because the three
+/// stores are at different points: Marten's loader carries an adaptive strategy the others lack,
+/// so it will adopt the primitives before it adopts a plain page read.
+/// </para>
+/// <para>
+/// A dialect renders whole commands rather than SQL strings so it keeps control of parameter
+/// naming and typing. Npgsql, Microsoft.Data.SqlClient and Microsoft.Data.Sqlite all accept
+/// <c>@name</c> placeholders, but Postgres wants an explicit <c>NpgsqlDbType.Bigint</c> on the
+/// bounds to keep the planner on an index scan, and only the dialect can say so.
+/// </para>
+/// </remarks>
+public interface IEventPagingDialect
+{
+    /// <summary>
+    /// The bounded page read: the events in <c>(Floor, Ceiling]</c> ordered by sequence, limited to
+    /// the batch size, with the tenant and event-type filters applied <b>in SQL</b>.
+    /// </summary>
+    /// <remarks>
+    /// The column list is the dialect's and the store's joint business — whatever the loader's
+    /// <see cref="EventLoaderBase.ReadEventAsync"/> reads back. The only column the base itself
+    /// touches is the sequence, through <see cref="EventLoaderBase.ReadSequence"/>, which defaults
+    /// to ordinal 0.
+    /// </remarks>
+    EventPageCommand BuildPageCommand(EventPageQuery query);
+
+    /// <summary>
+    /// The skip-ahead probe: the lowest <c>seq_id</c> above <see cref="EventPageQuery.Floor"/> and
+    /// at or below <see cref="EventPageQuery.Ceiling"/> that matches this query's filters, as a
+    /// single-column, single-row result — or no row when nothing matches.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the primitive Marten's adaptive loader needs and the other two stores do not have
+    /// yet. It exists on the interface rather than in Marten so the escalation strategy can be
+    /// layered on the shared base instead of forcing Marten to keep a private loader.
+    /// </para>
+    /// <para>
+    /// <b>Render it as <c>order by seq_id limit 1</c>, not as <c>min(seq_id)</c></b>. The two
+    /// return the same number, but a MIN aggregate is only rewritten into an ordered index scan
+    /// when its input is a single relation — joined to a streams table it degrades into a scan of
+    /// every remaining row, which makes the probe O(events after the floor) on the one code path
+    /// that exists precisely because the store is too large for the ordinary query. That was
+    /// marten#5277.
+    /// </para>
+    /// </remarks>
+    EventPageCommand BuildNextMatchingSequenceCommand(EventPageQuery query);
+}
+
+/// <summary>
+/// A rendered command: the SQL and the parameters to bind, in a form
+/// <see cref="EventLoaderBase"/> can apply to any <see cref="DbCommand"/>.
+/// </summary>
+public sealed record EventPageCommand(string Sql, IReadOnlyList<EventPageParameter> Parameters)
+{
+    /// <summary>Convenience for a command with no parameters.</summary>
+    public EventPageCommand(string sql) : this(sql, [])
+    {
+    }
+}
+
+/// <summary>
+/// One parameter of an <see cref="EventPageCommand"/>.
+/// </summary>
+/// <param name="Name">
+/// The parameter name <em>without</em> a provider prefix. <see cref="EventLoaderBase"/> assigns it
+/// to <see cref="DbParameter.ParameterName"/> verbatim, which every supported provider accepts
+/// whether or not the SQL spells the placeholder with an <c>@</c>.
+/// </param>
+/// <param name="Value">The value to bind. Null is written as <see cref="DBNull"/>.</param>
+/// <param name="DbType">
+/// Optional explicit type. Worth setting on the sequence bounds — an untyped bigint bound as a
+/// numeric can cost Postgres its index scan on <c>seq_id</c>.
+/// </param>
+public sealed record EventPageParameter(string Name, object? Value, System.Data.DbType? DbType = null);

--- a/src/Weasel.Storage/Events/IEventStoreSqlDialect.cs
+++ b/src/Weasel.Storage/Events/IEventStoreSqlDialect.cs
@@ -38,4 +38,17 @@ public interface IEventStoreSqlDialect
     /// throwing until a dialect opts in. See <see cref="EventAuxiliaryOperations"/>.
     /// </summary>
     EventAuxiliaryOperations? BuildAuxiliaryOperations(EventRegistry graph) => null;
+
+    /// <summary>
+    /// The read side: how this dialect renders the async daemon's paging query and skip-ahead
+    /// probe, for <see cref="EventLoaderBase"/>. The default returns <see langword="null"/>, so a
+    /// dialect that still owns a bespoke loader does not have to implement it.
+    /// </summary>
+    /// <remarks>
+    /// Kept separate from the append-side descriptors above because the two are adopted
+    /// independently. The descriptors are a whole append pipeline; this is one SELECT and one
+    /// probe, and a store with an adaptive loader of its own may well want the second before the
+    /// first.
+    /// </remarks>
+    IEventPagingDialect? EventPaging => null;
 }


### PR DESCRIPTION
Closes #566 — Stoat node `weasel-event-loader` (plan `internals-lifting-2026-09`).

The async daemon's inner event loader is the same shape in all three stores — Marten's
`EventLoader` (405 lines), Polecat's `PolecatEventLoader` (181), Fisher's `FisherEventLoader` (127).
Each pages the events table by `seq_id`, hydrates the rows, applies an event-type allow list,
honours the shard's skip policy and calls `page.CalculateCeiling(...)`. Only the batch-limit syntax
(`TOP(@n)` vs `LIMIT @n`) and the row reader genuinely differ — and the three copies have already
drifted in their skip accounting.

## What lands

| Type | Role |
|---|---|
| `EventLoaderBase` | Paging, skip accounting, the ceiling calculation, cancellation translation |
| `IEventPagingDialect` | The SQL — reached through `IEventStoreSqlDialect.EventPaging` |
| `EventPageQuery` / `EventPageCommand` | One bounded read, described without SQL in it |
| `EventTypeAllowList` | The shard's event types, in both column spellings |
| `EventLoaderOptions` | What one shard is scoped to read |

Nothing in Marten, Polecat or Fisher changes; adoption is separately gated in the plan.

## The two things preserved deliberately

**Marten's adaptive strategy progression.** Marten's loader escalates `normal → skip-ahead →
window-step` when the ordinary query times out; the other two have nothing like it. A base offering
only "load one page" would have left the store that pays most for the duplication unable to adopt
it. So the base is a set of primitives rather than one algorithm — `LoadRangeAsync`,
`ProbeNextMatchingSequenceAsync` and `LoadByWindowAsync`, with `LoadAsync` virtual over them. A
store layers escalation on top and never reimplements paging underneath.

Two hard-won details ride along in the base rather than in each store's copy:

- The window walk's page reports the ceiling of **the window it scanned**, never the high-water
  mark. That was marten#5239, and passing the high-water mark asserts an exhaustion that never
  happened — the consumer writes it as durable progress, so every matching event above the window
  is skipped permanently.
- The skip-ahead probe's contract says `order by seq_id limit 1`, **not** `min(seq_id)`. Postgres
  only rewrites a MIN into an ordered index scan when its input is a single relation; joined, it
  degrades into a scan of every remaining row — on the one code path that exists precisely because
  the store is too large for the ordinary query. That was marten#5277.

**The event-type filter is SQL.** `EventTypeAllowList` carries both the short alias and the
assembly-qualified .NET type name, so a dialect filters on whichever column it actually indexes, and
the base never filters a hydrated event. Filtering after hydration would silently undo the SQL-level
filters polecat and fisher#153 added — the page would look identical and the store would go back to
reading and discarding rows the subscription never asked for. `the_event_type_filter_is_applied_in_sql_not_after_hydration`
asserts the loader hydrated only the wanted rows, which is what tells the two apart.

## Other decisions

- Skip classification goes through `IEventFailureContext.Category`, walking the inner-exception
  chain — jasperfx#565's design, so nothing here sniffs a store's exception type names, and a store
  whose exception transformer wraps the one that knows is still classified correctly.
- `ReadEventAsync` returning null and throwing an `UnknownEventType` exception mean the same thing
  to the base; both spellings exist because the three stores use both.
- A provider error raised under cancellation is translated to `OperationCanceledException`, so a
  routine shard shutdown is not recorded as a shard error (SqlClient reports a cancelled command as
  a `SqlException`).
- `ReportLastObservedSequence` is a documented one-line seam rather than a direct assignment:
  `EventPage.LastObservedSequence` (jasperfx#667) postdates the JasperFx.Events floor this package
  builds against. The base tracks the value regardless — it is what `LoadByWindowAsync` decides on.

## Validation

Local, since CI is stalled org-wide.

- `dotnet build Weasel.slnx` — clean
- `Weasel.Core.Tests` — 472 passed (24 new)
- `Weasel.Sqlite.Tests` — 582 passed, 1 pre-existing failure (`TypeMappingIntegrationTests.all_types_together`, a date assertion; fails identically on unmodified `master`)
- `Weasel.Postgresql.Tests` — 974 passed, 3 skipped (Postgres 15.3 in Docker)
- `Weasel.SqlServer.Tests` — 558 passed, 8 skipped (azure-sql-edge in Docker)

The new tests run over a real SQLite events table rather than a mock. Verified load-bearing:
taking the ceiling from the high-water mark instead of the window fails three of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
