### PR TITLE
Expose a document's mapped version member, and let the enum in-fragments be told the stored name

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -46,6 +46,7 @@ export default withMermaid(
             { text: 'Installation', link: '/guide/installation' },
             { text: 'Quick Start', link: '/guide/quickstart' },
             { text: 'Migrating from 8.x to 9.0', link: '/migration-guide' },
+            { text: 'Upgrading to 9.32', link: '/release-9-32' },
             { text: 'Upgrading to 9.31', link: '/release-9-31' },
             { text: 'Upgrading to 9.30', link: '/release-9-30' },
             { text: 'Upgrading to 9.29', link: '/release-9-29' },

--- a/docs/release-9-32.md
+++ b/docs/release-9-32.md
@@ -1,0 +1,71 @@
+# Upgrading to 9.32
+
+9.32.0 adds two seams that let a document store answer a question only the store can answer, in
+places where Weasel previously had to guess. Both are additive, both default to today's behaviour,
+and neither changes what a migration does to an existing database.
+
+::: tip Coming from 9.31?
+Nothing here changes on upgrade. The two additions are opt-in: an interface member with a default
+implementation, and a new constructor overload. A store adopts them separately — Marten does so in
+its own release.
+:::
+
+## A storage can expose a document's mapped version / revision member
+
+[#590](https://github.com/JasperFx/weasel/issues/590), raised from
+[JasperFx/marten#5372](https://github.com/JasperFx/marten/issues/5372).
+
+`IDocumentStorage<T>` gains two members, both defaulting to `null`:
+
+```csharp
+Guid? MappedVersionFor(T document) => null;
+long? MappedRevisionFor(T document) => null;
+```
+
+The problem they solve is a store's session needing the expected version for a write's concurrency
+guard. A session seeds that from the document's versioned marker interface, which it can test for
+directly. A document that instead *maps* a plain member as its version — Marten's
+`Metadata(m => m.Version.MapTo(x => x.Etag))` — carries the same information, but the session holds
+the document only as `IDocumentStorage<T>` and had no way to ask for it. In Marten the consequence
+was that the upsert bound `DBNull` into its `WHERE … mt_version = ?` guard, so every cross-session
+write of such a document came back as a `ConcurrencyException` — a documented feature that could not
+do the one thing it is named for.
+
+The alternatives all involved a runtime type test on the storage plus explicit forwarding through
+each decorator, which fails *silently* when a decorator is missed. That is the wrong failure mode for
+a concurrency guard, hence the interface member.
+
+`MappedRevisionFor` returns a `long` whatever the member's own width is, matching
+`DocumentRevisionBinder`, which already accepts an `int` or a `long` revision member.
+
+## The enum `in` fragments can be told the name the serializer stored
+
+[#591](https://github.com/JasperFx/weasel/issues/591), raised from
+[JasperFx/marten#5376](https://github.com/JasperFx/marten/issues/5376).
+
+`EnumIsOneOfWhereFragment` and `EnumIsNotOneOfWhereFragment` each gain a constructor overload taking
+an optional renderer:
+
+```csharp
+public EnumIsOneOfWhereFragment(object values, EnumStorage enumStorage, string locator,
+    Func<object, string>? nameForValue)
+```
+
+Under `EnumStorage.AsString` both fragments rendered every value with `ToString()`, which is the enum
+member's **declared** name. That is the stored name only until somebody renames the member —
+`[JsonStringEnumMemberName]` on System.Text.Json, `[EnumMember]` on Newtonsoft. Then the filter
+compares against a name that is not in the data, matches nothing, and reports it as *no rows* rather
+than as an error, which reads as "no such data".
+
+Only the serializer knows which name it wrote, so the caller supplies it. Passing nothing keeps the
+previous behaviour byte for byte, which is why the existing three-argument constructors are
+unchanged.
+
+A delegate rather than an `ISerializer` keeps `Weasel.Postgresql.SqlGeneration` free of a
+serialization dependency — and `Weasel.Core.ISerializer` could not have served here anyway, since it
+carries no enum rendering.
+
+Worth recording, because it is the tempting fix: reflecting over the enum's fields for the rename
+attribute is **not** a substitute. It agrees with the serializer under a JIT and finds no attribute
+at all in a trimmed Native AOT binary, so a reflection-based fix would quietly fall back to the
+declared name in exactly the deployment where the symptom is hardest to diagnose.

--- a/src/Weasel.Postgresql.Tests/SqlGeneration/EnumIsOneOfWhereFragmentTests.cs
+++ b/src/Weasel.Postgresql.Tests/SqlGeneration/EnumIsOneOfWhereFragmentTests.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Linq;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Postgresql.SqlGeneration;
+using Xunit;
+
+namespace Weasel.Postgresql.Tests.SqlGeneration;
+
+/// <summary>
+///     weasel#591: under <see cref="EnumStorage.AsString" /> these two fragments rendered every
+///     value with <c>ToString()</c>, which is the enum member's <em>declared</em> name. A serializer
+///     that renamed the member — <c>[JsonStringEnumMemberName]</c> on System.Text.Json,
+///     <c>[EnumMember]</c> on Newtonsoft — stored something else, so the filter compared against a
+///     name that is not in the data and matched nothing, reporting it as "no rows" rather than as an
+///     error. The optional renderer lets the calling store supply the name the serializer actually
+///     wrote; omitting it keeps the historical behaviour exactly.
+/// </summary>
+public class EnumIsOneOfWhereFragmentTests
+{
+    public enum Zorgvorm
+    {
+        Huisarts,
+        Apotheek
+    }
+
+    // Stands in for a serializer that renamed one member.
+    private static string renamed(object value)
+        => value switch
+        {
+            Zorgvorm.Apotheek => "apotheek-houdend",
+            _ => value.ToString()!
+        };
+
+    private static object parameterValueFor(EnumIsOneOfWhereFragment fragment, out string sql)
+    {
+        var builder = new CommandBuilder();
+        fragment.Apply(builder);
+        var command = builder.Compile();
+        sql = command.CommandText;
+        return command.Parameters[0].Value!;
+    }
+
+    private static object parameterValueFor(EnumIsNotOneOfWhereFragment fragment)
+    {
+        var builder = new CommandBuilder();
+        fragment.Apply(builder);
+        return builder.Compile().Parameters[0].Value!;
+    }
+
+    [Fact]
+    public void as_string_without_a_renderer_keeps_the_declared_name()
+    {
+        var fragment = new EnumIsOneOfWhereFragment(
+            new[] { Zorgvorm.Apotheek, Zorgvorm.Huisarts }, EnumStorage.AsString, "d.data ->> 'Zorgvorm'");
+
+        ((string[])parameterValueFor(fragment, out _))
+            .ShouldBe(new[] { "Apotheek", "Huisarts" });
+    }
+
+    [Fact]
+    public void as_string_asks_the_renderer_for_the_stored_name()
+    {
+        var fragment = new EnumIsOneOfWhereFragment(
+            new[] { Zorgvorm.Apotheek, Zorgvorm.Huisarts }, EnumStorage.AsString, "d.data ->> 'Zorgvorm'",
+            renamed);
+
+        ((string[])parameterValueFor(fragment, out _))
+            .ShouldBe(new[] { "apotheek-houdend", "Huisarts" });
+    }
+
+    [Fact]
+    public void as_integer_never_consults_the_renderer()
+    {
+        var fragment = new EnumIsOneOfWhereFragment(
+            new[] { Zorgvorm.Apotheek }, EnumStorage.AsInteger, "d.data ->> 'Zorgvorm'",
+            _ => throw new InvalidOperationException("the renderer is for the string storage only"));
+
+        ((int?[])parameterValueFor(fragment, out _))
+            .ShouldBe(new int?[] { 1 });
+    }
+
+    [Fact]
+    public void a_null_entry_is_still_the_is_null_branch_and_never_reaches_the_renderer()
+    {
+        var fragment = new EnumIsOneOfWhereFragment(
+            new Zorgvorm?[] { Zorgvorm.Apotheek, null }, EnumStorage.AsString, "d.data ->> 'Zorgvorm'",
+            value => value is null
+                ? throw new InvalidOperationException("a null entry must not be rendered")
+                : renamed(value));
+
+        var values = (string[])parameterValueFor(fragment, out var sql);
+
+        values.ShouldBe(new[] { "apotheek-houdend" });
+        sql.ShouldContain("is null");
+    }
+
+    [Fact]
+    public void is_not_one_of_without_a_renderer_keeps_the_declared_name()
+    {
+        var fragment = new EnumIsNotOneOfWhereFragment(
+            new[] { Zorgvorm.Apotheek }, EnumStorage.AsString, "d.data ->> 'Zorgvorm'");
+
+        ((string[])parameterValueFor(fragment)).ShouldBe(new[] { "Apotheek" });
+    }
+
+    [Fact]
+    public void is_not_one_of_asks_the_renderer_for_the_stored_name()
+    {
+        var fragment = new EnumIsNotOneOfWhereFragment(
+            new[] { Zorgvorm.Apotheek }, EnumStorage.AsString, "d.data ->> 'Zorgvorm'", renamed);
+
+        ((string[])parameterValueFor(fragment)).ShouldBe(new[] { "apotheek-houdend" });
+    }
+
+    [Fact]
+    public void is_not_one_of_as_integer_never_consults_the_renderer()
+    {
+        var fragment = new EnumIsNotOneOfWhereFragment(
+            new[] { Zorgvorm.Apotheek }, EnumStorage.AsInteger, "d.data ->> 'Zorgvorm'",
+            _ => throw new InvalidOperationException("the renderer is for the string storage only"));
+
+        ((int[])parameterValueFor(fragment)).ShouldBe(new[] { 1 });
+    }
+}

--- a/src/Weasel.Postgresql/SqlGeneration/EnumIsNotOneOfWhereFragment.cs
+++ b/src/Weasel.Postgresql/SqlGeneration/EnumIsNotOneOfWhereFragment.cs
@@ -11,6 +11,18 @@ public class EnumIsNotOneOfWhereFragment: ISqlFragment
     private readonly object _values;
 
     public EnumIsNotOneOfWhereFragment(object values, EnumStorage enumStorage, string locator)
+        : this(values, enumStorage, locator, null)
+    {
+    }
+
+    /// <param name="nameForValue">
+    ///     Renders one enum value as the string the serializer actually stored for it. Null keeps
+    ///     the historical <see cref="object.ToString" /> behaviour, which is the member's
+    ///     <em>declared</em> name. See the sibling <see cref="EnumIsOneOfWhereFragment" /> and
+    ///     weasel#591.
+    /// </param>
+    public EnumIsNotOneOfWhereFragment(object values, EnumStorage enumStorage, string locator,
+        Func<object, string>? nameForValue)
     {
         var array = values.As<Array>();
         if (enumStorage == EnumStorage.AsInteger)
@@ -31,7 +43,8 @@ public class EnumIsNotOneOfWhereFragment: ISqlFragment
 
             for (var i = 0; i < array.Length; i++)
             {
-                strings[i] = array.GetValue(i)!.ToString()!;
+                var entry = array.GetValue(i)!;
+                strings[i] = nameForValue?.Invoke(entry) ?? entry.ToString()!;
             }
 
             _values = strings;

--- a/src/Weasel.Postgresql/SqlGeneration/EnumIsOneOfWhereFragment.cs
+++ b/src/Weasel.Postgresql/SqlGeneration/EnumIsOneOfWhereFragment.cs
@@ -12,6 +12,20 @@ public class EnumIsOneOfWhereFragment: ISqlFragment
     private readonly object _values;
 
     public EnumIsOneOfWhereFragment(object values, EnumStorage enumStorage, string locator)
+        : this(values, enumStorage, locator, null)
+    {
+    }
+
+    /// <param name="nameForValue">
+    ///     Renders one enum value as the string the serializer actually stored for it. Null keeps
+    ///     the historical <see cref="object.ToString" /> behaviour, which is the member's
+    ///     <em>declared</em> name. Those differ as soon as the member was renamed —
+    ///     <c>[JsonStringEnumMemberName]</c> on System.Text.Json, <c>[EnumMember]</c> on Newtonsoft —
+    ///     and a filter comparing against the declared name matches nothing and reports it as "no
+    ///     rows" rather than as an error. See weasel#591, raised from marten#5376.
+    /// </param>
+    public EnumIsOneOfWhereFragment(object values, EnumStorage enumStorage, string locator,
+        Func<object, string>? nameForValue)
     {
         var array = values.As<Array>();
         if (enumStorage == EnumStorage.AsInteger)
@@ -46,7 +60,7 @@ public class EnumIsOneOfWhereFragment: ISqlFragment
                     continue;
                 }
 
-                stringEntries[i] = stringEntry.ToString()!;
+                stringEntries[i] = nameForValue?.Invoke(stringEntry) ?? stringEntry.ToString()!;
             }
 
             _values = stringEntries.Where(n => n != null).ToArray();

--- a/src/Weasel.Storage/IDocumentStorage.cs
+++ b/src/Weasel.Storage/IDocumentStorage.cs
@@ -50,6 +50,28 @@ public interface IDocumentStorage<T>: IDocumentStorage where T : notnull
 
     Guid? VersionFor(T document, IStorageSession session);
 
+    /// <summary>
+    ///     The value of the document's mapped optimistic-concurrency member, or null when the
+    ///     mapping carries no mapped version member. Lets a session seed the expected version for a
+    ///     write's concurrency guard off the document itself, exactly as it already does for the
+    ///     store's versioned marker interfaces — without a runtime type test on the storage.
+    /// </summary>
+    /// <remarks>
+    ///     Defaults to null so this stays additive: a storage with no mapped version member, or a
+    ///     store that has not adopted the seam, keeps its current behaviour. See weasel#590, raised
+    ///     from marten#5372 — a member mapped with Marten's <c>Metadata.Version.MapTo(...)</c> was
+    ///     invisible to the session, so the upsert bound DBNull into its version guard and reported
+    ///     every cross-session write as a concurrency violation.
+    /// </remarks>
+    Guid? MappedVersionFor(T document) => null;
+
+    /// <summary>
+    ///     The value of the document's mapped numeric-revision member, or null when the mapping
+    ///     carries no mapped revision member. Returns a long whatever the member's own width is —
+    ///     an int member widens — because the revision column itself comes in both widths.
+    /// </summary>
+    long? MappedRevisionFor(T document) => null;
+
     void Store(IStorageSession session, T document);
     void Store(IStorageSession session, T document, Guid? version);
     void Store(IStorageSession session, T document, long revision);


### PR DESCRIPTION
Closes #590. Closes #591.

Two additive seams a document store can opt into. Both default to today's behaviour, neither changes
what a migration does to an existing database, and nothing in Weasel, Marten, Polecat or Fisher
changes until a store adopts them.

## A storage can expose a document's mapped version / revision member

`IDocumentStorage<T>` gains two default interface members:

```csharp
Guid? MappedVersionFor(T document) => null;
long? MappedRevisionFor(T document) => null;
```

A session needs the expected version for a write's concurrency guard. It can test a document for a
versioned marker interface directly, but a document that instead *maps* a plain member as its version
carries the same information somewhere the session cannot reach — it holds the storage only as
`IDocumentStorage<T>`.

In Marten (JasperFx/marten#5372, reported by @JurJean) the consequence was that a document configured
with `Metadata(m => m.Version.MapTo(x => x.Etag))` bound `DBNull` into its
`ON CONFLICT … WHERE table.mt_version = ?` guard on every cross-session `Store()`, so no RETURNING row
came back and a write that should have succeeded was reported as a `ConcurrencyException`. The member
is populated on save and on load, so the mapping looks like it works — only the write guard never
sees it.

Every alternative needed a runtime type test on the storage plus explicit forwarding in each
decorator, and a decorator that forgets to forward fails **silently**, which is the wrong failure
mode for a concurrency guard.

`MappedRevisionFor` returns a `long` whatever the member's own width is, matching
`DocumentRevisionBinder`, which already accepts an `int` or a `long` revision member.

## The enum `in` fragments can be told the name the serializer stored

`EnumIsOneOfWhereFragment` and `EnumIsNotOneOfWhereFragment` each gain a constructor overload taking
an optional `Func<object, string>? nameForValue`.

Under `EnumStorage.AsString` both rendered every value with `ToString()` — the member's **declared**
name, which stops being the stored name the moment somebody renames the member with
`[JsonStringEnumMemberName]` (System.Text.Json) or `[EnumMember]` (Newtonsoft). The filter then
compares against a name that is not in the data, matches nothing, and reports it as *no rows* rather
than as an error.

This is the collection-shaped half of JasperFx/marten#5376. Marten's own `EnumAsStringMember` covers
`==` / `!=`; every `in` / `Contains` shape funnels into these two fragments instead — `IsOneOf`,
`IsNotOneOf`, both `EnumerableContains` branches, and `MemoryExtensionsContains` — and kept the bug.

Passing nothing keeps the previous behaviour byte for byte, which is why the existing three-argument
constructors are unchanged and delegate. A delegate rather than an `ISerializer` keeps
`Weasel.Postgresql.SqlGeneration` free of a serialization dependency — and `Weasel.Core.ISerializer`
could not have served anyway, since it carries no enum rendering.

Worth recording because it is the tempting fix: reflecting over the enum's fields for the rename
attribute is **not** a substitute. It agrees with the serializer under a JIT and finds no attribute at
all in a trimmed Native AOT binary, so it would quietly fall back to the declared name in exactly the
deployment where the symptom is hardest to diagnose.

## Verification

- Solution-wide `dotnet build`: **0 errors**. The only in-repo implementer of `IDocumentStorage<T>`
  (`NoopDocumentStorage<T>` in `Weasel.Benchmarks`) compiles untouched, which is the default-interface-
  member guarantee doing its job.
- `EnumIsOneOfWhereFragmentTests` — 7 new tests, green: both fragments, with and without the renderer,
  `AsString` and `AsInteger`, plus the `AsInteger` path asserting the renderer is *never* consulted and
  the `IsOneOf` null entry still taking the `is null` branch without being rendered.

## Not here

The version bump — that belongs to the release commit, following the convention in this repo's
history. Suggested release is **9.32.0** (additive minor); `docs/release-9-32.md` is written and
registered in the sidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01481eiEZg1Bv6pu4DrgPRg3
