### PR TITLE
Move the ChangeTracker DeepEquals fallback behind an opt-in flag

### DIFF
--- a/src/Weasel.Benchmarks/ChangeTrackerBenchmarks.cs
+++ b/src/Weasel.Benchmarks/ChangeTrackerBenchmarks.cs
@@ -11,7 +11,7 @@ namespace Weasel.Benchmarks;
 /// <remarks>
 ///     Dirty tracking runs this once per tracked document on every <c>SaveChanges</c>, so a session
 ///     that loaded a hundred documents and changed one pays the unchanged cost ninety-nine times.
-///     Three paths are worth separating:
+///     Four paths are worth separating:
 ///     <list type="bullet">
 ///         <item>
 ///             <b>Unchanged</b> — the overwhelmingly common case. Re-serializes the document and
@@ -19,13 +19,20 @@ namespace Weasel.Benchmarks;
 ///         </item>
 ///         <item>
 ///             <b>SemanticallyEqual</b> — the strings differ but the JSON means the same thing
-///             (a reordered dictionary, most often). Falls through the ordinal compare into two
-///             <c>JsonNode.Parse</c> calls and a <c>DeepEquals</c>: two whole object graphs built
-///             and thrown away to conclude nothing changed.
+///             (a reordered dictionary, most often). Since weasel#577 the default answer is "it
+///             changed": the ordinal compare misses and the tracker goes straight to the upsert,
+///             writing a row of semantically identical JSON.
 ///         </item>
 ///         <item>
-///             <b>Changed</b> — pays for the serialize, the failed ordinal compare, the two parses
-///             and the failed deep compare before it reaches the storage operation.
+///             <b>SemanticallyEqualWithFallback</b> — the same document under a session that opted
+///             into <see cref="IStorageSession.UseSemanticJsonChangeDetection" />. Falls through
+///             the ordinal compare into two <c>JsonNode.Parse</c> calls and a <c>DeepEquals</c>:
+///             two whole object graphs built and thrown away to conclude nothing changed. This is
+///             what every session paid unconditionally before weasel#577.
+///         </item>
+///         <item>
+///             <b>Changed</b> — pays for the serialize and the failed ordinal compare before it
+///             reaches the storage operation.
 ///         </item>
 ///     </list>
 /// </remarks>
@@ -35,9 +42,11 @@ public class ChangeTrackerBenchmarks
 {
     private ChangeTracker<BenchmarkDocument> _unchanged = null!;
     private ChangeTracker<BenchmarkDocument> _semanticallyEqual = null!;
+    private ChangeTracker<BenchmarkDocument> _semanticallyEqualWithFallback = null!;
     private ChangeTracker<BenchmarkDocument> _changed = null!;
     private BenchmarkDocument _changedDocument = null!;
     private IStorageSession _session = null!;
+    private IStorageSession _fallbackSession = null!;
 
     /// <summary>The measured JSON size of the reference document, reported by Program.</summary>
     public static int DocumentJsonSize => BenchmarkDocument.JsonSize(BenchmarkDocument.Create());
@@ -48,24 +57,60 @@ public class ChangeTrackerBenchmarks
         var serializer = StorageSerializerAdapter.For(new SystemTextJsonSerializer());
         _session = new BenchmarkStorageSession(serializer,
             new BenchmarkProviderGraph<BenchmarkDocument>(new NoopDocumentStorage<BenchmarkDocument>()));
+        _fallbackSession = new BenchmarkStorageSession(serializer,
+            new BenchmarkProviderGraph<BenchmarkDocument>(new NoopDocumentStorage<BenchmarkDocument>()))
+        {
+            UseSemanticJsonChangeDetection = true
+        };
 
         _unchanged = new ChangeTracker<BenchmarkDocument>(_session, BenchmarkDocument.Create());
 
         // Re-inserting the attribute dictionary in a different order changes the JSON text
         // without changing what the JSON means, which is exactly the case the DeepEquals fallback
-        // exists for.
+        // exists for. The tracker has to take its baseline before the reorder, or there is no
+        // difference for it to find.
         var reordered = BenchmarkDocument.Create();
         _semanticallyEqual = new ChangeTracker<BenchmarkDocument>(_session, reordered);
-        var attributes = reordered.Attributes.ToArray();
-        reordered.Attributes.Clear();
-        foreach (var pair in attributes.Reverse())
-        {
-            reordered.Attributes[pair.Key] = pair.Value;
-        }
+        reorderTheAttributes(reordered);
+
+        var reorderedForFallback = BenchmarkDocument.Create();
+        _semanticallyEqualWithFallback =
+            new ChangeTracker<BenchmarkDocument>(_fallbackSession, reorderedForFallback);
+        reorderTheAttributes(reorderedForFallback);
 
         _changedDocument = BenchmarkDocument.Create();
         _changed = new ChangeTracker<BenchmarkDocument>(_session, _changedDocument);
         _changedDocument.Revision++;
+
+        assertEachScenarioAnswersWhatItClaims();
+    }
+
+    /// <summary>
+    ///     A tracker whose document was not actually made to differ measures the unchanged path
+    ///     under another name, and the table looks plausible while saying nothing. Check the four
+    ///     answers before measuring them.
+    /// </summary>
+    private void assertEachScenarioAnswersWhatItClaims()
+    {
+        assert(!Unchanged(), "Unchanged should report no change");
+        assert(SemanticallyEqual(), "SemanticallyEqual should report a change with the fallback off");
+        assert(!SemanticallyEqualWithFallback(), "SemanticallyEqualWithFallback should report no change");
+        assert(Changed(), "Changed should report a change");
+
+        static void assert(bool condition, string message)
+        {
+            if (!condition) throw new InvalidOperationException($"Benchmark setup is wrong: {message}.");
+        }
+    }
+
+    private static void reorderTheAttributes(BenchmarkDocument document)
+    {
+        var attributes = document.Attributes.ToArray();
+        document.Attributes.Clear();
+        foreach (var pair in attributes.Reverse())
+        {
+            document.Attributes[pair.Key] = pair.Value;
+        }
     }
 
     [Benchmark(Baseline = true, Description = "Unchanged (ordinal string compare wins)")]
@@ -74,10 +119,16 @@ public class ChangeTrackerBenchmarks
         return _unchanged.DetectChanges(_session, out _);
     }
 
-    [Benchmark(Description = "Reordered but equal (JsonNode DeepEquals fallback)")]
+    [Benchmark(Description = "Reordered but equal (default: reports a change)")]
     public bool SemanticallyEqual()
     {
         return _semanticallyEqual.DetectChanges(_session, out _);
+    }
+
+    [Benchmark(Description = "Reordered but equal (opt-in JsonNode DeepEquals fallback)")]
+    public bool SemanticallyEqualWithFallback()
+    {
+        return _semanticallyEqualWithFallback.DetectChanges(_fallbackSession, out _);
     }
 
     [Benchmark(Description = "Changed (full detection, then Upsert)")]

--- a/src/Weasel.Benchmarks/Results.md
+++ b/src/Weasel.Benchmarks/Results.md
@@ -54,6 +54,10 @@ below rests on timing, it says so, and it is stated as a range rather than a fig
 Dirty tracking calls this once per tracked document on every `SaveChanges`, so a session that loaded
 a hundred documents and changed one pays the *unchanged* cost ninety-nine times.
 
+### The original baseline (weasel#565, before #577)
+
+Every session ran the `JsonNode.DeepEquals` fallback unconditionally.
+
 | Path | Mean | Ratio | Allocated | Alloc ratio |
 |---|---:|---:|---:|---:|
 | Unchanged (ordinal string compare wins) | 4.47 us | 1.00 | 8.42 KB | 1.00 |
@@ -70,6 +74,35 @@ misses, and the fallback builds **two whole `JsonNode` trees and throws them bot
 that nothing changed: 7.7x the time and **9.8x the allocation of the unchanged path**, to produce
 the same answer. It is also more expensive than genuinely detecting a change (row 3), because a real
 change is usually visible early in the tree while equality has to walk all of it.
+
+### After weasel#577
+
+The fallback moved behind `IStorageSession.UseSemanticJsonChangeDetection`, off by default. Both
+tables below were re-recorded together on the machine described above, so they compare to each other
+rather than to the numbers up top; wall clock on this machine drifts by up to 2x between runs, and
+the allocation column reproduced exactly.
+
+| Path | Before | After | Alloc before | Alloc after |
+|---|---:|---:|---:|---:|
+| Unchanged (ordinal string compare wins) | 3.83 us | 4.09 us | 8.42 KB | 8.42 KB |
+| Reordered but equal (default: reports a change) | 31.09 us | **4.08 us** | 82.23 KB | **8.42 KB** |
+| Changed (full detection, then `Upsert`) | 15.67 us | **3.81 us** | 30.06 KB | **8.42 KB** |
+| Reordered but equal (opt-in fallback) | — | 32.55 us | — | 82.23 KB |
+
+Two things fall out of this that are worth stating separately.
+
+The reordered row does what it was meant to: 7.6x less time and **9.8x less allocation**, because
+the two `JsonNode` trees are simply never built. What it buys that with is a redundant write of
+semantically identical JSON — a cost the tracker is willing to pay, because the check being skipped
+is one that only ever turns "changed" into "unchanged" and so can never lose a write, only add one.
+A session that would rather pay the 32.55 us sets the flag and gets the old behaviour back, to the
+byte.
+
+The **Changed** row was the unadvertised win. Every genuinely dirty document used to parse both JSON
+documents and walk both trees before it was allowed to conclude what the string compare had already
+told it, so detecting a real change cost 4x an unchanged one. It now costs slightly *less* than the
+unchanged path — same one serialization, and the string compare bails at the first differing byte
+instead of running to the end.
 
 ## BatchBuilder.AppendParameter x 500
 

--- a/src/Weasel.Benchmarks/Support/BenchmarkStorageSession.cs
+++ b/src/Weasel.Benchmarks/Support/BenchmarkStorageSession.cs
@@ -27,6 +27,12 @@ internal sealed class BenchmarkStorageSession: IStorageSession
     public IStorageDatabase Database { get; }
     public ConcurrencyChecks Concurrency { get; set; } = ConcurrencyChecks.Enabled;
 
+    /// <summary>
+    ///     Settable so the same benchmark document can be measured with the semantic fallback both
+    ///     off (the default since weasel#577) and on.
+    /// </summary>
+    public bool UseSemanticJsonChangeDetection { get; set; }
+
     public IList<IChangeTracker> ChangeTrackers { get; } = new List<IChangeTracker>();
     public Dictionary<Type, object> ItemMap { get; } = new();
 

--- a/src/Weasel.Core.Tests/change_tracker.cs
+++ b/src/Weasel.Core.Tests/change_tracker.cs
@@ -1,0 +1,470 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using NSubstitute;
+using Shouldly;
+using Weasel.Core.Sequences;
+using Weasel.Storage;
+using Xunit;
+
+namespace Weasel.Core.Tests;
+
+/// <summary>
+/// <see cref="ChangeTracker{T}" />, and in particular the <c>JsonNode.DeepEquals</c> fallback that
+/// weasel#577 moved behind <see cref="IStorageSession.UseSemanticJsonChangeDetection" />.
+/// </summary>
+/// <remarks>
+///     <para>
+///     The tracker's contract is "did this document change since it was loaded", and its hazard is
+///     asymmetric: a false negative silently drops the user's edit, while a false positive only
+///     writes a row that did not need writing. So every genuine-change case here runs under
+///     <b>both</b> settings of the flag — the point of the change is that turning the fallback off
+///     cannot lose a write, and the point of keeping the fallback available is that turning it on
+///     cannot swallow one.
+///     </para>
+///     <para>
+///     Weasel.Storage has no test project of its own; this lives here for the same reason the
+///     flat-table and event-loader suites do. Pure in-memory serialization — no database.
+///     </para>
+/// </remarks>
+public class change_tracker
+{
+    private readonly StubStorageSession theSession = new();
+
+    private static TrackedDoc doc() => new();
+
+    // ------------------------------------------------------------------------------------------
+    // The unchanged path
+    // ------------------------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void an_untouched_document_is_not_dirty(bool semantic)
+    {
+        theSession.SemanticFallback = semantic;
+        var tracker = new ChangeTracker<TrackedDoc>(theSession, doc());
+
+        tracker.DetectChanges(theSession, out var operation).ShouldBeFalse();
+        operation.ShouldBeNull();
+    }
+
+    /// <summary>
+    /// A session that says nothing about the flag gets the fast path. Read through a session that
+    /// does not implement the member at all, so this exercises the default interface
+    /// implementation rather than a stub's field initializer.
+    /// </summary>
+    [Fact]
+    public void the_semantic_fallback_is_off_unless_a_session_opts_in()
+    {
+        IStorageSession silent = new SilentStorageSession();
+
+        silent.UseSemanticJsonChangeDetection.ShouldBeFalse();
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // Genuine changes, under both settings of the flag. These are the cases the DeepEquals path
+    // was covering, and none of them may go quiet in either configuration.
+    // ------------------------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData(false, "scalar")]
+    [InlineData(false, "number")]
+    [InlineData(false, "nested")]
+    [InlineData(false, "list-element")]
+    [InlineData(false, "list-append")]
+    [InlineData(false, "list-removal")]
+    [InlineData(false, "list-reorder")]
+    [InlineData(false, "dictionary-value")]
+    [InlineData(false, "dictionary-key-added")]
+    [InlineData(false, "dictionary-key-removed")]
+    [InlineData(false, "dictionary-value-changed-in-place-with-a-reorder")]
+    [InlineData(false, "null-out-a-member")]
+    [InlineData(true, "scalar")]
+    [InlineData(true, "number")]
+    [InlineData(true, "nested")]
+    [InlineData(true, "list-element")]
+    [InlineData(true, "list-append")]
+    [InlineData(true, "list-removal")]
+    [InlineData(true, "list-reorder")]
+    [InlineData(true, "dictionary-value")]
+    [InlineData(true, "dictionary-key-added")]
+    [InlineData(true, "dictionary-key-removed")]
+    [InlineData(true, "dictionary-value-changed-in-place-with-a-reorder")]
+    [InlineData(true, "null-out-a-member")]
+    public void a_genuine_change_is_detected(bool semantic, string change)
+    {
+        theSession.SemanticFallback = semantic;
+        var document = doc();
+        var tracker = new ChangeTracker<TrackedDoc>(theSession, document);
+
+        applyChange(document, change);
+
+        tracker.DetectChanges(theSession, out var operation).ShouldBeTrue();
+        operation.ShouldBeSameAs(theSession.TheUpsert);
+    }
+
+    private static void applyChange(TrackedDoc document, string change)
+    {
+        switch (change)
+        {
+            case "scalar":
+                document.Name = "changed";
+                break;
+            case "number":
+                document.Count += 1;
+                break;
+            case "nested":
+                document.Child.Value = "changed";
+                break;
+            case "list-element":
+                document.Tags[1] = "changed";
+                break;
+            case "list-append":
+                document.Tags.Add("d");
+                break;
+            case "list-removal":
+                document.Tags.RemoveAt(0);
+                break;
+            case "list-reorder":
+                // A JSON array's order *is* meaningful, so unlike a dictionary this must read as a
+                // change even with the fallback on.
+                document.Tags.Reverse();
+                break;
+            case "dictionary-value":
+                document.Attributes["one"] = "changed";
+                break;
+            case "dictionary-key-added":
+                document.Attributes["four"] = "4";
+                break;
+            case "dictionary-key-removed":
+                document.Attributes.Remove("two");
+                break;
+            case "dictionary-value-changed-in-place-with-a-reorder":
+                // Removing an entry and re-adding it moves it to the end, so here a reorder and a
+                // real change arrive together and the fallback has to look past the one to see the
+                // other.
+                document.Attributes.Remove("one");
+                document.Attributes["one"] = "a different value";
+                break;
+            case "null-out-a-member":
+                document.Name = null;
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(change), change, "Unknown change");
+        }
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // The reordered-but-equal case: the one thing the flag actually changes
+    // ------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// Re-inserting a dictionary's entries in a different order changes the JSON text without
+    /// changing what the JSON means. It needs no custom converter and no second serializer
+    /// instance, which is why the fallback is kept as an option rather than deleted outright.
+    /// </summary>
+    private static void reorderTheDictionary(TrackedDoc document)
+    {
+        var pairs = new List<KeyValuePair<string, string>>(document.Attributes);
+        pairs.Reverse();
+        document.Attributes.Clear();
+        foreach (var pair in pairs)
+        {
+            document.Attributes[pair.Key] = pair.Value;
+        }
+    }
+
+    /// <summary>
+    /// Guards the premise the rest of this section rests on. If the serializer ever started
+    /// emitting dictionary entries in a canonical order, the flag would have nothing left to do.
+    /// </summary>
+    [Fact]
+    public void reordering_a_dictionary_really_does_change_the_json_text()
+    {
+        var document = doc();
+        var before = theSession.Serializer.ToCleanJson(document);
+
+        reorderTheDictionary(document);
+
+        theSession.Serializer.ToCleanJson(document).ShouldNotBe(before);
+    }
+
+    [Fact]
+    public void a_reordered_dictionary_reports_a_change_by_default()
+    {
+        var document = doc();
+        var tracker = new ChangeTracker<TrackedDoc>(theSession, document);
+
+        reorderTheDictionary(document);
+
+        // The accepted cost of the default: a redundant write of semantically identical JSON.
+        tracker.DetectChanges(theSession, out _).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void a_reordered_dictionary_is_not_a_change_when_the_session_opts_in()
+    {
+        theSession.SemanticFallback = true;
+        var document = doc();
+        var tracker = new ChangeTracker<TrackedDoc>(theSession, document);
+
+        reorderTheDictionary(document);
+
+        tracker.DetectChanges(theSession, out var operation).ShouldBeFalse();
+        operation.ShouldBeNull();
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // Reset
+    // ------------------------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void reset_rebaselines_so_the_next_pass_sees_nothing(bool semantic)
+    {
+        theSession.SemanticFallback = semantic;
+        var document = doc();
+        var tracker = new ChangeTracker<TrackedDoc>(theSession, document);
+
+        document.Name = "changed";
+        tracker.DetectChanges(theSession, out _).ShouldBeTrue();
+
+        tracker.Reset(theSession);
+
+        tracker.DetectChanges(theSession, out _).ShouldBeFalse();
+    }
+
+    /// <summary>
+    /// Why <see cref="ChangeTracker{T}.Reset" /> re-serializes instead of reusing the JSON
+    /// <c>DetectChanges</c> already produced: the document is mutated in between. The write
+    /// binders project the session's correlation / causation / last-modified-by / headers onto it
+    /// before the body is serialized, and the concurrency operations write the new version or
+    /// revision back onto it from postprocess — both after <c>DetectChanges</c> has run and before
+    /// <c>Reset</c> does. A baseline captured at detection time would be stale, and the next
+    /// <c>DetectChanges</c> would report a change nobody made.
+    /// </summary>
+    [Fact]
+    public void reset_picks_up_a_mutation_made_after_detect_changes()
+    {
+        var document = doc();
+        var tracker = new ChangeTracker<TrackedDoc>(theSession, document);
+
+        document.Name = "changed";
+        tracker.DetectChanges(theSession, out _).ShouldBeTrue();
+
+        // Stands in for the version write-back and the ApplyToDocument write binders.
+        document.Version = Guid.NewGuid();
+        document.LastModifiedBy = "the session's user";
+
+        tracker.Reset(theSession);
+
+        tracker.DetectChanges(theSession, out _).ShouldBeFalse();
+    }
+
+    /// <summary>
+    /// A tracker constructed now baselines on <c>ToCleanJson</c> of the document as it stands, so a
+    /// reset tracker answering identically to a fresh one — on an unchanged document and then on a
+    /// changed one — is the byte-identity claim, exercised rather than asserted against a private
+    /// field.
+    /// </summary>
+    [Fact]
+    public void reset_leaves_a_baseline_a_fresh_tracker_would_agree_with()
+    {
+        var document = doc();
+        var tracker = new ChangeTracker<TrackedDoc>(theSession, document);
+
+        document.Name = "changed";
+        document.Attributes["four"] = "4";
+        tracker.DetectChanges(theSession, out _).ShouldBeTrue();
+        tracker.Reset(theSession);
+
+        var fresh = new ChangeTracker<TrackedDoc>(theSession, document);
+
+        tracker.DetectChanges(theSession, out _).ShouldBeFalse();
+        fresh.DetectChanges(theSession, out _).ShouldBeFalse();
+
+        document.Count = 99;
+
+        tracker.DetectChanges(theSession, out _).ShouldBeTrue();
+        fresh.DetectChanges(theSession, out _).ShouldBeTrue();
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // The concurrency routing sitting next to the code being changed
+    // ------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void a_versioned_document_routes_through_overwrite_when_concurrency_is_disabled()
+    {
+        theSession.Concurrency = ConcurrencyChecks.Disabled;
+        theSession.TheStorage.UseOptimisticConcurrency.Returns(true);
+
+        var document = doc();
+        var tracker = new ChangeTracker<TrackedDoc>(theSession, document);
+        document.Name = "changed";
+
+        tracker.DetectChanges(theSession, out var operation).ShouldBeTrue();
+        operation.ShouldBeSameAs(theSession.TheOverwrite);
+    }
+
+    [Fact]
+    public void an_unversioned_document_still_upserts_when_concurrency_is_disabled()
+    {
+        theSession.Concurrency = ConcurrencyChecks.Disabled;
+
+        var document = doc();
+        var tracker = new ChangeTracker<TrackedDoc>(theSession, document);
+        document.Name = "changed";
+
+        tracker.DetectChanges(theSession, out var operation).ShouldBeTrue();
+        operation.ShouldBeSameAs(theSession.TheUpsert);
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // Test doubles
+    // ------------------------------------------------------------------------------------------
+
+    public class TrackedDoc
+    {
+        public Guid Id { get; set; } = new("aaaaaaaa-0000-4000-8000-000000000001");
+        public string? Name { get; set; } = "original";
+        public int Count { get; set; } = 3;
+        public Guid Version { get; set; }
+        public string? LastModifiedBy { get; set; }
+        public NestedValue Child { get; set; } = new();
+        public List<string> Tags { get; set; } = ["a", "b", "c"];
+
+        public Dictionary<string, string> Attributes { get; set; } = new()
+        {
+            ["one"] = "1", ["two"] = "2", ["three"] = "3"
+        };
+    }
+
+    public class NestedValue
+    {
+        public string Value { get; set; } = "nested";
+    }
+
+    /// <summary>
+    /// Implements <see cref="IStorageSession" /> without saying anything about
+    /// <see cref="IStorageSession.UseSemanticJsonChangeDetection" />, so reading that member goes
+    /// to the interface's default implementation.
+    /// </summary>
+    private sealed class SilentStorageSession: StubStorageSessionBase;
+
+    /// <summary>
+    /// Re-implements the interface so the fallback can be switched per test.
+    /// </summary>
+    private sealed class StubStorageSession: StubStorageSessionBase, IStorageSession
+    {
+        public bool SemanticFallback { get; set; }
+
+        bool IStorageSession.UseSemanticJsonChangeDetection => SemanticFallback;
+    }
+
+    /// <summary>
+    /// The least <see cref="IStorageSession" /> <see cref="ChangeTracker{T}" /> touches: a real
+    /// serializer and a provider graph whose dirty-tracking storage hands back marker operations.
+    /// Everything else throws, so a test cannot quietly start exercising something else.
+    /// </summary>
+    private abstract class StubStorageSessionBase: IStorageSession
+    {
+        // Weasel.Storage.IStorageOperation is spelled out here and below on purpose. This file
+        // sits in namespace Weasel.Core.Tests, so the bare name IStorageOperation binds to
+        // Weasel.Core.IStorageOperation from the enclosing namespace, which beats both the
+        // `using Weasel.Storage` and any using-alias. Shortening it compiles and then fails at
+        // run time with a substitute that cannot return the operation the tracker asked for.
+        protected StubStorageSessionBase()
+        {
+            Weasel.Storage.IStorageOperation upsert = new MarkerOperation("upsert");
+            Weasel.Storage.IStorageOperation overwrite = new MarkerOperation("overwrite");
+            var storage = Substitute.For<IDocumentStorage<TrackedDoc>>();
+
+            storage.Upsert(Arg.Any<TrackedDoc>(), Arg.Any<IStorageSession>(), Arg.Any<string>())
+                .Returns(upsert);
+            storage.Overwrite(Arg.Any<TrackedDoc>(), Arg.Any<IStorageSession>(), Arg.Any<string>())
+                .Returns(overwrite);
+
+            TheUpsert = upsert;
+            TheOverwrite = overwrite;
+            TheStorage = storage;
+            Database = new StubDatabase(new StubProviderGraph(storage));
+        }
+
+        public IDocumentStorage<TrackedDoc> TheStorage { get; }
+        public Weasel.Storage.IStorageOperation TheUpsert { get; }
+        public Weasel.Storage.IStorageOperation TheOverwrite { get; }
+
+        public IStorageSerializer Serializer { get; } =
+            StorageSerializerAdapter.For(new SystemTextJsonSerializer());
+
+        public IStorageDatabase Database { get; }
+
+        public ConcurrencyChecks Concurrency { get; set; } = ConcurrencyChecks.Enabled;
+
+        public IList<IChangeTracker> ChangeTrackers { get; } = new List<IChangeTracker>();
+        public Dictionary<Type, object> ItemMap { get; } = new();
+
+        public string TenantId => "*DEFAULT*";
+        public string? CausationId { get; set; }
+        public string? CorrelationId { get; set; }
+        public string? CurrentUserName { get; set; }
+        public Dictionary<string, object>? Headers => null;
+        public bool CausationIdEnabled => false;
+        public bool CorrelationIdEnabled => false;
+        public bool HeadersEnabled => false;
+        public bool UserNameEnabled => false;
+
+        public IVersionTracker Versions => throw new NotSupportedException();
+        public IDocumentStorage StorageFor(Type documentType) => throw new NotSupportedException();
+        public IDocumentStorage<T> StorageFor<T>() where T : notnull => throw new NotSupportedException();
+        public void MarkAsAddedForStorage(object id, object document) => throw new NotSupportedException();
+        public void MarkAsDocumentLoaded(object id, object document) => throw new NotSupportedException();
+        public string NextTempTableName() => throw new NotSupportedException();
+
+        public Task<DbDataReader> ExecuteReaderAsync(DbCommand command, CancellationToken token = default) =>
+            throw new NotSupportedException();
+    }
+
+    /// <summary>
+    /// A distinguishable stand-in for the operation the tracker hands back, so a test can say
+    /// which of the two exits it took.
+    /// </summary>
+    private sealed class MarkerOperation(string name): Weasel.Storage.IStorageOperation
+    {
+        public override string ToString() => name;
+
+        public Type DocumentType => typeof(TrackedDoc);
+        public OperationRole Role() => OperationRole.Upsert;
+
+        public void ConfigureCommand(ICommandBuilder builder, IStorageSession session) =>
+            throw new NotSupportedException();
+
+        public Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token) =>
+            throw new NotSupportedException();
+    }
+
+    private sealed class StubDatabase(IProviderGraph providers): IStorageDatabase
+    {
+        public IProviderGraph Providers { get; } = providers;
+
+        public DbConnection CreateStorageConnection() => throw new NotSupportedException();
+        public Task RunSqlAsync(string sql, CancellationToken ct = default) => throw new NotSupportedException();
+        public ISequence SequenceFor(Type documentType) => throw new NotSupportedException();
+    }
+
+    private sealed class StubProviderGraph(IDocumentStorage<TrackedDoc> storage): IProviderGraph
+    {
+        private readonly DocumentProvider<TrackedDoc> _provider = new(storage, storage, storage, storage);
+
+        public DocumentProvider<T> StorageFor<T>() where T : notnull =>
+            _provider as DocumentProvider<T>
+            ?? throw new NotSupportedException($"Only {typeof(TrackedDoc).Name} is registered.");
+
+        public void Append<T>(DocumentProvider<T> provider) where T : notnull => throw new NotSupportedException();
+    }
+}

--- a/src/Weasel.Storage/ChangeTracker.cs
+++ b/src/Weasel.Storage/ChangeTracker.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Text.Json.Nodes;
 
 namespace Weasel.Storage;
@@ -26,21 +27,29 @@ public class ChangeTracker<T>: IChangeTracker where T : notnull
     {
         var newJson = session.Serializer.ToCleanJson(_document);
 
-        // Fast path: if the JSON strings are identical, skip expensive parsing
+        // The document is unchanged when it serializes to the text it serialized to on load.
+        // By default this ordinal compare is the whole detector — see SemanticallyEqual for the
+        // fallback and why it is opt-in.
         if (string.Equals(_json, newJson, StringComparison.Ordinal))
         {
             operation = null;
             return false;
         }
 
-        // Slow path: parse and deep-compare to handle semantically equivalent JSON
-        // (whitespace, property ordering).
-        if (JsonNode.DeepEquals(JsonNode.Parse(_json), JsonNode.Parse(newJson)))
+        if (session.UseSemanticJsonChangeDetection && SemanticallyEqual(_json, newJson))
         {
             operation = null;
             return false;
         }
 
+        // newJson is deliberately not handed to the operation to save it a serialization. Two
+        // things stand in the way. The data column is written with ToJson, not ToCleanJson, and
+        // those differ wherever a serializer carries type metadata (Newtonsoft's clean settings
+        // pin TypeNameHandling.None), so reusing the clean text would strip $type out of stored
+        // polymorphic documents. And the operation serializes only after its write binders have
+        // projected the session's correlation / causation / last-modified-by / headers onto the
+        // document, which is later than this.
+        //
         // When the session opts out of concurrency checks (Concurrency=Disabled) and the
         // document uses optimistic versioning, route through Overwrite so the SQL drops the
         // WHERE mt_version = ? guard — otherwise a stale version on the dirty-tracking copy
@@ -55,6 +64,48 @@ public class ChangeTracker<T>: IChangeTracker where T : notnull
         return true;
     }
 
+    /// <summary>
+    /// The opt-in fallback behind <see cref="IStorageSession.UseSemanticJsonChangeDetection"/>:
+    /// parse both documents and compare the trees, so JSON that differs only in property order
+    /// (or in whitespace) reports as unchanged.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Off by default because it spends two whole <see cref="JsonNode"/> trees, built and thrown
+    /// away, to reach an answer the ordinal compare above reaches for free — measured over a 5 KB
+    /// document at roughly 8x the time and 10x the allocation of the unchanged path, and dearer
+    /// than detecting a genuine change, because a real change is usually visible early in the
+    /// tree while proving equality has to walk all of it (weasel#577).
+    /// </para>
+    /// <para>
+    /// Skipping it cannot cost a write. It is a check that only ever turns "changed" into
+    /// "unchanged", so leaving it off can produce a redundant, semantically identical update but
+    /// never a missed one — which is the trade the tracker wants, since a false negative silently
+    /// drops the user's edit.
+    /// </para>
+    /// <para>
+    /// Not inlined: keeping the <see cref="JsonNode"/> code out of <see cref="DetectChanges"/>
+    /// leaves the hot path — one serialize and one string compare — as small as it reads.
+    /// </para>
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool SemanticallyEqual(string json, string newJson)
+    {
+        return JsonNode.DeepEquals(JsonNode.Parse(json), JsonNode.Parse(newJson));
+    }
+
+    /// <summary>
+    /// Re-baseline after a successful commit.
+    /// </summary>
+    /// <remarks>
+    /// This deliberately re-serializes rather than reusing the JSON <see cref="DetectChanges"/>
+    /// already produced, because the document is mutated in between: the write binders project
+    /// the session's correlation / causation / last-modified-by / headers onto the document
+    /// before the body is serialized (<see cref="IDocumentMetadataBinder{TDoc}.ApplyToDocument"/>),
+    /// and the concurrency operations write the new version or revision back onto it from their
+    /// postprocess. A baseline captured before those would report a phantom change on the very
+    /// next <see cref="DetectChanges"/>.
+    /// </remarks>
     public void Reset(IStorageSession session)
     {
         _json = session.Serializer.ToCleanJson(_document);

--- a/src/Weasel.Storage/IStorageSession.cs
+++ b/src/Weasel.Storage/IStorageSession.cs
@@ -32,6 +32,31 @@ public interface IStorageSession: IMetadataContext
     /// </summary>
     ConcurrencyChecks Concurrency { get; }
 
+    /// <summary>
+    ///     Opt in to <see cref="ChangeTracker{T}"/>'s semantic fallback: when a tracked document's
+    ///     JSON text differs from its load-time text, parse both and compare the trees before
+    ///     concluding that the document changed. Default <c>false</c>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///     The fallback exists for documents whose JSON text can reorder without changing meaning.
+    ///     A <c>Dictionary</c> or <c>HashSet</c> member serializes in enumeration order, and
+    ///     enumeration order follows the collection's insertion and removal history rather than
+    ///     its contents — so a dictionary that is rebuilt, or has an entry removed and re-added,
+    ///     serializes to different text for the same document under one deterministic serializer
+    ///     and no custom converter. STJ's <c>[JsonExtensionData]</c> is backed by a dictionary and
+    ///     behaves the same way.
+    ///     </para>
+    ///     <para>
+    ///     It is off by default because it costs roughly 8x the time and 10x the allocation of an
+    ///     ordinary unchanged check (weasel#577). Turning it on buys exactly one thing: not
+    ///     issuing a redundant, semantically identical update when a collection reorders. It can
+    ///     never buy a write back, because the check it performs only ever turns "changed" into
+    ///     "unchanged" — so a session that leaves it off risks a spurious write, never a lost one.
+    ///     </para>
+    /// </remarks>
+    bool UseSemanticJsonChangeDetection => false;
+
     IDocumentStorage StorageFor(Type documentType);
 
     IDocumentStorage<T> StorageFor<T>() where T : notnull;


### PR DESCRIPTION
Closes #577. Stoat plan `critter-performance-2026-09`, node `weasel-changetracker`.

`ChangeTracker.DetectChanges` runs once per tracked document on every `SaveChanges`. When the
ordinal JSON compare missed, it fell into two `JsonNode.Parse` calls and a `JsonNode.DeepEquals` —
two whole object graphs built and thrown away to reach an answer the string compare had already
implied.

The fallback now sits behind `IStorageSession.UseSemanticJsonChangeDetection`, a default interface
member that defaults to `false`. No existing implementor has to change.

### Why gated and not deleted

The proposal was to delete it outright, on the argument that only whitespace and property ordering
could differ and a single deterministic serializer cannot produce either for the same object graph.
That argument is true about the *serializer* and beside the point about the *document*:

`Dictionary<TKey,TValue>` and `HashSet<T>` members serialize in enumeration order, and enumeration
order follows the collection's insertion and removal history rather than its contents. A dictionary
that is rebuilt — or has one entry removed and re-added — serializes to different text for the same
document under one deterministic serializer instance and no custom converter. STJ's
`[JsonExtensionData]` is backed by a dictionary and behaves the same way. That is the case the
benchmark's `SemanticallyEqual` scenario constructs, and it is what forced the flag rather than a
deletion. `change_tracker.reordering_a_dictionary_really_does_change_the_json_text` pins the
premise, so the flag stops being load-bearing loudly rather than quietly if a serializer ever
canonicalises.

Turning the fallback off can only ever cost a redundant, semantically identical write — never a
missed one — because the check being skipped only turns "changed" into "unchanged". That is the
right direction for a detector whose real hazard is silently dropping a user's edit.

### Measured

Same machine, full BenchmarkDotNet job, before and after. Allocation reproduced exactly across runs;
wall clock on this machine drifts by up to 2x, so read the ratios.

| Path | Before | After | Alloc before | Alloc after |
|---|---:|---:|---:|---:|
| Unchanged (ordinal string compare wins) | 3.83 us | 4.09 us | 8.42 KB | 8.42 KB |
| Reordered but equal (default: reports a change) | 31.09 us | **4.08 us** | 82.23 KB | **8.42 KB** |
| Changed (full detection, then `Upsert`) | 15.67 us | **3.81 us** | 30.06 KB | **8.42 KB** |
| Reordered but equal (opt-in fallback) | — | 32.55 us | — | 82.23 KB |

The **Changed** row was the unadvertised win. Every genuinely dirty document used to parse both JSON
documents and walk both trees before it was allowed to conclude what the string compare had already
told it, so detecting a real change cost 4x an unchanged one. It now costs marginally *less* than the
unchanged path, since the compare bails at the first differing byte instead of running to the end.

The opt-in row reproduces the old numbers to the byte (82.23 KB), which is the check that the
fallback still does exactly what it used to when a session asks for it.

### Two survey items checked and rejected

The survey also proposed handing `newJson` to the upsert and reusing it as the `Reset` baseline.
Both are unsound; the reasons are recorded next to the code rather than only here.

**Handing `newJson` to the upsert.** The `data` column is written with `ToJson`, not `ToCleanJson`,
and the two differ wherever a serializer carries type metadata — Marten's Newtonsoft serializer pins
`TypeNameHandling.None` on its *clean* settings specifically so that `ToCleanJson` strips it. Reusing
the clean text would write `$type`-free JSON into the data column and break polymorphic
deserialization. Independently, `ClosedShapeUpsertOperation.BindPreOnConflictParameters` serializes
only *after* running `IDocumentMetadataBinder.ApplyToDocument` for every write binder — the
documented pre-serialization hook that projects the session's correlation / causation /
last-modified-by / headers onto the document so they reach the JSON too. `newJson` predates that.

**Reusing `newJson` as the `Reset` baseline.** `Reset` runs after the batch executes
(`DocumentSessionBase.SaveChangesAsync` calls `resetDirtyChecking()` after `ExecuteBatchAsync`), by
which point those same write binders have run and the concurrency operations have written the new
version (`OptimisticClosedShapeUpsertOperation`, via `ApplyVersionTo`) or revision
(`NumericClosedShapeUpsertOperation`, via `ApplyRevisionTo` in postprocess) back onto the document.
A baseline captured at detection time would be stale, and the *next* `DetectChanges` would report a
change nobody made — the phantom-change failure the issue warns about.
`change_tracker.reset_picks_up_a_mutation_made_after_detect_changes` now fails if anyone tries it.

### Tests

`src/Weasel.Core.Tests/change_tracker.cs`, 36 cases (Weasel.Storage has no test project of its own;
this sits where the flat-table and event-loader suites do). Every genuine-change case — scalar,
number, nested member, list element/append/removal/reorder, dictionary value/key-added/key-removed,
a value change that also reorders the dictionary, and nulling a member — runs under **both** settings
of the flag, so the change cannot lose a write with the fallback off and the fallback cannot swallow
one with it on. Plus the reordered-dictionary behaviour either way, the `Reset` cases above, and the
`Concurrency=Disabled` Upsert/Overwrite routing next door.

`ChangeTrackerBenchmarks.Setup` now asserts each of the four scenarios actually answers what its name
claims before measuring it. That guard is not decorative — it caught this PR's own first draft
measuring the unchanged path under three different names, because the reorder was applied before the
tracker took its baseline.

### Validation

CI is stalled org-wide, so this was validated locally on macOS / .NET 9:

- `dotnet build` — 0 errors.
- `Weasel.Core.Tests` — 547 passed, 0 failed.
- `Weasel.Sqlite.Tests` — 583 passed, 0 failed.
- `Weasel.Postgresql.Tests` — 974 passed, 3 skipped, 0 failed (local container).
- `Weasel.SqlServer.Tests` — 561 passed, 8 skipped, 0 failed (local container).

Oracle and MySQL suites were not run; nothing in this change is dialect-specific.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
