### PR TITLE
Lift MasterTableTenancy into Weasel.Core.MultiTenancy over a DbDataSource seam

### DIFF
--- a/src/Weasel.Core.Tests/master_table_tenancy.cs
+++ b/src/Weasel.Core.Tests/master_table_tenancy.cs
@@ -1,0 +1,695 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using JasperFx.MultiTenancy;
+using Microsoft.Data.Sqlite;
+using NSubstitute;
+using Shouldly;
+using Weasel.Core.MultiTenancy;
+using Weasel.Sqlite;
+using Xunit;
+
+namespace Weasel.Core.Tests;
+
+/// <summary>
+/// The lifted <see cref="MasterTableTenancyBase{TDatabase,TDataSource}" /> (weasel#567), exercised
+/// against a real control table so the provisioning, the cache and the runtime tenant lifecycle are
+/// checked against a database rather than against a mock that agrees with them.
+/// </summary>
+/// <remarks>
+/// SQLite because it needs no server. The base only ever touches <see cref="System.Data.Common.DbDataSource" />
+/// and <see cref="System.Data.Common.DbConnection" />, and the dialect here renders SQL the way
+/// Marten's and Polecat's would.
+/// </remarks>
+public class master_table_tenancy: IAsyncDisposable
+{
+    private readonly string _path = Path.Combine(Path.GetTempPath(), $"weasel_tenancy_{Guid.NewGuid():n}.db");
+    private readonly List<TestTenancy> _tenancies = [];
+    private readonly string _connectionString;
+
+    public master_table_tenancy() => _connectionString = $"Data Source={_path}";
+
+    public async ValueTask DisposeAsync()
+    {
+        foreach (var tenancy in _tenancies) await tenancy.DisposeAsync();
+
+        SqliteConnection.ClearPool(new SqliteConnection(_connectionString));
+        if (File.Exists(_path)) File.Delete(_path);
+        GC.SuppressFinalize(this);
+    }
+
+    private TestTenancy TenancyFor(Action<MasterTableTenancyOptions<SqliteDataSource>>? configure = null)
+    {
+        var options = new MasterTableTenancyOptions<SqliteDataSource>(SqliteProvider.Instance)
+        {
+            ConnectionString = _connectionString, SchemaName = "main"
+        };
+
+        configure?.Invoke(options);
+
+        var tenancy = new TestTenancy(options);
+        _tenancies.Add(tenancy);
+        return tenancy;
+    }
+
+    private async Task<List<(string TenantId, string ConnectionString, bool Disabled)>> RowsAsync()
+    {
+        var rows = new List<(string, string, bool)>();
+
+        await using var conn = new SqliteConnection(_connectionString);
+        await conn.OpenAsync();
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "select tenant_id, connection_string, is_disabled from tenants order by tenant_id";
+
+        await using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            rows.Add((reader.GetString(0), reader.GetString(1), reader.GetInt64(2) != 0));
+        }
+
+        return rows;
+    }
+
+    private async Task<bool> ControlTableExistsAsync()
+    {
+        await using var conn = new SqliteConnection(_connectionString);
+        await conn.OpenAsync();
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "select count(*) from sqlite_master where type = 'table' and name = 'tenants'";
+        return Convert.ToInt64(await cmd.ExecuteScalarAsync()) > 0;
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // Configuration
+    // ------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void neither_a_data_source_nor_a_connection_string_is_refused()
+    {
+        var options = new MasterTableTenancyOptions<SqliteDataSource>(SqliteProvider.Instance);
+
+        Should.Throw<ArgumentOutOfRangeException>(() => new TestTenancy(options));
+    }
+
+    [Fact]
+    public async Task a_supplied_data_source_is_not_disposed_by_the_tenancy()
+    {
+        // Somebody else built it, so somebody else disposes it. Getting this wrong surfaces as an
+        // ObjectDisposedException somewhere unrelated.
+        var dataSource = new SqliteDataSource(_connectionString);
+
+        var tenancy = new TestTenancy(new MasterTableTenancyOptions<SqliteDataSource>(SqliteProvider.Instance)
+        {
+            DataSource = dataSource, SchemaName = "main"
+        });
+
+        await tenancy.AddDatabaseRecordAsync("blue", "Data Source=blue.db");
+        await tenancy.DisposeAsync();
+
+        // Still usable.
+        await using var connection = await dataSource.OpenConnectionAsync();
+        connection.State.ShouldBe(System.Data.ConnectionState.Open);
+        await dataSource.DisposeAsync();
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // Control table provisioning
+    // ------------------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task the_control_table_is_created_on_first_use()
+    {
+        (await ControlTableExistsAsync()).ShouldBeFalse();
+
+        await TenancyFor().BuildDatabasesAsync();
+
+        (await ControlTableExistsAsync()).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task provisioning_is_idempotent_across_instances()
+    {
+        // The semaphore guards one process; a deployment has several, which is why the DDL itself
+        // has to be idempotent rather than guarded by a prior existence check.
+        await TenancyFor().BuildDatabasesAsync();
+        await TenancyFor().BuildDatabasesAsync();
+
+        (await ControlTableExistsAsync()).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task provisioning_runs_once_per_instance()
+    {
+        var tenancy = TenancyFor();
+
+        await tenancy.BuildDatabasesAsync();
+        await tenancy.AddDatabaseRecordAsync("blue", "Data Source=blue.db");
+        await tenancy.AllDisabledAsync();
+
+        tenancy.ProvisioningAttempts.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task auto_create_none_never_emits_ddl()
+    {
+        // The schema is the operator's, and the control table is exactly the object a
+        // least-privilege deployment provisions by hand.
+        var tenancy = TenancyFor(x => x.AutoCreate = AutoCreate.None);
+
+        await Should.ThrowAsync<SqliteException>(() => tenancy.BuildDatabasesAsync());
+
+        (await ControlTableExistsAsync()).ShouldBeFalse();
+        tenancy.ProvisioningAttempts.ShouldBe(0);
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // The runtime lifecycle
+    // ------------------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task adding_a_tenant_records_it_and_caches_it_eagerly()
+    {
+        var tenancy = TenancyFor();
+
+        await tenancy.AddDatabaseRecordAsync("blue", "Data Source=blue.db");
+
+        (await RowsAsync()).ShouldBe([("blue", "Data Source=blue.db", false)]);
+
+        // Cached without a second read: the tenant is usable by the next session immediately.
+        tenancy.FindCachedDatabase("blue").ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task adding_a_tenant_twice_is_an_upsert()
+    {
+        var tenancy = TenancyFor();
+
+        await tenancy.AddDatabaseRecordAsync("blue", "Data Source=one.db");
+        await tenancy.AddDatabaseRecordAsync("blue", "Data Source=two.db");
+
+        (await RowsAsync()).ShouldBe([("blue", "Data Source=two.db", false)]);
+        tenancy.FindCachedDatabase("blue")!.ConnectionString.ShouldBe("Data Source=two.db");
+    }
+
+    [Fact]
+    public async Task re_pointing_a_tenant_disposes_the_database_it_replaced()
+    {
+        var tenancy = TenancyFor();
+
+        await tenancy.AddDatabaseRecordAsync("blue", "Data Source=one.db");
+        var first = tenancy.FindCachedDatabase("blue")!;
+
+        await tenancy.AddDatabaseRecordAsync("blue", "Data Source=two.db");
+
+        first.Disposed.ShouldBeTrue();
+        tenancy.FindCachedDatabase("blue")!.Disposed.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task building_databases_is_idempotent()
+    {
+        var tenancy = TenancyFor();
+        await tenancy.AddDatabaseRecordAsync("blue", "Data Source=blue.db");
+
+        var built = await tenancy.BuildDatabasesAsync();
+        var again = await tenancy.BuildDatabasesAsync();
+
+        // The same instance, not an equal one. A refresh on a schedule must not churn every
+        // tenant's connection pool.
+        built.Single().ShouldBeSameAs(again.Single());
+    }
+
+    [Fact]
+    public async Task building_databases_rebuilds_a_tenant_whose_connection_string_changed()
+    {
+        var tenancy = TenancyFor();
+        await tenancy.AddDatabaseRecordAsync("blue", "Data Source=one.db");
+        var first = tenancy.FindCachedDatabase("blue")!;
+
+        // Somebody else re-pointed the tenant.
+        await using (var conn = new SqliteConnection(_connectionString))
+        {
+            await conn.OpenAsync();
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = "update tenants set connection_string = 'Data Source=two.db' where tenant_id = 'blue'";
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        await tenancy.BuildDatabasesAsync();
+
+        tenancy.FindCachedDatabase("blue")!.ConnectionString.ShouldBe("Data Source=two.db");
+        first.Disposed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task an_unknown_tenant_resolves_to_nothing()
+    {
+        var tenancy = TenancyFor();
+        await tenancy.BuildDatabasesAsync();
+
+        (await tenancy.TryFindDatabaseAsync("nobody")).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task a_tenant_is_resolved_from_the_control_table_when_it_is_not_cached()
+    {
+        var writer = TenancyFor();
+        await writer.AddDatabaseRecordAsync("blue", "Data Source=blue.db");
+
+        // A second process, with an empty cache.
+        var reader = TenancyFor();
+        var database = await reader.TryFindDatabaseAsync("blue");
+
+        database.ShouldNotBeNull();
+        database.ConnectionString.ShouldBe("Data Source=blue.db");
+    }
+
+    [Fact]
+    public async Task disabling_a_tenant_stops_it_resolving_and_evicts_it()
+    {
+        var tenancy = TenancyFor();
+        await tenancy.AddDatabaseRecordAsync("blue", "Data Source=blue.db");
+        var database = tenancy.FindCachedDatabase("blue")!;
+
+        await tenancy.DisableTenantAsync("blue");
+
+        // The eviction is what makes disabling take effect at all -- the cache does not consult
+        // the control table, so a cached database would go on serving a switched-off tenant.
+        tenancy.FindCachedDatabase("blue").ShouldBeNull();
+        database.Disposed.ShouldBeTrue();
+        (await tenancy.TryFindDatabaseAsync("blue")).ShouldBeNull();
+
+        // The record survives -- disabling is not deleting.
+        (await RowsAsync()).ShouldBe([("blue", "Data Source=blue.db", true)]);
+    }
+
+    [Fact]
+    public async Task a_disabled_tenant_is_excluded_from_the_build()
+    {
+        var tenancy = TenancyFor();
+        await tenancy.AddDatabaseRecordAsync("blue", "Data Source=blue.db");
+        await tenancy.AddDatabaseRecordAsync("green", "Data Source=green.db");
+        await tenancy.DisableTenantAsync("green");
+
+        var databases = await tenancy.BuildDatabasesAsync();
+
+        databases.Select(x => x.TenantId).ShouldBe(["blue"]);
+    }
+
+    [Fact]
+    public async Task enabling_a_tenant_makes_it_resolve_again()
+    {
+        var tenancy = TenancyFor();
+        await tenancy.AddDatabaseRecordAsync("blue", "Data Source=blue.db");
+        await tenancy.DisableTenantAsync("blue");
+
+        await tenancy.EnableTenantAsync("blue");
+
+        (await tenancy.TryFindDatabaseAsync("blue")).ShouldNotBeNull();
+        (await RowsAsync()).ShouldBe([("blue", "Data Source=blue.db", false)]);
+    }
+
+    [Fact]
+    public async Task enabling_a_tenant_does_not_conjure_one_that_was_never_added()
+    {
+        var tenancy = TenancyFor();
+        await tenancy.BuildDatabasesAsync();
+
+        await tenancy.EnableTenantAsync("nobody");
+
+        // Lazily loaded on next access, which is also what keeps this a no-op rather than a
+        // phantom database for a tenant with no record.
+        tenancy.FindCachedDatabase("nobody").ShouldBeNull();
+        (await RowsAsync()).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task all_disabled_reports_the_disabled_tenants()
+    {
+        var tenancy = TenancyFor();
+        await tenancy.AddDatabaseRecordAsync("blue", "Data Source=blue.db");
+        await tenancy.AddDatabaseRecordAsync("green", "Data Source=green.db");
+        await tenancy.AddDatabaseRecordAsync("red", "Data Source=red.db");
+        await tenancy.DisableTenantAsync("green");
+        await tenancy.DisableTenantAsync("red");
+
+        (await tenancy.AllDisabledAsync()).OrderBy(x => x).ShouldBe(["green", "red"]);
+    }
+
+    [Fact]
+    public async Task deleting_a_tenant_removes_its_record_and_evicts_it()
+    {
+        var tenancy = TenancyFor();
+        await tenancy.AddDatabaseRecordAsync("blue", "Data Source=blue.db");
+        var database = tenancy.FindCachedDatabase("blue")!;
+
+        await tenancy.DeleteDatabaseRecordAsync("blue");
+
+        (await RowsAsync()).ShouldBeEmpty();
+        tenancy.FindCachedDatabase("blue").ShouldBeNull();
+        database.Disposed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task clearing_removes_every_record_and_empties_the_cache()
+    {
+        var tenancy = TenancyFor();
+        await tenancy.AddDatabaseRecordAsync("blue", "Data Source=blue.db");
+        await tenancy.AddDatabaseRecordAsync("green", "Data Source=green.db");
+
+        await tenancy.ClearAllDatabaseRecordsAsync();
+
+        (await RowsAsync()).ShouldBeEmpty();
+        tenancy.AllDatabases().ShouldBeEmpty();
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // The shared options -- what Polecat's inline re-implementation was missing
+    // ------------------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task seed_databases_are_written_into_the_control_table()
+    {
+        var tenancy = TenancyFor(x =>
+        {
+            x.SeedDatabases.Register("blue", "Data Source=blue.db");
+            x.SeedDatabases.Register("green", "Data Source=green.db");
+        });
+
+        var databases = await tenancy.BuildDatabasesAsync();
+
+        databases.Select(x => x.TenantId).OrderBy(x => x).ShouldBe(["blue", "green"]);
+        (await RowsAsync()).Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task seeding_happens_once()
+    {
+        var tenancy = TenancyFor(x => x.SeedDatabases.Register("blue", "Data Source=blue.db"));
+
+        await tenancy.BuildDatabasesAsync();
+        await tenancy.AddDatabaseRecordAsync("blue", "Data Source=corrected.db");
+        await tenancy.BuildDatabasesAsync();
+
+        // A second seed would have put the configured string back over the runtime change.
+        (await RowsAsync()).Single().ConnectionString.ShouldBe("Data Source=corrected.db");
+    }
+
+    [Fact]
+    public async Task the_application_name_reaches_the_tenant_database()
+    {
+        // The reason a store wants the shared options rather than its own: every tenant connection
+        // string gets the application name applied, for diagnostics. Polecat's inline options had
+        // no equivalent at all.
+        var provider = Substitute.For<IDatabaseProvider>();
+        provider.DefaultDatabaseSchemaName.Returns("main");
+        provider.AddApplicationNameToConnectionString(Arg.Any<string>(), Arg.Any<string>())
+            .Returns(call => $"{call.ArgAt<string>(0)};App={call.ArgAt<string>(1)}");
+
+        var tenancy = new TestTenancy(new MasterTableTenancyOptions<SqliteDataSource>(provider)
+        {
+            DataSource = new SqliteDataSource(_connectionString),
+            SchemaName = "main",
+            ApplicationName = "reporting"
+        });
+        _tenancies.Add(tenancy);
+
+        await tenancy.AddDatabaseRecordAsync("blue", "Data Source=blue.db");
+
+        tenancy.FindCachedDatabase("blue")!.ConnectionString.ShouldBe("Data Source=blue.db;App=reporting");
+
+        // The stored record keeps the caller's string -- the application name is this process's
+        // diagnostic label, not part of the tenant's identity.
+        (await RowsAsync()).Single().ConnectionString.ShouldBe("Data Source=blue.db");
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // Seams
+    // ------------------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task every_control_plane_call_goes_through_the_execute_seam()
+    {
+        // Polecat wraps every control-table call in its Polly pipeline. The base has to route all
+        // of them through one overridable point or the store gets a partly-resilient tenancy.
+        var tenancy = TenancyFor();
+
+        await tenancy.AddDatabaseRecordAsync("blue", "Data Source=blue.db");
+        await tenancy.BuildDatabasesAsync();
+        await tenancy.DisableTenantAsync("blue");
+        await tenancy.EnableTenantAsync("blue");
+        await tenancy.AllDisabledAsync();
+        await tenancy.LookupConnectionStringAsync("blue");
+        await tenancy.DeleteDatabaseRecordAsync("blue");
+        await tenancy.ClearAllDatabaseRecordsAsync();
+
+        tenancy.Executions.ShouldBeGreaterThanOrEqualTo(9);
+    }
+
+    [Fact]
+    public async Task tenant_ids_are_corrected_on_every_entry_point()
+    {
+        // One place, applied everywhere, because the failure mode of missing one is a tenant that
+        // resolves through one method and not another -- which reads as an intermittent.
+        var tenancy = TenancyFor();
+        tenancy.LowerCaseTenantIds = true;
+
+        await tenancy.AddDatabaseRecordAsync("BLUE", "Data Source=blue.db");
+
+        (await RowsAsync()).Single().TenantId.ShouldBe("blue");
+        tenancy.FindCachedDatabase("Blue").ShouldNotBeNull();
+        (await tenancy.TryFindDatabaseAsync("bLuE")).ShouldNotBeNull();
+
+        await tenancy.DisableTenantAsync("Blue");
+        (await tenancy.AllDisabledAsync()).ShouldBe(["blue"]);
+    }
+
+    [Fact]
+    public async Task disposal_disposes_every_cached_database()
+    {
+        var tenancy = TenancyFor();
+        await tenancy.AddDatabaseRecordAsync("blue", "Data Source=blue.db");
+        await tenancy.AddDatabaseRecordAsync("green", "Data Source=green.db");
+
+        var databases = tenancy.AllDatabases().ToList();
+        await tenancy.DisposeAsync();
+
+        databases.ShouldAllBe(x => x.Disposed);
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // IDynamicTenantSource<string> -- the block both stores wrote by hand
+    // ------------------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task the_dynamic_source_finds_a_tenants_connection_string()
+    {
+        var tenancy = TenancyFor();
+        await tenancy.AddDatabaseRecordAsync("blue", "Data Source=blue.db");
+
+        ITenantedSource<string> source = tenancy;
+
+        (await source.FindAsync("blue")).ShouldBe("Data Source=blue.db");
+        source.Cardinality.ShouldBe(JasperFx.Descriptors.DatabaseCardinality.DynamicMultiple);
+    }
+
+    [Fact]
+    public async Task the_dynamic_source_refuses_an_unknown_or_disabled_tenant_the_same_way()
+    {
+        var tenancy = TenancyFor();
+        await tenancy.AddDatabaseRecordAsync("blue", "Data Source=blue.db");
+        await tenancy.DisableTenantAsync("blue");
+
+        ITenantedSource<string> source = tenancy;
+
+        await Should.ThrowAsync<UnknownTenantIdException>(async () => await source.FindAsync("blue"));
+        await Should.ThrowAsync<UnknownTenantIdException>(async () => await source.FindAsync("nobody"));
+    }
+
+    [Fact]
+    public async Task the_dynamic_source_reports_tenant_ids_never_connection_strings()
+    {
+        // Deliberately not the connection strings, which would put credentials on an admin
+        // dashboard.
+        var tenancy = TenancyFor();
+        await tenancy.AddDatabaseRecordAsync("blue", "Data Source=blue.db;Password=hunter2");
+
+        ITenantedSource<string> source = tenancy;
+
+        source.AllActive().ShouldBe(["blue"]);
+        source.AllActiveByTenant().Single().ShouldBe(new Assignment<string>("blue", "blue"));
+    }
+
+    [Fact]
+    public async Task refreshing_drops_a_tenant_that_has_since_been_removed()
+    {
+        var tenancy = TenancyFor();
+        await tenancy.AddDatabaseRecordAsync("blue", "Data Source=blue.db");
+        await tenancy.AddDatabaseRecordAsync("green", "Data Source=green.db");
+
+        // Removed by another process.
+        await using (var conn = new SqliteConnection(_connectionString))
+        {
+            await conn.OpenAsync();
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = "delete from tenants where tenant_id = 'green'";
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        ITenantedSource<string> source = tenancy;
+        await source.RefreshAsync();
+
+        // A merge would have gone on serving the removed tenant from cache forever.
+        source.AllActive().ShouldBe(["blue"]);
+    }
+
+    [Fact]
+    public async Task the_dynamic_lifecycle_drives_the_same_runtime()
+    {
+        IDynamicTenantSource<string> source = TenancyFor();
+
+        await source.AddTenantAsync("blue", "Data Source=blue.db");
+        (await RowsAsync()).ShouldBe([("blue", "Data Source=blue.db", false)]);
+
+        await source.DisableTenantAsync("blue");
+        (await source.AllDisabledAsync()).ShouldBe(["blue"]);
+
+        await source.EnableTenantAsync("blue");
+        (await source.AllDisabledAsync()).ShouldBeEmpty();
+
+        await source.RemoveTenantAsync("blue");
+        (await RowsAsync()).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task auto_assignment_is_refused()
+    {
+        // There is no pool for a database-per-tenant model to assign from, so a caller has to
+        // supply a connection string. Left on the interface's throwing default rather than
+        // answered wrongly.
+        IDynamicTenantSource<string> source = TenancyFor();
+
+        await Should.ThrowAsync<NotSupportedException>(() => source.AddTenantAsync("blue"));
+    }
+
+    [Fact]
+    public async Task the_host_level_convenience_surface_is_wired_up()
+    {
+        IMasterTableMultiTenancy tenancy = TenancyFor();
+
+        (await tenancy.TryAddTenantDatabaseRecordsAsync("blue", "Data Source=blue.db")).ShouldBeTrue();
+        (await RowsAsync()).Count.ShouldBe(1);
+
+        (await tenancy.ClearAllDatabaseRecordsAsync()).ShouldBeTrue();
+        (await RowsAsync()).ShouldBeEmpty();
+    }
+
+    #region test doubles
+
+    /// <summary>Stands in for a store's own database type.</summary>
+    private sealed class TestDatabase(string tenantId, string connectionString): IAsyncDisposable
+    {
+        public string TenantId { get; } = tenantId;
+        public string ConnectionString { get; } = connectionString;
+        public bool Disposed { get; private set; }
+
+        public ValueTask DisposeAsync()
+        {
+            Disposed = true;
+            return default;
+        }
+    }
+
+    /// <summary>SQLite control-table SQL. SQLite has no schemas, so the schema folds into the name.</summary>
+    private sealed class SqliteTenantDialect: IMasterTenantTableDialect
+    {
+        /// <summary>
+        /// How many times the base actually rendered the control-table DDL. Counted here rather
+        /// than around <c>ProvisionControlTableAsync</c>, which is called on every entry point and
+        /// returns early once provisioned — so counting the calls would say nothing.
+        /// </summary>
+        public int CreateControlTableCalls { get; private set; }
+
+        public string QualifiedTableName(string schemaName, string tableName) =>
+            string.IsNullOrWhiteSpace(schemaName) || schemaName == "main"
+                ? $"\"{tableName}\""
+                : $"\"{schemaName}_{tableName}\"";
+
+        public string CreateControlTable(string schemaName, string tableName, string qualifiedTableName)
+        {
+            CreateControlTableCalls++;
+            return $"""
+             create table if not exists {qualifiedTableName} (
+                 tenant_id text not null primary key,
+                 connection_string text not null,
+                 is_disabled integer not null default 0
+             );
+             """;
+        }
+
+        public string SelectEnabledTenants(string qualifiedTableName) =>
+            $"select tenant_id, connection_string from {qualifiedTableName} where is_disabled = 0";
+
+        public string SelectDisabledTenantIds(string qualifiedTableName) =>
+            $"select tenant_id from {qualifiedTableName} where is_disabled = 1";
+
+        public string SelectConnectionString(string qualifiedTableName) =>
+            $"select connection_string from {qualifiedTableName} where tenant_id = @id and is_disabled = 0";
+
+        public string UpsertTenant(string qualifiedTableName) =>
+            $"""
+             insert into {qualifiedTableName} (tenant_id, connection_string, is_disabled)
+             values (@id, @connection, 0)
+             on conflict (tenant_id) do update set connection_string = excluded.connection_string
+             """;
+
+        public string DeleteTenant(string qualifiedTableName) =>
+            $"delete from {qualifiedTableName} where tenant_id = @id";
+
+        public string DeleteAllTenants(string qualifiedTableName) => $"delete from {qualifiedTableName}";
+
+        public string SetTenantDisabled(string qualifiedTableName, bool disabled) =>
+            $"update {qualifiedTableName} set is_disabled = {(disabled ? 1 : 0)} where tenant_id = @id";
+    }
+
+    private sealed class TestTenancy: MasterTableTenancyBase<TestDatabase, SqliteDataSource>
+    {
+        private readonly SqliteTenantDialect _dialect;
+        private int _executions;
+
+        public TestTenancy(MasterTableTenancyOptions<SqliteDataSource> options)
+            : this(options, new SqliteTenantDialect())
+        {
+        }
+
+        private TestTenancy(MasterTableTenancyOptions<SqliteDataSource> options, SqliteTenantDialect dialect)
+            : base(options, "tenants", dialect) => _dialect = dialect;
+
+        public int Executions => _executions;
+        public int ProvisioningAttempts => _dialect.CreateControlTableCalls;
+        public bool LowerCaseTenantIds { get; set; }
+
+        protected override SqliteDataSource BuildDataSource(string connectionString) => new(connectionString);
+
+        protected override TestDatabase BuildDatabase(string tenantId, string connectionString) =>
+            new(tenantId, connectionString);
+
+        protected override string CorrectTenantId(string tenantId) =>
+            LowerCaseTenantIds ? tenantId.ToLowerInvariant() : tenantId;
+
+        protected override Task<T> ExecuteAsync<T>(
+            Func<CancellationToken, Task<T>> operation, CancellationToken token)
+        {
+            Interlocked.Increment(ref _executions);
+            return base.ExecuteAsync(operation, token);
+        }
+    }
+
+    #endregion
+}

--- a/src/Weasel.Core/MultiTenancy/IMasterTenantTableDialect.cs
+++ b/src/Weasel.Core/MultiTenancy/IMasterTenantTableDialect.cs
@@ -1,0 +1,89 @@
+#nullable enable
+namespace Weasel.Core.MultiTenancy;
+
+/// <summary>
+/// The SQL half of master-table multi-tenancy. Everything about the control table that is not
+/// dialect-specific — the cache, the guarded provisioning, the runtime tenant lifecycle — lives in
+/// <see cref="MasterTableTenancyBase{TDatabase,TDataSource}" />; this is the part that has to know
+/// whether an upsert spells itself <c>on conflict … do update</c> or <c>MERGE</c>, and whether a
+/// boolean is <c>false</c> or <c>0</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Two hard contracts, because the base binds and reads positionally.</b>
+/// </para>
+/// <list type="number">
+/// <item>
+/// Every statement that takes a tenant id names the parameter <c>@id</c>, and
+/// <see cref="UpsertTenant" /> additionally names <c>@connection</c>. Npgsql,
+/// Microsoft.Data.SqlClient and Microsoft.Data.Sqlite all accept <c>@</c>-prefixed names, so one
+/// spelling serves every dialect the Critter Stack ships.
+/// </item>
+/// <item>
+/// <see cref="SelectEnabledTenants" /> returns <c>tenant_id</c> at ordinal 0 and
+/// <c>connection_string</c> at ordinal 1; <see cref="SelectDisabledTenantIds" /> and
+/// <see cref="SelectConnectionString" /> return a single column at ordinal 0.
+/// </item>
+/// </list>
+/// </remarks>
+public interface IMasterTenantTableDialect
+{
+    /// <summary>
+    /// The control table's name, qualified and quoted the way this dialect wants it — e.g.
+    /// <c>public.mt_tenant_databases</c> or <c>[dbo].[pc_tenants]</c>. Every other member is
+    /// handed the result of this, so the qualification rule lives in one place.
+    /// </summary>
+    string QualifiedTableName(string schemaName, string tableName);
+
+    /// <summary>
+    /// Idempotent DDL creating the schema (if the dialect has schemas) and the control table.
+    /// </summary>
+    /// <remarks>
+    /// It has to be idempotent rather than guarded by a prior existence check, because two
+    /// processes can reach it at once — the semaphore in the base guards one process, not a
+    /// deployment. A store that would rather run this through Weasel's migration pipeline should
+    /// override <see cref="MasterTableTenancyBase{TDatabase,TDataSource}.ProvisionControlTableAsync" />
+    /// instead, in which case this member is never called.
+    /// </remarks>
+    string CreateControlTable(string schemaName, string tableName, string qualifiedTableName);
+
+    /// <summary>
+    /// <c>tenant_id, connection_string</c> for every tenant that is not disabled.
+    /// </summary>
+    string SelectEnabledTenants(string qualifiedTableName);
+
+    /// <summary>
+    /// <c>tenant_id</c> for every disabled tenant.
+    /// </summary>
+    string SelectDisabledTenantIds(string qualifiedTableName);
+
+    /// <summary>
+    /// <c>connection_string</c> for one enabled tenant (<c>@id</c>), or no row.
+    /// </summary>
+    /// <remarks>
+    /// <b>The "and not disabled" half is not optional.</b> Without it a disabled tenant resolves
+    /// and opens sessions, which is the one thing disabling is for — and it would do so silently,
+    /// because everything else about the tenant is intact.
+    /// </remarks>
+    string SelectConnectionString(string qualifiedTableName);
+
+    /// <summary>
+    /// Insert or update a tenant's connection string (<c>@id</c>, <c>@connection</c>).
+    /// </summary>
+    /// <remarks>
+    /// An upsert rather than an insert, so re-adding a tenant is idempotent. Whether it also clears
+    /// the disabled flag is the dialect's call and the two shipped stores disagree — Polecat's
+    /// MERGE re-enables, Marten's <c>on conflict</c> does not — so the base does not assume either;
+    /// callers wanting a re-enable can say so.
+    /// </remarks>
+    string UpsertTenant(string qualifiedTableName);
+
+    /// <summary>Delete one tenant's record (<c>@id</c>).</summary>
+    string DeleteTenant(string qualifiedTableName);
+
+    /// <summary>Delete every tenant record.</summary>
+    string DeleteAllTenants(string qualifiedTableName);
+
+    /// <summary>Set or clear one tenant's disabled flag (<c>@id</c>).</summary>
+    string SetTenantDisabled(string qualifiedTableName, bool disabled);
+}

--- a/src/Weasel.Core/MultiTenancy/MasterTableTenancyBase.cs
+++ b/src/Weasel.Core/MultiTenancy/MasterTableTenancyBase.cs
@@ -1,0 +1,749 @@
+#nullable enable
+using System.Collections.Concurrent;
+using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
+using JasperFx;
+using JasperFx.Descriptors;
+using JasperFx.MultiTenancy;
+
+namespace Weasel.Core.MultiTenancy;
+
+/// <summary>
+/// Dynamic database-per-tenant driven by a control table mapping <c>tenant_id</c> to a connection
+/// string, with tenants added, disabled, enabled and removed at runtime rather than fixed at
+/// registration. The runtime Marten's <c>MasterTableTenancy</c> (515 lines) and Polecat's (434)
+/// each carried a copy of — weasel#567.
+/// </summary>
+/// <typeparam name="TDatabase">
+/// The store's own database type. Left unconstrained on purpose: the three stores' database types
+/// share no interface Weasel could name here, and the lift does not need one — everything this
+/// class does with a <typeparamref name="TDatabase" /> is cache it, hand it back, and dispose it
+/// through <see cref="DisposeDatabaseAsync" />.
+/// </typeparam>
+/// <typeparam name="TDataSource">
+/// The provider's data source, which is what makes <see cref="MasterTableTenancyOptions{T}" />
+/// usable from here. Marten already closes that type over <c>NpgsqlDataSource</c>; Polecat
+/// re-implemented the same options inline and never touched the shared type at all, which is the
+/// asymmetry this lift exists to close.
+/// </typeparam>
+/// <remarks>
+/// <para>
+/// <b>What is here and what is not.</b> The base owns the control-table contract, the resolved
+/// database cache, provisioning the table exactly once, and the whole
+/// <see cref="IDynamicTenantSource{T}" /> lifecycle — which in both stores today is ~80 lines of
+/// adapter forwarding to the store's own cancellable methods. The dialect owns every SQL string
+/// (<see cref="IMasterTenantTableDialect" />) and the store owns building a database from a
+/// connection string.
+/// </para>
+/// <para>
+/// <b><see cref="ITenancy" /> is deliberately not touched.</b> All three stores declare their own,
+/// differing only in the concrete database type, and an <c>ITenancy&lt;TDatabase&gt;</c> would
+/// unify them — but it is a breaking change to three public API surfaces and this class does not
+/// need it, being generic over its database type already. A store adopting this base implements
+/// its own <c>ITenancy</c> on top and forwards.
+/// </para>
+/// </remarks>
+public abstract class MasterTableTenancyBase<TDatabase, TDataSource>:
+    IMasterTableMultiTenancy, IDynamicTenantSource<string>, IDisposable, IAsyncDisposable
+    where TDatabase : class
+    where TDataSource : DbDataSource
+{
+    private readonly ConcurrentDictionary<string, TenantEntry> _databases;
+    private readonly Func<TDataSource> _dataSourceFactory;
+    private readonly Lock _dataSourceLock = new();
+    private readonly bool _ownsDataSource;
+    private readonly SemaphoreSlim _provisioning = new(1, 1);
+
+    private TDataSource? _dataSource;
+
+    private volatile bool _controlTableProvisioned;
+    private volatile bool _seeded;
+
+    /// <param name="options">
+    /// The shared options — master connection string or data source, schema name, application name,
+    /// <see cref="MasterTableTenancyOptions{T}.AutoCreate" /> override and seed databases.
+    /// </param>
+    /// <param name="tableName">
+    /// The control table's unqualified name. The stores each pick their own prefixed spelling
+    /// (<c>mt_tenant_databases</c>, <c>pc_tenants</c>) and neither should change, because a rename
+    /// is a migration of a table an operator may already be populating by hand.
+    /// </param>
+    /// <param name="dialect">Renders this store's control-table SQL.</param>
+    /// <param name="tenantIdComparer">
+    /// How tenant ids are compared in the cache. Defaults to
+    /// <see cref="StringComparer.Ordinal" />, which is the conservative choice: a store folding
+    /// case should do it in <see cref="CorrectTenantId" /> so the folded id is what reaches the
+    /// database as well as the cache, rather than having the two disagree.
+    /// </param>
+    protected MasterTableTenancyBase(
+        MasterTableTenancyOptions<TDataSource> options,
+        string tableName,
+        IMasterTenantTableDialect dialect,
+        IEqualityComparer<string>? tenantIdComparer = null)
+    {
+        Options = options ?? throw new ArgumentNullException(nameof(options));
+        Dialect = dialect ?? throw new ArgumentNullException(nameof(dialect));
+        ArgumentException.ThrowIfNullOrWhiteSpace(tableName);
+
+        TableName = tableName;
+        QualifiedTableName = dialect.QualifiedTableName(options.SchemaName, tableName);
+
+        _databases = new ConcurrentDictionary<string, TenantEntry>(tenantIdComparer ?? StringComparer.Ordinal);
+
+        if (options.DataSource is not null)
+        {
+            // Somebody else built it, so somebody else disposes it. Disposing a caller-supplied
+            // data source is the kind of thing that only shows up as an ObjectDisposedException in
+            // an unrelated part of an application.
+            var supplied = options.DataSource;
+            _ownsDataSource = false;
+            _dataSourceFactory = () => supplied;
+        }
+        else if (!string.IsNullOrWhiteSpace(options.ConnectionString))
+        {
+            _ownsDataSource = true;
+            _dataSourceFactory = () => BuildDataSource(options.CorrectedConnectionString());
+        }
+        else
+        {
+            throw new ArgumentOutOfRangeException(nameof(options),
+                $"Master table tenancy needs either a {typeof(TDataSource).Name} or a connection string for the control-plane database.");
+        }
+    }
+
+    /// <summary>The shared options this tenancy was configured with.</summary>
+    public MasterTableTenancyOptions<TDataSource> Options { get; }
+
+    /// <summary>The control table's unqualified name.</summary>
+    public string TableName { get; }
+
+    /// <summary>The control table's name as this dialect qualifies it.</summary>
+    public string QualifiedTableName { get; }
+
+    /// <summary>The SQL seam.</summary>
+    protected IMasterTenantTableDialect Dialect { get; }
+
+    /// <summary>The control-plane data source. Built lazily; never opened by the constructor.</summary>
+    /// <remarks>
+    /// Lazy by hand rather than through <see cref="Lazy{T}" />, which would need
+    /// <typeparamref name="TDataSource" /> annotated for trimming and push that annotation onto
+    /// every store closing the generic.
+    /// </remarks>
+    protected TDataSource MasterDataSource
+    {
+        get
+        {
+            if (_dataSource is not null)
+            {
+                return _dataSource;
+            }
+
+            lock (_dataSourceLock)
+            {
+                return _dataSource ??= _dataSourceFactory();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Always <see cref="DatabaseCardinality.DynamicMultiple" /> — the tenant set is read from the
+    /// control table and changes while the store runs.
+    /// </summary>
+    public DatabaseCardinality Cardinality => DatabaseCardinality.DynamicMultiple;
+
+    /// <summary>
+    /// Whether the control table may be created at runtime. Defaults to the options' override, and
+    /// to <see cref="AutoCreate.CreateOrUpdate" /> when it names none; override to fall back to the
+    /// store's own schema policy instead.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="AutoCreate.None" /> has to be honoured here, not merely respected elsewhere: it
+    /// says the schema is the operator's, and the control table is exactly the object a
+    /// least-privilege deployment provisions by hand. A read against a table that is genuinely
+    /// missing then surfaces as the database's own clean "no such table" error.
+    /// </remarks>
+    protected virtual AutoCreate EffectiveAutoCreate => Options.AutoCreate ?? AutoCreate.CreateOrUpdate;
+
+    /// <summary>Build the control-plane data source from a connection string.</summary>
+    protected abstract TDataSource BuildDataSource(string connectionString);
+
+    /// <summary>Build a tenant database from its connection string.</summary>
+    /// <remarks>
+    /// The connection string reaching here has already been through
+    /// <see cref="MasterTableTenancyOptions{T}.CorrectConnectionString" />, so the application name
+    /// is on it — which is the whole reason a store wants the shared options rather than its own.
+    /// </remarks>
+    protected abstract TDatabase BuildDatabase(string tenantId, string connectionString);
+
+    /// <summary>
+    /// Normalize a tenant id before it is used as a cache key or bound as a parameter. Defaults to
+    /// leaving it alone; a store with a <see cref="TenantIdStyle" /> applies it here.
+    /// </summary>
+    /// <remarks>
+    /// One place, applied on every public entry point, because the failure mode of missing one is
+    /// a tenant that resolves through one method and not another — which reads as an intermittent.
+    /// </remarks>
+    protected virtual string CorrectTenantId(string tenantId) => tenantId;
+
+    /// <summary>
+    /// Dispose a tenant database evicted from the cache, asynchronously. The default routes an
+    /// <see cref="IAsyncDisposable" /> to its async disposal and everything else to
+    /// <see cref="DisposeDatabase" />.
+    /// </summary>
+    /// <remarks>
+    /// Preferring the async form matters where a store's database owns a data source: a
+    /// <see cref="DbDataSource" /> closes pooled connections on async disposal and blocks on sync
+    /// disposal, and this runs on the path a tenant is disabled or removed on.
+    /// </remarks>
+    protected virtual ValueTask DisposeDatabaseAsync(TDatabase database)
+    {
+        if (database is IAsyncDisposable asyncDisposable)
+        {
+            return asyncDisposable.DisposeAsync();
+        }
+
+        DisposeDatabase(database);
+        return default;
+    }
+
+    /// <summary>
+    /// Dispose a tenant database synchronously, for <see cref="Dispose" />. The default disposes an
+    /// <see cref="IDisposable" /> and ignores anything else.
+    /// </summary>
+    protected virtual void DisposeDatabase(TDatabase database) => (database as IDisposable)?.Dispose();
+
+    /// <summary>
+    /// Run one control-plane operation. The default just runs it; override to wrap every database
+    /// call in the store's resilience pipeline, as Polecat does.
+    /// </summary>
+    protected virtual Task<T> ExecuteAsync<T>(Func<CancellationToken, Task<T>> operation, CancellationToken token)
+        => operation(token);
+
+    /// <summary>Run one control-plane operation with no result.</summary>
+    protected async Task ExecuteAsync(Func<CancellationToken, Task> operation, CancellationToken token) =>
+        await ExecuteAsync<object?>(async ct =>
+        {
+            await operation(ct).ConfigureAwait(false);
+            return null;
+        }, token).ConfigureAwait(false);
+
+    // ------------------------------------------------------------------------------------------
+    // Reads
+    // ------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// Read every enabled tenant from the control table, refreshing the cache, and return the
+    /// databases this tenancy now knows about.
+    /// </summary>
+    /// <remarks>
+    /// Idempotent: a tenant already cached under the same connection string keeps its existing
+    /// database rather than getting a new one, so calling this on a schedule does not churn
+    /// connection pools. A tenant whose connection string has <em>changed</em> is rebuilt, and the
+    /// database it replaces is disposed.
+    /// </remarks>
+    public async Task<IReadOnlyList<TDatabase>> BuildDatabasesAsync(CancellationToken token = default)
+    {
+        await ProvisionControlTableAsync(token).ConfigureAwait(false);
+        await SeedDatabasesAsync(token).ConfigureAwait(false);
+
+        var rows = await ExecuteAsync(async ct =>
+        {
+            var list = new List<(string TenantId, string ConnectionString)>();
+
+            await using var conn = await MasterDataSource.OpenConnectionAsync(ct).ConfigureAwait(false);
+            await using var cmd = CreateCommand(conn, Dialect.SelectEnabledTenants(QualifiedTableName));
+            await using var reader = await cmd.ExecuteReaderAsync(ct).ConfigureAwait(false);
+
+            while (await reader.ReadAsync(ct).ConfigureAwait(false))
+            {
+                list.Add((reader.GetString(0), reader.GetString(1)));
+            }
+
+            await reader.CloseAsync().ConfigureAwait(false);
+            return list;
+        }, token).ConfigureAwait(false);
+
+        foreach (var (rawTenantId, rawConnectionString) in rows)
+        {
+            var tenantId = CorrectTenantId(rawTenantId);
+            var connectionString = Options.CorrectConnectionString(rawConnectionString);
+
+            var replaced = default(TDatabase);
+
+            _databases.AddOrUpdate(tenantId,
+                id => new TenantEntry(connectionString, BuildDatabase(id, connectionString)),
+                (id, existing) =>
+                {
+                    if (string.Equals(existing.ConnectionString, connectionString, StringComparison.Ordinal))
+                    {
+                        return existing;
+                    }
+
+                    replaced = existing.Database;
+                    return new TenantEntry(connectionString, BuildDatabase(id, connectionString));
+                });
+
+            if (replaced is not null)
+            {
+                await DisposeDatabaseAsync(replaced).ConfigureAwait(false);
+            }
+        }
+
+        return AllDatabases();
+    }
+
+    /// <summary>Every tenant database currently cached.</summary>
+    public IReadOnlyList<TDatabase> AllDatabases() =>
+        _databases.Values.Select(x => x.Database).ToList();
+
+    /// <summary>Every tenant id currently cached.</summary>
+    public IReadOnlyList<string> AllTenantIds() => _databases.Keys.ToList();
+
+    /// <summary>
+    /// Resolve a tenant's database, reading the control table when it is not cached. Returns null
+    /// for a tenant that is unknown or disabled.
+    /// </summary>
+    /// <remarks>
+    /// Unknown and disabled are deliberately the same answer <em>here</em> — a disabled tenant is
+    /// not routable, which is what disabling means — but a caller turning this into an exception
+    /// should throw <see cref="UnknownTenantIdException" /> so it is the same failure an
+    /// unregistered tenant produces, rather than something a caller has to handle twice.
+    /// </remarks>
+    public async ValueTask<TDatabase?> TryFindDatabaseAsync(string tenantId, CancellationToken token = default)
+    {
+        tenantId = CorrectTenantId(tenantId);
+
+        if (_databases.TryGetValue(tenantId, out var cached))
+        {
+            return cached.Database;
+        }
+
+        var connectionString = await LookupConnectionStringAsync(tenantId, token).ConfigureAwait(false);
+        if (connectionString is null)
+        {
+            return null;
+        }
+
+        return _databases.GetOrAdd(tenantId,
+            id => new TenantEntry(connectionString, BuildDatabase(id, connectionString))).Database;
+    }
+
+    /// <summary>The cached database for a tenant, without touching the control table.</summary>
+    public TDatabase? FindCachedDatabase(string tenantId) =>
+        _databases.TryGetValue(CorrectTenantId(tenantId), out var entry) ? entry.Database : null;
+
+    /// <summary>
+    /// The connection string recorded for one enabled tenant, with the application name applied,
+    /// or null when the tenant is unknown or disabled.
+    /// </summary>
+    public async Task<string?> LookupConnectionStringAsync(string tenantId, CancellationToken token = default)
+    {
+        tenantId = CorrectTenantId(tenantId);
+        await ProvisionControlTableAsync(token).ConfigureAwait(false);
+
+        var connectionString = await ExecuteAsync(async ct =>
+        {
+            await using var conn = await MasterDataSource.OpenConnectionAsync(ct).ConfigureAwait(false);
+            await using var cmd = CreateCommand(conn, Dialect.SelectConnectionString(QualifiedTableName),
+                ("@id", tenantId));
+
+            return await cmd.ExecuteScalarAsync(ct).ConfigureAwait(false) as string;
+        }, token).ConfigureAwait(false);
+
+        return string.IsNullOrEmpty(connectionString)
+            ? null
+            : Options.CorrectConnectionString(connectionString);
+    }
+
+    /// <summary>The tenant ids currently disabled.</summary>
+    public async Task<IReadOnlyList<string>> AllDisabledAsync(CancellationToken token = default)
+    {
+        await ProvisionControlTableAsync(token).ConfigureAwait(false);
+
+        return await ExecuteAsync(async ct =>
+        {
+            var list = new List<string>();
+
+            await using var conn = await MasterDataSource.OpenConnectionAsync(ct).ConfigureAwait(false);
+            await using var cmd = CreateCommand(conn, Dialect.SelectDisabledTenantIds(QualifiedTableName));
+            await using var reader = await cmd.ExecuteReaderAsync(ct).ConfigureAwait(false);
+
+            while (await reader.ReadAsync(ct).ConfigureAwait(false))
+            {
+                list.Add(reader.GetString(0));
+            }
+
+            await reader.CloseAsync().ConfigureAwait(false);
+            return (IReadOnlyList<string>)list;
+        }, token).ConfigureAwait(false);
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // The runtime lifecycle
+    // ------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// Record a tenant's connection string, creating or updating it. The tenant is cached eagerly,
+    /// so it is usable by the next session without waiting for a refresh.
+    /// </summary>
+    public async Task AddDatabaseRecordAsync(
+        string tenantId, string connectionString, CancellationToken token = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tenantId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
+
+        tenantId = CorrectTenantId(tenantId);
+        await ProvisionControlTableAsync(token).ConfigureAwait(false);
+
+        await ExecuteAsync(async ct =>
+        {
+            await using var conn = await MasterDataSource.OpenConnectionAsync(ct).ConfigureAwait(false);
+            await using var cmd = CreateCommand(conn, Dialect.UpsertTenant(QualifiedTableName),
+                ("@id", tenantId), ("@connection", connectionString));
+
+            await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+        }, token).ConfigureAwait(false);
+
+        // The stored string is the caller's; the built database gets the corrected one.
+        var corrected = Options.CorrectConnectionString(connectionString);
+        var replaced = default(TDatabase);
+
+        _databases.AddOrUpdate(tenantId,
+            id => new TenantEntry(corrected, BuildDatabase(id, corrected)),
+            (id, existing) =>
+            {
+                replaced = existing.Database;
+                return new TenantEntry(corrected, BuildDatabase(id, corrected));
+            });
+
+        if (replaced is not null)
+        {
+            await DisposeDatabaseAsync(replaced).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Remove a tenant's record. The tenant's own database is left completely alone.
+    /// </summary>
+    public async Task DeleteDatabaseRecordAsync(string tenantId, CancellationToken token = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tenantId);
+
+        tenantId = CorrectTenantId(tenantId);
+        await ProvisionControlTableAsync(token).ConfigureAwait(false);
+
+        // Evicted before the delete, not after: a caller racing this must not be handed a database
+        // for a record that is on its way out.
+        await EvictAsync(tenantId).ConfigureAwait(false);
+
+        await ExecuteAsync(async ct =>
+        {
+            await using var conn = await MasterDataSource.OpenConnectionAsync(ct).ConfigureAwait(false);
+            await using var cmd = CreateCommand(conn, Dialect.DeleteTenant(QualifiedTableName),
+                ("@id", tenantId));
+
+            await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+        }, token).ConfigureAwait(false);
+    }
+
+    /// <summary>Remove every tenant record and empty the cache.</summary>
+    public async Task ClearAllDatabaseRecordsAsync(CancellationToken token = default)
+    {
+        await ProvisionControlTableAsync(token).ConfigureAwait(false);
+
+        foreach (var tenantId in _databases.Keys.ToList())
+        {
+            await EvictAsync(tenantId).ConfigureAwait(false);
+        }
+
+        await ExecuteAsync(async ct =>
+        {
+            await using var conn = await MasterDataSource.OpenConnectionAsync(ct).ConfigureAwait(false);
+            await using var cmd = CreateCommand(conn, Dialect.DeleteAllTenants(QualifiedTableName));
+
+            await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+        }, token).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Disable a tenant without deleting its record. It is evicted from the cache and stops
+    /// resolving until re-enabled.
+    /// </summary>
+    public async Task DisableTenantAsync(string tenantId, CancellationToken token = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tenantId);
+
+        tenantId = CorrectTenantId(tenantId);
+        await ProvisionControlTableAsync(token).ConfigureAwait(false);
+
+        await SetDisabledAsync(tenantId, true, token).ConfigureAwait(false);
+
+        // The eviction is what makes disabling take effect at all — the cache does not consult the
+        // control table, so a cached database would go on serving a tenant that is switched off.
+        await EvictAsync(tenantId).ConfigureAwait(false);
+    }
+
+    /// <summary>Re-enable a disabled tenant. It resolves again on next access.</summary>
+    public async Task EnableTenantAsync(string tenantId, CancellationToken token = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tenantId);
+
+        tenantId = CorrectTenantId(tenantId);
+        await ProvisionControlTableAsync(token).ConfigureAwait(false);
+
+        await SetDisabledAsync(tenantId, false, token).ConfigureAwait(false);
+
+        // No eager cache fill: the tenant is loaded lazily on next access, which is also what makes
+        // "enable a tenant that was never added" a no-op rather than a phantom database.
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // Control table provisioning
+    // ------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// Create the control table on first use, once per instance.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Guarded by a semaphore with the flag re-checked inside it, so a burst of concurrent first
+    /// calls issues one statement rather than N. That is the cheap half; the DDL itself has to be
+    /// idempotent regardless (see <see cref="IMasterTenantTableDialect.CreateControlTable" />),
+    /// because a semaphore guards one process and a deployment has several.
+    /// </para>
+    /// <para>
+    /// <b>The flag is only set after the statement succeeds.</b> Remembering a failed attempt as
+    /// done would leave the tenancy permanently broken with nothing to say why — the same
+    /// discipline a first-use migration cache needs.
+    /// </para>
+    /// <para>
+    /// Override to run the store's own Weasel migration for the table instead, as Marten does; an
+    /// override that does so never calls the dialect's DDL.
+    /// </para>
+    /// </remarks>
+    protected virtual async Task ProvisionControlTableAsync(CancellationToken token)
+    {
+        if (_controlTableProvisioned)
+        {
+            return;
+        }
+
+        if (EffectiveAutoCreate == AutoCreate.None)
+        {
+            // The schema is the operator's. Do not emit DDL on what may be a least-privilege
+            // connection; a genuinely missing table surfaces as the database's own error.
+            _controlTableProvisioned = true;
+            return;
+        }
+
+        await _provisioning.WaitAsync(token).ConfigureAwait(false);
+        try
+        {
+            if (_controlTableProvisioned)
+            {
+                return;
+            }
+
+            await ExecuteAsync(async ct =>
+            {
+                await using var conn = await MasterDataSource.OpenConnectionAsync(ct).ConfigureAwait(false);
+                await using var cmd = CreateCommand(conn,
+                    Dialect.CreateControlTable(Options.SchemaName, TableName, QualifiedTableName));
+
+                await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+            }, token).ConfigureAwait(false);
+
+            _controlTableProvisioned = true;
+        }
+        finally
+        {
+            _provisioning.Release();
+        }
+    }
+
+    /// <summary>
+    /// Write the configured <see cref="MasterTableTenancyOptions{T}.SeedDatabases" /> into the
+    /// control table, once.
+    /// </summary>
+    /// <remarks>
+    /// Upserts rather than inserts, so a seeded tenant whose connection string changed in
+    /// configuration is corrected on the next start rather than silently keeping the old one.
+    /// </remarks>
+    protected virtual async Task SeedDatabasesAsync(CancellationToken token)
+    {
+        if (_seeded || !Options.SeedDatabases.HasAny())
+        {
+            return;
+        }
+
+        foreach (var assignment in Options.SeedDatabases.AllActiveByTenant())
+        {
+            await ExecuteAsync(async ct =>
+            {
+                await using var conn = await MasterDataSource.OpenConnectionAsync(ct).ConfigureAwait(false);
+                await using var cmd = CreateCommand(conn, Dialect.UpsertTenant(QualifiedTableName),
+                    ("@id", CorrectTenantId(assignment.TenantId)), ("@connection", assignment.Value));
+
+                await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+            }, token).ConfigureAwait(false);
+        }
+
+        _seeded = true;
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // IMasterTableMultiTenancy — the host-level convenience surface
+    // ------------------------------------------------------------------------------------------
+
+    async Task<bool> IMasterTableMultiTenancy.TryAddTenantDatabaseRecordsAsync(
+        string tenantId, string connectionString)
+    {
+        await AddDatabaseRecordAsync(tenantId, connectionString, CancellationToken.None).ConfigureAwait(false);
+        return true;
+    }
+
+    async Task<bool> IMasterTableMultiTenancy.ClearAllDatabaseRecordsAsync()
+    {
+        await ClearAllDatabaseRecordsAsync(CancellationToken.None).ConfigureAwait(false);
+        return true;
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // IDynamicTenantSource<string> — the store-agnostic admin surface (CritterWatch)
+    // ------------------------------------------------------------------------------------------
+
+    // Implemented explicitly throughout, because every member here has a cancellable twin above and
+    // the concrete API should stay the cancellable one. Both stores wrote this adapter by hand; it
+    // is the single largest block the lift removes from each.
+
+    async ValueTask<string> ITenantedSource<string>.FindAsync(string tenantId) =>
+        await LookupConnectionStringAsync(tenantId, CancellationToken.None).ConfigureAwait(false)
+        ?? throw new UnknownTenantIdException(tenantId);
+
+    async Task ITenantedSource<string>.RefreshAsync()
+    {
+        // Clear rather than merge: the point of a refresh is to drop tenants that have since been
+        // removed or disabled, and a merge would keep serving them from cache forever.
+        foreach (var tenantId in _databases.Keys.ToList())
+        {
+            await EvictAsync(tenantId).ConfigureAwait(false);
+        }
+
+        await BuildDatabasesAsync(CancellationToken.None).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// The tenant identifiers currently active. Deliberately not the connection strings, which
+    /// would put credentials on an admin dashboard.
+    /// </summary>
+    IReadOnlyList<string> ITenantedSource<string>.AllActive() => AllTenantIds();
+
+    IReadOnlyList<Assignment<string>> ITenantedSource<string>.AllActiveByTenant() =>
+        _databases.Keys.Select(id => new Assignment<string>(id, id)).ToList();
+
+    Task IDynamicTenantSource<string>.AddTenantAsync(string tenantId, string connectionValue) =>
+        AddDatabaseRecordAsync(tenantId, connectionValue, CancellationToken.None);
+
+    // The auto-assign overload -- Task<string> AddTenantAsync(string, CancellationToken) -- is left
+    // on its throwing default deliberately. There is no pool for a database-per-tenant model to
+    // assign from, so a caller has to supply a connection string.
+
+    Task IDynamicTenantSource<string>.DisableTenantAsync(string tenantId) =>
+        DisableTenantAsync(tenantId, CancellationToken.None);
+
+    Task IDynamicTenantSource<string>.EnableTenantAsync(string tenantId) =>
+        EnableTenantAsync(tenantId, CancellationToken.None);
+
+    Task IDynamicTenantSource<string>.RemoveTenantAsync(string tenantId) =>
+        DeleteDatabaseRecordAsync(tenantId, CancellationToken.None);
+
+    Task<IReadOnlyList<string>> IDynamicTenantSource<string>.AllDisabledAsync() =>
+        AllDisabledAsync(CancellationToken.None);
+
+    // ------------------------------------------------------------------------------------------
+
+    private async Task SetDisabledAsync(string tenantId, bool disabled, CancellationToken token) =>
+        await ExecuteAsync(async ct =>
+        {
+            await using var conn = await MasterDataSource.OpenConnectionAsync(ct).ConfigureAwait(false);
+            await using var cmd = CreateCommand(conn,
+                Dialect.SetTenantDisabled(QualifiedTableName, disabled), ("@id", tenantId));
+
+            await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+        }, token).ConfigureAwait(false);
+
+    private async ValueTask EvictAsync(string tenantId)
+    {
+        if (_databases.TryRemove(tenantId, out var entry))
+        {
+            await DisposeDatabaseAsync(entry.Database).ConfigureAwait(false);
+        }
+    }
+
+    [SuppressMessage("Reliability", "CA2100:Review SQL queries for security vulnerabilities",
+        Justification = "The SQL comes from the store's own IMasterTenantTableDialect; tenant ids and connection strings are bound as parameters.")]
+    private static DbCommand CreateCommand(
+        DbConnection connection, string sql, params (string Name, object? Value)[] parameters)
+    {
+        var command = connection.CreateCommand();
+        command.CommandText = sql;
+
+        foreach (var (name, value) in parameters)
+        {
+            var parameter = command.CreateParameter();
+            parameter.ParameterName = name;
+            parameter.Value = value ?? DBNull.Value;
+            command.Parameters.Add(parameter);
+        }
+
+        return command;
+    }
+
+    /// <summary>
+    /// Dispose every cached tenant database and, when this tenancy built it, the control-plane data
+    /// source.
+    /// </summary>
+    /// <remarks>
+    /// Written out synchronously rather than blocking on <see cref="DisposeAsync" />. A container
+    /// disposed synchronously reaches this one, and sync-over-async here would be a deadlock risk
+    /// on exactly the shutdown path that has nowhere to report it.
+    /// </remarks>
+    public void Dispose()
+    {
+        foreach (var entry in _databases.Values)
+        {
+            DisposeDatabase(entry.Database);
+        }
+
+        _databases.Clear();
+
+        if (_ownsDataSource)
+        {
+            _dataSource?.Dispose();
+        }
+
+        _provisioning.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    /// <inheritdoc cref="Dispose" />
+    public async ValueTask DisposeAsync()
+    {
+        foreach (var entry in _databases.Values)
+        {
+            await DisposeDatabaseAsync(entry.Database).ConfigureAwait(false);
+        }
+
+        _databases.Clear();
+
+        if (_ownsDataSource && _dataSource is not null)
+        {
+            await _dataSource.DisposeAsync().ConfigureAwait(false);
+        }
+
+        _provisioning.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private sealed record TenantEntry(string ConnectionString, TDatabase Database);
+}


### PR DESCRIPTION
Closes #567 — Stoat node `weasel-master-tenancy` (plan `internals-lifting-2026-09`).

Dynamic database-per-tenant driven by a control table is implemented twice: Marten's
`MasterTableTenancy` (515 lines) and Polecat's (434), whose own class remark says it

> Mirrors Marten's `MasterTableTenancy: ITenancy, ITenancyWithMasterDatabase, IDynamicTenantSource<string>`.

Both carry a control table (`mt_tenant_databases` / `pc_tenants`) mapping tenant id to connection
string, a cache of resolved tenant databases, a lazily-created control table guarded so two callers
cannot race the DDL, and the runtime add / disable / enable / remove lifecycle behind
`IDynamicTenantSource<string>`.

## What lands

| Type | Role |
|---|---|
| `MasterTableTenancyBase<TDatabase, TDataSource>` | The runtime: cache, provisioning, seeding, lifecycle, `IDynamicTenantSource<string>`, `IMasterTableMultiTenancy` |
| `IMasterTenantTableDialect` | Every SQL string — `on conflict … do update` vs `MERGE`, `false`/`true` vs `0`/`1` |

Nothing in Marten or Polecat changes; adoption is separately gated in the plan.

## The asymmetry this closes

Weasel already ships `Weasel.Core.MultiTenancy.MasterTableTenancyOptions<T> where T : DbDataSource`
— connection string, data source, schema name, application name, `AutoCreate` override, seed
databases, and the `CorrectConnectionString` application-name rewrite.

**Marten uses it**, through a 17-line subclass closing it over `NpgsqlDataSource`.
**Polecat re-implements the same options inline and never touches the shared type at all** — a bare
`(StoreOptions, masterConnectionString, schemaName)` triple, so no application-name rewrite, no
`AutoCreate` override of its own, and no seed-database support. The store that adopted the shared
type quietly has features the other lacks, and nothing held the two to one definition.

The base is typed over `MasterTableTenancyOptions<TDataSource>`, so adopting it is what gets Polecat
the shared options — that is the point of the `DbDataSource` seam rather than a `TConnection` one.

## Decisions worth naming

- **The `IDynamicTenantSource<string>` block is implemented once here.** Both stores wrote that
  adapter by hand — every member forwarding to a cancellable twin — and it is the single largest
  thing the lift removes from each. Implemented explicitly, so the concrete API stays the
  cancellable one.
- **Disabling evicts from the cache.** That is what makes disabling take effect at all: the cache
  does not consult the control table, so a cached database would go on serving a switched-off
  tenant. Removing the eviction fails two tests.
- **`AutoCreate.None` is honoured by never emitting DDL.** The control table is exactly the object a
  least-privilege deployment provisions by hand; a genuinely missing table then surfaces as the
  database's own clean error. The provisioned flag is set only *after* the statement succeeds —
  remembering a failed attempt as done would leave the tenancy permanently broken with nothing to
  say why.
- **The semaphore is not the whole guard.** It collapses a burst of concurrent first calls in one
  process; the dialect's DDL still has to be idempotent, because a deployment has several
  processes. Said on the interface member.
- **A caller-supplied `DbDataSource` is never disposed by the tenancy.** Disposing one is the kind
  of thing that only shows up as an `ObjectDisposedException` somewhere unrelated.
- **`Dispose()` is written out synchronously** rather than blocking on `DisposeAsync`. A container
  disposed synchronously reaches it, and sync-over-async on a shutdown path has nowhere to report a
  deadlock.
- **`TDatabase` is unconstrained.** The three stores' database types share no interface Weasel could
  name, and the base does not need one: it caches, hands back and disposes.
- The auto-assign `AddTenantAsync(string, CancellationToken)` overload is left on its throwing
  default. There is no pool for a database-per-tenant model to assign from.

## `ITenancy` — assessed, and deliberately not in this PR

`ITenancy` is declared three times with much the same shape, differing mainly in the concrete
database type: Marten 78 lines, Polecat 141, Fisher 480. An `ITenancy<TDatabase>` in `Weasel.Core`
would unify them, and it belongs in a follow-up:

- It is a breaking change to three stores' public API surfaces, where this lift adds a new type and
  breaks nothing. Bundling them means the tenancy lift cannot ship until three stores are ready to
  take an API break.
- The three are less identical than the line counts suggest — Fisher's 480 lines carry a whole
  runtime-tenant story (`DynamicTenancy`, suspension vs deletion, per-file provisioning) with no
  sibling, so unifying needs a reconciliation pass rather than a parameterisation.
- `MasterTableTenancyBase` does not need it: it is generic over its database type already, so
  nothing here is blocked by the three declarations staying separate.

Recorded on #567.

## Validation

Local, since CI is stalled org-wide.

- `dotnet build Weasel.slnx` — clean
- `Weasel.Core.Tests` — 505 passed (33 new)
- `Weasel.Sqlite.Tests` — 582 passed, 1 pre-existing failure (`TypeMappingIntegrationTests.all_types_together`, a date assertion; fails identically on unmodified `master`)
- `Weasel.Postgresql.Tests` — 973 passed, 3 skipped, 1 flake (`StoredProcedureTests.an_unchanged_procedure_does_not_report_permanent_drift`, an Npgsql read timeout; passes on re-run)
- `Weasel.SqlServer.Tests` — 558 passed, 8 skipped

The new tests drive a real SQLite control table — provisioning, upserts, disable/enable, eviction,
seeding, the application-name rewrite and the whole dynamic-source surface — rather than a mock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
