### PR TITLE
Insert the negated parameter for a member-valued flat-table decrement (jasperfx#773)

### DIFF
--- a/src/Weasel.Core.Tests/Flattened/flat_table_column_map_rendering.cs
+++ b/src/Weasel.Core.Tests/Flattened/flat_table_column_map_rendering.cs
@@ -89,6 +89,36 @@ public class flat_table_column_map_rendering
     }
 
     [Fact]
+    public void decrementing_by_a_member_inserts_the_negated_value()
+    {
+        // jasperfx#773: a row that does not exist yet is decremented from zero, so a first sighting
+        // of 5 lands at -5. Inserting the parameter as given — which Polecat, Fisher and the first
+        // cut of these maps all did — makes a *decrement* event raise the column, which is the one
+        // reading of the insert branch nobody could defend.
+        var map = new DecrementMemberMap("amount", typeof(int));
+
+        map.InsertExpression(SqlServer, "@p1").ShouldBe("-@p1");
+        map.InsertExpression(Sqlite, "@p1").ShouldBe("-@p1");
+        map.InsertExpression(Postgresql, "p_amount").ShouldBe("-p_amount");
+    }
+
+    [Fact]
+    public void the_member_valued_insert_branch_is_deliberately_asymmetric()
+    {
+        // The two halves of the ruling, side by side so neither can be "tidied up" into the other.
+        // Increment inserts the bare parameter and Decrement inserts its negation: both are "apply
+        // this event to an implicit zero row", which is the only reading under which they agree.
+        var increment = new IncrementMemberMap("amount", typeof(int));
+        var decrement = new DecrementMemberMap("amount", typeof(int));
+
+        increment.InsertExpression(Sqlite, "@p1").ShouldBe("@p1");
+        decrement.InsertExpression(Sqlite, "@p1").ShouldBe("-@p1");
+
+        decrement.InsertExpression(Sqlite, "@p1")
+            .ShouldNotBe(increment.InsertExpression(Sqlite, "@p1"));
+    }
+
+    [Fact]
     public void increment_by_one_needs_no_parameter()
     {
         var map = new IncrementMap("count");

--- a/src/Weasel.Core.Tests/Flattened/flat_table_statement_composition.cs
+++ b/src/Weasel.Core.Tests/Flattened/flat_table_statement_composition.cs
@@ -220,13 +220,18 @@ public class flat_table_statement_composition
     }
 
     [Fact]
-    public void the_insert_branch_follows_polecat_and_fisher_where_the_three_stores_disagree()
+    public void the_insert_branch_is_pinned_where_the_stores_disagreed()
     {
-        // Pinned as a decision rather than left to be discovered at adoption. Marten's equivalents
-        // insert 0 for Increment(column) and negate the parameter for Decrement(member); Polecat's
-        // and Fisher's, which are byte-for-byte the same as each other, do neither. The lifted maps
-        // take the two-store majority, so Marten's adoption is a behaviour change to make
-        // deliberately.
+        // Pinned as a decision rather than left to be discovered at adoption, and the two halves
+        // were settled separately.
+        //
+        // Increment(column) inserts 1 — marten#5341's ruling, which Marten then adopted in #5342, so
+        // all four stores agree.
+        //
+        // Decrement(member) inserts the *negated* parameter — jasperfx#773's ruling. That was
+        // Marten's shape alone; Polecat, Fisher and the first cut of these maps inserted the
+        // parameter as given, which made a decrement onto a missing row leave the column positive.
+        // Adopting these maps is therefore a behaviour change for Polecat and Fisher, deliberately.
         var table = Sqlite();
 
         IReadOnlyList<IColumnMap> columns =
@@ -238,7 +243,7 @@ public class flat_table_statement_composition
         Resolve(table, columns);
 
         FlatTableStatementBuilder.Upsert(ReferenceFlatTableDialects.Sqlite, table, typeof(Deposit), columns)
-            .Sql.ShouldContain("values (@p0, 1, @p1)");
+            .Sql.ShouldContain("values (@p0, 1, -@p1)");
     }
 
     private static string WriteCreateStatement(ISchemaObject schemaObject)

--- a/src/Weasel.Storage/Flattened/ColumnMaps.cs
+++ b/src/Weasel.Storage/Flattened/ColumnMaps.cs
@@ -81,12 +81,33 @@ public sealed class DecrementMemberMap: IColumnMap
         => $"{context.Quote(ColumnName)} = {context.Existing(ColumnName)} - {parameterName}";
 
     /// <summary>
-    ///     Polecat's and Fisher's shape: a first sighting inserts the value as given. Marten's
-    ///     equivalent inserts <c>-value</c> instead — see the type's remarks in the lift's PR; the
-    ///     divergence is preserved here as the two-store majority rather than reconciled silently.
+    ///     A row that does not exist yet is decremented <em>from zero</em>, so a first sighting of
+    ///     <c>5</c> lands the column at <c>-5</c> — the parameter negated, not the parameter as given.
     /// </summary>
+    /// <remarks>
+    ///     This is Marten's shape, and it was the minority one at the lift: Polecat, Fisher and the
+    ///     first cut of these maps all inserted the value unchanged, which made a <em>decrement</em>
+    ///     event raise the column on a fresh row. jasperfx#773 ruled Marten correct, so the negation
+    ///     is now the shared behaviour and the other stores are the ones that change. The asymmetry
+    ///     with <see cref="IncrementMemberMap" />, whose insert is the bare parameter, is intended:
+    ///     read both as "apply this event to an implicit zero row" and they agree.
+    ///     <para>
+    ///         The negation lives here rather than behind a dialect hook because a leading unary minus
+    ///         on a placeholder is valid in every position the insert expression is rendered into — a
+    ///         <c>MERGE</c>'s <c>WHEN NOT MATCHED … VALUES</c>, an <c>INSERT … ON CONFLICT</c>'s
+    ///         <c>VALUES</c>, and the <c>VALUES</c> of a generated upsert function's body, which is
+    ///         where Marten has been shipping it. A provider that ever needs <c>(0 - @p)</c> instead
+    ///         can supply its own <see cref="IColumnMap" /> rather than every dialect carrying a hook
+    ///         no dialect uses.
+    ///     </para>
+    ///     <para>
+    ///         Note that the parameterless <see cref="DecrementMap" /> still inserts <c>0</c> on all
+    ///         four stores. jasperfx#773 asked about both and only the member-valued form was ruled
+    ///         on; that one is unchanged and still agrees everywhere.
+    ///     </para>
+    /// </remarks>
     public string InsertExpression(in FlatTableColumnContext context, string parameterName)
-        => parameterName;
+        => "-" + parameterName;
 }
 
 /// <summary>Adds one to the column, with nothing read from the event.</summary>
@@ -111,9 +132,12 @@ public sealed class IncrementMap: IColumnMap
         => $"{context.Quote(ColumnName)} = {context.Existing(ColumnName)} + 1";
 
     /// <summary>
-    ///     A first sighting counts once, so the row starts at 1. Marten's equivalent inserts 0 — see
-    ///     the lift's PR; the divergence is preserved here as the two-store majority.
+    ///     A first sighting counts once, so the row starts at 1 rather than at 0 plus a later event.
     /// </summary>
+    /// <remarks>
+    ///     No longer a divergence: marten#5341 ruled 1 correct and marten#5342 brought Marten's
+    ///     <c>IncrementMap</c> in line with Polecat, Fisher and these maps, so all four now agree.
+    /// </remarks>
     public string InsertExpression(in FlatTableColumnContext context, string parameterName) => "1";
 }
 


### PR DESCRIPTION
Applies the ruling on [jasperfx#773](https://github.com/JasperFx/jasperfx/issues/773) to the lifted `Weasel.Storage.Flattened` maps.

## The ruling

For a member-valued `Decrement(x => x.Amount)` landing on a row that **does not exist yet**, the insert branch applies the event to an implicit zero row. A first sighting of `5` lands the column at **-5**. A decrement event must never raise a column.

Marten was the only store already doing this (`MemberMap.ToInsertExpression`, `ColumnMapType.Decrement => "-" + …`). Polecat, Fisher and the first cut of these lifted maps all inserted the parameter unchanged, so the same first event left the column at `+5` — the reading the issue could not find a defence for. The maps here took the two-store majority at the lift ([#569](https://github.com/JasperFx/weasel/pull/569)) and are therefore the ones that change.

## What changed

- `DecrementMemberMap.InsertExpression` now returns `-<param>`, and its XML comment records the ruling instead of the old divergence.
- Two new tests in `Weasel.Core.Tests/Flattened/flat_table_column_map_rendering.cs`: one pinning the negated decrement across all three reference dialect shapes, one placing increment (bare parameter) and decrement (negated) side by side so the asymmetry cannot be "tidied up" into symmetry.
- `flat_table_statement_composition.cs`'s `the_insert_branch_follows_polecat_and_fisher_where_the_three_stores_disagree` renamed and re-commented — it asserted the old value in a rendered statement and now expects `values (@p0, 1, -@p1)`.

Only the **member-valued** form was ruled on. The parameterless `DecrementMap` still inserts `0`, which all four stores agree on; jasperfx#773 raised it as a separate open question and it stays open.

## No dialect seam was needed

Checked against how the expression is actually assembled in `InlineFlatTableSqlDialect.BuildUpsert` and in the function-emitting reference dialect. `InsertExpression` lands in exactly one kind of position — an element of a `VALUES` list:

- SQL Server `MERGE … WHEN NOT MATCHED THEN INSERT (…) VALUES (-@p1)`
- SQLite `insert into … values (-@p1) on conflict …`
- PostgreSQL, inside the generated upsert function's body: `INSERT INTO … VALUES (-p_amount)` — a named `plpgsql` argument, which is the form Marten has shipped in production all along

A leading unary minus on a placeholder or a typed argument is valid in all three, so the negation belongs in the shared map. Adding an `IFlatTableSqlDialect` hook no dialect would override would be speculative API; a provider that ever needs `(0 - @p)` can supply its own `IColumnMap`, which is the existing escape hatch.

## Also in here

`IncrementMap`'s XML comment still claimed Marten diverged by inserting `0`. marten#5342 brought Marten to `1`, so that divergence no longer exists — the comment now says so rather than describing a state that is two PRs old.

## Validation

Solution builds clean. `Weasel.Core.Tests` 507/507 pass. `Weasel.Sqlite.Tests` 582/583 — the one failure is `TypeMappingIntegrationTests.all_types_together`, a pre-existing UTC-vs-local date flake unrelated to this change (it writes `DateTime.UtcNow` and reads it back with `DateTime.Parse`, so it fails any evening in a timezone behind UTC), dating from the original SQLite commit `0561b1b`.

CI is stalled org-wide, so this was validated locally.

## Downstream

Polecat and Fisher still insert the unnegated parameter and need the same change; filed separately, and both are behaviour changes that want a release note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)