### PR TITLE
gh-588: SqliteDataSource registers functions and loads extensions on every open

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -721,7 +721,7 @@ connection.CreateAggregate(
 - No ALTER FUNCTION or DROP FUNCTION SQL (functions unregister when connection closes)
 
 **Best Practices:**
-- Register commonly used functions in a connection factory or startup code
+- Register functions on `SqliteDataSource` through a `SqliteFunctionRegistry` (and extensions through `SqliteExtensionSettings`) so every connection it opens gets them; registering on a single connection is the classic "sometimes isn't there" bug. See `docs/sqlite/functions.md` (weasel#588)
 - Use extension methods to encapsulate function registration logic
 - Consider wrapping function registration in a helper class for reuse
 - Document custom functions in application code since they're not visible in the database schema

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -137,6 +137,7 @@ export default withMermaid(
             { text: 'Views', link: '/sqlite/views' },
             { text: 'JSON Support', link: '/sqlite/json' },
             { text: 'PRAGMA Settings', link: '/sqlite/pragmas' },
+            { text: 'Functions and Extensions', link: '/sqlite/functions' },
             { text: 'SqliteHelper', link: '/sqlite/helper' }
           ]
         },

--- a/docs/sqlite/functions.md
+++ b/docs/sqlite/functions.md
@@ -1,0 +1,74 @@
+# Functions and Extensions
+
+SQLite has no `CREATE FUNCTION`. Application-defined functions are registered on a connection
+handle through `Microsoft.Data.Sqlite`, and loadable extensions are likewise attached per
+connection. Both are gone the moment the connection closes. That makes them a per-open concern
+rather than a schema object, and the place Weasel handles them is `SqliteDataSource`.
+
+## Registering functions through the data source
+
+Hand a `SqliteFunctionRegistry` (and optionally a `SqliteExtensionSettings`) to `SqliteDataSource`
+and every connection it opens, synchronously or asynchronously, gets the same functions:
+
+<!-- snippet: sample_sqlite_data_source_functions -->
+<a id='snippet-sample_sqlite_data_source_functions'></a>
+```cs
+var functions = new SqliteFunctionRegistry();
+functions.AddScalar<double>("cosine_distance", (object? a, object? b) =>
+{
+    var x = (byte[])a!;
+    var y = (byte[])b!;
+    double dot = 0, nx = 0, ny = 0;
+    for (var i = 0; i + 3 < x.Length; i += 4)
+    {
+        var xi = BitConverter.ToSingle(x, i);
+        var yi = BitConverter.ToSingle(y, i);
+        dot += xi * yi;
+        nx += xi * xi;
+        ny += yi * yi;
+    }
+
+    return 1 - dot / (Math.Sqrt(nx) * Math.Sqrt(ny));
+});
+
+var extensions = new SqliteExtensionSettings();
+// extensions.AddExtension("vec0"); // a native extension, if you need one
+
+await using var dataSource = new SqliteDataSource(
+    "Data Source=myapp.db",
+    SqlitePragmaSettings.Default,
+    functions,
+    extensions);
+
+// every connection the data source opens has cosine_distance() registered
+await using var connection = await dataSource.OpenConnectionAsync();
+await using var cmd = connection.CreateCommand();
+cmd.CommandText = "select id from vectors order by cosine_distance(embedding, @q) limit 10";
+```
+<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L453-L485' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_data_source_functions' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+The registry is live. Functions added to `dataSource.Functions` after construction are registered
+on connections opened from then on, so a library can build the data source first and let the
+application contribute functions later.
+
+The per-open order is connection-scoped PRAGMAs, then extensions, then functions, so a managed
+function can build on something an extension provides.
+
+## Why not register on a connection directly?
+
+You can, and the `Microsoft.Data.Sqlite` API for it is `connection.CreateFunction(...)`. The
+trap is that a function registered on one connection does not exist on the next one, and a
+connection pool hands out whichever is free. A function that "sometimes isn't there" is almost
+always a function registered on a connection instead of on the data source that produces them.
+
+## Extensions
+
+`SqliteExtensionSettings.AddExtension(libraryPath, entryPoint?)` names a native extension to load.
+Extension loading is enabled only for the duration of the loads and disabled again afterwards. A
+library that cannot be loaded fails the open with the library path in the message, and the
+connection is disposed rather than handed out half-configured.
+
+The bundled `e_sqlite3` build that `Microsoft.Data.Sqlite` ships with already has FTS5, JSON and
+R*Tree compiled in, so many applications never need an extension at all; a registered managed
+function covers cases like a cosine distance over a BLOB with no native dependency.

--- a/docs/sqlite/helper.md
+++ b/docs/sqlite/helper.md
@@ -15,7 +15,7 @@ await connection.OpenAsync();
 // Apply default PRAGMA settings (WAL mode, NORMAL sync, 64MB cache, foreign keys enabled)
 await SqlitePragmaSettings.Default.ApplyToConnectionAsync(connection);
 ```
-<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L357-L363' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_helper_basic_connection' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L358-L364' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_helper_basic_connection' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 This opens the connection and applies `SqlitePragmaSettings.Default` (WAL mode, NORMAL sync, 64MB cache, foreign keys enabled).
@@ -37,7 +37,7 @@ var connection = new SqliteConnection("Data Source=myapp.db");
 await connection.OpenAsync();
 await settings.ApplyToConnectionAsync(connection);
 ```
-<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L368-L378' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_helper_custom_pragmas' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L369-L379' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_helper_custom_pragmas' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Using Presets
@@ -55,7 +55,7 @@ var highSafetyConn = new SqliteConnection("Data Source=myapp.db");
 await highSafetyConn.OpenAsync();
 await SqlitePragmaSettings.HighSafety.ApplyToConnectionAsync(highSafetyConn);
 ```
-<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L383-L393' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_helper_presets' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L384-L394' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_helper_presets' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 See [PRAGMA Settings](/sqlite/pragmas) for details on each preset.
@@ -77,7 +77,7 @@ var writer = new StringWriter();
 table.WriteCreateStatement(migrator, writer);
 Console.WriteLine(writer.ToString());
 ```
-<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L398-L408' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_helper_create_migrator' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L399-L409' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_helper_create_migrator' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Connection String Examples
@@ -97,7 +97,7 @@ var sharedCache = "Data Source=myapp;Mode=Memory;Cache=Shared";
 // Read-only access
 var readOnly = "Data Source=myapp.db;Mode=ReadOnly";
 ```
-<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L413-L425' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_connection_string_examples' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L414-L426' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_connection_string_examples' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Method Reference
@@ -129,5 +129,5 @@ await settings.ApplyToConnectionAsync(connection);
 // var cmd = connection.CreateCommand();
 // cmd.CommandText = "PRAGMA journal_mode = WAL; PRAGMA foreign_keys = ON;";
 ```
-<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L430-L445' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_helper_recommended_usage' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L431-L446' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_helper_recommended_usage' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/docs/sqlite/index.md
+++ b/docs/sqlite/index.md
@@ -72,5 +72,5 @@ var cmd = connection.CreateCommand();
 cmd.CommandText = writer.ToString();
 await cmd.ExecuteNonQueryAsync();
 ```
-<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L15-L30' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_quick_example' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L16-L31' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_quick_example' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/docs/sqlite/json.md
+++ b/docs/sqlite/json.md
@@ -24,7 +24,7 @@ table.AddColumn<int>("id").AsPrimaryKey().AutoIncrement();
 table.AddColumn<string>("name").NotNull();
 table.AddColumn("metadata", "TEXT"); // JSON column
 ```
-<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L222-L227' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_json_columns' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L223-L228' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_json_columns' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Querying JSON Data
@@ -67,7 +67,7 @@ var skuIdx = new IndexDefinition("idx_products_sku") { IsUnique = true };
 skuIdx.ForJsonPath("metadata", "$.sku");
 table.Indexes.Add(skuIdx);
 ```
-<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L232-L247' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_json_expression_indexes' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L233-L248' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_json_expression_indexes' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 This generates an expression index using `json_extract()`:
@@ -90,7 +90,7 @@ json_extract(metadata, '$.price') as price,
 json_extract(metadata, '$.in_stock') as in_stock
 FROM products");
 ```
-<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L252-L259' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_json_views' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L253-L260' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_json_views' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Full Example
@@ -120,7 +120,7 @@ var cmd = connection.CreateCommand();
 cmd.CommandText = writer.ToString();
 await cmd.ExecuteNonQueryAsync();
 ```
-<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L264-L286' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_json_full_example' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L265-L287' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_json_full_example' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Notes

--- a/docs/sqlite/pragmas.md
+++ b/docs/sqlite/pragmas.md
@@ -24,7 +24,7 @@ var connection = new SqliteConnection("Data Source=myapp.db");
 await connection.OpenAsync();
 await settings.ApplyToConnectionAsync(connection);
 ```
-<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L293-L298' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_pragma_high_performance' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L294-L299' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_pragma_high_performance' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 - WAL journal mode, OFF synchronous mode
@@ -46,7 +46,7 @@ var connection = new SqliteConnection("Data Source=myapp.db");
 await connection.OpenAsync();
 await settings.ApplyToConnectionAsync(connection);
 ```
-<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L303-L308' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_pragma_high_safety' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L304-L309' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_pragma_high_safety' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 - WAL journal mode, FULL synchronous mode
@@ -86,7 +86,7 @@ var connection = new SqliteConnection("Data Source=myapp.db");
 await connection.OpenAsync();
 await settings.ApplyToConnectionAsync(connection);
 ```
-<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L313-L326' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_pragma_custom_configuration' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L314-L327' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_pragma_custom_configuration' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Applying to an Existing Connection
@@ -99,7 +99,7 @@ var connection = new SqliteConnection("Data Source=myapp.db");
 await connection.OpenAsync();
 await settings.ApplyToConnectionAsync(connection);
 ```
-<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L331-L336' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_pragma_apply_existing_connection' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L332-L337' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_pragma_apply_existing_connection' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Generating a SQL Script
@@ -116,7 +116,7 @@ Console.WriteLine(settings.ToSqlScript());
 // PRAGMA cache_size = -64000;
 // ...
 ```
-<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L341-L350' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_pragma_sql_script' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L342-L351' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_pragma_sql_script' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Important Notes

--- a/docs/sqlite/tables.md
+++ b/docs/sqlite/tables.md
@@ -13,7 +13,7 @@ table.AddColumn<string>("name").NotNull();
 table.AddColumn<string>("email").NotNull();
 table.AddColumn("settings", "TEXT"); // raw type
 ```
-<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L37-L43' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_create_table' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L38-L44' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_create_table' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Primary Keys and AUTOINCREMENT
@@ -26,7 +26,7 @@ Use `AsPrimaryKey()` and `AutoIncrement()` for `INTEGER PRIMARY KEY AUTOINCREMEN
 var table = new Table("users");
 table.AddColumn<int>("id").AsPrimaryKey().AutoIncrement();
 ```
-<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L48-L51' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_autoincrement' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L49-L52' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_autoincrement' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Generated Columns
@@ -40,7 +40,7 @@ var table = new Table("users");
 table.AddColumn("email_domain", "TEXT")
     .GeneratedAs("substr(email, instr(email, '@') + 1)", GeneratedColumnType.Stored);
 ```
-<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L56-L60' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_generated_columns' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L57-L61' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_generated_columns' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Generated columns are read back during delta detection, so a table declaring one converges on the second migration run rather than re-adding the column every time. Adding a `Virtual` generated column to an existing table is an `ALTER TABLE ADD COLUMN`; adding a `Stored` one is not — SQLite rejects that outright, so Weasel migrates it through a table recreation instead.
@@ -66,7 +66,7 @@ orders.ForeignKeys.Add(new ForeignKey("fk_orders_user")
     LinkedNames = new[] { "id" }
 });
 ```
-<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L65-L77' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_foreign_keys' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L66-L78' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_foreign_keys' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ::: warning
@@ -98,7 +98,7 @@ activeIdx.AgainstColumns("name");
 activeIdx.Predicate = "active = 1";
 table.Indexes.Add(activeIdx);
 ```
-<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L82-L100' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_indexes' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L83-L101' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_indexes' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## STRICT Mode and WITHOUT ROWID
@@ -112,7 +112,7 @@ var table = new Table("users");
 table.StrictTypes = true;   // CREATE TABLE ... (...) STRICT
 table.WithoutRowId = true;  // CREATE TABLE ... (...) WITHOUT ROWID
 ```
-<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L105-L109' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_strict_and_without_rowid' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L106-L110' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_strict_and_without_rowid' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Schema Support
@@ -130,7 +130,7 @@ var temp = new Table(new SqliteObjectName("temp", "session_data"));
 var table = new Table("users");
 table.MoveToSchema("temp");
 ```
-<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L114-L122' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_schema_support' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L115-L123' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_schema_support' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Delta Detection and Table Recreation

--- a/docs/sqlite/views.md
+++ b/docs/sqlite/views.md
@@ -10,7 +10,7 @@ The `View` class in `Weasel.Sqlite.Views` provides CREATE/DROP support with auto
 var view = new View("active_users",
     "SELECT id, name, email FROM users WHERE active = 1");
 ```
-<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L129-L132' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_create_view' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L130-L133' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_create_view' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Generating DDL
@@ -31,7 +31,7 @@ view.WriteCreateStatement(migrator, writer);
 // DROP VIEW IF EXISTS "active_users";
 // CREATE VIEW "active_users" AS SELECT id, name, email FROM users WHERE active = 1;
 ```
-<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L137-L148' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_view_ddl' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L138-L149' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_view_ddl' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Schema Support
@@ -49,7 +49,7 @@ var tempView = new View(
 // DDL: DROP VIEW IF EXISTS "temp"."session_summary";
 // CREATE VIEW "temp"."session_summary" AS SELECT ...
 ```
-<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L153-L161' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_view_schema' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L154-L162' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_view_schema' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Complex View Examples
@@ -73,7 +73,7 @@ json_extract(metadata, '$.category') as category,
 json_extract(metadata, '$.price') as price
 FROM products");
 ```
-<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L166-L180' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_complex_views' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L167-L181' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_complex_views' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Delta Detection
@@ -113,7 +113,7 @@ switch (delta.Difference)
         break;
 }
 ```
-<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L185-L215' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_view_delta_detection' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/weasel/blob/master/src/DocSamples/SqliteSamples.cs#L186-L216' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sqlite_view_delta_detection' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Limitations

--- a/src/DocSamples/SqliteSamples.cs
+++ b/src/DocSamples/SqliteSamples.cs
@@ -1,6 +1,7 @@
 using Microsoft.Data.Sqlite;
 using Weasel.Core;
 using Weasel.Sqlite;
+using Weasel.Sqlite.Functions;
 using Weasel.Sqlite.Tables;
 using Weasel.Sqlite.Views;
 
@@ -442,6 +443,45 @@ public class SqliteSamples
         // Avoid: raw PRAGMA statements
         // var cmd = connection.CreateCommand();
         // cmd.CommandText = "PRAGMA journal_mode = WAL; PRAGMA foreign_keys = ON;";
+        #endregion
+    }
+
+    // === functions.md samples ===
+
+    public async Task sqlite_data_source_functions()
+    {
+        #region sample_sqlite_data_source_functions
+        var functions = new SqliteFunctionRegistry();
+        functions.AddScalar<double>("cosine_distance", (object? a, object? b) =>
+        {
+            var x = (byte[])a!;
+            var y = (byte[])b!;
+            double dot = 0, nx = 0, ny = 0;
+            for (var i = 0; i + 3 < x.Length; i += 4)
+            {
+                var xi = BitConverter.ToSingle(x, i);
+                var yi = BitConverter.ToSingle(y, i);
+                dot += xi * yi;
+                nx += xi * xi;
+                ny += yi * yi;
+            }
+
+            return 1 - dot / (Math.Sqrt(nx) * Math.Sqrt(ny));
+        });
+
+        var extensions = new SqliteExtensionSettings();
+        // extensions.AddExtension("vec0"); // a native extension, if you need one
+
+        await using var dataSource = new SqliteDataSource(
+            "Data Source=myapp.db",
+            SqlitePragmaSettings.Default,
+            functions,
+            extensions);
+
+        // every connection the data source opens has cosine_distance() registered
+        await using var connection = await dataSource.OpenConnectionAsync();
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = "select id from vectors order by cosine_distance(embedding, @q) limit 10";
         #endregion
     }
 }

--- a/src/Weasel.Sqlite.Tests/SqliteDataSourceFunctionWiringTests.cs
+++ b/src/Weasel.Sqlite.Tests/SqliteDataSourceFunctionWiringTests.cs
@@ -1,0 +1,139 @@
+using Microsoft.Data.Sqlite;
+using Shouldly;
+using Weasel.Sqlite.Functions;
+using Xunit;
+
+namespace Weasel.Sqlite.Tests;
+
+/// <summary>
+///     SqliteDataSource applies the function registry and extension settings on every connection
+///     it opens, sync and async, and keeps doing so for functions added after construction.
+///     See JasperFx/weasel#588.
+/// </summary>
+public class SqliteDataSourceFunctionWiringTests : IDisposable
+{
+    private readonly string _path = Path.Combine(Path.GetTempPath(), $"weasel-fn-{Guid.NewGuid():N}.db");
+
+    private string ConnectionString => new SqliteConnectionStringBuilder { DataSource = _path }.ToString();
+
+    public void Dispose()
+    {
+        SqliteConnection.ClearAllPools();
+        if (File.Exists(_path)) File.Delete(_path);
+    }
+
+    [Fact]
+    public async Task functions_are_registered_on_every_async_open()
+    {
+        var functions = new SqliteFunctionRegistry();
+        functions.AddScalar<long>("twice", (object? x) => Convert.ToInt64(x) * 2);
+
+        using var dataSource = new SqliteDataSource(ConnectionString, null, functions, null);
+
+        await using var first = await dataSource.OpenConnectionAsync(TestContext.Current.CancellationToken);
+        await using var second = await dataSource.OpenConnectionAsync(TestContext.Current.CancellationToken);
+
+        (await scalarAsync(first, "select twice(21)")).ShouldBe(42L);
+        (await scalarAsync(second, "select twice(4)")).ShouldBe(8L);
+    }
+
+    [Fact]
+    public void functions_are_registered_on_a_sync_open()
+    {
+        var functions = new SqliteFunctionRegistry();
+        functions.AddScalar<string>("shout", (object? x) => x?.ToString()?.ToUpperInvariant() ?? "");
+
+        using var dataSource = new SqliteDataSource(ConnectionString, null, functions, null);
+
+        using var conn = dataSource.OpenConnection();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = "select shout('weasel')";
+        cmd.ExecuteScalar().ShouldBe("WEASEL");
+    }
+
+    [Fact]
+    public async Task functions_added_after_construction_reach_later_opens()
+    {
+        using var dataSource = new SqliteDataSource(ConnectionString);
+
+        dataSource.Functions.AddScalar<double>("cosine_distance",
+            (object? a, object? b) => 1 - Convert.ToDouble(a) * Convert.ToDouble(b));
+
+        await using var conn = await dataSource.OpenConnectionAsync(TestContext.Current.CancellationToken);
+        (await scalarAsync(conn, "select cosine_distance(0.5, 1.0)")).ShouldBe(0.5);
+    }
+
+    [Fact]
+    public async Task aggregate_functions_are_registered_too()
+    {
+        var functions = new SqliteFunctionRegistry();
+        functions.AddAggregate<long, long>("sum_of_squares", 0L, (acc, x) => acc + (long)Math.Pow(Convert.ToInt64(x), 2));
+
+        using var dataSource = new SqliteDataSource(ConnectionString, null, functions, null);
+
+        await using var conn = await dataSource.OpenConnectionAsync(TestContext.Current.CancellationToken);
+        (await scalarAsync(conn, "select sum_of_squares(value) from (select 1 as value union all select 2 union all select 3)"))
+            .ShouldBe(14L);
+    }
+
+    [Fact]
+    public async Task a_function_from_one_data_source_is_not_visible_through_a_bare_connection()
+    {
+        // Pins the reason the wiring lives in the data source: functions are per connection.
+        var functions = new SqliteFunctionRegistry();
+        functions.AddScalar<long>("twice", (object? x) => Convert.ToInt64(x) * 2);
+        using var dataSource = new SqliteDataSource(ConnectionString, null, functions, null);
+        await using var _ = await dataSource.OpenConnectionAsync(TestContext.Current.CancellationToken);
+
+        await using var bare = new SqliteConnection(ConnectionString);
+        await bare.OpenAsync(TestContext.Current.CancellationToken);
+
+        await Should.ThrowAsync<SqliteException>(() => scalarAsync(bare, "select twice(1)"));
+    }
+
+    [Fact]
+    public void the_two_argument_constructor_still_works_with_empty_registry_and_settings()
+    {
+        using var dataSource = new SqliteDataSource(ConnectionString, SqlitePragmaSettings.Default);
+
+        dataSource.Functions.Functions.ShouldBeEmpty();
+        dataSource.Extensions.Extensions.ShouldBeEmpty();
+
+        using var conn = dataSource.OpenConnection();
+        conn.State.ShouldBe(System.Data.ConnectionState.Open);
+    }
+
+    [Fact]
+    public async Task a_failing_extension_load_fails_the_open_and_names_the_library()
+    {
+        var extensions = new SqliteExtensionSettings();
+        extensions.AddExtension("/definitely/not/here/libnope");
+
+        using var dataSource = new SqliteDataSource(ConnectionString, null, null, extensions);
+
+        var ex = await Should.ThrowAsync<InvalidOperationException>(async () =>
+        {
+            await using var conn = await dataSource.OpenConnectionAsync(TestContext.Current.CancellationToken);
+        });
+
+        ex.Message.ShouldContain("libnope");
+    }
+
+    [Fact]
+    public void a_failing_extension_load_fails_a_sync_open_too()
+    {
+        var extensions = new SqliteExtensionSettings();
+        extensions.AddExtension("/definitely/not/here/libnope");
+
+        using var dataSource = new SqliteDataSource(ConnectionString, null, null, extensions);
+
+        Should.Throw<InvalidOperationException>(() => dataSource.OpenConnection());
+    }
+
+    private static async Task<object?> scalarAsync(System.Data.Common.DbConnection conn, string sql)
+    {
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = sql;
+        return await cmd.ExecuteScalarAsync(TestContext.Current.CancellationToken);
+    }
+}

--- a/src/Weasel.Sqlite/SqliteDataSource.cs
+++ b/src/Weasel.Sqlite/SqliteDataSource.cs
@@ -1,12 +1,13 @@
 using System.Data.Common;
 using Microsoft.Data.Sqlite;
+using Weasel.Sqlite.Functions;
 
 namespace Weasel.Sqlite;
 
 /// <summary>
-/// A DbDataSource for SQLite that applies PRAGMA settings (WAL mode, busy timeout, etc.)
-/// to every connection it opens. The default DbDataSource from SqliteFactory does not
-/// apply any PRAGMAs.
+/// A DbDataSource for SQLite that applies PRAGMA settings (WAL mode, busy timeout, etc.),
+/// loads configured extensions, and registers application-defined functions on every
+/// connection it opens. The default DbDataSource from SqliteFactory does none of that.
 ///
 /// For in-memory databases with Cache=Shared, this class maintains a keep-alive connection
 /// to prevent the database from being destroyed when all other connections close.
@@ -17,6 +18,14 @@ namespace Weasel.Sqlite;
 /// are applied only on the first connection this data source opens. Re-issuing
 /// "PRAGMA journal_mode = WAL" on every open forces SQLite to take file locks to verify the
 /// journal mode and can return SQLITE_BUSY under a concurrent writer.
+///
+/// Extensions (<see cref="SqliteExtensionSettings" />) and functions
+/// (<see cref="SqliteFunctionRegistry" />) are the opposite of file-scoped: SQLite attaches both
+/// to a connection handle, so they are gone the moment the connection closes and have to be
+/// re-applied on every open. That is why they belong here rather than in the schema, and why a
+/// consumer that registers a function through any other path sees it on some connections and
+/// not others. The per-open order is connection PRAGMAs, then extensions, then functions, so a
+/// managed function can build on something an extension provides. See JasperFx/weasel#588.
 ///
 /// Assumption: for a database file that is not being modified externally, applying the
 /// file-scoped PRAGMAs once gives the same guarantee as re-applying them per open (the per-open
@@ -29,14 +38,42 @@ public class SqliteDataSource : DbDataSource
 {
     private readonly string _connectionString;
     private readonly SqlitePragmaSettings _pragmaSettings;
+    private readonly SqliteFunctionRegistry _functions;
+    private readonly SqliteExtensionSettings _extensions;
     private SqliteConnection? _keepAliveConnection;
     private readonly bool _isInMemory;
     private volatile bool _databasePragmasApplied;
 
     public SqliteDataSource(string connectionString, SqlitePragmaSettings? pragmaSettings = null)
+        : this(connectionString, pragmaSettings, null, null)
+    {
+    }
+
+    /// <summary>
+    /// Create a data source that also loads <paramref name="extensions" /> and registers
+    /// <paramref name="functions" /> on every connection it opens.
+    /// </summary>
+    /// <param name="connectionString">The SQLite connection string.</param>
+    /// <param name="pragmaSettings">PRAGMA settings, or <c>null</c> for <see cref="SqlitePragmaSettings.Default" />.</param>
+    /// <param name="functions">
+    /// Functions to register on every opened connection, or <c>null</c> for an empty registry.
+    /// The registry stays live: functions added to <see cref="Functions" /> after construction
+    /// are registered on connections opened from then on.
+    /// </param>
+    /// <param name="extensions">
+    /// Extensions to load on every opened connection, or <c>null</c> for none. Likewise live via
+    /// <see cref="Extensions" />.
+    /// </param>
+    public SqliteDataSource(
+        string connectionString,
+        SqlitePragmaSettings? pragmaSettings,
+        SqliteFunctionRegistry? functions,
+        SqliteExtensionSettings? extensions)
     {
         _connectionString = connectionString ?? throw new ArgumentNullException(nameof(connectionString));
         _pragmaSettings = pragmaSettings ?? SqlitePragmaSettings.Default;
+        _functions = functions ?? new SqliteFunctionRegistry();
+        _extensions = extensions ?? new SqliteExtensionSettings();
         _isInMemory = IsInMemoryConnectionString(connectionString);
     }
 
@@ -46,6 +83,16 @@ public class SqliteDataSource : DbDataSource
     /// Whether this data source targets an in-memory database.
     /// </summary>
     public bool IsInMemory => _isInMemory;
+
+    /// <summary>
+    /// The functions registered on every connection this data source opens.
+    /// </summary>
+    public SqliteFunctionRegistry Functions => _functions;
+
+    /// <summary>
+    /// The extensions loaded on every connection this data source opens.
+    /// </summary>
+    public SqliteExtensionSettings Extensions => _extensions;
 
     protected override DbConnection CreateDbConnection()
     {
@@ -62,6 +109,7 @@ public class SqliteDataSource : DbDataSource
             await conn.OpenAsync(cancellationToken).ConfigureAwait(false);
             await _pragmaSettings.ApplyConnectionPragmasAsync(conn, cancellationToken).ConfigureAwait(false);
             await EnsureDatabasePragmasAsync(conn, cancellationToken).ConfigureAwait(false);
+            applyExtensionsAndFunctions(conn);
         }
         catch
         {
@@ -88,6 +136,8 @@ public class SqliteDataSource : DbDataSource
                 _pragmaSettings.ApplyDatabasePragmas(conn);
                 _databasePragmasApplied = true;
             }
+
+            applyExtensionsAndFunctions(conn);
         }
         catch
         {
@@ -96,6 +146,16 @@ public class SqliteDataSource : DbDataSource
         }
 
         return conn;
+    }
+
+    /// <summary>
+    /// Loading an extension and registering a function are both synchronous native calls with no
+    /// I/O, so the async open path calls this directly rather than paying a thread hop per open.
+    /// </summary>
+    private void applyExtensionsAndFunctions(SqliteConnection conn)
+    {
+        _extensions.ApplyToConnection(conn);
+        _functions.RegisterAll(conn);
     }
 
     /// <summary>

--- a/src/Weasel.Sqlite/SqliteExtensionSettings.cs
+++ b/src/Weasel.Sqlite/SqliteExtensionSettings.cs
@@ -4,6 +4,12 @@ namespace Weasel.Sqlite;
 /// Configuration for SQLite extensions that should be loaded when opening database connections.
 /// Extensions provide additional functionality like spatial data support, full-text search, or custom functions.
 /// </summary>
+/// <remarks>
+/// Hand an instance to <see cref="SqliteDataSource" /> and every connection it opens loads the
+/// configured extensions, in order, right after the connection-scoped PRAGMAs and before any
+/// <see cref="Functions.SqliteFunctionRegistry" /> functions are registered. Loaded extensions live
+/// only for the connection's lifetime, which is why this is a per-open step and not a schema object.
+/// </remarks>
 public class SqliteExtensionSettings
 {
     /// <summary>
@@ -32,8 +38,13 @@ public class SqliteExtensionSettings
     /// Apply extension settings to a connection by loading all configured extensions.
     /// </summary>
     /// <param name="connection">The connection to load extensions into. Must be open.</param>
-    /// <param name="ct">Cancellation token</param>
-    public async Task ApplyToConnectionAsync(Microsoft.Data.Sqlite.SqliteConnection connection, CancellationToken ct = default)
+    /// <remarks>
+    /// Loading is a synchronous native call in Microsoft.Data.Sqlite, so this is the real
+    /// implementation and <see cref="ApplyToConnectionAsync" /> is a thin wrapper over it.
+    /// Extension loading is enabled only for the duration of the loads and disabled again
+    /// afterwards; with nothing configured the connection is not touched at all.
+    /// </remarks>
+    public void ApplyToConnection(Microsoft.Data.Sqlite.SqliteConnection connection)
     {
         if (connection == null)
         {
@@ -45,19 +56,19 @@ public class SqliteExtensionSettings
             throw new InvalidOperationException("Connection must be open before loading extensions");
         }
 
+        if (Extensions.Count == 0)
+        {
+            return;
+        }
+
         // EnableExtensions is required before LoadExtension can be called
         connection.EnableExtensions(true);
-
-        foreach (var extension in Extensions)
+        try
         {
-            try
+            foreach (var extension in Extensions)
             {
-                // LoadExtension is synchronous in Microsoft.Data.Sqlite
-                // but we'll wrap it in Task.Run to be awaitable and respect cancellation
-                await Task.Run(() =>
+                try
                 {
-                    ct.ThrowIfCancellationRequested();
-
                     if (extension.EntryPoint != null)
                     {
                         connection.LoadExtension(extension.LibraryPath, extension.EntryPoint);
@@ -66,20 +77,34 @@ public class SqliteExtensionSettings
                     {
                         connection.LoadExtension(extension.LibraryPath);
                     }
-                }, ct).ConfigureAwait(false);
-            }
-            catch (Exception ex)
-            {
-                throw new InvalidOperationException(
-                    $"Failed to load SQLite extension '{extension.LibraryPath}'" +
-                    (extension.EntryPoint != null ? $" with entry point '{extension.EntryPoint}'" : "") +
-                    ". Ensure the extension library is in the system path (PATH/LD_LIBRARY_PATH/DYLD_LIBRARY_PATH) " +
-                    "or provide a full path to the library file.", ex);
+                }
+                catch (Exception ex)
+                {
+                    throw new InvalidOperationException(
+                        $"Failed to load SQLite extension '{extension.LibraryPath}'" +
+                        (extension.EntryPoint != null ? $" with entry point '{extension.EntryPoint}'" : "") +
+                        ". Ensure the extension library is in the system path (PATH/LD_LIBRARY_PATH/DYLD_LIBRARY_PATH) " +
+                        "or provide a full path to the library file.", ex);
+                }
             }
         }
+        finally
+        {
+            // Disable extension loading after all extensions are loaded for security
+            connection.EnableExtensions(false);
+        }
+    }
 
-        // Disable extension loading after all extensions are loaded for security
-        connection.EnableExtensions(false);
+    /// <summary>
+    /// Apply extension settings to a connection by loading all configured extensions.
+    /// </summary>
+    /// <param name="connection">The connection to load extensions into. Must be open.</param>
+    /// <param name="ct">Cancellation token, checked before loading begins.</param>
+    public Task ApplyToConnectionAsync(Microsoft.Data.Sqlite.SqliteConnection connection, CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        ApplyToConnection(connection);
+        return Task.CompletedTask;
     }
 }
 


### PR DESCRIPTION
Closes #588

Part of the Stoat coordination plan `search-parity-and-stoat-memory` (node `weasel-sqlite-function-wiring`). Fisher's vector search registers a `cosine_distance` scalar through this.

## Problem

`SqliteFunctionRegistry` and `SqliteExtensionSettings` existed, with tests, but nothing called either: `SqliteDataSource.OpenDbConnectionAsync` applied PRAGMAs and stopped. Functions and extensions are per connection handle in SQLite, so the only correct place to apply them is the thing that opens connections.

## What

- `SqliteDataSource` gains a four-argument constructor `(connectionString, pragmaSettings, functions, extensions)`. The existing two-argument constructor is untouched and defaults both to empty, so current callers (Fisher's `new SqliteDataSource(cs, options.PragmaSettings)`) keep compiling and binding.
- Every open, sync and async, now applies connection PRAGMAs, then extensions, then functions, inside the existing try/catch so a failed load disposes the connection rather than handing it out half-configured. Both are exposed as live `Functions` / `Extensions` properties, so functions added after construction reach later opens.
- `SqliteExtensionSettings` gets a synchronous `ApplyToConnection` holding the real implementation (loading is a synchronous native call); the async method wraps it. With nothing configured the connection is not touched at all, and `EnableExtensions(false)` now runs in a `finally`.

## Docs

New `docs/sqlite/functions.md` with a compiled sample (a cosine distance over a float32 BLOB, no native dependency), a sidebar entry, and a pointer in `CLAUDE.md`. The other `docs/sqlite/*.md` diffs are mdsnippets line-number updates after the sample insertion.

## Tests

`SqliteDataSourceFunctionWiringTests` (8): scalar and aggregate functions on async and sync opens, late-added functions, the per-connection nature of functions pinned through a bare connection, the two-argument constructor unchanged, and a failing extension load on both open paths. Full Weasel.Sqlite suite green on net10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
