### PR TITLE
Parse round-tripped SQLite dates with RoundtripKind in type mapping tests

### DIFF
--- a/src/Weasel.Sqlite.Tests/TypeMappingIntegrationTests.cs
+++ b/src/Weasel.Sqlite.Tests/TypeMappingIntegrationTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Microsoft.Data.Sqlite;
 using Shouldly;
 using Weasel.Sqlite;
@@ -32,7 +33,7 @@ public class TypeMappingIntegrationTests
         var result = await selectCmd.ExecuteScalarAsync();
 
         result.ShouldNotBeNull();
-        var retrieved = DateTime.Parse(result.ToString()!, null, System.Globalization.DateTimeStyles.RoundtripKind);
+        var retrieved = DateTime.Parse(result.ToString()!, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
 
         // SQLite stores as ISO8601 string, verify it roundtrips correctly with UTC preserved
         retrieved.Kind.ShouldBe(DateTimeKind.Utc);
@@ -107,7 +108,8 @@ public class TypeMappingIntegrationTests
         var result = await selectCmd.ExecuteScalarAsync();
 
         result.ShouldNotBeNull();
-        var retrieved = DateTimeOffset.Parse(result.ToString()!);
+        var retrieved = DateTimeOffset.Parse(result.ToString()!,
+            CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
 
         // Verify roundtrip
         retrieved.Year.ShouldBe(expected.Year);
@@ -410,13 +412,16 @@ public class TypeMappingIntegrationTests
         Math.Abs((double)amount - await reader.GetFieldValueAsync<double>(5)).ShouldBeLessThan(0.01);
         (await reader.GetFieldValueAsync<bool>(6)).ShouldBe(isActive);
 
-        var retrievedDate = DateTime.Parse(await reader.GetFieldValueAsync<string>(7));
-        retrievedDate.Year.ShouldBe(createdAt.Year);
-        retrievedDate.Month.ShouldBe(createdAt.Month);
-        retrievedDate.Day.ShouldBe(createdAt.Day);
+        // Parse with RoundtripKind so the UTC values written above come back as UTC
+        // instead of being shifted into the machine's local time zone
+        var retrievedDate = DateTime.Parse(await reader.GetFieldValueAsync<string>(7),
+            CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+        retrievedDate.Kind.ShouldBe(DateTimeKind.Utc);
+        retrievedDate.ShouldBe(createdAt);
 
-        var retrievedOffset = DateTimeOffset.Parse(await reader.GetFieldValueAsync<string>(8));
-        retrievedOffset.Day.ShouldBe(scheduledFor.Day);
+        var retrievedOffset = DateTimeOffset.Parse(await reader.GetFieldValueAsync<string>(8),
+            CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+        retrievedOffset.ShouldBe(scheduledFor);
 
         var retrievedDuration = TimeSpan.Parse(await reader.GetFieldValueAsync<string>(9));
         retrievedDuration.ShouldBe(duration);


### PR DESCRIPTION
## Problem

`Weasel.Sqlite.Tests.TypeMappingIntegrationTests.all_types_together` fails whenever the machine's local date is behind the UTC date — any evening in US Central, for example.

The test sets `createdAt` from `DateTime.UtcNow` and writes it with `.ToString("o")`, which for a `Utc` Kind emits a trailing `Z`. It then read it back with a bare `DateTime.Parse`, which converts a `Z`-offset string to **local** time by default. So `retrievedDate.Day` was the local day while `createdAt.Day` was the UTC day:

```
Shouldly.ShouldAssertException : retrievedDate.Day should be 6 but was 5
  at TypeMappingIntegrationTests.all_types_together() line 416
```

## Fix

Parse with `DateTimeStyles.RoundtripKind` and `CultureInfo.InvariantCulture` so the round trip preserves `Kind`, rather than loosening the assertion. Since `"o"` carries full tick precision, the assertion is also tightened from comparing individual date components to full equality, plus an explicit `Kind` check.

The same invariant/roundtrip parse is applied to the `DateTimeOffset` read on the following line and to the two sibling round-trip tests (`datetime_roundtrip`, `datetimeoffset_roundtrip`), which had the same culture-sensitive parse of an ISO 8601 string.

## Scope

Test-only. No production code is wrong — this has been latent since the original "Add complete SQLite support to Weasel" commit (0561b1b).

## Validation

`dotnet test src/Weasel.Sqlite.Tests/Weasel.Sqlite.Tests.csproj --framework net10.0` — 583 passed, 0 failed (no database needed).

Verified the fix is real rather than incidental to the local clock: under `TZ=Etc/GMT+12` the pre-fix code fails at line 416 as reported, and the full 583-test suite passes with the fix applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)