### PR TITLE
Give the streaming-refusal assertion its own reader type (#576)

### DIFF
--- a/src/Weasel.Core.Tests/system_text_json_serializer_tests.cs
+++ b/src/Weasel.Core.Tests/system_text_json_serializer_tests.cs
@@ -269,7 +269,8 @@ public class system_text_json_serializer_tests
         await using var inner = await command.ExecuteReaderAsync();
         (await inner.ReadAsync()).ShouldBeTrue();
 
-        await using var reader = new NonStreamingReader(inner);
+        // Its OWN reader type, deliberately — see CountingNonStreamingReader below.
+        await using var reader = new CountingNonStreamingReader(inner);
 
         theSerializer.FromJson<TestDoc>(reader, 0).Name.ShouldBe("fell back");
         theSerializer.FromJson(typeof(TestDoc), reader, 0)
@@ -320,7 +321,21 @@ public class system_text_json_serializer_tests
     ///     <c>nvarchar(max)</c> or <c>json</c> column, while delegating everything else to a real
     ///     reader. Lets the fallback be tested without a SQL Server container.
     /// </summary>
-    private sealed class NonStreamingReader(DbDataReader inner): DbDataReader
+    /// <summary>
+    ///     A refusing reader that no other test has put through the read path.
+    ///
+    ///     weasel#576: <c>JsonColumnStreaming</c> learns a provider's refusal once and remembers it in a
+    ///     process-wide cache keyed by reader TYPE — deliberately, so the refusal costs one exception per
+    ///     reader type per process rather than one per read. That makes "was a stream actually attempted?"
+    ///     an assertion about the FIRST use of a type in the process, so a test making it cannot share a
+    ///     reader type with any other test. When <see cref="NonStreamingReader"/> was shared, whichever
+    ///     test ran first decided the answer: the other one then short-circuited at the cache and saw zero
+    ///     attempts. Ordering between the two is not fixed, which is why this was reliably red on CI and
+    ///     reliably green locally.
+    /// </summary>
+    private sealed class CountingNonStreamingReader(DbDataReader inner): NonStreamingReader(inner);
+
+    private class NonStreamingReader(DbDataReader inner): DbDataReader
     {
         public int StreamAttempts { get; private set; }
 


### PR DESCRIPTION
The `Core` workflow has been red on `master` for five consecutive commits, starting exactly at `5ce73b4` (#576). This fixes it. Not a product bug — the test is asserting something that a shared type makes order-dependent.

## What fails

`system_text_json_serializer_tests.falls_back_to_the_string_path_when_a_provider_refuses_to_stream`, on `reader.StreamAttempts.ShouldBeGreaterThan(0)`.

## Why

`JsonColumnStreaming` learns a provider's refusal once and remembers it in a **process-wide cache keyed by reader type**. That is deliberate and documented: it makes the refusal cost one exception per reader type per process rather than one per read.

The consequence is that "was a stream actually attempted?" is an assertion about the **first** use of a type in the process. Two tests in the class shared the `NonStreamingReader` type:

- `reads_a_reader_column_the_same_way_whether_or_not_the_provider_streams` puts one through the read path, caching "does not stream"
- `falls_back_to_the_string_path_when_a_provider_refuses_to_stream` then short-circuits at the cache check, never calls `GetStream`, and sees `StreamAttempts == 0`

Whichever runs first wins. Ordering between them is not fixed, which is why this is reliably red on Ubuntu CI and reliably green locally — I could not reproduce it in 6 consecutive full-suite runs on macOS.

I confirmed the mechanism directly with a throwaway test: a second instance of the same refusing reader type attempts nothing, because the first instance already populated the cache.

## The fix

The assertion test gets a reader type of its own, so its cache entry starts empty and the first call genuinely attempts. `NonStreamingReader` becomes non-sealed and `CountingNonStreamingReader` derives from it — no behavior duplicated, and a comment records why the type may not be shared.

The product is untouched.

Full `Weasel.Core.Tests` green locally on net9.0 and net10.0 (547 each). The real confirmation is this workflow going green here, since the failing ordering only occurs on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)