### PR TITLE
Add Weasel.Benchmarks with baselines for the perf survey findings

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,6 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
+    <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="Meziantou.Analyzer" Version="2.0.260" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.12.19" />

--- a/Weasel.slnx
+++ b/Weasel.slnx
@@ -60,6 +60,7 @@
   <Folder Name="/src/">
     <Project Path="src/Weasel.Storage/Weasel.Storage.csproj" />
   </Folder>
+  <Project Path="src/Weasel.Benchmarks/Weasel.Benchmarks.csproj" />
   <Project Path="src/Weasel.Core.AotSmoke/Weasel.Core.AotSmoke.csproj" />
   <Project Path="src/Weasel.Core.Tests/Weasel.Core.Tests.csproj" />
   <Project Path="src/Weasel.Testing/Weasel.Testing.csproj" />

--- a/src/Weasel.Benchmarks/.gitignore
+++ b/src/Weasel.Benchmarks/.gitignore
@@ -1,0 +1,1 @@
+BenchmarkDotNet.Artifacts/

--- a/src/Weasel.Benchmarks/BatchBuilderBenchmarks.cs
+++ b/src/Weasel.Benchmarks/BatchBuilderBenchmarks.cs
@@ -1,0 +1,102 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Weasel.Benchmarks;
+
+/// <summary>
+///     Appending 500 parameters to a batch command.
+/// </summary>
+/// <remarks>
+///     <para>
+///         SQL Server's <see cref="Weasel.SqlServer.BatchBuilder" /> names every parameter by its
+///         position, which used to be a <c>"p" + count</c> string allocation per parameter.
+///         weasel#558 replaced that with the precomputed <see cref="Weasel.Core.ParameterNames" />
+///         table (512 entries), so 500 parameters now stay inside the table and the naming itself
+///         allocates nothing. This measures where that left the append path — what remains is the
+///         driver's own <c>SqlParameter</c> plus the SQL text.
+///     </para>
+///     <para>
+///         PostgreSQL's builder is included as the contrast: it writes <c>$N</c> positionally and
+///         never named its parameters, so it never paid the allocation and is unaffected by #558.
+///         The gap between the two rows is the cost of naming, not of appending.
+///     </para>
+///     <para>
+///         500 is a deliberate choice: it is inside the 512-entry table. See
+///         <see cref="ParameterNamesBenchmarks" /> for what happens past the end of it.
+///     </para>
+/// </remarks>
+[MemoryDiagnoser]
+[HideColumns("Error", "StdDev", "Median", "RatioSD")]
+public class BatchBuilderBenchmarks
+{
+    private const int ParameterCount = 500;
+
+    private object[] _values = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _values = Enumerable.Range(0, ParameterCount).Select(i => (object)("value-" + i)).ToArray();
+    }
+
+    [Benchmark(Baseline = true, Description = "SqlServer BatchBuilder.AppendParameter x500")]
+    public int SqlServer()
+    {
+        var builder = new SqlServer.BatchBuilder();
+        for (var i = 0; i < _values.Length; i++)
+        {
+            builder.Append(", ");
+            builder.AppendParameter(_values[i]);
+        }
+
+        return _values.Length;
+    }
+
+    [Benchmark(Description = "Postgresql BatchBuilder.AppendParameter x500 ($N, never named)")]
+    public int Postgresql()
+    {
+        var builder = new Postgresql.BatchBuilder();
+        for (var i = 0; i < _values.Length; i++)
+        {
+            builder.Append(", ");
+            builder.AppendParameter(_values[i]);
+        }
+
+        return _values.Length;
+    }
+}
+
+/// <summary>
+///     The parameter-name lookup on its own, isolated from any driver type, at a position inside the
+///     512-entry table and at one past the end of it. The second row is what every position used to
+///     cost before weasel#558.
+/// </summary>
+[MemoryDiagnoser]
+[HideColumns("Error", "StdDev", "Median", "RatioSD")]
+public class ParameterNamesBenchmarks
+{
+    private const int Count = 500;
+
+    [Benchmark(Baseline = true, Description = "ParameterNames.ForPosition x500 (inside the table)")]
+    public string InsideTheTable()
+    {
+        var last = string.Empty;
+        for (var i = 0; i < Count; i++)
+        {
+            last = Core.ParameterNames.ForPosition(i);
+        }
+
+        return last;
+    }
+
+    [Benchmark(Description = "ParameterNames.ForPosition x500 (past the table, concatenates)")]
+    public string PastTheTable()
+    {
+        var last = string.Empty;
+        for (var i = 0; i < Count; i++)
+        {
+            last = Core.ParameterNames.ForPosition(1024 + i);
+        }
+
+        return last;
+    }
+}

--- a/src/Weasel.Benchmarks/ChangeTrackerBenchmarks.cs
+++ b/src/Weasel.Benchmarks/ChangeTrackerBenchmarks.cs
@@ -1,0 +1,88 @@
+using BenchmarkDotNet.Attributes;
+using Weasel.Benchmarks.Support;
+using Weasel.Core;
+using Weasel.Storage;
+
+namespace Weasel.Benchmarks;
+
+/// <summary>
+///     <see cref="ChangeTracker{T}.DetectChanges" /> over a ~5 KB document.
+/// </summary>
+/// <remarks>
+///     Dirty tracking runs this once per tracked document on every <c>SaveChanges</c>, so a session
+///     that loaded a hundred documents and changed one pays the unchanged cost ninety-nine times.
+///     Three paths are worth separating:
+///     <list type="bullet">
+///         <item>
+///             <b>Unchanged</b> — the overwhelmingly common case. Re-serializes the document and
+///             compares the two strings ordinally. One full-size string allocation per document.
+///         </item>
+///         <item>
+///             <b>SemanticallyEqual</b> — the strings differ but the JSON means the same thing
+///             (a reordered dictionary, most often). Falls through the ordinal compare into two
+///             <c>JsonNode.Parse</c> calls and a <c>DeepEquals</c>: two whole object graphs built
+///             and thrown away to conclude nothing changed.
+///         </item>
+///         <item>
+///             <b>Changed</b> — pays for the serialize, the failed ordinal compare, the two parses
+///             and the failed deep compare before it reaches the storage operation.
+///         </item>
+///     </list>
+/// </remarks>
+[MemoryDiagnoser]
+[HideColumns("Error", "StdDev", "Median", "RatioSD")]
+public class ChangeTrackerBenchmarks
+{
+    private ChangeTracker<BenchmarkDocument> _unchanged = null!;
+    private ChangeTracker<BenchmarkDocument> _semanticallyEqual = null!;
+    private ChangeTracker<BenchmarkDocument> _changed = null!;
+    private BenchmarkDocument _changedDocument = null!;
+    private IStorageSession _session = null!;
+
+    /// <summary>The measured JSON size of the reference document, reported by Program.</summary>
+    public static int DocumentJsonSize => BenchmarkDocument.JsonSize(BenchmarkDocument.Create());
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var serializer = StorageSerializerAdapter.For(new SystemTextJsonSerializer());
+        _session = new BenchmarkStorageSession(serializer,
+            new BenchmarkProviderGraph<BenchmarkDocument>(new NoopDocumentStorage<BenchmarkDocument>()));
+
+        _unchanged = new ChangeTracker<BenchmarkDocument>(_session, BenchmarkDocument.Create());
+
+        // Re-inserting the attribute dictionary in a different order changes the JSON text
+        // without changing what the JSON means, which is exactly the case the DeepEquals fallback
+        // exists for.
+        var reordered = BenchmarkDocument.Create();
+        _semanticallyEqual = new ChangeTracker<BenchmarkDocument>(_session, reordered);
+        var attributes = reordered.Attributes.ToArray();
+        reordered.Attributes.Clear();
+        foreach (var pair in attributes.Reverse())
+        {
+            reordered.Attributes[pair.Key] = pair.Value;
+        }
+
+        _changedDocument = BenchmarkDocument.Create();
+        _changed = new ChangeTracker<BenchmarkDocument>(_session, _changedDocument);
+        _changedDocument.Revision++;
+    }
+
+    [Benchmark(Baseline = true, Description = "Unchanged (ordinal string compare wins)")]
+    public bool Unchanged()
+    {
+        return _unchanged.DetectChanges(_session, out _);
+    }
+
+    [Benchmark(Description = "Reordered but equal (JsonNode DeepEquals fallback)")]
+    public bool SemanticallyEqual()
+    {
+        return _semanticallyEqual.DetectChanges(_session, out _);
+    }
+
+    [Benchmark(Description = "Changed (full detection, then Upsert)")]
+    public bool Changed()
+    {
+        return _changed.DetectChanges(_session, out _);
+    }
+}

--- a/src/Weasel.Benchmarks/JsonReadBenchmarks.cs
+++ b/src/Weasel.Benchmarks/JsonReadBenchmarks.cs
@@ -1,0 +1,289 @@
+using System.Buffers;
+using System.Text;
+using System.Text.Json;
+using BenchmarkDotNet.Attributes;
+using Microsoft.Data.Sqlite;
+using Weasel.Benchmarks.Support;
+using Weasel.Core;
+
+namespace Weasel.Benchmarks;
+
+/// <summary>
+///     Reading one JSON document out of a <see cref="System.Data.Common.DbDataReader" /> column —
+///     the whole path, query included.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <b>What this is the baseline for.</b> <c>Weasel.Core.SystemTextJsonSerializer</c>'s
+///         <c>FromJson&lt;T&gt;(DbDataReader, int)</c> calls <c>reader.GetString(index)</c> and hands
+///         the result to STJ, which transcodes the fresh UTF-16 string straight back to UTF-8 to
+///         parse it. Every document read and every event read therefore allocates a full-size string
+///         that is discarded microseconds later. The <c>Current</c> row calls the real serializer, so
+///         the same row can be re-run after the read path changes.
+///     </para>
+///     <para>
+///         <b>Where the win actually is.</b> See <see cref="JsonDeserializeBenchmarks" />: STJ parses
+///         UTF-8 substantially faster than UTF-16, so the prize is reaching the column's bytes
+///         <i>without</i> building a string. <c>GetStream</c> does exactly that on providers that
+///         store the column as UTF-8. Transcoding UTF-16 characters to UTF-8 by hand
+///         (<c>PooledTextReader</c>) buys nothing — it just moves the transcode from inside STJ to
+///         outside it, and pays for a buffer on the way. It is kept as a measured, rejected
+///         candidate rather than deleted, because "why not just use GetTextReader everywhere" is the
+///         obvious question and this row is the answer.
+///     </para>
+///     <para>
+///         <b>Provider support for GetStream</b>, measured against live databases rather than assumed:
+///         <list type="bullet">
+///             <item>SQLite (Microsoft.Data.Sqlite), TEXT column — works.</item>
+///             <item>PostgreSQL (Npgsql), <c>jsonb</c> / <c>json</c> / <c>text</c> — works.</item>
+///             <item>
+///                 SQL Server (Microsoft.Data.SqlClient), <c>nvarchar(max)</c> <b>and</b> SQL Server
+///                 2025's native <c>json</c> — throws <c>InvalidCastException</c>: "can only be used
+///                 on columns of type Binary, Image, Udt or VarBinary". SQL Server also sends these
+///                 columns as UTF-16 on the wire, so there is no UTF-8 to reach for in the first
+///                 place; the string path is already the right one there.
+///             </item>
+///         </list>
+///     </para>
+///     <para>
+///         <b>Sizes.</b> 5 KB is the perf survey's reference document. 120 KB is there because the
+///         gap between UTF-8 and UTF-16 parsing only opens up with size, and because 120 K characters
+///         is 240 KB of UTF-16 — well past the 85 KB large-object threshold, so the string path
+///         starts allocating on the LOH once per read.
+///     </para>
+/// </remarks>
+[MemoryDiagnoser]
+[HideColumns("Error", "StdDev", "Median", "RatioSD")]
+public class JsonReadBenchmarks
+{
+    private SystemTextJsonSerializer _serializer = null!;
+    private string _path = null!;
+    private SqliteConnection _connection = null!;
+    private SqliteCommand _command = null!;
+
+    /// <summary>Approximate JSON payload size in kilobytes.</summary>
+    [Params(5, 120)]
+    public int SizeKb { get; set; }
+
+    [GlobalSetup]
+    public async Task SetupAsync()
+    {
+        _serializer = new SystemTextJsonSerializer();
+
+        _path = Path.Combine(Path.GetTempPath(), "weasel-json-bench-" + Guid.NewGuid().ToString("N") + ".db");
+        _connection = new SqliteConnection($"Data Source={_path};");
+        await _connection.OpenAsync();
+
+        var create = _connection.CreateCommand();
+        create.CommandText = "create table docs (id integer primary key, doc text not null)";
+        await create.ExecuteNonQueryAsync();
+
+        var insert = _connection.CreateCommand();
+        insert.CommandText = "insert into docs (id, doc) values (1, $d)";
+        insert.Parameters.AddWithValue("$d", JsonPayload.Build(SizeKb));
+        await insert.ExecuteNonQueryAsync();
+
+        _command = _connection.CreateCommand();
+        _command.CommandText = "select doc from docs where id = 1";
+    }
+
+    [GlobalCleanup]
+    public async Task CleanupAsync()
+    {
+        _command.Dispose();
+        await _connection.DisposeAsync();
+        SqliteConnection.ClearAllPools();
+        try
+        {
+            File.Delete(_path);
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    [Benchmark(Baseline = true, Description = "Current: serializer.FromJson<T>(reader, index) [GetString + parse]")]
+    public int Current()
+    {
+        using var reader = _command.ExecuteReader();
+        reader.Read();
+        return _serializer.FromJson<JsonPayload>(reader, 0).Items.Count;
+    }
+
+    [Benchmark(Description = "GetStream -> Deserialize(Stream) [SQLite + Npgsql only]")]
+    public int Stream()
+    {
+        using var reader = _command.ExecuteReader();
+        reader.Read();
+
+        using var stream = reader.GetStream(0);
+        return JsonSerializer.Deserialize<JsonPayload>(stream, _serializer.Options)!.Items.Count;
+    }
+
+    [Benchmark(Description = "Rejected: GetTextReader -> hand transcode -> Deserialize(span)")]
+    public int PooledTextReader()
+    {
+        using var reader = _command.ExecuteReader();
+        reader.Read();
+
+        using var buffer = PooledUtf8.ReadFrom(reader, 0);
+        return JsonSerializer.Deserialize<JsonPayload>(buffer.Span, _serializer.Options)!.Items.Count;
+    }
+}
+
+/// <summary>
+///     The deserialize step on its own, with the payload already in memory, so the provider and the
+///     query are out of the picture. This is the measurement that says whether reaching the column's
+///     UTF-8 bytes is worth any plumbing at all: if <c>ReadOnlySpan&lt;byte&gt;</c> and <c>string</c>
+///     cost the same, no amount of stream routing in the serializer can help.
+/// </summary>
+[MemoryDiagnoser]
+[HideColumns("Error", "StdDev", "Median", "RatioSD")]
+public class JsonDeserializeBenchmarks
+{
+    private string _json = null!;
+    private byte[] _utf8 = null!;
+    private JsonSerializerOptions _options = null!;
+
+    /// <summary>Approximate JSON payload size in kilobytes.</summary>
+    [Params(5, 120)]
+    public int SizeKb { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _options = SystemTextJsonSerializer.DefaultOptions();
+        _json = JsonPayload.Build(SizeKb);
+        _utf8 = Encoding.UTF8.GetBytes(_json);
+    }
+
+    [Benchmark(Baseline = true, Description = "Deserialize<T>(string) [what GetString feeds]")]
+    public int FromString()
+    {
+        return JsonSerializer.Deserialize<JsonPayload>(_json, _options)!.Items.Count;
+    }
+
+    [Benchmark(Description = "Deserialize<T>(ReadOnlySpan<byte>) [UTF-8, no transcode]")]
+    public int FromUtf8Span()
+    {
+        return JsonSerializer.Deserialize<JsonPayload>(_utf8.AsSpan(), _options)!.Items.Count;
+    }
+
+    [Benchmark(Description = "Deserialize<T>(Stream) [what GetStream feeds]")]
+    public int FromStream()
+    {
+        using var stream = new MemoryStream(_utf8, false);
+        return JsonSerializer.Deserialize<JsonPayload>(stream, _options)!.Items.Count;
+    }
+
+    [Benchmark(Description = "UTF8.GetBytes(string) + Deserialize(span) [the transcode, priced]")]
+    public int TranscodeThenSpan()
+    {
+        var bytes = Encoding.UTF8.GetBytes(_json);
+        return JsonSerializer.Deserialize<JsonPayload>(bytes.AsSpan(), _options)!.Items.Count;
+    }
+}
+
+/// <summary>The document these benchmarks deserialize into, and the generator for its JSON.</summary>
+public class JsonPayload
+{
+    public Guid Id { get; set; }
+    public string? Name { get; set; }
+    public string? Description { get; set; }
+    public List<BenchmarkDocument.LineItem> Items { get; set; } = [];
+    public Dictionary<string, string> Attributes { get; set; } = [];
+
+    /// <summary>
+    ///     Repeats the reference document's line items until the serialized form clears the target,
+    ///     so both sizes have the same shape and differ only in how much of it there is.
+    /// </summary>
+    public static string Build(int sizeKb)
+    {
+        // Serialized with the serializer's own options (camelCase), because that is what a stored
+        // document looks like. Round-tripping through different options would leave every property
+        // unmatched and quietly benchmark parsing into an empty object.
+        var serializer = new SystemTextJsonSerializer();
+        var document = BenchmarkDocument.Create();
+        var target = sizeKb * 1024;
+        var seed = document.Items.ToArray();
+
+        while (serializer.ToJson(document).Length < target)
+        {
+            document.Items.AddRange(seed);
+        }
+
+        return serializer.ToJson(document);
+    }
+}
+
+/// <summary>
+///     The rejected candidate: pull the column's characters through <c>GetTextReader</c> and
+///     transcode them into a rented UTF-8 buffer, so no full-size <see cref="string" /> is
+///     materialized. It works, and it is portable in a way <c>GetStream</c> is not — but the
+///     transcode it performs is the same one STJ would have performed internally, so it saves the
+///     string allocation and pays for a buffer instead. Kept because the benchmark row it backs is
+///     the evidence for not doing this.
+/// </summary>
+internal readonly struct PooledUtf8: IDisposable
+{
+    private readonly byte[] _buffer;
+    private readonly int _length;
+
+    private PooledUtf8(byte[] buffer, int length)
+    {
+        _buffer = buffer;
+        _length = length;
+    }
+
+    public ReadOnlySpan<byte> Span => _buffer.AsSpan(0, _length);
+
+    public static PooledUtf8 ReadFrom(System.Data.Common.DbDataReader reader, int index)
+    {
+        using var text = reader.GetTextReader(index);
+
+        var chars = ArrayPool<char>.Shared.Rent(8 * 1024);
+        var bytes = ArrayPool<byte>.Shared.Rent(32 * 1024);
+        var written = 0;
+
+        var encoder = Encoding.UTF8.GetEncoder();
+        try
+        {
+            while (true)
+            {
+                var read = text.Read(chars, 0, chars.Length);
+                if (read == 0)
+                {
+                    break;
+                }
+
+                // Worst case 3 bytes per BMP char, 4 with a surrogate pair carried over.
+                var needed = written + (read * 4);
+                if (needed > bytes.Length)
+                {
+                    var grown = ArrayPool<byte>.Shared.Rent(Math.Max(needed, bytes.Length * 2));
+                    Array.Copy(bytes, grown, written);
+                    ArrayPool<byte>.Shared.Return(bytes);
+                    bytes = grown;
+                }
+
+                written += encoder.GetBytes(chars.AsSpan(0, read), bytes.AsSpan(written), false);
+            }
+
+            written += encoder.GetBytes(ReadOnlySpan<char>.Empty, bytes.AsSpan(written), true);
+        }
+        finally
+        {
+            ArrayPool<char>.Shared.Return(chars);
+        }
+
+        return new PooledUtf8(bytes, written);
+    }
+
+    public void Dispose()
+    {
+        if (_buffer is not null)
+        {
+            ArrayPool<byte>.Shared.Return(_buffer);
+        }
+    }
+}

--- a/src/Weasel.Benchmarks/Program.cs
+++ b/src/Weasel.Benchmarks/Program.cs
@@ -1,0 +1,44 @@
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Running;
+
+namespace Weasel.Benchmarks;
+
+public static class Program
+{
+    /// <summary>
+    ///     The checked-in run. Short — a couple of minutes for the whole suite — so that "run the
+    ///     benchmarks" is a thing a contributor actually does rather than schedules. The numbers it
+    ///     produces are good to a few percent, which is enough to see a change of the size these
+    ///     benchmarks exist to catch. For a publishable number use <c>--full</c>; see Results.md.
+    /// </summary>
+    private static IConfig ShortConfig()
+    {
+        return DefaultConfig.Instance
+            .AddJob(Job.ShortRun
+                .WithWarmupCount(3)
+                .WithIterationCount(5)
+                .WithId("short"));
+    }
+
+    public static void Main(string[] args)
+    {
+        var full = args.Contains("--full", StringComparer.OrdinalIgnoreCase);
+        var remaining = args.Where(a => !string.Equals(a, "--full", StringComparison.OrdinalIgnoreCase)).ToArray();
+
+        var config = full ? DefaultConfig.Instance : ShortConfig();
+
+        if (remaining.Length > 0)
+        {
+            BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(remaining, config);
+            return;
+        }
+
+        BenchmarkRunner.Run<ChangeTrackerBenchmarks>(config);
+        BenchmarkRunner.Run<BatchBuilderBenchmarks>(config);
+        BenchmarkRunner.Run<ParameterNamesBenchmarks>(config);
+        BenchmarkRunner.Run<SchemaMigrationBenchmarks>(config);
+        BenchmarkRunner.Run<JsonDeserializeBenchmarks>(config);
+        BenchmarkRunner.Run<JsonReadBenchmarks>(config);
+    }
+}

--- a/src/Weasel.Benchmarks/Results.md
+++ b/src/Weasel.Benchmarks/Results.md
@@ -1,0 +1,182 @@
+# Weasel benchmark baselines
+
+Numbers recorded at the introduction of this project (weasel#565), so later changes have something
+to be compared against. **A number here is only meaningful next to the machine it came from** — see
+[The machine](#the-machine). Re-record on your own hardware before drawing a conclusion from a
+change; compare ratios rather than absolute times.
+
+## Running them
+
+```bash
+# The checked-in configuration: 3 warmup + 5 measured iterations per benchmark.
+# The whole suite takes a couple of minutes.
+dotnet run -c Release -f net9.0 --project src/Weasel.Benchmarks
+
+# One class at a time
+dotnet run -c Release -f net9.0 --project src/Weasel.Benchmarks -- --filter '*JsonRead*'
+
+# The full-fidelity run: BenchmarkDotNet's default job (pilot + overhead + ~15 measured
+# iterations, with outlier analysis). Roughly 20 minutes for the whole suite. This is what
+# the numbers below came from, and what you should use before claiming a regression or a win.
+dotnet run -c Release -f net9.0 --project src/Weasel.Benchmarks -- --full
+dotnet run -c Release -f net9.0 --project src/Weasel.Benchmarks -- --full --filter '*JsonRead*'
+```
+
+Everything runs with `[MemoryDiagnoser]`. `net10.0` also works — pass `-f net10.0`.
+
+No benchmark needs a container. `SchemaMigrationBenchmarks` and `JsonReadBenchmarks` create a
+temporary SQLite database file and delete it afterwards.
+
+### Reading these numbers honestly
+
+**Allocation is the trustworthy column here.** It is deterministic, and it reproduced exactly
+across every run. The wall-clock times moved by as much as 2x between runs of the same benchmark on
+this machine, because it was not quiet (a few dozen containers were running). Where a conclusion
+below rests on timing, it says so, and it is stated as a range rather than a figure.
+
+## The machine
+
+| | |
+|---|---|
+| CPU | Apple M5 Max, 18 physical / 18 logical cores |
+| OS | macOS Tahoe 26.4.1 (Darwin 25.4.0) |
+| SDK | .NET SDK 10.0.101 |
+| Runtime | .NET 9.0.8, Arm64 RyuJIT armv8.0-a |
+| GC | Concurrent Workstation |
+| BenchmarkDotNet | 0.15.8 |
+| Recorded | 2026-09-05 |
+| Load | **Not a quiet machine** — see above |
+
+---
+
+## ChangeTracker.DetectChanges (~5 KB document)
+
+Dirty tracking calls this once per tracked document on every `SaveChanges`, so a session that loaded
+a hundred documents and changed one pays the *unchanged* cost ninety-nine times.
+
+| Path | Mean | Ratio | Allocated | Alloc ratio |
+|---|---:|---:|---:|---:|
+| Unchanged (ordinal string compare wins) | 4.47 us | 1.00 | 8.42 KB | 1.00 |
+| Reordered but equal (`JsonNode.DeepEquals` fallback) | 34.55 us | 7.73 | 82.23 KB | 9.76 |
+| Changed (full detection, then `Upsert`) | 17.09 us | 3.82 | 30.06 KB | 3.57 |
+
+The reference document serializes to ~5 KB, and the unchanged path allocates 8.42 KB — one
+re-serialization of the document, which is the floor for a design that detects changes by
+re-serializing. Nothing here is free, but the common case is the cheap one.
+
+The row worth staring at is the middle one. When two JSON strings differ but mean the same thing —
+a dictionary that re-ordered itself between load and save is the usual cause — the ordinal compare
+misses, and the fallback builds **two whole `JsonNode` trees and throws them both away** to conclude
+that nothing changed: 7.7x the time and **9.8x the allocation of the unchanged path**, to produce
+the same answer. It is also more expensive than genuinely detecting a change (row 3), because a real
+change is usually visible early in the tree while equality has to walk all of it.
+
+## BatchBuilder.AppendParameter x 500
+
+| Builder | Mean | Ratio | Allocated | Alloc ratio |
+|---|---:|---:|---:|---:|
+| SQL Server (`ParameterNames` table) | 10.43 us | 1.00 | 95.49 KB | 1.00 |
+| PostgreSQL (`$N`, never named) | 9.22 us | 0.88 | 105.30 KB | 1.10 |
+
+Both builders sit around 20 ns per parameter, and what is left is the driver's own parameter object
+plus the SQL text — not the naming. The precomputed name table from #558 did its job: SQL Server
+names all 500 parameters and still allocates *less* than PostgreSQL, which names none.
+
+### The name table in isolation
+
+| Lookup | Mean | Allocated |
+|---|---:|---:|
+| `ParameterNames.ForPosition` x 500, inside the 512-entry table | 285 ns | **0 B** |
+| `ParameterNames.ForPosition` x 500, past the table (concatenates) | 4,421 ns | 32,000 B |
+
+This is the #558 change measured directly, and the second row is what *every* position cost before
+it: **15x the time and 32 KB of garbage per 500 parameters**. It also prices the table's edge —
+a command binding more than 512 parameters pays the old cost from 512 onward. Nothing in Weasel
+approaches that (SQL Server's hard limit is 2100 and a table's introspection query binds two), but
+if a caller ever does, the cliff is here and it is measured.
+
+## SchemaMigration.DetermineAsync over 200 tables
+
+Against a real SQLite database file, so the render is measured next to the round trip it feeds.
+
+| Scenario | Mean | Ratio | Allocated | Alloc ratio |
+|---|---:|---:|---:|---:|
+| 200 tables, schema already matches | 17.84 ms | 1.00 | 3.70 MB | 1.00 |
+| 200 tables, empty database | 9.67 ms | 0.54 | 2.06 MB | 0.56 |
+
+About 89 us and 18 KB per table for the steady-state case — the one a healthy application start
+hits, where every table exists as configured and the entire cost is introspection and comparison.
+The empty database is roughly half of that, because every table comes back missing and there is
+nothing to compare it against.
+
+These are *post*-#560 numbers, and #560's whole subject is how many times each object renders. There
+is no pre-change measurement to set beside them, because the benchmark did not exist when the change
+landed — which is the reason this project does. Treat the 17.84 ms as the line to defend.
+
+## JSON reads
+
+### The deserialize step alone (payload already in memory)
+
+This is the measurement that decides whether reaching a column's UTF-8 bytes is worth any plumbing:
+if `ReadOnlySpan<byte>` and `string` cost the same, no amount of stream routing can help.
+
+| Source | 5 KB | 120 KB | Allocated (5 KB / 120 KB) |
+|---|---:|---:|---:|
+| `Deserialize<T>(string)` — what `GetString` feeds | 19.92 us | 284.25 us | 19.12 KB / 317.43 KB |
+| `Deserialize<T>(ReadOnlySpan<byte>)` — UTF-8, no transcode | 13.93 us | 277.66 us | 19.12 KB / 317.43 KB |
+| `Deserialize<T>(Stream)` — what `GetStream` feeds | 17.89 us | 289.73 us | 19.18 KB / 317.49 KB |
+| `UTF8.GetBytes(string)` + `Deserialize(span)` — the transcode, priced | 16.35 us | 289.52 us | 26.17 KB / 437.97 KB |
+
+Two things to take from this:
+
+- **Allocation is identical** across the first three rows (the payload is pre-built, so what is
+  counted is the object graph only). Whatever the read path saves, it saves on the *string*, not on
+  the parse.
+- **Parsing UTF-8 is somewhat cheaper than parsing UTF-16 at 5 KB and roughly a wash at 120 KB.**
+  The last row is the one that settles the design question: transcoding by hand and then parsing the
+  span costs about what parsing the string costs, and allocates 38% more. Moving the transcode from
+  inside STJ to outside it buys nothing.
+
+### The whole read, query included (SQLite, TEXT column)
+
+| Path | 5 KB | Ratio | 120 KB | Ratio | Alloc 5 KB | Alloc 120 KB |
+|---|---:|---:|---:|---:|---:|---:|
+| **Current** — `serializer.FromJson<T>(reader, index)` (`GetString` + parse) | 25.55 us | 1.00 | 322.78 us | 1.00 | 33.58 KB | 558.85 KB |
+| `GetStream` → `Deserialize(Stream)` | 20.24 us | 0.82 | 351.47 us | 1.09 | **26.74 KB** | **438.54 KB** |
+| *Rejected:* `GetTextReader` → hand transcode → `Deserialize(span)` | 20.37 us | 0.82 | 324.89 us | 1.01 | 29.99 KB | 441.79 KB |
+
+**The stream path is an allocation and GC-pressure win, not a throughput win.** It removes ~20% of
+allocated bytes at both sizes — the full-size string that `GetString` builds and STJ discards
+microseconds later. At 120 KB it also halves the Gen2 collections (38.1 vs 76.7 per 1000 ops),
+because a 120 K-character string is 240 KB of UTF-16 and lands on the large object heap on every
+single read. Wall-clock is a wash: better at 5 KB, slightly worse at 120 KB, and both differences
+are inside this machine's noise.
+
+### Provider support for `GetStream`
+
+Measured against live databases rather than assumed, because the answer is not what the method's
+presence on `DbDataReader` suggests:
+
+| Provider | Column type | `GetStream` | `GetTextReader` |
+|---|---|---|---|
+| SQLite (Microsoft.Data.Sqlite) | `TEXT` | works | works |
+| PostgreSQL (Npgsql 9) | `jsonb`, `json`, `text` | works | works |
+| SQL Server (Microsoft.Data.SqlClient 6.1) | `nvarchar(max)` | **`InvalidCastException`** | works |
+| SQL Server (Microsoft.Data.SqlClient 6.1) | `json` (SQL Server 2025 native) | **`InvalidCastException`** | works |
+
+> Invalid attempt to GetStream on column 'x'. The GetStream function can only be used on columns of
+> type Binary, Image, Udt or VarBinary.
+
+Both SQL Server results hold under `CommandBehavior.Default` and `CommandBehavior.SequentialAccess`.
+Marten can use `reader.GetStream(index)` because Npgsql is the only provider it targets; the same
+call is not portable to the shared serializer in Weasel.Core, and any change to that read path has
+to keep a string fallback for SQL Server. SQL Server also sends both column types as UTF-16 on the
+wire, so there is no UTF-8 there to reach for — the string path is already the right one.
+
+Two smaller findings from the same probe, recorded so nobody has to rediscover them:
+
+- `GetString` still works on a column after `GetStream` has thrown `InvalidCastException` on it, in
+  both command behaviors. A try-stream-then-fall-back-to-string read path is therefore safe.
+- `GetFieldValueAsync<TextReader>` throws `NullReferenceException` on SQL Server 2025's native
+  `json` column under `CommandBehavior.SequentialAccess`. It works on `nvarchar(max)`, and it works
+  on `json` under `CommandBehavior.Default`. Prefer the synchronous `GetTextReader`.

--- a/src/Weasel.Benchmarks/SchemaMigrationBenchmarks.cs
+++ b/src/Weasel.Benchmarks/SchemaMigrationBenchmarks.cs
@@ -1,0 +1,115 @@
+using BenchmarkDotNet.Attributes;
+using Microsoft.Data.Sqlite;
+using Weasel.Core;
+using Weasel.Sqlite;
+using Weasel.Sqlite.Tables;
+
+namespace Weasel.Benchmarks;
+
+/// <summary>
+///     <see cref="SchemaMigration.DetermineAsync(System.Data.Common.DbConnection, Migrator, CancellationToken, ISchemaObject[])" />
+///     over 200 tables, against a real SQLite database file.
+/// </summary>
+/// <remarks>
+///     <para>
+///         This one is not a pure micro-benchmark — it does real I/O against a temp-file SQLite
+///         database — and that is deliberate: the thing weasel#560 changed is how many times each
+///         object's <c>ConfigureQueryCommand</c> renders, and rendering is only meaningful next to
+///         the round trip it feeds. Pricing used to be a separate probe pass (a throwaway builder
+///         per object, running the whole introspection query just to read <c>Parameters.Count</c>
+///         off it), so every determination rendered every query twice. The costs are now recorded
+///         from the real render.
+///     </para>
+///     <para>
+///         SQLite is the provider here because it needs no container, so the benchmark runs
+///         anywhere. The shape of the work — render N queries, execute one batched command, read N
+///         result sets, diff N tables — is the same on every provider.
+///     </para>
+///     <para>
+///         <b>MatchingSchema</b> is the steady state a healthy application start hits: every table
+///         already exists as configured, so the whole cost is introspection and comparison.
+///         <b>EmptyDatabase</b> is the cold start: every table comes back missing.
+///     </para>
+/// </remarks>
+[MemoryDiagnoser]
+[HideColumns("Error", "StdDev", "Median", "RatioSD")]
+public class SchemaMigrationBenchmarks
+{
+    private const int TableCount = 200;
+
+    private readonly SqliteMigrator _migrator = new();
+
+    private string _populatedPath = null!;
+    private string _emptyPath = null!;
+    private SqliteConnection _populated = null!;
+    private SqliteConnection _empty = null!;
+    private Table[] _tables = null!;
+
+    [GlobalSetup]
+    public async Task SetupAsync()
+    {
+        _tables = Enumerable.Range(0, TableCount).Select(buildTable).ToArray();
+
+        _populatedPath = Path.Combine(Path.GetTempPath(), "weasel-bench-" + Guid.NewGuid().ToString("N") + ".db");
+        _emptyPath = Path.Combine(Path.GetTempPath(), "weasel-bench-" + Guid.NewGuid().ToString("N") + ".db");
+
+        _populated = new SqliteConnection($"Data Source={_populatedPath};");
+        await _populated.OpenAsync();
+
+        _empty = new SqliteConnection($"Data Source={_emptyPath};");
+        await _empty.OpenAsync();
+
+        // Apply the whole set once, so the "matching schema" run measures a determination that
+        // finds no differences.
+        var migration = await SchemaMigration
+            .DetermineAsync(_populated, _migrator, CancellationToken.None, _tables.Cast<ISchemaObject>().ToArray());
+        await _migrator.ApplyAllAsync(_populated, migration, JasperFx.AutoCreate.All);
+    }
+
+    [GlobalCleanup]
+    public async Task CleanupAsync()
+    {
+        await _populated.DisposeAsync();
+        await _empty.DisposeAsync();
+        SqliteConnection.ClearAllPools();
+
+        foreach (var path in new[] { _populatedPath, _emptyPath })
+        {
+            try
+            {
+                File.Delete(path);
+            }
+            catch (IOException)
+            {
+                // A benchmark run leaving a temp file behind is not worth failing over.
+            }
+        }
+    }
+
+    [Benchmark(Baseline = true, Description = "DetermineAsync over 200 matching tables")]
+    public async Task<int> MatchingSchema()
+    {
+        var migration = await SchemaMigration
+            .DetermineAsync(_populated, _migrator, CancellationToken.None, _tables.Cast<ISchemaObject>().ToArray());
+        return migration.Deltas.Count;
+    }
+
+    [Benchmark(Description = "DetermineAsync over 200 tables against an empty database")]
+    public async Task<int> EmptyDatabase()
+    {
+        var migration = await SchemaMigration
+            .DetermineAsync(_empty, _migrator, CancellationToken.None, _tables.Cast<ISchemaObject>().ToArray());
+        return migration.Deltas.Count;
+    }
+
+    private static Table buildTable(int index)
+    {
+        var table = new Table("bench_table_" + index);
+        table.AddColumn<int>("id").AsPrimaryKey();
+        table.AddColumn<string>("name").NotNull();
+        table.AddColumn<string>("data");
+        table.AddColumn<long>("version");
+        table.AddColumn<string>("created_at");
+        return table;
+    }
+}

--- a/src/Weasel.Benchmarks/Support/BenchmarkDocument.cs
+++ b/src/Weasel.Benchmarks/Support/BenchmarkDocument.cs
@@ -1,0 +1,132 @@
+using System.Text.Json;
+
+namespace Weasel.Benchmarks.Support;
+
+/// <summary>
+///     A document shaped to serialize to roughly 5 KB of JSON — the size the perf survey used as
+///     its reference "realistic document". Deterministically generated from a fixed seed so a
+///     benchmark run is comparable to the one before it.
+/// </summary>
+public class BenchmarkDocument
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public DateTimeOffset CreatedAt { get; set; }
+    public int Revision { get; set; }
+    public bool IsActive { get; set; }
+    public decimal Balance { get; set; }
+    public string[] Tags { get; set; } = [];
+    public Address Shipping { get; set; } = new();
+    public Address Billing { get; set; } = new();
+    public List<LineItem> Items { get; set; } = [];
+    public Dictionary<string, string> Attributes { get; set; } = [];
+
+    /// <summary>
+    ///     Builds the reference document. The item count is tuned so <c>ToJson</c> lands within a
+    ///     few hundred bytes of 5 KB; <see cref="JsonSize" /> reports what it actually produced so
+    ///     the number in Results.md is measured rather than asserted.
+    /// </summary>
+    public static BenchmarkDocument Create(int seed = 1337)
+    {
+        var random = new Random(seed);
+
+        var document = new BenchmarkDocument
+        {
+            Id = new Guid("f1a1f4a0-0000-4000-8000-000000000001"),
+            Name = "Benchmark Order " + random.Next(1000, 9999),
+            Description = word(random, 24),
+            CreatedAt = new DateTimeOffset(2026, 1, 15, 9, 30, 0, TimeSpan.Zero),
+            Revision = 7,
+            IsActive = true,
+            Balance = 12345.67m,
+            Tags = Enumerable.Range(0, 8).Select(_ => word(random, 3)).ToArray(),
+            Shipping = Address.Create(random),
+            Billing = Address.Create(random)
+        };
+
+        for (var i = 0; i < 18; i++)
+        {
+            document.Items.Add(LineItem.Create(random, i));
+        }
+
+        for (var i = 0; i < 12; i++)
+        {
+            document.Attributes["attribute_" + i] = word(random, 4);
+        }
+
+        return document;
+    }
+
+    /// <summary>
+    ///     A deep copy, so a benchmark can mutate one copy without disturbing the shared original.
+    /// </summary>
+    public BenchmarkDocument Copy()
+    {
+        return JsonSerializer.Deserialize<BenchmarkDocument>(JsonSerializer.Serialize(this))!;
+    }
+
+    public static int JsonSize(BenchmarkDocument document)
+    {
+        return JsonSerializer.SerializeToUtf8Bytes(document).Length;
+    }
+
+    private static string word(Random random, int syllables)
+    {
+        const string alphabet = "abcdefghijklmnopqrstuvwxyz";
+        return string.Create(syllables * 4, random,
+            static (span, r) =>
+            {
+                for (var i = 0; i < span.Length; i++)
+                {
+                    span[i] = i % 5 == 4 ? ' ' : alphabet[r.Next(alphabet.Length)];
+                }
+            });
+    }
+
+    public class Address
+    {
+        public string Line1 { get; set; } = string.Empty;
+        public string Line2 { get; set; } = string.Empty;
+        public string City { get; set; } = string.Empty;
+        public string Region { get; set; } = string.Empty;
+        public string PostalCode { get; set; } = string.Empty;
+        public string Country { get; set; } = string.Empty;
+
+        public static Address Create(Random random)
+        {
+            return new Address
+            {
+                Line1 = random.Next(100, 9999) + " " + word(random, 3),
+                Line2 = "Suite " + random.Next(1, 400),
+                City = word(random, 2),
+                Region = "TX",
+                PostalCode = random.Next(10000, 99999).ToString(),
+                Country = "USA"
+            };
+        }
+    }
+
+    public class LineItem
+    {
+        public Guid Sku { get; set; }
+        public string Title { get; set; } = string.Empty;
+        public int Quantity { get; set; }
+        public decimal UnitPrice { get; set; }
+        public string[] Categories { get; set; } = [];
+        public string? Note { get; set; }
+
+        public static LineItem Create(Random random, int index)
+        {
+            return new LineItem
+            {
+                Sku = new Guid(index + 1, 0, 0, [1, 2, 3, 4, 5, 6, 7, 8]),
+                Title = word(random, 5),
+                Quantity = random.Next(1, 20),
+                UnitPrice = Math.Round((decimal)random.NextDouble() * 500m, 2),
+                Categories = Enumerable.Range(0, 3).Select(_ => word(random, 2)).ToArray(),
+                Note = index % 3 == 0 ? word(random, 6) : null
+            };
+        }
+    }
+}

--- a/src/Weasel.Benchmarks/Support/BenchmarkStorageSession.cs
+++ b/src/Weasel.Benchmarks/Support/BenchmarkStorageSession.cs
@@ -1,0 +1,170 @@
+using System.Data.Common;
+using JasperFx.Events.Aggregation;
+using JasperFx.MultiTenancy;
+using Weasel.Core;
+using Weasel.Core.Sequences;
+using Weasel.Core.SqlGeneration;
+using Weasel.Storage;
+using IStorageOperation = Weasel.Storage.IStorageOperation;
+
+namespace Weasel.Benchmarks.Support;
+
+/// <summary>
+///     The least <see cref="IStorageSession" /> a <see cref="ChangeTracker{T}" /> needs: a real
+///     serializer (the thing being measured) and a provider graph whose dirty-tracking storage
+///     hands back a trivial operation. Everything the change-tracking path never touches throws,
+///     so the benchmark cannot quietly start measuring something else.
+/// </summary>
+internal sealed class BenchmarkStorageSession: IStorageSession
+{
+    public BenchmarkStorageSession(IStorageSerializer serializer, IProviderGraph providers)
+    {
+        Serializer = serializer;
+        Database = new StubDatabase(providers);
+    }
+
+    public IStorageSerializer Serializer { get; }
+    public IStorageDatabase Database { get; }
+    public ConcurrencyChecks Concurrency { get; set; } = ConcurrencyChecks.Enabled;
+
+    public IList<IChangeTracker> ChangeTrackers { get; } = new List<IChangeTracker>();
+    public Dictionary<Type, object> ItemMap { get; } = new();
+
+    public string TenantId => StorageConstants.DefaultTenantId;
+    public string? CausationId { get; set; }
+    public string? CorrelationId { get; set; }
+    public string? CurrentUserName { get; set; }
+    public Dictionary<string, object>? Headers => null;
+    public bool CausationIdEnabled => false;
+    public bool CorrelationIdEnabled => false;
+    public bool HeadersEnabled => false;
+    public bool UserNameEnabled => false;
+
+    public IVersionTracker Versions => throw new NotSupportedException();
+    public IDocumentStorage StorageFor(Type documentType) => throw new NotSupportedException();
+    public IDocumentStorage<T> StorageFor<T>() where T : notnull => throw new NotSupportedException();
+    public void MarkAsAddedForStorage(object id, object document) => throw new NotSupportedException();
+    public void MarkAsDocumentLoaded(object id, object document) => throw new NotSupportedException();
+    public string NextTempTableName() => throw new NotSupportedException();
+
+    public Task<DbDataReader> ExecuteReaderAsync(DbCommand command, CancellationToken token = default) =>
+        throw new NotSupportedException();
+
+    private sealed class StubDatabase: IStorageDatabase
+    {
+        public StubDatabase(IProviderGraph providers) => Providers = providers;
+
+        public IProviderGraph Providers { get; }
+
+        public DbConnection CreateStorageConnection() => throw new NotSupportedException();
+        public Task RunSqlAsync(string sql, CancellationToken ct = default) => throw new NotSupportedException();
+
+        public ISequence SequenceFor(Type documentType) => throw new NotSupportedException();
+    }
+}
+
+internal static class StorageConstants
+{
+    public const string DefaultTenantId = "*DEFAULT*";
+}
+
+/// <summary>
+///     A provider graph holding exactly one document type's storage.
+/// </summary>
+internal sealed class BenchmarkProviderGraph<TDoc>: IProviderGraph where TDoc : notnull
+{
+    private readonly DocumentProvider<TDoc> _provider;
+
+    public BenchmarkProviderGraph(IDocumentStorage<TDoc> storage)
+    {
+        _provider = new DocumentProvider<TDoc>(storage, storage, storage, storage);
+    }
+
+    public DocumentProvider<T> StorageFor<T>() where T : notnull
+    {
+        return _provider as DocumentProvider<T>
+               ?? throw new NotSupportedException($"Only {typeof(TDoc).Name} is registered.");
+    }
+
+    public void Append<T>(DocumentProvider<T> provider) where T : notnull => throw new NotSupportedException();
+}
+
+/// <summary>
+///     Implements only the three members <see cref="ChangeTracker{T}.DetectChanges" /> reaches on
+///     the changed path — the two concurrency flags and <c>Upsert</c> — and returns an operation
+///     that does nothing, so the benchmark reports the cost of detecting the change rather than the
+///     cost of a store's real upsert construction.
+/// </summary>
+internal sealed class NoopDocumentStorage<T>: IDocumentStorage<T> where T : notnull
+{
+    private static readonly IStorageOperation _operation = new NoopOperation();
+
+    public bool UseOptimisticConcurrency => false;
+    public bool UseNumericRevisions => false;
+
+    public IStorageOperation Upsert(T document, IStorageSession session, string tenantId) => _operation;
+    public IStorageOperation Overwrite(T document, IStorageSession session, string tenantId) => _operation;
+
+    // ---- everything below is unreachable from the change-tracking path ----
+
+    public Type SourceType => typeof(T);
+    public Type IdType => typeof(Guid);
+    public Type DocumentType => typeof(T);
+    public IOperationFragment DeleteFragment => throw new NotSupportedException();
+    public IOperationFragment HardDeleteFragment => throw new NotSupportedException();
+    public IReadOnlyList<IDuplicatedField> DuplicatedFields => throw new NotSupportedException();
+    public DbObjectName TableName => throw new NotSupportedException();
+    public TenancyStyle TenancyStyle => throw new NotSupportedException();
+    public string FromObject => throw new NotSupportedException();
+    public Type SelectedType => throw new NotSupportedException();
+
+    public string[] SelectFields() => throw new NotSupportedException();
+    public ISelector BuildSelector(IStorageSession session) => throw new NotSupportedException();
+    public void Apply(ICommandBuilder builder) => throw new NotSupportedException();
+    public bool Contains(Type type) => throw new NotSupportedException();
+
+    public Task TruncateDocumentStorageAsync(IStorageDatabase database, CancellationToken ct = default) =>
+        throw new NotSupportedException();
+
+    public ISqlFragment FilterDocuments(ISqlFragment query, IStorageSession session) =>
+        throw new NotSupportedException();
+
+    public ISqlFragment? DefaultWhereFragment() => throw new NotSupportedException();
+    public object RawIdentityValue(object id) => throw new NotSupportedException();
+    public object IdentityFor(T document) => throw new NotSupportedException();
+    public Guid? VersionFor(T document, IStorageSession session) => throw new NotSupportedException();
+    public void Store(IStorageSession session, T document) => throw new NotSupportedException();
+    public void Store(IStorageSession session, T document, Guid? version) => throw new NotSupportedException();
+    public void Store(IStorageSession session, T document, long revision) => throw new NotSupportedException();
+    public void Eject(IStorageSession session, T document) => throw new NotSupportedException();
+
+    public IStorageOperation Update(T document, IStorageSession session, string tenantId) =>
+        throw new NotSupportedException();
+
+    public IStorageOperation Insert(T document, IStorageSession session, string tenantId) =>
+        throw new NotSupportedException();
+
+    public IStorageOperation OverwriteProjected(T document, string tenantId) => throw new NotSupportedException();
+    public IStorageOperation UpsertProjected(T document, string tenantId) => throw new NotSupportedException();
+    public IStorageOperation InsertProjected(T document, string tenantId) => throw new NotSupportedException();
+    public IStorageOperation UpdateProjected(T document, string tenantId) => throw new NotSupportedException();
+    public IDeletion DeleteForDocument(T document, string tenantId) => throw new NotSupportedException();
+    public void EjectById(IStorageSession session, object id) => throw new NotSupportedException();
+    public void RemoveDirtyTracker(IStorageSession session, object id) => throw new NotSupportedException();
+    public IDeletion HardDeleteForDocument(T document, string tenantId) => throw new NotSupportedException();
+    public void SetIdentityFromString(T document, string identityString) => throw new NotSupportedException();
+    public void SetIdentityFromGuid(T document, Guid identityGuid) => throw new NotSupportedException();
+
+    private sealed class NoopOperation: IStorageOperation
+    {
+        public Type DocumentType => typeof(T);
+        public OperationRole Role() => OperationRole.Upsert;
+
+        public void ConfigureCommand(ICommandBuilder builder, IStorageSession session)
+        {
+        }
+
+        public Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token) =>
+            Task.CompletedTask;
+    }
+}

--- a/src/Weasel.Benchmarks/Weasel.Benchmarks.csproj
+++ b/src/Weasel.Benchmarks/Weasel.Benchmarks.csproj
@@ -1,0 +1,39 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+        <OutputType>Exe</OutputType>
+        <IsPackable>false</IsPackable>
+
+        <!-- BenchmarkDotNet reads these off the assembly and prints them in the run header;
+             suppressing them keeps the report clean. Same as MartenBenchmarks. -->
+        <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+        <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+        <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+
+        <!-- Benchmarks measure the reflection-based serializer and the reflection-based
+             storage runtime on purpose, so the AOT analyzers have nothing useful to say here. -->
+        <IsAotCompatible>false</IsAotCompatible>
+
+        <!-- A benchmark body that "does nothing" with its result is the point, and BDN wants
+             the value returned rather than discarded. -->
+        <NoWarn>$(NoWarn);CA1822</NoWarn>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="BenchmarkDotNet" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Weasel.Core\Weasel.Core.csproj" />
+        <ProjectReference Include="..\Weasel.Storage\Weasel.Storage.csproj" />
+        <ProjectReference Include="..\Weasel.Sqlite\Weasel.Sqlite.csproj" />
+        <ProjectReference Include="..\Weasel.SqlServer\Weasel.SqlServer.csproj" />
+        <ProjectReference Include="..\Weasel.Postgresql\Weasel.Postgresql.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <None Update="Results.md" CopyToOutputDirectory="Never" />
+    </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Closes #565. Part of Stoat plan `critter-performance-2026-09`, node `weasel-benchmarks`.

Weasel had no benchmark project, so the performance changes that landed this week (#558, #560) shipped on reasoning alone with no numbers attached. This adds `src/Weasel.Benchmarks` — BenchmarkDotNet + `[MemoryDiagnoser]`, house style borrowed from Marten's `src/MartenBenchmarks` — covering the four things the perf survey raised, plus a `Results.md` recording the baselines against the machine they came from.

## What it measures

**`ChangeTracker.DetectChanges`** over a ~5 KB document, split by path:

| Path | Mean | Ratio | Allocated | Alloc ratio |
|---|---:|---:|---:|---:|
| Unchanged (ordinal string compare wins) | 4.47 us | 1.00 | 8.42 KB | 1.00 |
| Reordered but equal (`JsonNode.DeepEquals` fallback) | 34.55 us | 7.73 | 82.23 KB | 9.76 |
| Changed (full detection, then `Upsert`) | 17.09 us | 3.82 | 30.06 KB | 3.57 |

The middle row is the interesting one. When two JSON strings differ but mean the same thing — a dictionary that re-ordered itself between load and save is the usual cause — the ordinal compare misses and the fallback builds two whole `JsonNode` trees and throws them both away to conclude nothing changed. That costs **more than genuinely detecting a change does**, because a real change is usually visible early in the tree while equality has to walk all of it.

**`BatchBuilder.AppendParameter` x 500**, and the #558 name table in isolation:

| | Mean | Allocated |
|---|---:|---:|
| SqlServer `BatchBuilder` (names via `ParameterNames`) | 10.43 us | 95.49 KB |
| Postgresql `BatchBuilder` (`$N`, never named) | 9.22 us | 105.30 KB |
| `ParameterNames.ForPosition` x500, inside the 512-entry table | 285 ns | **0 B** |
| `ParameterNames.ForPosition` x500, past the table | 4,421 ns | 32,000 B |

The last two rows are #558 measured directly: the second is what every position cost before it, 15x the time and 32 KB of garbage per 500 parameters. SQL Server names all 500 parameters and still allocates less than PostgreSQL, which names none — the table did its job.

**`SchemaMigration.DetermineAsync` over 200 tables**, against a real SQLite file so the render is measured next to the round trip it feeds: **17.84 ms / 3.70 MB** where the schema already matches (the steady state a healthy application start hits), 9.67 ms / 2.06 MB against an empty database. These are post-#560 numbers with no pre-change measurement to set beside them, because the benchmark did not exist when the change landed — which is the reason for this PR.

**JSON reads**, the baseline for the `SystemTextJsonSerializer` read-path work, split into the deserialize step alone and the whole read including the query.

## Two findings that contradict the API surface

Both came out of building the JSON benchmark, and both are recorded in `Results.md` so nobody has to rediscover them.

**`SqlDataReader.GetStream` is not usable for JSON columns.** It throws `InvalidCastException` on `nvarchar(max)` *and* on SQL Server 2025's native `json` type — "can only be used on columns of type Binary, Image, Udt or VarBinary" — under both `CommandBehavior.Default` and `SequentialAccess`. Verified against a live SQL Server 2025 container, alongside Npgsql 9 (`jsonb`/`json`/`text` all stream fine) and Microsoft.Data.Sqlite (`TEXT` streams fine). Marten's read path can use `reader.GetStream(index)` because Npgsql is the only provider it targets; the shared serializer in Weasel.Core cannot, and any change to that read path will need a string fallback for SQL Server. `GetString` does still work on a column after `GetStream` has thrown on it, in both behaviors — so that fallback is safe to build.

**Hand-transcoding UTF-16 to UTF-8 buys nothing.** `GetTextReader` into a pooled buffer and then `Deserialize(ReadOnlySpan<byte>)` costs about what `Deserialize(string)` costs and allocates 38% more; it just moves the transcode from inside STJ to outside it and pays for a buffer on the way. It is kept as a measured, *rejected* benchmark row rather than deleted, because "why not just use `GetTextReader` everywhere" is the obvious question and this row is the answer.

Also recorded: `GetFieldValueAsync<TextReader>` throws `NullReferenceException` on SQL Server 2025's native `json` column under `SequentialAccess` (it is fine on `nvarchar(max)`, and fine on `json` under `Default`). Prefer the synchronous `GetTextReader`.

## Running it

```bash
dotnet run -c Release -f net9.0 --project src/Weasel.Benchmarks              # checked in: ~2 min
dotnet run -c Release -f net9.0 --project src/Weasel.Benchmarks -- --full    # what the numbers came from
dotnet run -c Release -f net9.0 --project src/Weasel.Benchmarks -- --filter '*JsonRead*'
```

No benchmark needs a container — the two database-backed ones create and delete a temporary SQLite file. `Results.md` notes that the recording machine was **not quiet** (a few dozen containers running), that allocation is the trustworthy column because it reproduced exactly across runs, and that wall-clock moved by up to 2x between runs of the same benchmark. Conclusions that rest on timing say so.

## Validation

Built the solution; `Weasel.Core.Tests` **417 passed**, `Weasel.Sqlite.Tests` **582 passed / 1 failed**, `Weasel.Postgresql.Tests` **974 passed** (against a local container), `Weasel.SqlServer.Tests` **558 passed** (against a local SQL Server 2025 container). Oracle and MySql were not run — no local containers.

The one SQLite failure is **pre-existing and unrelated**: `TypeMappingIntegrationTests.all_types_together` stores `DateTime.UtcNow` in a TEXT column and reads it back with `DateTime.Parse`, which interprets the round-tripped string as *local* time, then asserts the days are equal. It fails on any machine whose local date differs from the UTC date — i.e. every evening in US timezones. This branch adds a project and touches nothing it could reach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)