### PR TITLE
Publish the managed partition registries as swapped snapshots (#583)

### DIFF
--- a/src/Weasel.Postgresql.Tests/Tables/partitioning/managed_list_partitions_are_snapshots.cs
+++ b/src/Weasel.Postgresql.Tests/Tables/partitioning/managed_list_partitions_are_snapshots.cs
@@ -1,0 +1,100 @@
+using System.Collections.Concurrent;
+using System.Linq;
+using Weasel.Postgresql.Tables.Partitioning;
+using Xunit;
+using Shouldly;
+
+namespace Weasel.Postgresql.Tests.Tables.partitioning;
+
+/// <summary>
+/// weasel#583. <see cref="ManagedListPartitions"/> publishes its tenant registry through a
+/// <c>ReadOnlyDictionary</c>, which WRAPS the underlying dictionary rather than copying it, and through
+/// <see cref="IListPartitionManager.Partitions"/>, which is a lazy iterator over it. Mutating that
+/// dictionary in place therefore mutates what every concurrent reader is holding.
+///
+/// One manager instance is shared across every database in a store, so a `db-apply --parallel N` over more
+/// databases than N has a late-starting worker reloading the registry while an earlier worker is still
+/// enumerating it. The reported symptom was "Collection was modified; enumeration operation may not execute"
+/// out of DatabaseBase.assertValidIdentifiers; the quieter one is a reader seeing an empty or half-loaded
+/// partition set and generating DDL, or a partition delta, against it — with nothing raised at all.
+/// </summary>
+[Collection("managed_lists")]
+public class managed_list_partitions_are_snapshots: IntegrationContext
+{
+    private const int TenantCount = 400;
+
+    public managed_list_partitions_are_snapshots() : base("managed_lists")
+    {
+    }
+
+    public override ValueTask InitializeAsync() => new(ResetSchema());
+
+    [Fact]
+    public async Task readers_never_see_the_registry_being_reloaded()
+    {
+        var database = new ManagedListDatabase();
+        var values = Enumerable.Range(0, TenantCount)
+            .ToDictionary(i => "tenant" + i, i => "tenant" + i);
+
+        await database.Partitions.ResetValues(database, values, CancellationToken.None);
+
+        var manager = (IListPartitionManager)database.Partitions;
+
+        var failures = new ConcurrentQueue<Exception>();
+        var tornReads = 0;
+
+        // The writer is the real reload path — ForceReload + InitializeAsync is exactly what each database's
+        // schema initializer runs, and what the late worker in the report was running.
+        var writer = Task.Run(async () =>
+        {
+            for (var i = 0; i < 25; i++)
+            {
+                database.Partitions.ForceReload();
+                await database.Partitions.InitializeAsync(database, CancellationToken.None);
+            }
+        });
+
+        var readers = Enumerable.Range(0, 3).Select(_ => Task.Run(() =>
+        {
+            while (!writer.IsCompleted)
+            {
+                try
+                {
+                    // The DDL and delta read side: ListPartitioning.Partitions() calls straight through here.
+                    if (manager.Partitions().Count() != TenantCount)
+                    {
+                        Interlocked.Increment(ref tornReads);
+                    }
+
+                    // ...and the published map, which callers enumerate directly.
+                    var published = database.Partitions.Partitions;
+                    var counted = 0;
+                    foreach (var _ in published)
+                    {
+                        counted++;
+                    }
+
+                    if (counted != TenantCount)
+                    {
+                        Interlocked.Increment(ref tornReads);
+                    }
+                }
+                catch (Exception e)
+                {
+                    failures.Enqueue(e);
+                }
+            }
+        })).ToArray();
+
+        await writer;
+        await Task.WhenAll(readers);
+
+        if (failures.TryDequeue(out var failure))
+        {
+            throw new Exception(
+                "A reader threw while the partition registry was being reloaded underneath it", failure);
+        }
+
+        tornReads.ShouldBe(0, "A reader observed an incomplete partition registry");
+    }
+}

--- a/src/Weasel.Postgresql/Tables/Partitioning/ManagedListPartitions.cs
+++ b/src/Weasel.Postgresql/Tables/Partitioning/ManagedListPartitions.cs
@@ -25,9 +25,22 @@ public interface IListPartitionManager
 public class ManagedListPartitions : FeatureSchemaBase, IDatabaseInitializer<NpgsqlConnection>, IListPartitionManager
 {
     private readonly Table _table;
-    private Dictionary<string, string> _partitions = new();
+    // weasel#583: the published partition map is an immutable snapshot that is swapped copy-on-write.
+    // It is never mutated in place once assigned here, because Partitions hands callers a ReadOnlyDictionary
+    // that WRAPS this instance rather than copying it, and IListPartitionManager.Partitions() enumerates it
+    // lazily. A concurrent InitializeAsync used to Clear() it out from under those readers: that surfaced as
+    // "Collection was modified; enumeration operation may not execute" from DatabaseBase.assertValidIdentifiers
+    // during a parallel db-apply, and silently as a torn (empty or partial) partition set everywhere else —
+    // including in generated DDL and partition deltas. Hardening the read side cannot fix it; ToArray() over a
+    // dictionary growing underneath just trades the exception for "Destination array is not long enough".
+    private volatile Dictionary<string, string> _partitions = new();
     private bool _hasInitialized;
     private readonly SemaphoreSlim _semaphoreSlim = new(1);
+
+    // Serializes the read-copy-write sequences against each other. Deliberately NOT _semaphoreSlim, which is
+    // held across database round trips inside InitializeAsync — a writer blocking on that would stall a thread
+    // pool thread for the duration of a query.
+    private readonly object _partitionsLock = new();
 
     public ManagedListPartitions(string identifier, DbObjectName tableName): base(identifier, new PostgresqlMigrator())
     {
@@ -40,6 +53,20 @@ public class ManagedListPartitions : FeatureSchemaBase, IDatabaseInitializer<Npg
 
     public ReadOnlyDictionary<string, string> Partitions => new(_partitions);
 
+    /// <summary>
+    /// Copy-on-write swap of the published partition map: copy, mutate the copy, publish it. Readers that
+    /// already captured the previous snapshot go on enumerating a complete, consistent map.
+    /// </summary>
+    private void swapPartitions(Action<Dictionary<string, string>> mutation)
+    {
+        lock (_partitionsLock)
+        {
+            var copy = new Dictionary<string, string>(_partitions, _partitions.Comparer);
+            mutation(copy);
+            _partitions = copy;
+        }
+    }
+
     protected override IEnumerable<ISchemaObject> schemaObjects()
     {
         yield return _table;
@@ -47,7 +74,10 @@ public class ManagedListPartitions : FeatureSchemaBase, IDatabaseInitializer<Npg
 
     IEnumerable<ListPartition> IListPartitionManager.Partitions()
     {
-        var paths = _partitions.GroupBy(x => x.Value);
+        // Capture the snapshot before enumerating: this is an iterator, so the field read would otherwise
+        // happen at the caller's first MoveNext and could be re-read against a newer map mid-enumeration.
+        var partitions = _partitions;
+        var paths = partitions.GroupBy(x => x.Value);
         foreach (var path in paths)
         {
             // weasel#416: build the bound literal through FormatSqlValue rather than interpolating the
@@ -84,7 +114,12 @@ public class ManagedListPartitions : FeatureSchemaBase, IDatabaseInitializer<Npg
                 .With("suffix", pair.Value ?? pair.Key).ExecuteNonQueryAsync(token).ConfigureAwait(false);
         }
 
-        _partitions = values;
+        // Copy rather than alias: the caller keeps its dictionary and may well mutate it afterwards, which
+        // would be a mutation of the published snapshot.
+        lock (_partitionsLock)
+        {
+            _partitions = new Dictionary<string, string>(values);
+        }
 
         await tx.CommitAsync(token).ConfigureAwait(false);
         await conn.CloseAsync().ConfigureAwait(false);
@@ -99,7 +134,9 @@ public class ManagedListPartitions : FeatureSchemaBase, IDatabaseInitializer<Npg
         // This is idempotent, so just do it here
         await InitializeAsync(conn, token).ConfigureAwait(false);
 
-        if (!_partitions.TryGetValue(value, out var suffix))
+        var partitions = _partitions;
+
+        if (!partitions.TryGetValue(value, out var suffix))
         {
             await conn.CloseAsync().ConfigureAwait(false);
             throw new ArgumentOutOfRangeException(nameof(value),
@@ -111,7 +148,7 @@ public class ManagedListPartitions : FeatureSchemaBase, IDatabaseInitializer<Npg
         // silently destroyed unrelated co-tenants' rows. When other values still share the partition, narrow
         // the bucket instead; the partition is only released once its last member is gone.
         var sanitizedSuffix = ListPartition.SanitizeSuffix(suffix);
-        var survivors = _partitions
+        var survivors = partitions
             .Where(pair => pair.Key != value && ListPartition.SanitizeSuffix(pair.Value) == sanitizedSuffix)
             .Select(pair => pair.Key)
             .ToArray();
@@ -140,7 +177,7 @@ public class ManagedListPartitions : FeatureSchemaBase, IDatabaseInitializer<Npg
             .With("value", value)
             .ExecuteNonQueryAsync(token).ConfigureAwait(false);
 
-        _partitions.Remove(value);
+        swapPartitions(x => x.Remove(value));
 
         var remainingValues = survivors.Select(x => x.FormatSqlValue()).ToArray();
 
@@ -308,12 +345,20 @@ public class ManagedListPartitions : FeatureSchemaBase, IDatabaseInitializer<Npg
                 .With("value", pair.Key)
                 .With("suffix", pair.Value);
 
-            _partitions[pair.Key] = pair.Value;
-
             await cmd.ExecuteNonQueryAsync(token).ConfigureAwait(false);
         }
 
         await tx.CommitAsync(token).ConfigureAwait(false);
+
+        // Publish once, after the write actually lands. resolveBuckets below reads the map back to work out
+        // each bucket's full membership, so this has to happen before additivelyMigrateTablesForNewPartitions.
+        swapPartitions(map =>
+        {
+            foreach (var pair in values)
+            {
+                map[pair.Key] = pair.Value;
+            }
+        });
 
         var list = await additivelyMigrateTablesForNewPartitions(logger, database, token, conn, values.ToArray()).ConfigureAwait(false);
 
@@ -385,6 +430,7 @@ public class ManagedListPartitions : FeatureSchemaBase, IDatabaseInitializer<Npg
         IReadOnlyCollection<KeyValuePair<string, string>> newPartitions)
     {
         var buckets = new Dictionary<string, string[]>();
+        var partitions = _partitions;
 
         foreach (var group in newPartitions.GroupBy(pair => ListPartition.SanitizeSuffix(pair.Value)))
         {
@@ -392,7 +438,7 @@ public class ManagedListPartitions : FeatureSchemaBase, IDatabaseInitializer<Npg
             // call. Bucket members are normally registered one tenant at a time, so widening an existing
             // partition has to keep the members already in it. _partitions is authoritative here: callers
             // record the new pairs into it before reaching this method.
-            buckets[group.Key] = _partitions
+            buckets[group.Key] = partitions
                 .Where(pair => ListPartition.SanitizeSuffix(pair.Value) == group.Key)
                 .Select(pair => pair.Key)
                 .Concat(group.Select(pair => pair.Key))
@@ -505,7 +551,7 @@ public class ManagedListPartitions : FeatureSchemaBase, IDatabaseInitializer<Npg
             .With("value", value)
             .With("suffix", suffix);
 
-        _partitions[value] = suffix;
+        swapPartitions(x => x[value] = suffix);
 
         return cmd.ExecuteNonQueryAsync(token);
     }
@@ -533,7 +579,10 @@ public class ManagedListPartitions : FeatureSchemaBase, IDatabaseInitializer<Npg
         {
             if (_hasInitialized) return;
 
-            _partitions.Clear();
+            // Build into a detached map and publish it in one assignment. Clearing and refilling the
+            // published instance is what let a concurrent reader see it empty or half-loaded (weasel#583).
+            var values = new Dictionary<string, string>();
+
             await using var reader = await conn
                 .CreateCommand($"select partition_value, partition_suffix from {_table.Identifier.QualifiedName}")
                 .ExecuteReaderAsync(token).ConfigureAwait(false);
@@ -548,7 +597,12 @@ public class ManagedListPartitions : FeatureSchemaBase, IDatabaseInitializer<Npg
                         (await reader.GetFieldValueAsync<string>(1, token).ConfigureAwait(false)).ToLowerInvariant();
                 }
 
-                _partitions[value] = suffix;
+                values[value] = suffix;
+            }
+
+            lock (_partitionsLock)
+            {
+                _partitions = values;
             }
 
             _hasInitialized = true;
@@ -558,6 +612,12 @@ public class ManagedListPartitions : FeatureSchemaBase, IDatabaseInitializer<Npg
         {
             if (e.SqlState == PostgresErrorCodes.UndefinedTable)
             {
+                // No registry table means no partitions, same as the Clear() this used to leave behind.
+                lock (_partitionsLock)
+                {
+                    _partitions = new Dictionary<string, string>();
+                }
+
                 _hasInitialized = true;
                 return;
             }

--- a/src/Weasel.SqlServer.Tests/Tables/partitioning/managed_tenant_partitions.cs
+++ b/src/Weasel.SqlServer.Tests/Tables/partitioning/managed_tenant_partitions.cs
@@ -531,18 +531,26 @@ ORDER BY prv.boundary_id;";
         ManagedTenantPartitions manager,
         params (string tenantId, int ordinal)[] entries)
     {
-        // The only legal way into _ordinals is through ResetValues (writes DB)
-        // or AddPartitionToAllTables (writes DB + DDL). For pure unit tests we
+        // The only legal way into the registry is through ResetValues (writes DB) or
+        // AddPartitionToAllTables (writes DB + DDL). For pure unit tests we
         // synthesize a SqlServerPartitionInfo + CreateDelta round-trip instead
         // — actually simpler: just reflect.
+        //
+        // weasel#583 turned the registry into an immutable snapshot that is swapped rather than mutated, so
+        // seeding publishes a whole new snapshot instead of editing the live maps.
         var field = typeof(ManagedTenantPartitions).GetField(
-            "_ordinals",
+            "_registryState",
             System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-        var map = (Dictionary<string, int>)field!.GetValue(manager)!;
-        map.Clear();
+
+        var snapshotType = field!.GetValue(manager)!.GetType();
+
+        var ordinals = new Dictionary<string, int>(StringComparer.Ordinal);
         foreach (var (tenantId, ordinal) in entries)
         {
-            map[tenantId] = ordinal;
+            ordinals[tenantId] = ordinal;
         }
+
+        field.SetValue(manager, Activator.CreateInstance(snapshotType,
+            ordinals, new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)));
     }
 }

--- a/src/Weasel.SqlServer.Tests/Tables/partitioning/managed_tenant_partitions_are_snapshots.cs
+++ b/src/Weasel.SqlServer.Tests/Tables/partitioning/managed_tenant_partitions_are_snapshots.cs
@@ -1,0 +1,122 @@
+using System.Collections.Concurrent;
+using Shouldly;
+using Weasel.Core;
+using Weasel.SqlServer.Tables;
+using Weasel.SqlServer.Tables.Partitioning;
+using Xunit;
+
+namespace Weasel.SqlServer.Tests.Tables.partitioning;
+
+/// <summary>
+/// weasel#583, the SQL Server half. <see cref="ManagedTenantPartitions"/> has the same shape as the
+/// PostgreSQL <c>ManagedListPartitions</c>: the tenant registry is published through
+/// <c>ReadOnlyDictionary</c> wrappers that do not copy, and it is read straight off the schema-object path
+/// that emits partition-function DDL and computes its delta. Clearing and refilling those maps in place
+/// while another database's worker is generating DDL either throws "Collection was modified" or, with
+/// nothing raised at all, writes a partition function missing boundaries for real tenants.
+/// </summary>
+[Collection("integration")]
+public class managed_tenant_partitions_are_snapshots: IntegrationContext
+{
+    private const int TenantCount = 400;
+
+    public managed_tenant_partitions_are_snapshots() : base("mtp_snapshot")
+    {
+    }
+
+    [Fact]
+    public async Task readers_never_see_the_registry_being_reloaded()
+    {
+        await ResetSchema();
+
+        var database = new DatabaseWithTables("mtp_snapshot_integration", ConnectionSource.ConnectionString);
+        var manager = new ManagedTenantPartitions(
+            "tenants", new DbObjectName("mtp_snapshot", "tenant_registry")) { AllowOrdinalSharing = true };
+
+        var values = new Dictionary<string, int>(StringComparer.Ordinal);
+        for (var i = 1; i <= TenantCount; i++)
+        {
+            values["tenant" + i] = i;
+        }
+
+        await manager.ResetValues(database, values, CancellationToken.None);
+
+        var orders = new Table("mtp_snapshot.orders");
+        orders.AddColumn<int>("tenant_ordinal").AsPrimaryKey().NotNull();
+        orders.AddColumn<int>("id").AsPrimaryKey();
+        orders.PartitionByManagedTenants(manager);
+
+        var migrator = new SqlServerMigrator();
+        var failures = new ConcurrentQueue<Exception>();
+        var tornReads = 0;
+
+        var writer = Task.Run(async () =>
+        {
+            for (var i = 0; i < 25; i++)
+            {
+                manager.ForceReload();
+                await manager.InitializeAsync(database, CancellationToken.None);
+            }
+        });
+
+        var readers = Enumerable.Range(0, 3).Select(_ => Task.Run(() =>
+        {
+            while (!writer.IsCompleted)
+            {
+                try
+                {
+                    // The DDL read side — OrderedBoundaries() enumerates the registry from in here.
+                    var text = new StringWriter();
+                    orders.WriteCreateStatement(migrator, text);
+
+                    if (BoundaryCount(text.ToString()) != TenantCount + 1)
+                    {
+                        // +1 for the sentinel boundary 0 that is always present.
+                        Interlocked.Increment(ref tornReads);
+                    }
+
+                    // ...and the published map, which callers enumerate directly.
+                    var counted = 0;
+                    foreach (var _ in manager.Ordinals)
+                    {
+                        counted++;
+                    }
+
+                    if (counted != TenantCount)
+                    {
+                        Interlocked.Increment(ref tornReads);
+                    }
+                }
+                catch (Exception e)
+                {
+                    failures.Enqueue(e);
+                }
+            }
+        })).ToArray();
+
+        await writer;
+        await Task.WhenAll(readers);
+
+        if (failures.TryDequeue(out var failure))
+        {
+            throw new Exception(
+                "A reader threw while the tenant registry was being reloaded underneath it", failure);
+        }
+
+        tornReads.ShouldBe(0, "A reader observed an incomplete tenant registry");
+    }
+
+    private static int BoundaryCount(string ddl)
+    {
+        const string marker = "AS RANGE RIGHT FOR VALUES (";
+        var start = ddl.IndexOf(marker, StringComparison.Ordinal);
+        if (start < 0)
+        {
+            return 0;
+        }
+
+        start += marker.Length;
+        var end = ddl.IndexOf(')', start);
+        return ddl.Substring(start, end - start).Split(',').Length;
+    }
+}

--- a/src/Weasel.SqlServer/Tables/Partitioning/ManagedTenantPartitions.cs
+++ b/src/Weasel.SqlServer/Tables/Partitioning/ManagedTenantPartitions.cs
@@ -67,10 +67,19 @@ public class ManagedTenantPartitions: FeatureSchemaBase, ISqlServerPartitioning,
 {
     private readonly Table _registry;
     private readonly IndexDefinition _uniqueOrdinalIndex;
-    private readonly Dictionary<string, int> _ordinals = new(StringComparer.Ordinal);
-    private readonly Dictionary<string, int> _buckets = new(StringComparer.OrdinalIgnoreCase);
+    // weasel#583: the tenant registry is published as an immutable snapshot and swapped copy-on-write. The
+    // maps behind Ordinals/Buckets are never mutated in place once assigned, because those properties hand
+    // callers a ReadOnlyDictionary that WRAPS the instance rather than copying it, and OrderedBoundaries()
+    // enumerates _ordinals straight from the schema-object path that builds partition-function DDL and its
+    // delta. Clearing and refilling them in place let a concurrent reader either throw "Collection was
+    // modified" or — worse, because nothing reports it — read a torn, half-loaded boundary set.
+    private volatile RegistrySnapshot _registryState = RegistrySnapshot.Empty();
     private readonly SemaphoreSlim _semaphore = new(1, 1);
     private bool _hasInitialized;
+
+    // Serializes the read-copy-write sequences against each other. Deliberately NOT _semaphore, which is held
+    // across database round trips inside InitializeAsync.
+    private readonly object _registryLock = new();
 
     /// <summary>
     ///     Create a managed tenant partition strategy backed by a registry table.
@@ -126,6 +135,43 @@ public class ManagedTenantPartitions: FeatureSchemaBase, ISqlServerPartitioning,
     }
 
     /// <summary>
+    ///     Point-in-time view of the registry. The two maps travel together because they are read against each
+    ///     other — the drop path prunes buckets whose ordinal no longer has any tenant — so a reader that saw
+    ///     one updated and the other not would resolve a bucket to a released partition.
+    /// </summary>
+    private sealed record RegistrySnapshot(
+        Dictionary<string, int> Ordinals,
+        Dictionary<string, int> Buckets)
+    {
+        public static RegistrySnapshot Empty()
+        {
+            return new RegistrySnapshot(
+                new Dictionary<string, int>(StringComparer.Ordinal),
+                new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase));
+        }
+    }
+
+    /// <summary>
+    ///     Copy-on-write swap: copy both maps, mutate the copies, publish them as one new snapshot. Returns the
+    ///     published snapshot so a caller can go on reading the state it just produced.
+    /// </summary>
+    private RegistrySnapshot swapRegistry(Action<Dictionary<string, int>, Dictionary<string, int>> mutation)
+    {
+        lock (_registryLock)
+        {
+            var current = _registryState;
+            var ordinals = new Dictionary<string, int>(current.Ordinals, current.Ordinals.Comparer);
+            var buckets = new Dictionary<string, int>(current.Buckets, current.Buckets.Comparer);
+
+            mutation(ordinals, buckets);
+
+            var next = new RegistrySnapshot(ordinals, buckets);
+            _registryState = next;
+            return next;
+        }
+    }
+
+    /// <summary>
     ///     Opt-in tenant bucketing: allow multiple tenant ids to share one
     ///     ordinal (and therefore one partition per table) through the
     ///     explicit-ordinal <c>AddPartitionsToAllTables</c> overloads. Off by
@@ -178,7 +224,7 @@ public class ManagedTenantPartitions: FeatureSchemaBase, ISqlServerPartitioning,
 
     /// <inheritdoc />
     public IReadOnlyDictionary<string, int> Ordinals =>
-        new ReadOnlyDictionary<string, int>(_ordinals);
+        new ReadOnlyDictionary<string, int>(_registryState.Ordinals);
 
     /// <summary>
     ///     Current bucket -&gt; ordinal map, i.e. which physical partition each named
@@ -187,7 +233,7 @@ public class ManagedTenantPartitions: FeatureSchemaBase, ISqlServerPartitioning,
     ///     is resolvable here. A bucket disappears once its last member is dropped.
     /// </summary>
     public IReadOnlyDictionary<string, int> Buckets =>
-        new ReadOnlyDictionary<string, int>(_buckets);
+        new ReadOnlyDictionary<string, int>(_registryState.Buckets);
 
     /// <inheritdoc />
     protected override IEnumerable<ISchemaObject> schemaObjects()
@@ -337,7 +383,7 @@ public class ManagedTenantPartitions: FeatureSchemaBase, ISqlServerPartitioning,
     private int[] OrderedBoundaries()
     {
         var values = new SortedSet<int> { SentinelBoundary };
-        foreach (var ordinal in _ordinals.Values)
+        foreach (var ordinal in _registryState.Ordinals.Values)
         {
             values.Add(ordinal);
         }
@@ -374,8 +420,9 @@ public class ManagedTenantPartitions: FeatureSchemaBase, ISqlServerPartitioning,
             // structure and MigrateAsync is a no-op.
             await _registry.MigrateAsync(conn, token).ConfigureAwait(false);
 
-            _ordinals.Clear();
-            _buckets.Clear();
+            // Build into detached maps and publish them in one assignment. Clearing and refilling the
+            // published instances is what let a concurrent reader see them empty or half-loaded (weasel#583).
+            var loaded = RegistrySnapshot.Empty();
 
             await using var cmd = conn.CreateCommand();
             cmd.CommandText =
@@ -385,12 +432,17 @@ public class ManagedTenantPartitions: FeatureSchemaBase, ISqlServerPartitioning,
             {
                 var tenantId = reader.GetString(0);
                 var ordinal = reader.GetInt32(1);
-                _ordinals[tenantId] = ordinal;
+                loaded.Ordinals[tenantId] = ordinal;
 
                 if (!await reader.IsDBNullAsync(2, token).ConfigureAwait(false))
                 {
-                    _buckets[reader.GetString(2)] = ordinal;
+                    loaded.Buckets[reader.GetString(2)] = ordinal;
                 }
+            }
+
+            lock (_registryLock)
+            {
+                _registryState = loaded;
             }
 
             _hasInitialized = true;
@@ -634,13 +686,15 @@ public class ManagedTenantPartitions: FeatureSchemaBase, ISqlServerPartitioning,
     /// </summary>
     private int resolveBucketOrdinal(string bucket, string[] members)
     {
-        if (_buckets.TryGetValue(bucket, out var known))
+        var state = _registryState;
+
+        if (state.Buckets.TryGetValue(bucket, out var known))
         {
             return known;
         }
 
-        var existing = members.Where(m => _ordinals.ContainsKey(m))
-            .Select(m => _ordinals[m])
+        var existing = members.Where(m => state.Ordinals.ContainsKey(m))
+            .Select(m => state.Ordinals[m])
             .Distinct()
             .ToArray();
 
@@ -654,7 +708,7 @@ public class ManagedTenantPartitions: FeatureSchemaBase, ISqlServerPartitioning,
 
         return existing.Length == 1
             ? existing[0]
-            : (_ordinals.Count == 0 ? 1 : _ordinals.Values.Max() + 1);
+            : (state.Ordinals.Count == 0 ? 1 : state.Ordinals.Values.Max() + 1);
     }
 
     /// <summary>
@@ -745,14 +799,17 @@ public class ManagedTenantPartitions: FeatureSchemaBase, ISqlServerPartitioning,
                 await insert.ExecuteNonQueryAsync(token).ConfigureAwait(false);
             }
 
-            _ordinals.Clear();
-
             // ResetValues rewrites the registry wholesale and carries no bucket names, so every previously
-            // known bucket is gone with it.
-            _buckets.Clear();
+            // known bucket is gone with it. Published as one fresh snapshot rather than cleared in place.
+            var replacement = RegistrySnapshot.Empty();
             foreach (var pair in values)
             {
-                _ordinals[pair.Key] = pair.Value;
+                replacement.Ordinals[pair.Key] = pair.Value;
+            }
+
+            lock (_registryLock)
+            {
+                _registryState = replacement;
             }
 
             await tx.CommitAsync(token).ConfigureAwait(false);
@@ -813,9 +870,10 @@ public class ManagedTenantPartitions: FeatureSchemaBase, ISqlServerPartitioning,
         await InitializeAsync(conn, token).ConfigureAwait(false);
 
         var droppedOrdinals = new HashSet<int>();
+        var state = _registryState;
         foreach (var tenantId in tenants)
         {
-            if (_ordinals.TryGetValue(tenantId, out var ordinal))
+            if (state.Ordinals.TryGetValue(tenantId, out var ordinal))
             {
                 droppedOrdinals.Add(ordinal);
             }
@@ -850,19 +908,24 @@ public class ManagedTenantPartitions: FeatureSchemaBase, ISqlServerPartitioning,
             await delete.ExecuteNonQueryAsync(token).ConfigureAwait(false);
         }
 
-        foreach (var tenant in tenants)
+        // The removals and the bucket pruning are one swap: a reader must never see a bucket still pointing
+        // at an ordinal whose last tenant has already gone.
+        state = swapRegistry((ordinals, buckets) =>
         {
-            _ordinals.Remove(tenant);
-        }
+            foreach (var tenant in tenants)
+            {
+                ordinals.Remove(tenant);
+            }
 
-        // A bucket only exists while it has members. Forgetting it once the last one is dropped keeps the
-        // ordinal genuinely releasable — the whole reason the bucket key is a nullable column rather than a
-        // pseudo-tenant row, which would have pinned the partition forever.
-        foreach (var stale in _buckets.Where(pair => !_ordinals.ContainsValue(pair.Value))
-                     .Select(pair => pair.Key).ToArray())
-        {
-            _buckets.Remove(stale);
-        }
+            // A bucket only exists while it has members. Forgetting it once the last one is dropped keeps the
+            // ordinal genuinely releasable — the whole reason the bucket key is a nullable column rather than a
+            // pseudo-tenant row, which would have pinned the partition forever.
+            foreach (var stale in buckets.Where(pair => !ordinals.ContainsValue(pair.Value))
+                         .Select(pair => pair.Key).ToArray())
+            {
+                buckets.Remove(stale);
+            }
+        });
 
         // With ordinal sharing, an ordinal is only released once its LAST tenant
         // is dropped; while other tenants still map to it the partition must
@@ -870,7 +933,7 @@ public class ManagedTenantPartitions: FeatureSchemaBase, ISqlServerPartitioning,
         var ordinalsToMerge = new List<int>();
         foreach (var ordinal in droppedOrdinals.OrderBy(x => x))
         {
-            if (_ordinals.ContainsValue(ordinal))
+            if (state.Ordinals.ContainsValue(ordinal))
             {
                 logger.LogWarning(
                     "Ordinal {Ordinal} is still shared by other tenants — the partition is retained and " +
@@ -966,7 +1029,9 @@ public class ManagedTenantPartitions: FeatureSchemaBase, ISqlServerPartitioning,
         int? requestedOrdinal = null,
         string? bucket = null)
     {
-        if (_ordinals.TryGetValue(tenantId, out var existing))
+        var state = _registryState;
+
+        if (state.Ordinals.TryGetValue(tenantId, out var existing))
         {
             if (requestedOrdinal.HasValue && requestedOrdinal.Value != existing)
             {
@@ -978,7 +1043,7 @@ public class ManagedTenantPartitions: FeatureSchemaBase, ISqlServerPartitioning,
 
             if (bucket != null)
             {
-                _buckets[bucket] = existing;
+                swapRegistry((_, buckets) => buckets[bucket] = existing);
             }
 
             return existing;
@@ -991,7 +1056,7 @@ public class ManagedTenantPartitions: FeatureSchemaBase, ISqlServerPartitioning,
         }
 
         if (requestedOrdinal.HasValue && !AllowOrdinalSharing &&
-            _ordinals.ContainsValue(requestedOrdinal.Value))
+            state.Ordinals.ContainsValue(requestedOrdinal.Value))
         {
             throw new InvalidOperationException(
                 $"Ordinal {requestedOrdinal.Value} is already assigned to another tenant. Set " +
@@ -999,7 +1064,7 @@ public class ManagedTenantPartitions: FeatureSchemaBase, ISqlServerPartitioning,
         }
 
         var nextOrdinal = requestedOrdinal ??
-                          ((_ordinals.Count == 0) ? 1 : _ordinals.Values.Max() + 1);
+                          ((state.Ordinals.Count == 0) ? 1 : state.Ordinals.Values.Max() + 1);
 
         await using var cmd = conn.CreateCommand();
         // MERGE rather than INSERT to handle a race where another process
@@ -1035,14 +1100,17 @@ OUTPUT inserted.ordinal;";
                 $"Failed to register tenant '{tenantId}' in {_registry.Identifier.QualifiedName}");
         }
 
-        _ordinals[tenantId] = insertedOrdinal.Value;
-
-        if (bucket != null)
+        swapRegistry((ordinals, buckets) =>
         {
-            // Record the bucket against whatever ordinal actually landed — which may be another process's
-            // if it won the MERGE race — so every later member of this bucket resolves to the same partition.
-            _buckets[bucket] = insertedOrdinal.Value;
-        }
+            ordinals[tenantId] = insertedOrdinal.Value;
+
+            if (bucket != null)
+            {
+                // Record the bucket against whatever ordinal actually landed — which may be another process's
+                // if it won the MERGE race — so every later member of this bucket resolves to the same partition.
+                buckets[bucket] = insertedOrdinal.Value;
+            }
+        });
 
         return insertedOrdinal.Value;
     }


### PR DESCRIPTION
Closes #583.

## The bug

`ManagedListPartitions` kept its tenant registry in a plain `Dictionary` that it mutated **in place**, and published it two ways that both hand out the live instance:

- `Partitions` returns a `ReadOnlyDictionary`, which *wraps* — it never copies
- `IListPartitionManager.Partitions()` is a lazy iterator over the same instance, and it is what `ListPartitioning.Partitions()` calls for DDL and delta calculation

`InitializeAsync` then `Clear()`ed and refilled that live instance. `_semaphoreSlim` serializes writers against each other and does nothing for readers.

One manager instance is shared across every database in a store, so `db-apply --parallel N` over more than N databases has a late-starting worker reloading the registry while an earlier worker is still enumerating it — which is why the report was 1 failure out of 29 at `--parallel 16`, and why the retry was clean.

## Two failure modes

The loud one is the reported `InvalidOperationException: Collection was modified; enumeration operation may not execute` out of `DatabaseBase.assertValidIdentifiers`.

The quiet one is worse, because nothing reports it: `Clear()`-then-refill also lets a reader observe an **empty or partial** partition set and generate DDL, or compute a partition delta, against it. Script-generation paths are the obvious exposure since they do not hold the migration's global lock.

## Why the read side is not where to fix it

`ToArray()` over the published map routes through `ICollection<T>.CopyTo`, which has no version check and so cannot throw `InvalidOperationException`. It reads `Count`, the dictionary grows underneath, and it throws `ArgumentException: Destination array is not long enough` instead. Any read-side snapshot against an in-place-mutated dictionary only changes which exception you get, or tears silently.

## The fix

Both managers publish an immutable snapshot and swap it copy-on-write: build or copy a detached map, mutate that, assign it in one write. Readers capture the field once and enumerate a complete, consistent map.

A dedicated lock serializes the read-copy-write sequences against each other. Deliberately **not** the existing semaphore — that one is held across database round trips inside `InitializeAsync`, so a writer blocking on it would stall a thread pool thread for the duration of a query.

Two incidental improvements fall out of the same pass:

- `ResetValues` now copies the caller's dictionary instead of aliasing it, so a caller mutating its own dictionary afterwards is no longer mutating the published snapshot
- the batch `AddPartitionToAllTables` publishes after its transaction commits rather than mid-loop, so a failed insert no longer leaves partially-registered tenants in memory

## `Weasel.SqlServer` had the identical shape

`ManagedTenantPartitions`: `_ordinals` / `_buckets` published as live `ReadOnlyDictionary` wrappers, `Clear()`ed and refilled in the initializer and the reset path, and enumerated by `OrderedBoundaries()` straight off the schema-object path that emits partition-function DDL and its delta. Same treatment.

The two maps swap **together**, as one `RegistrySnapshot`, because the drop path prunes buckets against the ordinals it just removed — a reader that saw one updated and not the other would resolve a bucket to a released partition.

## Tests

One regression test per provider. Each races the real reload path (`ForceReload` + `InitializeAsync`, exactly what a per-database schema initializer runs) against the real read paths, and asserts both that no reader throws and that no reader saw an incomplete registry — the silent mode would otherwise go unnoticed.

Both were confirmed to fail against the previous code with the reported `Collection was modified` exception, in under half a second each, and pass after.

Full `Weasel.Postgresql.Tests` (975), `Weasel.SqlServer.Tests` (559) and `Weasel.Core.Tests` (505) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)