### PR TITLE
Stream JSON column reads instead of materializing a UTF-16 string

### DIFF
--- a/src/Weasel.Benchmarks/JsonReadBenchmarks.cs
+++ b/src/Weasel.Benchmarks/JsonReadBenchmarks.cs
@@ -14,12 +14,13 @@ namespace Weasel.Benchmarks;
 /// </summary>
 /// <remarks>
 ///     <para>
-///         <b>What this is the baseline for.</b> <c>Weasel.Core.SystemTextJsonSerializer</c>'s
-///         <c>FromJson&lt;T&gt;(DbDataReader, int)</c> calls <c>reader.GetString(index)</c> and hands
-///         the result to STJ, which transcodes the fresh UTF-16 string straight back to UTF-8 to
-///         parse it. Every document read and every event read therefore allocates a full-size string
-///         that is discarded microseconds later. The <c>Current</c> row calls the real serializer, so
-///         the same row can be re-run after the read path changes.
+///         <b>What the first row is.</b> <c>Weasel.Core.SystemTextJsonSerializer</c>'s
+///         <c>FromJson&lt;T&gt;(DbDataReader, int)</c>, whatever it currently does. Until weasel#573
+///         that was <c>reader.GetString(index)</c> handed to STJ, which transcoded the fresh UTF-16
+///         string straight back to UTF-8 to parse it — a full-size string allocated and discarded on
+///         every document and every event read. It now streams the column where the provider allows
+///         it and falls back to the string path where it does not. The row is deliberately labelled
+///         for the method rather than its implementation, so it stays comparable across that change.
 ///     </para>
 ///     <para>
 ///         <b>Where the win actually is.</b> See <see cref="JsonDeserializeBenchmarks" />: STJ parses
@@ -102,7 +103,7 @@ public class JsonReadBenchmarks
         }
     }
 
-    [Benchmark(Baseline = true, Description = "Current: serializer.FromJson<T>(reader, index) [GetString + parse]")]
+    [Benchmark(Baseline = true, Description = "serializer.FromJson<T>(reader, index) [the shipped read path]")]
     public int Current()
     {
         using var reader = _command.ExecuteReader();
@@ -110,7 +111,7 @@ public class JsonReadBenchmarks
         return _serializer.FromJson<JsonPayload>(reader, 0).Items.Count;
     }
 
-    [Benchmark(Description = "GetStream -> Deserialize(Stream) [SQLite + Npgsql only]")]
+    [Benchmark(Description = "GetStream -> Deserialize(Stream) [no capability check]")]
     public int Stream()
     {
         using var reader = _command.ExecuteReader();

--- a/src/Weasel.Benchmarks/Results.md
+++ b/src/Weasel.Benchmarks/Results.md
@@ -139,18 +139,25 @@ Two things to take from this:
 
 ### The whole read, query included (SQLite, TEXT column)
 
-| Path | 5 KB | Ratio | 120 KB | Ratio | Alloc 5 KB | Alloc 120 KB |
-|---|---:|---:|---:|---:|---:|---:|
-| **Current** — `serializer.FromJson<T>(reader, index)` (`GetString` + parse) | 25.55 us | 1.00 | 322.78 us | 1.00 | 33.58 KB | 558.85 KB |
-| `GetStream` → `Deserialize(Stream)` | 20.24 us | 0.82 | 351.47 us | 1.09 | **26.74 KB** | **438.54 KB** |
-| *Rejected:* `GetTextReader` → hand transcode → `Deserialize(span)` | 20.37 us | 0.82 | 324.89 us | 1.01 | 29.99 KB | 441.79 KB |
+Measured before and after weasel#573, which routed `SystemTextJsonSerializer`'s reader overloads
+through `GetStream` on providers that support it.
 
-**The stream path is an allocation and GC-pressure win, not a throughput win.** It removes ~20% of
-allocated bytes at both sizes — the full-size string that `GetString` builds and STJ discards
-microseconds later. At 120 KB it also halves the Gen2 collections (38.1 vs 76.7 per 1000 ops),
-because a 120 K-character string is 240 KB of UTF-16 and lands on the large object heap on every
-single read. Wall-clock is a wash: better at 5 KB, slightly worse at 120 KB, and both differences
-are inside this machine's noise.
+| Path | 5 KB | 120 KB | Alloc 5 KB | Alloc 120 KB | Gen2 @ 120 KB |
+|---|---:|---:|---:|---:|---:|
+| `serializer.FromJson<T>(reader, index)` — **before** (`GetString` + parse) | 25.55 us | 322.78 us | 33.58 KB | 558.85 KB | 76.66 |
+| `serializer.FromJson<T>(reader, index)` — **after** (streams, with fallback) | 22.94 us | 349.59 us | **26.74 KB** | **438.54 KB** | **38.09** |
+| `GetStream` → `Deserialize(Stream)` directly, no capability check | 23.76 us | 342.06 us | 26.74 KB | 438.54 KB | 38.09 |
+| *Rejected:* `GetTextReader` → hand transcode → `Deserialize(span)` | 23.81 us | 316.96 us | 29.99 KB | 441.79 KB | 38.09 |
+
+**The change is an allocation and GC-pressure win, not a throughput win.** It removes **20% of
+allocated bytes** at 5 KB and **21% at 120 KB** — the full-size string `GetString` built and STJ
+discarded microseconds later — and at 120 KB it **halves the Gen2 collections**, because 120 K
+characters is 240 KB of UTF-16 and landed on the large object heap on every single read. Wall-clock
+is a wash in both directions and inside this machine's noise; do not quote it as a speedup.
+
+The third row is the same read with the capability check taken out. It allocates identically to the
+shipped path, which is the check confirming it costs nothing after the first call — and, on this
+provider, that the shipped path really is streaming rather than quietly falling back.
 
 ### Provider support for `GetStream`
 

--- a/src/Weasel.Core.Tests/system_text_json_serializer_tests.cs
+++ b/src/Weasel.Core.Tests/system_text_json_serializer_tests.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Data.Common;
 using System.Text;
 using Microsoft.Data.Sqlite;
 using Shouldly;
@@ -225,6 +226,155 @@ public class system_text_json_serializer_tests
         (await theSerializer.FromJsonAsync<TestDoc>(reader, 0)).Name.ShouldBe("row");
         (await theSerializer.FromJsonAsync(typeof(TestDoc), reader, 0))
             .ShouldBeOfType<TestDoc>().Number.ShouldBe(11);
+    }
+
+    [Fact]
+    public async Task reads_a_reader_column_the_same_way_whether_or_not_the_provider_streams()
+    {
+        // Microsoft.Data.Sqlite streams a TEXT column, so this exercises the stream path; the
+        // NonStreamingReader case below covers the fallback. Both must produce the same document.
+        await using var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+
+        var command = connection.CreateCommand();
+        command.CommandText = "select '{\"name\":\"streamed\",\"number\":42,\"color\":1}'";
+
+        await using var reader = await command.ExecuteReaderAsync();
+        (await reader.ReadAsync()).ShouldBeTrue();
+
+        var streamed = theSerializer.FromJson<TestDoc>(reader, 0);
+        streamed.Name.ShouldBe("streamed");
+        streamed.Number.ShouldBe(42);
+        streamed.Color.ShouldBe(TestColor.LightGreen);
+
+        await using var fallback = new NonStreamingReader(reader);
+        var viaString = theSerializer.FromJson<TestDoc>(fallback, 0);
+        viaString.Name.ShouldBe("streamed");
+        viaString.Number.ShouldBe(42);
+        viaString.Color.ShouldBe(TestColor.LightGreen);
+    }
+
+    [Fact]
+    public async Task falls_back_to_the_string_path_when_a_provider_refuses_to_stream()
+    {
+        // SqlDataReader throws InvalidCastException from GetStream on nvarchar(max) and on SQL
+        // Server 2025's native json type, so the read path has to survive a provider that refuses
+        // (weasel#573). NonStreamingReader reproduces that refusal without needing a container.
+        await using var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+
+        var command = connection.CreateCommand();
+        command.CommandText = "select '{\"name\":\"fell back\",\"number\":7}'";
+
+        await using var inner = await command.ExecuteReaderAsync();
+        (await inner.ReadAsync()).ShouldBeTrue();
+
+        await using var reader = new NonStreamingReader(inner);
+
+        theSerializer.FromJson<TestDoc>(reader, 0).Name.ShouldBe("fell back");
+        theSerializer.FromJson(typeof(TestDoc), reader, 0)
+            .ShouldBeOfType<TestDoc>().Number.ShouldBe(7);
+
+        (await theSerializer.FromJsonAsync<TestDoc>(reader, 0)).Name.ShouldBe("fell back");
+        (await theSerializer.FromJsonAsync(typeof(TestDoc), reader, 0))
+            .ShouldBeOfType<TestDoc>().Number.ShouldBe(7);
+
+        reader.StreamAttempts.ShouldBeGreaterThan(0);
+    }
+
+    [Fact]
+    public void write_to_reuses_its_json_writer_across_calls()
+    {
+        // The writer is pooled per thread and reset onto each call's buffer, so two calls must not
+        // bleed into one another.
+        var first = new ArrayBufferWriter<byte>();
+        var second = new ArrayBufferWriter<byte>();
+
+        theSerializer.WriteTo(first, new TestDoc { Name = "one", Number = 1 });
+        theSerializer.WriteTo(second, new TestDoc { Name = "two", Number = 2 });
+
+        Encoding.UTF8.GetString(first.WrittenSpan).ShouldBe("{\"name\":\"one\",\"number\":1,\"color\":0}");
+        Encoding.UTF8.GetString(second.WrittenSpan).ShouldBe("{\"name\":\"two\",\"number\":2,\"color\":0}");
+    }
+
+    [Fact]
+    public async Task write_to_is_safe_from_two_threads_at_once()
+    {
+        // A store's serializer is a singleton, so the pooled writer is thread-static. Two threads
+        // writing at the same time must each get intact JSON.
+        var results = await Task.WhenAll(Enumerable.Range(0, 16).Select(i => Task.Run(() =>
+        {
+            var buffer = new ArrayBufferWriter<byte>();
+            theSerializer.WriteTo(buffer, new TestDoc { Name = "doc" + i, Number = i });
+            return Encoding.UTF8.GetString(buffer.WrittenSpan);
+        })));
+
+        for (var i = 0; i < results.Length; i++)
+        {
+            results.ShouldContain("{\"name\":\"doc" + i + "\",\"number\":" + i + ",\"color\":0}");
+        }
+    }
+
+    /// <summary>
+    ///     A reader that refuses to stream, the way Microsoft.Data.SqlClient refuses on an
+    ///     <c>nvarchar(max)</c> or <c>json</c> column, while delegating everything else to a real
+    ///     reader. Lets the fallback be tested without a SQL Server container.
+    /// </summary>
+    private sealed class NonStreamingReader(DbDataReader inner): DbDataReader
+    {
+        public int StreamAttempts { get; private set; }
+
+        public override Stream GetStream(int ordinal)
+        {
+            StreamAttempts++;
+            throw new InvalidCastException(
+                $"Invalid attempt to GetStream on column '{GetName(ordinal)}'. The GetStream function can only be used on columns of type Binary, Image, Udt or VarBinary.");
+        }
+
+        public override Task<T> GetFieldValueAsync<T>(int ordinal, CancellationToken cancellationToken)
+        {
+            if (typeof(T) == typeof(Stream))
+            {
+                StreamAttempts++;
+                throw new InvalidCastException("Invalid attempt to GetStream.");
+            }
+
+            return inner.GetFieldValueAsync<T>(ordinal, cancellationToken);
+        }
+
+        public override string GetString(int ordinal) => inner.GetString(ordinal);
+        public override object GetValue(int ordinal) => inner.GetValue(ordinal);
+        public override int GetValues(object[] values) => inner.GetValues(values);
+        public override bool IsDBNull(int ordinal) => inner.IsDBNull(ordinal);
+        public override int FieldCount => inner.FieldCount;
+        public override object this[int ordinal] => inner[ordinal];
+        public override object this[string name] => inner[name];
+        public override int RecordsAffected => inner.RecordsAffected;
+        public override bool HasRows => inner.HasRows;
+        public override bool IsClosed => inner.IsClosed;
+        public override int Depth => inner.Depth;
+        public override bool NextResult() => inner.NextResult();
+        public override bool Read() => inner.Read();
+        public override System.Collections.IEnumerator GetEnumerator() => inner.GetEnumerator();
+        public override bool GetBoolean(int ordinal) => inner.GetBoolean(ordinal);
+        public override byte GetByte(int ordinal) => inner.GetByte(ordinal);
+        public override long GetBytes(int ordinal, long dataOffset, byte[]? buffer, int bufferOffset, int length) =>
+            inner.GetBytes(ordinal, dataOffset, buffer, bufferOffset, length);
+        public override char GetChar(int ordinal) => inner.GetChar(ordinal);
+        public override long GetChars(int ordinal, long dataOffset, char[]? buffer, int bufferOffset, int length) =>
+            inner.GetChars(ordinal, dataOffset, buffer, bufferOffset, length);
+        public override string GetDataTypeName(int ordinal) => inner.GetDataTypeName(ordinal);
+        public override DateTime GetDateTime(int ordinal) => inner.GetDateTime(ordinal);
+        public override decimal GetDecimal(int ordinal) => inner.GetDecimal(ordinal);
+        public override double GetDouble(int ordinal) => inner.GetDouble(ordinal);
+        public override Type GetFieldType(int ordinal) => inner.GetFieldType(ordinal);
+        public override float GetFloat(int ordinal) => inner.GetFloat(ordinal);
+        public override Guid GetGuid(int ordinal) => inner.GetGuid(ordinal);
+        public override short GetInt16(int ordinal) => inner.GetInt16(ordinal);
+        public override int GetInt32(int ordinal) => inner.GetInt32(ordinal);
+        public override long GetInt64(int ordinal) => inner.GetInt64(ordinal);
+        public override string GetName(int ordinal) => inner.GetName(ordinal);
+        public override int GetOrdinal(string name) => inner.GetOrdinal(name);
     }
 
     [Fact]

--- a/src/Weasel.Core/JsonColumnStreaming.cs
+++ b/src/Weasel.Core/JsonColumnStreaming.cs
@@ -1,0 +1,98 @@
+using System.Collections.Concurrent;
+using System.Data.Common;
+
+namespace Weasel.Core;
+
+/// <summary>
+///     Decides whether a given <see cref="DbDataReader" /> implementation can hand back a JSON
+///     column as a <see cref="Stream" />, so the read path can skip materializing a full-size
+///     UTF-16 string that System.Text.Json would only transcode back to UTF-8 to parse.
+/// </summary>
+/// <remarks>
+///     <para>
+///         The answer is per provider and cannot be read off the API surface: every
+///         <see cref="DbDataReader" /> has <c>GetStream</c>, but only some will use it for a text
+///         column. Measured against live databases (weasel#565):
+///     </para>
+///     <list type="table">
+///         <item><term>Microsoft.Data.Sqlite</term><description><c>TEXT</c> — streams.</description></item>
+///         <item><term>Npgsql</term><description><c>jsonb</c>, <c>json</c>, <c>text</c> — all stream.</description></item>
+///         <item>
+///             <term>Microsoft.Data.SqlClient</term>
+///             <description>
+///                 <c>nvarchar(max)</c> and SQL Server 2025's native <c>json</c> both throw
+///                 <c>InvalidCastException</c>: "can only be used on columns of type Binary, Image,
+///                 Udt or VarBinary". SQL Server also sends both as UTF-16 on the wire, so there is
+///                 no UTF-8 to reach for — the string path is already the right one there.
+///             </description>
+///         </item>
+///     </list>
+///     <para>
+///         Rather than enumerate providers — which would be wrong for the next one — the capability
+///         is learned once per reader type by attempting the call and remembering the refusal. That
+///         costs one exception per reader type per process, and is safe because a failed
+///         <c>GetStream</c> does not consume the column: <c>GetString</c> on the same column
+///         afterwards still returns the value, under both <c>CommandBehavior.Default</c> and
+///         <c>SequentialAccess</c> (also measured in weasel#565).
+///     </para>
+///     <para>
+///         Only the accessor call itself is guarded. An <see cref="InvalidCastException" /> thrown
+///         from inside deserialization — by a custom converter, say — must not be mistaken for a
+///         provider that cannot stream, so deserialization happens outside the guard.
+///     </para>
+/// </remarks>
+internal static class JsonColumnStreaming
+{
+    private static readonly ConcurrentDictionary<Type, bool> _supported = new();
+
+    /// <summary>
+    ///     The column's value as a stream, or null when this provider will not stream it — in which
+    ///     case the caller should fall back to <see cref="DbDataReader.GetString" />.
+    /// </summary>
+    public static Stream? TryGetStream(DbDataReader reader, int index)
+    {
+        var readerType = reader.GetType();
+        if (_supported.TryGetValue(readerType, out var supported) && !supported)
+        {
+            return null;
+        }
+
+        try
+        {
+            var stream = reader.GetStream(index);
+            _supported[readerType] = true;
+            return stream;
+        }
+        catch (Exception e) when (e is InvalidCastException or NotSupportedException)
+        {
+            _supported[readerType] = false;
+            return null;
+        }
+    }
+
+    /// <summary>
+    ///     The async counterpart of <see cref="TryGetStream" />, going through
+    ///     <c>GetFieldValueAsync&lt;Stream&gt;</c> so a provider that streams asynchronously can.
+    /// </summary>
+    public static async ValueTask<Stream?> TryGetStreamAsync(DbDataReader reader, int index,
+        CancellationToken cancellationToken)
+    {
+        var readerType = reader.GetType();
+        if (_supported.TryGetValue(readerType, out var supported) && !supported)
+        {
+            return null;
+        }
+
+        try
+        {
+            var stream = await reader.GetFieldValueAsync<Stream>(index, cancellationToken).ConfigureAwait(false);
+            _supported[readerType] = true;
+            return stream;
+        }
+        catch (Exception e) when (e is InvalidCastException or NotSupportedException)
+        {
+            _supported[readerType] = false;
+            return null;
+        }
+    }
+}

--- a/src/Weasel.Core/SystemTextJsonSerializer.cs
+++ b/src/Weasel.Core/SystemTextJsonSerializer.cs
@@ -118,12 +118,57 @@ public class SystemTextJsonSerializer : ISerializer
         return ToJson(document);
     }
 
+    /// <summary>
+    ///     One <see cref="Utf8JsonWriter" /> per thread, reset onto each call's buffer writer
+    ///     instead of allocated fresh — the type is built to be reused that way, and this is the
+    ///     allocation-free append/write hot path of the storage runtime.
+    /// </summary>
+    /// <remarks>
+    ///     Thread-static rather than a plain field because a store's serializer is a singleton
+    ///     shared across sessions, and <see cref="Utf8JsonWriter" /> is not thread-safe.
+    ///     <see cref="_writerInUse" /> covers the remaining case: a custom converter that calls
+    ///     back into <see cref="WriteTo" /> on the same thread would otherwise scribble over the
+    ///     writer mid-document, so a re-entrant call gets its own.
+    /// </remarks>
+    [ThreadStatic] private static Utf8JsonWriter? _cachedWriter;
+
+    [ThreadStatic] private static bool _writerInUse;
+
     [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification = SharedSerializerSuppression)]
     [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = SharedSerializerSuppression)]
     public void WriteTo(IBufferWriter<byte> writer, object? value)
     {
-        using var jsonWriter = new Utf8JsonWriter(writer);
-        JsonSerializer.Serialize(jsonWriter, value, value?.GetType() ?? typeof(object), _options);
+        var type = value?.GetType() ?? typeof(object);
+
+        if (_writerInUse)
+        {
+            using var reentrant = new Utf8JsonWriter(writer);
+            JsonSerializer.Serialize(reentrant, value, type, _options);
+            return;
+        }
+
+        var jsonWriter = _cachedWriter;
+        if (jsonWriter is null)
+        {
+            _cachedWriter = jsonWriter = new Utf8JsonWriter(writer);
+        }
+        else
+        {
+            jsonWriter.Reset(writer);
+        }
+
+        _writerInUse = true;
+        try
+        {
+            JsonSerializer.Serialize(jsonWriter, value, type, _options);
+        }
+        finally
+        {
+            _writerInUse = false;
+            // Drop the reference to the caller's buffer writer; the pooled writer must not keep
+            // it alive between calls.
+            jsonWriter.Reset();
+        }
     }
 
     /// <summary>
@@ -139,22 +184,51 @@ public class SystemTextJsonSerializer : ISerializer
         parameter.Value = value is null ? DBNull.Value : ToJson(value);
     }
 
+    /// <summary>
+    ///     Deserialize the reader's JSON column, streaming the bytes straight into the parser where
+    ///     the provider allows it and falling back to the string path where it does not. See
+    ///     <see cref="JsonColumnStreaming" /> for which providers are which, and why the capability
+    ///     is discovered rather than declared.
+    /// </summary>
     [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification = SharedSerializerSuppression)]
     [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = SharedSerializerSuppression)]
     public async ValueTask<T> FromJsonAsync<T>(DbDataReader reader, int index,
         CancellationToken cancellationToken = default)
     {
-        var json = await reader.GetFieldValueAsync<string>(index, cancellationToken).ConfigureAwait(false);
-        return FromJson<T>(json);
+        var stream = await JsonColumnStreaming.TryGetStreamAsync(reader, index, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (stream is null)
+        {
+            var json = await reader.GetFieldValueAsync<string>(index, cancellationToken).ConfigureAwait(false);
+            return FromJson<T>(json);
+        }
+
+        await using (stream.ConfigureAwait(false))
+        {
+            return await FromJsonAsync<T>(stream, cancellationToken).ConfigureAwait(false);
+        }
     }
 
+    /// <inheritdoc cref="FromJsonAsync{T}(DbDataReader,int,CancellationToken)" />
     [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification = SharedSerializerSuppression)]
     [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = SharedSerializerSuppression)]
     public async ValueTask<object> FromJsonAsync(Type type, DbDataReader reader, int index,
         CancellationToken cancellationToken = default)
     {
-        var json = await reader.GetFieldValueAsync<string>(index, cancellationToken).ConfigureAwait(false);
-        return FromJson(type, json);
+        var stream = await JsonColumnStreaming.TryGetStreamAsync(reader, index, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (stream is null)
+        {
+            var json = await reader.GetFieldValueAsync<string>(index, cancellationToken).ConfigureAwait(false);
+            return FromJson(type, json);
+        }
+
+        await using (stream.ConfigureAwait(false))
+        {
+            return await FromJsonAsync(type, stream, cancellationToken).ConfigureAwait(false);
+        }
     }
 
     [RequiresUnreferencedCode("STJ JsonSerializer.Deserialize<T> uses reflection over T.")]
@@ -189,16 +263,35 @@ public class SystemTextJsonSerializer : ISerializer
     [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = SharedSerializerSuppression)]
     public T FromJson<T>(DbDataReader reader, int index)
     {
-        var json = reader.GetString(index);
-        return FromJson<T>(json);
+        // See FromJsonAsync<T>(DbDataReader, int, CancellationToken) for why this is a try-then-
+        // fall-back rather than one path or the other.
+        var stream = JsonColumnStreaming.TryGetStream(reader, index);
+        if (stream is null)
+        {
+            return FromJson<T>(reader.GetString(index));
+        }
+
+        using (stream)
+        {
+            return FromJson<T>(stream);
+        }
     }
 
+    /// <inheritdoc cref="FromJson{T}(DbDataReader,int)" />
     [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification = SharedSerializerSuppression)]
     [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = SharedSerializerSuppression)]
     public object FromJson(Type type, DbDataReader reader, int index)
     {
-        var json = reader.GetString(index);
-        return FromJson(type, json);
+        var stream = JsonColumnStreaming.TryGetStream(reader, index);
+        if (stream is null)
+        {
+            return FromJson(type, reader.GetString(index));
+        }
+
+        using (stream)
+        {
+            return FromJson(type, stream);
+        }
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification = SharedSerializerSuppression)]

--- a/src/Weasel.SqlServer.Tests/json_column_reads_fall_back_to_the_string_path.cs
+++ b/src/Weasel.SqlServer.Tests/json_column_reads_fall_back_to_the_string_path.cs
@@ -1,0 +1,143 @@
+using Microsoft.Data.SqlClient;
+using Shouldly;
+using Weasel.Core;
+using Xunit;
+
+namespace Weasel.SqlServer.Tests;
+
+/// <summary>
+///     <see cref="SystemTextJsonSerializer" />'s reader overloads stream a JSON column straight into
+///     the parser where the provider supports it, avoiding a full-size UTF-16 string that STJ would
+///     only transcode back to UTF-8 (weasel#573). SqlClient is the provider that does <b>not</b>
+///     support it: <c>SqlDataReader.GetStream</c> throws <c>InvalidCastException</c> on
+///     <c>nvarchar(max)</c> and on SQL Server 2025's native <c>json</c> type — "can only be used on
+///     columns of type Binary, Image, Udt or VarBinary".
+/// </summary>
+/// <remarks>
+///     The unit tests in Weasel.Core.Tests cover the fallback with a stub reader. This covers it
+///     against the real driver, because the stub is only worth anything if SqlClient still behaves
+///     the way it was measured — a future SqlClient that starts streaming <c>json</c> would make the
+///     stub a fiction, and this test is what would notice.
+/// </remarks>
+[Collection("integration")]
+public class json_column_reads_fall_back_to_the_string_path
+{
+    public class Doc
+    {
+        public string? Name { get; set; }
+        public int Number { get; set; }
+        public string[]? Tags { get; set; }
+    }
+
+    private readonly SystemTextJsonSerializer theSerializer = new();
+
+    [Fact]
+    public async Task nvarchar_max_round_trips_through_the_fallback()
+    {
+        await assertRoundTripAsync("nvarchar(max)");
+    }
+
+    [Fact]
+    public async Task native_json_round_trips_through_the_fallback()
+    {
+        if (!await supportsNativeJsonAsync())
+        {
+            // Pre-2025 servers have no json type; the nvarchar(max) case still covers the fallback.
+            return;
+        }
+
+        await assertRoundTripAsync("json");
+    }
+
+    [Fact]
+    public async Task get_stream_is_still_refused_for_a_json_column()
+    {
+        // The premise the fallback exists for. If this ever starts passing a stream back, the
+        // capability probe in Weasel.Core will notice on its own and start streaming — but the
+        // documentation claiming SqlClient cannot would then be wrong, and this is where it shows.
+        await using var conn = new SqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await createAsync(conn, "nvarchar(max)");
+
+        var query = conn.CreateCommand();
+        query.CommandText = "select doc from dbo.weasel_json_probe where id = 1";
+
+        await using var reader = await query.ExecuteReaderAsync();
+        (await reader.ReadAsync()).ShouldBeTrue();
+
+        Should.Throw<InvalidCastException>(() => reader.GetStream(0));
+
+        // And the column is still readable afterwards, which is what makes try-then-fall-back safe.
+        reader.GetString(0).ShouldContain("streamed or not");
+    }
+
+    private async Task assertRoundTripAsync(string columnType)
+    {
+        await using var conn = new SqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await createAsync(conn, columnType);
+
+        var query = conn.CreateCommand();
+        query.CommandText = "select doc from dbo.weasel_json_probe where id = 1";
+
+        await using (var reader = await query.ExecuteReaderAsync())
+        {
+            (await reader.ReadAsync()).ShouldBeTrue();
+
+            var sync = theSerializer.FromJson<Doc>(reader, 0);
+            sync.Name.ShouldBe("streamed or not");
+            sync.Number.ShouldBe(99);
+            sync.Tags.ShouldBe(["a", "b"]);
+
+            theSerializer.FromJson(typeof(Doc), reader, 0)
+                .ShouldBeOfType<Doc>().Number.ShouldBe(99);
+        }
+
+        await using (var reader = await query.ExecuteReaderAsync())
+        {
+            (await reader.ReadAsync()).ShouldBeTrue();
+
+            var async = await theSerializer.FromJsonAsync<Doc>(reader, 0, TestContext.Current.CancellationToken);
+            async.Name.ShouldBe("streamed or not");
+            async.Tags.ShouldBe(["a", "b"]);
+
+            (await theSerializer.FromJsonAsync(typeof(Doc), reader, 0, TestContext.Current.CancellationToken))
+                .ShouldBeOfType<Doc>().Number.ShouldBe(99);
+        }
+    }
+
+    private async Task createAsync(SqlConnection conn, string columnType)
+    {
+        await executeAsync(conn, "if object_id('dbo.weasel_json_probe') is not null drop table dbo.weasel_json_probe");
+        await executeAsync(conn, $"create table dbo.weasel_json_probe (id int primary key, doc {columnType})");
+
+        var insert = conn.CreateCommand();
+        insert.CommandText = "insert into dbo.weasel_json_probe (id, doc) values (1, @doc)";
+        insert.Parameters.AddWithValue("@doc",
+            theSerializer.ToJson(new Doc { Name = "streamed or not", Number = 99, Tags = ["a", "b"] }));
+        await insert.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static async Task<bool> supportsNativeJsonAsync()
+    {
+        await using var conn = new SqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+
+        try
+        {
+            await executeAsync(conn, "declare @probe json = '{}'");
+            return true;
+        }
+        catch (SqlException)
+        {
+            return false;
+        }
+    }
+
+    private static async Task executeAsync(SqlConnection conn, string sql)
+    {
+        var command = conn.CreateCommand();
+        command.CommandText = sql;
+        await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+}


### PR DESCRIPTION
Closes #573. Part of Stoat plan `critter-performance-2026-09`, node `weasel-serializer-stream-reads`.

`SystemTextJsonSerializer`'s four `DbDataReader` overloads read every JSON column through `GetString` / `GetFieldValueAsync<string>`, and STJ then transcodes that fresh UTF-16 string straight back to UTF-8 to parse it. Every document read and every event read allocated a full-size string that was discarded microseconds later.

They now take the column as a `Stream` where the provider supports it and fall back to the string path where it does not.

## The numbers

Measured with the `JsonReadBenchmarks` row added in #572 — SQLite, TEXT column, BenchmarkDotNet default job.

| | 5 KB | 120 KB | Alloc 5 KB | Alloc 120 KB | Gen2 @ 120 KB |
|---|---:|---:|---:|---:|---:|
| **Before** (`GetString` + parse) | 25.55 us | 322.78 us | 33.58 KB | 558.85 KB | 76.66 |
| **After** (streams, with fallback) | 22.94 us | 349.59 us | **26.74 KB** | **438.54 KB** | **38.09** |
| `GetStream` directly, no capability check | 23.76 us | 342.06 us | 26.74 KB | 438.54 KB | 38.09 |

**20% fewer allocated bytes at 5 KB, 21% at 120 KB, and Gen2 collections halved at 120 KB** — a 120 K-character document is 240 KB of UTF-16 and was landing on the large object heap on every single read.

**This is an allocation and GC-pressure win, not a throughput win.** Wall clock moved a few percent in both directions and stayed inside the measurement noise on the recording machine; please do not quote it as a speedup. The third row is the same read with the capability check removed — it allocates identically to the shipped path, which is the check confirming it costs nothing after the first call, and confirming the shipped path really is streaming here rather than quietly falling back.

## Why there is a capability check rather than just `GetStream`

Marten does this with `reader.GetStream(index)`, but Npgsql is the only provider it targets. Every `DbDataReader` has `GetStream`; not every one will use it for a text column. Measured against live databases:

| Provider | Column | `GetStream` |
|---|---|---|
| Microsoft.Data.Sqlite | `TEXT` | works |
| Npgsql 9 | `jsonb`, `json`, `text` | works |
| Microsoft.Data.SqlClient 6.1 | `nvarchar(max)` | **`InvalidCastException`** |
| Microsoft.Data.SqlClient 6.1 | `json` (SQL Server 2025 native) | **`InvalidCastException`** |

> Invalid attempt to GetStream on column 'x'. The GetStream function can only be used on columns of type Binary, Image, Udt or VarBinary.

Both SQL Server results hold under `CommandBehavior.Default` and `SequentialAccess`. SQL Server also sends both column types as UTF-16 on the wire, so there is no UTF-8 there to reach for — the string path is already the right one for it, and this PR leaves it on that path.

`JsonColumnStreaming` learns the answer once per reader type by attempting the call and remembering a refusal, rather than enumerating providers — an enumeration would be wrong for the next provider, and wrong again if a driver changes. That costs one exception per reader type per process, and it is safe because **a failed `GetStream` does not consume the column**: `GetString` on it afterwards still returns the value, in both command behaviors. That is asserted against the real driver, not assumed.

Only the accessor call is inside the guard. An `InvalidCastException` thrown from *inside* deserialization — by a custom converter — must not be mistaken for a provider that cannot stream, so deserialization happens outside it.

## `WriteTo`

`WriteTo(IBufferWriter<byte>, object?)` allocated a fresh `Utf8JsonWriter` on every call, where the type is built to be reset and reused. It now keeps one per thread and resets it onto each call's buffer. Thread-static rather than a plain field because a store's serializer is a singleton shared across sessions and `Utf8JsonWriter` is not thread-safe; an in-use flag covers the remaining case, where a custom converter re-enters `WriteTo` on the same thread and would otherwise scribble over the writer mid-document — a re-entrant call gets its own.

## Out of scope: the write path

`WriteToParameter` is deliberately untouched. SqlClient wants string/`SqlChars` for `nvarchar` and `json`, and Microsoft.Data.Sqlite binds `byte[]` as a BLOB, so switching to `SerializeToUtf8Bytes` would change the **stored column type** on both providers. That is a compatibility change, not a performance one, and does not belong here.

## Tests

- `Weasel.Core.Tests` — the stream path and the fallback, using a stub reader that refuses to stream the way SqlClient does; plus writer reuse across calls and `WriteTo` from 16 threads at once.
- `Weasel.SqlServer.Tests` — the same fallback against the **real driver**, on `nvarchar(max)` and on native `json`, sync and async overloads. It also asserts that `GetStream` is still refused and that `GetString` still works afterwards. If a future SqlClient starts streaming `json`, that is where it surfaces, rather than the stub quietly becoming a fiction.

## Validation

Built the solution; `Weasel.Core.Tests` **509 passed**, `Weasel.SqlServer.Tests` **561 passed** against a local SQL Server 2025 container (up 3 — the new fallback tests), `Weasel.Postgresql.Tests` **974 passed** against a local container, `Weasel.Sqlite.Tests` **582 passed / 1 failed**. Oracle and MySql were not run — no local containers.

The one SQLite failure is the same pre-existing, unrelated one noted in #572: `TypeMappingIntegrationTests.all_types_together` compares a UTC day against a locally-parsed day, so it fails on any machine whose local date differs from the UTC date. It fails identically on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)