### PR TITLE
9.31.0: a never-created stream is at version 0, not a conflict

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>9.30.0</Version>
+        <Version>9.31.0</Version>
         <LangVersion>13.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/src/Weasel.Storage/Events/Operations/AssertStreamVersionOperation.cs
+++ b/src/Weasel.Storage/Events/Operations/AssertStreamVersionOperation.cs
@@ -61,8 +61,16 @@ public abstract class AssertStreamVersionOperation<TId>: IStorageOperation where
     {
         if (!await reader.ReadAsync(token).ConfigureAwait(false))
         {
-            exceptions.Add(new EventStreamUnexpectedMaxEventIdException(StreamIdentity, Stream.AggregateType,
-                Stream.ExpectedVersionOnServer!.Value, 0));
+            // No row means the stream does not exist, and a stream that does not exist is at version 0.
+            // That is a conflict only when the caller expected something other than 0 -- asserting
+            // unconditionally here threw "expected 0 but was 0" for a never-created stream under
+            // AlwaysEnforceConsistency (marten#5345).
+            if (Stream.ExpectedVersionOnServer!.Value != 0)
+            {
+                exceptions.Add(new EventStreamUnexpectedMaxEventIdException(StreamIdentity, Stream.AggregateType,
+                    Stream.ExpectedVersionOnServer.Value, 0));
+            }
+
             return;
         }
 


### PR DESCRIPTION
Two things: the marten#5345 fix, and the version bump for release.

**The fix.** `AssertStreamVersionOperation.PostprocessAsync` treated "no row came back" as an unconditional conflict, so `AlwaysEnforceConsistency` on a never-created stream threw `Unexpected starting version number ... expected 0 but was 0` — the guard firing where expectation and reality agree. A stream with no row is at version 0; that is a conflict only when the caller expected otherwise. Root-caused in marten#5345 from the new `AlwaysEnforceConsistencyCompliance` suite, whose remark anticipated exactly this: *"it is the case a naive 'is there a row?' implementation of the check gets wrong."* The operation is shared with Polecat, which is why the fix belongs here rather than in Marten.

**The bump.** `master` has carried the whole 2026-09-05/06 wave (#558–#578) under the already-published 9.30.0; this releases it as **9.31.0**.

Local runs are the gate per the September policy; org Actions runners are stalled. `Weasel.Storage` builds clean; `Weasel.Core.Tests` 546/547 — the one failure is `system_text_json_serializer_tests.falls_back_to_the_string_path_when_a_provider_refuses_to_stream`, which I verified **fails identically on unmodified master** and filed as #579 (a static per-reader-type capability cache leaking between two tests that share a fake reader type; correctness-safe, since the path falls back to the string read).

🤖 Generated with [Claude Code](https://claude.com/claude-code)